### PR TITLE
Revert to Helm2 hash in `requirements.yaml` to retain compatibility with Helm 2

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.4.26
+
+* Revert to Helm2 hash in `requirements.yaml` to retain compatibility with Helm 2
+
 ## 2.4.25
 
 * Update default `datadog/agent` image tag to `7.23.0`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.25
+version: 2.4.26
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.4.25](https://img.shields.io/badge/Version-2.4.25-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.4.26](https://img.shields.io/badge/Version-2.4.26-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.8.11
-digest: sha256:e4a8095dc982575fa6cc63207855dcf3c7419c1c5cb8ef03f3e9f4fc7d5d801d
-generated: "2020-07-23T12:39:40.942181+02:00"
+digest: sha256:ca16dbfb025e4fdd4f5665fc5adfd8f8cf62100cae882d1d94e32efd2e9ce156
+generated: "2020-10-19T18:49:38.132849+02:00"


### PR DESCRIPTION
#### What this PR does / why we need it:

Revert to Helm2 hash in `requirements.yaml` to retain compatibility with Helm 2

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #56

#### Special notes for your reviewer:

Helm 3 understand Helm 2 hashes but the opposite is not true.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
