### PR TITLE
fix: mount config volume always

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.4.18
+
+* Fix `config` volume not being mounted in clusterChecksRunner pods.
+
 ## 2.4.17
 
 * Update default `Agent` and `Cluster-Agent` image tags: `7.22` and `1.18`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.17
+version: 2.4.18
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -144,9 +144,9 @@ spec:
             mountPath: /etc/datadog-agent/install_info
             {{- end }}
             readOnly: true
-{{- if .Values.clusterChecksRunner.volumeMounts }}
           - name: config
             mountPath: {{ template "datadog.confPath" . }}
+{{- if .Values.clusterChecksRunner.volumeMounts }}
 {{ toYaml .Values.clusterChecksRunner.volumeMounts | indent 10 }}
 {{- end }}
         livenessProbe:


### PR DESCRIPTION
#### What this PR does / why we need it:

The cluster checks runner currently does not mount the config volume unless other volumeMounts are defined. This breaks custom checks defined in `datadog.checksd` and `datadog.confd` without a workaround:

```yaml
clusterChecksRunner:
  enabled: true

  # Force config volume to mount
  volumes:
    - name: workaround-volume
      emptyDir: {}
  volumeMounts:
    - name: workaround-volume
      mountPath: /workaround-ignore
```

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist

- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
