### PR TITLE
Add parameter to set system_probe_config.enable_conntrack_all_namespaces

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.4.26
+
+* Add `datadog.systemProbe.enableConntrackAllNamespaces` parameter to support conntrack listening for updates from all network namespaces
+
 ## 2.4.25
 
 * Update default `datadog/agent` image tag to `7.23.0`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.25
+version: 2.4.26
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.4.25](https://img.shields.io/badge/Version-2.4.25-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.4.26](https://img.shields.io/badge/Version-2.4.26-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -475,6 +475,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.systemProbe.collectDNSStats | bool | `false` | Enable DNS stat collection |
 | datadog.systemProbe.debugPort | int | `0` | Specify the port to expose pprof and expvar for system-probe agent |
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
+| datadog.systemProbe.enableConntrackAllNamespaces | bool | `true` | Enable conntrack updates from all network namespaces |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
 | datadog.systemProbe.enabled | bool | `false` | Set this to true to enable system-probe agent |

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -21,6 +21,7 @@ data:
       enable_tcp_queue_length: {{ $.Values.datadog.systemProbe.enableTCPQueueLength }}
       enable_oom_kill: {{ $.Values.datadog.systemProbe.enableOOMKill }}
       collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
+      enable_conntrack_all_namespaces: {{ $.Values.datadog.systemProbe.enableConntrackAllNamespaces }}
     runtime_security_config:
       enabled: {{ $.Values.datadog.securityAgent.runtime.enabled }}
       debug: false

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -277,6 +277,9 @@ datadog:
     # datadog.systemProbe.collectDNSStats -- Enable DNS stat collection
     collectDNSStats: false
 
+    # datadog.systemProbe.enableConntrackAllNamespaces -- Enable conntrack updates from all network namespaces
+    enableConntrackAllNamespaces: true
+
   orchestratorExplorer:
     # datadog.orchestratorExplorer.enabled -- Set this to true to enable the orchestrator explorer
     ## This requires processAgent.enabled and clusterAgent.enabled to be set to true


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a new parameter to set `system_probe_config.enable_conntrack_all_namespaces` config flag

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
