### PR TITLE
Add network policy for KSM

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.4.24
+
+* Fix the Cluster Agent's network policy (allow ingress from node Agents)
+* Add kube-state-metrics network policy
+
 ## 2.4.23
 
 * Add `datadog.envFrom` parameter to support passing references to secrets and/or configmaps for environment

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.23
+version: 2.4.24
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.4.23](https://img.shields.io/badge/Version-2.4.23-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.4.24](https://img.shields.io/badge/Version-2.4.24-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -448,6 +448,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.envFrom | list | `[]` | Set environment variables for all Agents directly from configMaps and/or secrets |
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.kubeStateMetricsEnabled | bool | `true` | If true, deploys the kube-state-metrics deployment |
+| datadog.kubeStateMetricsNetworkPolicy.create | bool | `false` | If true, create a NetworkPolicy for kube state metrics |
 | datadog.leaderElection | bool | `false` | Enables leader election mechanism for event collection |
 | datadog.leaderLeaseDuration | string | `nil` | Set the lease time for leader election in second |
 | datadog.logLevel | string | `"INFO"` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, off |

--- a/charts/datadog/templates/cluster-agent-network-policy.yaml
+++ b/charts/datadog/templates/cluster-agent-network-policy.yaml
@@ -17,6 +17,13 @@ spec:
     - Ingress
     - Egress
   ingress:
+  - # Ingress from the node agents (for the metadata provider)
+    ports:
+      - port: 5005
+    from:
+      - podSelector:
+          matchLabels:
+            app: {{ template "datadog.fullname" . }}
 {{- if $.Values.clusterChecksRunner.enabled }}
   - # Ingress from cluster checks runner
     ports:

--- a/charts/datadog/templates/kube-state-metrics-network-policy.yaml
+++ b/charts/datadog/templates/kube-state-metrics-network-policy.yaml
@@ -1,0 +1,31 @@
+{{- if $.Values.datadog.kubeStateMetricsNetworkPolicy.create -}}
+apiVersion: "networking.k8s.io/v1"
+kind: NetworkPolicy
+metadata:
+  name: {{ template "datadog.fullname" . }}-kube-state-metrics
+  labels:
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - # Egress to Kube API server
+      ports:
+        - port: 443
+  ingress:
+    - # Ingress from the node agents and the cluster check runners
+      ports:
+        - port: 8080
+      from:
+          - podSelector:
+              matchExpressions:
+                - {key: app, operator: In, values: [ {{ template "datadog.fullname" . }}, {{ template "datadog.fullname" . }}-clusterchecks ]}
+{{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -65,6 +65,10 @@ datadog:
   ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics
   kubeStateMetricsEnabled: true
 
+  kubeStateMetricsNetworkPolicy:
+    # datadog.kubeStateMetricsNetworkPolicy.create -- If true, create a NetworkPolicy for kube state metrics
+    create: false
+
   ## Manage Cluster checks feature
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
   ## Autodiscovery via Kube Service annotations is automatically enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

* Fix the Cluster Agent's network policy (allow ingress from node Agents)
* Add kube-state-metrics network policy

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [X] Variables are documented in the `README.md`
