### PR TITLE
Added synthetics private location worker configuration capabilities

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.4.26
+
+* Added synthetics private location worker configuration capabilities
+
 ## 2.4.25
 
 * Update default `datadog/agent` image tag to `7.23.0`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.25
+version: 2.4.26
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.4.25](https://img.shields.io/badge/Version-2.4.25-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.4.26](https://img.shields.io/badge/Version-2.4.26-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -487,6 +487,21 @@ helm install --name <RELEASE_NAME> \
 | kube-state-metrics.serviceAccount.create | bool | `true` | If true, create ServiceAccount, require rbac kube-state-metrics.rbac.create true |
 | kube-state-metrics.serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. |
 | nameOverride | string | `nil` | Override name of app |
+| syntheticsPrivateLocationWorker.affinity | object | `{}` | Allow the private location worker deployment to schedule using affinity rules. |
+| syntheticsPrivateLocationWorker.config | string | `nil` | JSON config obtained when creating the new private location from the Datadog UI/API |
+| syntheticsPrivateLocationWorker.dnsConfig | object | `{}` | specify dns configuration options for private location worker containers e.g ndots |
+| syntheticsPrivateLocationWorker.enabled | bool | `false` | If true, deploys private worker to perform synthetics checks |
+| syntheticsPrivateLocationWorker.env | list | `[]` | Environment variables specific to private location worker containers |
+| syntheticsPrivateLocationWorker.envFrom | list | `[]` | Set environment variables for private location worker containers directly from configMaps and/or secrets |
+| syntheticsPrivateLocationWorker.image.pullPolicy | string | `"IfNotPresent"` | Datadog private location worker image pull policy |
+| syntheticsPrivateLocationWorker.image.pullSecrets | list | `[]` | Datadog private location worker repository pullSecret (ex: specify docker registry credentials) |
+| syntheticsPrivateLocationWorker.image.repository | string | `"datadog/synthetics-private-location-worker"` | Datadog synthetics private location worker image repository to use |
+| syntheticsPrivateLocationWorker.image.tag | string | `"1.4.0"` | Define the worker version to use |
+| syntheticsPrivateLocationWorker.nodeSelector | object | `{}` | Allow the private location worker Deployment to schedule on selected nodes |
+| syntheticsPrivateLocationWorker.replicas | int | `1` | Number of worker instances |
+| syntheticsPrivateLocationWorker.resources | object | `{}` | Datadog private location worker resource requests and limits. |
+| syntheticsPrivateLocationWorker.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` | Allow the private location worker deployment to perform a rolling update on helm update |
+| syntheticsPrivateLocationWorker.tolerations | list | `[]` | Tolerations for pod assignment |
 | targetSystem | string | `"linux"` | Target OS for this deployment (possible values: linux, windows) |
 
 ## Configuration options for Windows deployments

--- a/charts/datadog/templates/synthetics-private-location-worker-deployment.yaml
+++ b/charts/datadog/templates/synthetics-private-location-worker-deployment.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.syntheticsPrivateLocationWorker.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "datadog.fullname" . }}-synthetics-private-location-worker
+  labels:
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+spec:
+  replicas: {{ .Values.syntheticsPrivateLocationWorker.replicas }}
+  strategy:
+{{ toYaml .Values.syntheticsPrivateLocationWorker.strategy | indent 4 }}
+  selector:
+    matchLabels:
+      app: {{ template "datadog.fullname" . }}-synthetics-private-location-worker
+  template:
+    metadata:
+      labels:
+        app: {{ template "datadog.fullname" . }}-synthetics-private-location-worker
+      name: {{ template "datadog.fullname" . }}-synthetics-private-location-worker
+      annotations:
+        checksum/config: {{ tpl (toYaml .Values.syntheticsPrivateLocationWorker.config) . | sha256sum }}
+    spec:
+      {{- if .Values.syntheticsPrivateLocationWorker.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.syntheticsPrivateLocationWorker.dnsConfig | indent 8 }}
+      {{- end }}
+      imagePullSecrets:
+{{ toYaml .Values.syntheticsPrivateLocationWorker.image.pullSecrets | indent 8 }}
+      containers:
+      - name: agent
+        image: "{{ .Values.syntheticsPrivateLocationWorker.image.repository }}:{{ .Values.syntheticsPrivateLocationWorker.image.tag }}"
+        imagePullPolicy: {{ .Values.syntheticsPrivateLocationWorker.image.pullPolicy }}
+{{- if .Values.syntheticsPrivateLocationWorker.env }}
+        env:
+{{ toYaml .Values.syntheticsPrivateLocationWorker.env | indent 10 }}
+{{- end }}
+{{- if .Values.syntheticsPrivateLocationWorker.envFrom }}
+        envFrom:
+{{ toYaml .Values.syntheticsPrivateLocationWorker.envFrom | indent 10 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.syntheticsPrivateLocationWorker.resources | indent 10 }}
+        volumeMounts:
+          - name: config
+            mountPath: /etc/datadog/synthetics-check-runner.json
+            subPath: config.json
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ template "datadog.fullname" . }}-synthetics-private-location-worker-config
+{{- if .Values.syntheticsPrivateLocationWorker.affinity }}
+      affinity:
+{{ toYaml .Values.syntheticsPrivateLocationWorker.affinity | indent 8 }}
+{{- end }}
+      nodeSelector:
+        {{ template "label.os" . }}: {{ .Values.targetSystem }}
+{{- if .Values.syntheticsPrivateLocationWorker.nodeSelector }}
+{{ toYaml .Values.syntheticsPrivateLocationWorker.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.syntheticsPrivateLocationWorker.tolerations }}
+      tolerations:
+{{ toYaml .Values.syntheticsPrivateLocationWorker.tolerations | indent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/datadog/templates/synthetics-private-location-worker-secret.yaml
+++ b/charts/datadog/templates/synthetics-private-location-worker-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.syntheticsPrivateLocationWorker.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "datadog.fullname" . }}-synthetics-private-location-worker-config
+  labels:
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+type: Opaque
+data:
+  config.json: {{ .Values.syntheticsPrivateLocationWorker.config | b64enc | quote }}
+{{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -971,6 +971,85 @@ clusterChecksRunner:
     # clusterChecksRunner.networkPolicy.create -- If true, create a NetworkPolicy for the cluster checks runners
     create: false
 
+syntheticsPrivateLocationWorker:
+  # syntheticsPrivateLocationWorker.enabled -- If true, deploys private worker to perform synthetics checks
+  ## ref: https://docs.datadoghq.com/getting_started/synthetics/private_location/
+  enabled: false
+
+  ## Define the Datadog image to work with.
+  image:
+    # syntheticsPrivateLocationWorker.image.repository -- Datadog synthetics private location worker image repository to use
+    repository: datadog/synthetics-private-location-worker
+
+    # syntheticsPrivateLocationWorker.image.tag -- Define the worker version to use
+    tag: 1.4.0
+
+    # syntheticsPrivateLocationWorker.image.pullPolicy -- Datadog private location worker image pull policy
+    pullPolicy: IfNotPresent
+
+    # syntheticsPrivateLocationWorker.image.pullSecrets -- Datadog private location worker repository pullSecret (ex: specify docker registry credentials)
+    ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets: []
+    #   - name: "<REG_SECRET>"
+
+  # syntheticsPrivateLocationWorker.replicas -- Number of worker instances
+  replicas: 1
+
+  # syntheticsPrivateLocationWorker.resources -- Datadog private location worker resource requests and limits.
+  resources: {}
+  # requests:
+  #   cpu: 200m
+  #   memory: 500Mi
+  # limits:
+  #   cpu: 200m
+  #   memory: 500Mi
+
+  # syntheticsPrivateLocationWorker.affinity -- Allow the private location worker deployment to schedule using affinity rules.
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
+  # syntheticsPrivateLocationWorker.strategy -- Allow the private location worker deployment to perform a rolling update on helm update
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
+  # syntheticsPrivateLocationWorker.dnsConfig -- specify dns configuration options for private location worker containers e.g ndots
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  dnsConfig: {}
+  #  options:
+  #  - name: ndots
+  #    value: "1"
+
+  # syntheticsPrivateLocationWorker.nodeSelector -- Allow the private location worker Deployment to schedule on selected nodes
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
+
+  # syntheticsPrivateLocationWorker.tolerations -- Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  #
+  tolerations: []
+
+  # syntheticsPrivateLocationWorker.env -- Environment variables specific to private location worker containers
+  ## ref: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent#environment-variables
+  env: []
+  #   - name: <ENV_VAR_NAME>
+  #     value: <ENV_VAR_VALUE>
+
+  # syntheticsPrivateLocationWorker.envFrom -- Set environment variables for private location worker containers
+  # directly from configMaps and/or secrets
+  envFrom: []
+  #   - configMapRef:
+  #       name: <CONFIGMAP_NAME>
+  #   - secretRef:
+  #       name: <SECRET_NAME>
+
+  # syntheticsPrivateLocationWorker.config -- JSON config obtained when creating the new private location from the Datadog UI/API
+  config:
+
 kube-state-metrics:
   rbac:
     # kube-state-metrics.rbac.create -- If true, create & use RBAC resources


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR will allow end users to manage private location worker from the chart instead of having to manually do so.

#### Checklist

- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
