### PR TITLE
[synthetics] add Private Location helm chart

### DIFF
--- a/charts/synthetics-private-location/.helmignore
+++ b/charts/synthetics-private-location/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Datadog changelog
 
-### 0.0.1
+### 0.1.0
 
 * Initial version

--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Datadog changelog
+
+### 0.0.1
+
+* Initial version

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -14,5 +14,3 @@ sources:
 maintainers:
 - name: Datadog
   email: support@datadoghq.com
-
-

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: synthetics-private-location
+version: 0.1.0
+appVersion: 1.4.0
+description: Datadog Synthetics Private Location
+keywords:
+- monitoring
+- synthetics
+home: https://www.datadoghq.com
+icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
+sources:
+- https://docs.datadoghq.com/synthetics/private_locations
+- https://app.datadoghq.com/synthetics/settings/private-locations
+maintainers:
+- name: Datadog
+  email: support@datadoghq.com
+
+

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -26,7 +26,8 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Allows to specify affinity for Datadog Synthetics Private Location PODs |
-| fullnameOverride | string | `""` |  |
+| configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
+| fullnameOverride | string | `""` | Override the full qualified app name |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Synthetics Private Location image |
 | image.repository | string | `"datadog/synthetics-private-location-worker"` | Repository to use for Datadog Synthetics Private Location image |
 | image.tag | string | `"1.4.0"` | Define the Datadog Synthetics Private Location version to use |
@@ -35,9 +36,9 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | nodeSelector | object | `{}` | Allows to schedule Datadog Synthetics Private Location on specific nodes |
 | podAnnotations | object | `{}` | Annotations to set to Datadog Synthetics Private Location PODs |
 | podSecurityContext | object | `{}` | Security context to set to Datadog Synthetics Private Location PODs |
-| securityContext | object | `{}` | Security context to set to the Datadog Synthetics Private Location container |
 | replicaCount | int | `1` | Number of instances of Datadog Synthetics Private Location |
 | resources | object | `{}` | Set resources requests/limits for Datadog Synthetics Private Location PODs |
