### PR TITLE
Add eventfd and eventfd2 to allowed syscalls for system-probe

### DIFF
--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.6
+version: 2.4.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.5
+version: 2.4.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -68,6 +68,8 @@ data:
             "epoll_wait",
             "epoll_wait",
             "epoll_wait_old",
+            "eventfd",
+            "eventfd2",
             "execve",
             "execveat",
             "exit",


### PR DESCRIPTION
#### What this PR does / why we need it:

The cilium-based library needs these syscalls for perf buffer epoll usage.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