+| securityContext | object | `{}` | Security context to set to the Datadog Synthetics Private Location container |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| serviceAccount.name | string | `nil` | The name of the service account to use. If not set name is generated using the fullname template |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set name is generated using the fullname template |
 | tolerations | list | `[]` | Allows to schedule Datadog Synthetics Private Location on tainted nodes |

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,0 +1,43 @@
+# Datadog Synthetics Private Location
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+
+[Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
+
+## How to use Datadog Helm repository
+
+You need to add this repository to your Helm repositories:
+
+```
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+```
+
+## Quick start
+
+To install the chart with the release name `<RELEASE_NAME>`, retrieve your Private Location configuration file from your [Synthetics Private Location settings page](https://app.datadoghq.com/synthetics/settings/private-locations/) and save it under `config.json` then run:
+
+```bash
+helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file configFile=config.json
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Allows to specify affinity for Datadog Synthetics Private Location PODs |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Synthetics Private Location image |
+| image.repository | string | `"datadog/synthetics-private-location-worker"` | Repository to use for Datadog Synthetics Private Location image |
+| image.tag | string | `"1.4.0"` | Define the Datadog Synthetics Private Location version to use |
+| imagePullSecrets | list | `[]` | Datadog Synthetics Private Location repository pullSecret (ex: specify docker registry credentials) |
+| nameOverride | string | `""` | Override name of app |
+| nodeSelector | object | `{}` | Allows to schedule Datadog Synthetics Private Location on specific nodes |
+| podAnnotations | object | `{}` | Annotations to set to Datadog Synthetics Private Location PODs |
+| podSecurityContext | object | `{}` | Security context to set to Datadog Synthetics Private Location PODs |
+| securityContext | object | `{}` | Security context to set to the Datadog Synthetics Private Location container |
+| replicaCount | int | `1` | Number of instances of Datadog Synthetics Private Location |
+| resources | object | `{}` | Set resources requests/limits for Datadog Synthetics Private Location PODs |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `nil` | The name of the service account to use. If not set name is generated using the fullname template |
+| tolerations | list | `[]` | Allows to schedule Datadog Synthetics Private Location on tainted nodes |

--- a/charts/synthetics-private-location/README.md.gotmpl
+++ b/charts/synthetics-private-location/README.md.gotmpl
@@ -1,0 +1,24 @@
+# Datadog Synthetics Private Location
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+[Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
+
+## How to use Datadog Helm repository
+
+You need to add this repository to your Helm repositories:
+
+```
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+```
+
+## Quick start
+
+To install the chart with the release name `<RELEASE_NAME>`, retrieve your Private Location configuration file from your [Synthetics Private Location settings page](https://app.datadoghq.com/synthetics/settings/private-locations/) and save it under `config.json` then run:
+
+```bash
+helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file configFile=config.json
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/synthetics-private-location/templates/_helpers.tpl
+++ b/charts/synthetics-private-location/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "synthetics-private-location.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "synthetics-private-location.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "synthetics-private-location.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "synthetics-private-location.labels" -}}
+helm.sh/chart: {{ include "synthetics-private-location.chart" . }}
+{{ include "synthetics-private-location.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "synthetics-private-location.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "synthetics-private-location.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "synthetics-private-location.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "synthetics-private-location.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/synthetics-private-location/templates/configmap.yaml
+++ b/charts/synthetics-private-location/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "synthetics-private-location.fullname" . }}-config
+  labels:
+    {{- include "synthetics-private-location.labels" . | nindent 4 }}
+data:
+  synthetics-check-runner.json: |-
+{{ .Values.configFile | indent 4 }}
+
+---

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "synthetics-private-location.fullname" . }}
+  labels:
+    {{- include "synthetics-private-location.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "synthetics-private-location.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "synthetics-private-location.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "synthetics-private-location.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - '[ $(expr $(cat /tmp/liveness.date) + 300000) -gt $(date +%s%3N) ]'
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          volumeMounts:
+          - mountPath: /etc/datadog
+            name: worker-config
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: worker-config
+        configMap:
+          name: {{ include "synthetics-private-location.fullname" . }}-config

--- a/charts/synthetics-private-location/templates/service_account.yaml
+++ b/charts/synthetics-private-location/templates/service_account.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "synthetics-private-location.serviceAccountName" . }}
+  labels:
+{{ include "synthetics-private-location.labels" . | indent 4 }}
+{{- end -}}

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -1,0 +1,53 @@
+# Default values for synthetics-private-location.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: datadog/synthetics-private-location-worker
+  pullPolicy: IfNotPresent
+  tag: 1.4.0
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# nodeSelector -- Allows to schedule Datadog Synthetics Private Location on specific nodes
+nodeSelector: {}
+# tolerations -- Allows to schedule Datadog Synthetics Private Location on tainted nodes
+tolerations: []
+# affinity -- Allows to specify affinity for Datadog Synthetics Private Location PODs
+affinity: {}

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -2,29 +2,38 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# replicaCount -- Number of instances of Datadog Synthetics Private Location
 replicaCount: 1
 
 image:
+  # image.repository -- Repository to use for Datadog Synthetics Private Location image
   repository: datadog/synthetics-private-location-worker
+  # image.pullPolicy -- Define the pullPolicy for Datadog Synthetics Private Location image
   pullPolicy: IfNotPresent
+  # image.tag -- Define the Datadog Synthetics Private Location version to use
   tag: 1.4.0
 
+# imagePullSecrets -- Datadog Synthetics Private Location repository pullSecret (ex: specify docker registry credentials)
 imagePullSecrets: []
+# nameOverride -- Override name of app
 nameOverride: ""
+# fullnameOverride -- Override the full qualified app name
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # serviceAccount.create -- Specifies whether a service account should be created
   create: true
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # serviceAccount.name -- The name of the service account to use. If not set name is generated using the fullname template
   name: ""
 
+# podAnnotations -- Annotations to set to Datadog Synthetics Private Location PODs
 podAnnotations: {}
 
+# podSecurityContext -- Security context to set to Datadog Synthetics Private Location PODs
 podSecurityContext: {}
   # fsGroup: 2000
 
+# securityContext -- Security context to set to the Datadog Synthetics Private Location container
 securityContext: {}
   # capabilities:
   #   drop:
@@ -33,6 +42,7 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# resources -- Set resources requests/limits for Datadog Synthetics Private Location PODs
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -51,3 +61,6 @@ nodeSelector: {}
 tolerations: []
 # affinity -- Allows to specify affinity for Datadog Synthetics Private Location PODs
 affinity: {}
+
+# configFile -- JSON string containing the configuration of the private location worker
+configFile: "{}"


### PR DESCRIPTION
#### What this PR does / why we need it:

It adds a chart for Datadog Synthetics Private Locations

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
