### PR TITLE
Allow the system-probe to be run without network performance monitoring being enabled

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.30
 
-* Add `datadog.networkConfig` section to allow the system-probe to be run without network performance monitoring. Deprecates `systemProbe.enabled`.
+* Add `datadog.networkMonitoring` section to allow the system-probe to be run without network performance monitoring. Deprecates `systemProbe.enabled`.
 
 ## 2.4.29
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.4.30
+
+* Add `datadog.networkConfig` section to allow the system-probe to be run without network performance monitoring. Deprecates `systemProbe.enabled`.
+
 ## 2.4.29
 
 * Add `common-env-vars` to `system-probe` container

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.4.34
 
 * Add `datadog.networkMonitoring` section to allow the system-probe to be run without network performance monitoring. Deprecates `systemProbe.enabled`.
+
 ## 2.4.33
 
 * Introduce overall cluster-name limit of 80

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -16,7 +16,6 @@
   probes entirely.
 * Introduce `clusterChecksRunner.healthPort` default setting.
 * Use health port defaults instead of hardcoded values.
->>>>>>> origin/master
 
 ## 2.4.29
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.29
+version: 2.4.30
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -461,9 +461,9 @@ helm install --name <RELEASE_NAME> \
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
-| datadog.neworkMonitoring.container_scrubbing.enabled | bool | `true` |  |
 | datadog.neworkMonitoring.enabled | bool | `false` |  |
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
+| datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
 | datadog.orchestratorExplorer.enabled | bool | `false` | Set this to true to enable the orchestrator explorer |
 | datadog.podAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Annotations to Datadog Tags |
 | datadog.podLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Labels to Datadog Tags |
@@ -484,7 +484,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
-| datadog.systemProbe.enabled | bool | `false` | Enable the system-probe agent. |
+| datadog.systemProbe.enabled | bool | `false` | Set this to true to enable system-probe agent |
 | datadog.systemProbe.seccomp | string | `"localhost/system-probe"` | Apply an ad-hoc seccomp profile to the system-probe agent to restrict its privileges |
 | datadog.systemProbe.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |
 | datadog.tags | list | `[]` | List of static tags to attach to every metric, event and service check collected by this Agent. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -457,8 +457,9 @@ helm install --name <RELEASE_NAME> \
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
+| datadog.networkConfig.container_scrubbing.enabled | bool | `true` |  |
+| datadog.networkConfig.enabled | bool | `false` | Enable network performance monitoring. |
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
-| datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
 | datadog.orchestratorExplorer.enabled | bool | `false` | Set this to true to enable the orchestrator explorer |
 | datadog.podAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Annotations to Datadog Tags |
 | datadog.podLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Labels to Datadog Tags |
@@ -479,7 +480,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
-| datadog.systemProbe.enabled | bool | `false` | Set this to true to enable system-probe agent |
+| datadog.systemProbe.enabled | bool | `false` | Enable the system-probe agent. DEPRECATED: use networkConfig or securityAgent blocks. |
 | datadog.systemProbe.seccomp | string | `"localhost/system-probe"` | Apply an ad-hoc seccomp profile to the system-probe agent to restrict its privileges |
 | datadog.systemProbe.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |
 | datadog.tags | list | `[]` | List of static tags to attach to every metric, event and service check collected by this Agent. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.4.29](https://img.shields.io/badge/Version-2.4.29-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.4.30](https://img.shields.io/badge/Version-2.4.30-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -480,7 +480,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
-| datadog.systemProbe.enabled | bool | `false` | Enable the system-probe agent. DEPRECATED: use networkConfig or securityAgent blocks. |
+| datadog.systemProbe.enabled | bool | `false` | Enable the system-probe agent. |
 | datadog.systemProbe.seccomp | string | `"localhost/system-probe"` | Apply an ad-hoc seccomp profile to the system-probe agent to restrict its privileges |
 | datadog.systemProbe.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |
 | datadog.tags | list | `[]` | List of static tags to attach to every metric, event and service check collected by this Agent. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -461,7 +461,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
-| datadog.neworkMonitoring.enabled | bool | `false` |  |
+| datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
 | datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
 | datadog.orchestratorExplorer.enabled | bool | `false` | Set this to true to enable the orchestrator explorer |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -457,8 +457,8 @@ helm install --name <RELEASE_NAME> \
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
-| datadog.networkConfig.container_scrubbing.enabled | bool | `true` |  |
-| datadog.networkConfig.enabled | bool | `false` | Enable network performance monitoring. |
+| datadog.neworkMonitoring.container_scrubbing.enabled | bool | `true` |  |
+| datadog.neworkMonitoring.enabled | bool | `false` |  |
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
 | datadog.orchestratorExplorer.enabled | bool | `false` | Set this to true to enable the orchestrator explorer |
 | datadog.podAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Annotations to Datadog Tags |

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -150,3 +150,15 @@ true
 false
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Return true if the system-probe container should be created.
+*/}}
+{{- define "should-enable-system-probe" -}}
+{{- if (or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled)  -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -156,7 +156,7 @@ false
 Return true if the system-probe container should be created.
 */}}
 {{- define "should-enable-system-probe" -}}
-{{- if (or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled)  -}}
+{{- if (or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkMonitoring.enabled)  -}}
 true
 {{- else -}}
 false

--- a/charts/datadog/templates/container-process-agent.yaml
+++ b/charts/datadog/templates/container-process-agent.yaml
@@ -22,9 +22,13 @@
     {{- end }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.processAgent.logLevel | default .Values.datadog.logLevel | quote }}
-    {{- if .Values.datadog.systemProbe.enabled }}
+    {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.networkConfig.enabled }}
     - name: DD_SYSTEM_PROBE_ENABLED
-      value: {{ .Values.datadog.systemProbe.enabled | quote }}
+      value: {{ true | quote }}
+    {{- end }}
+    {{- if .Values.datadog.networkConfig.enabled }}
+    - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
+      value: {{ .Values.datadog.networkConfig.enabled | quote }}
     {{- end }}
     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
       value: {{ .Values.datadog.orchestratorExplorer.enabled | quote }}

--- a/charts/datadog/templates/container-process-agent.yaml
+++ b/charts/datadog/templates/container-process-agent.yaml
@@ -22,13 +22,13 @@
     {{- end }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.processAgent.logLevel | default .Values.datadog.logLevel | quote }}
-    {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.networkConfig.enabled }}
+    {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.networkMonitoring.enabled }}
     - name: DD_SYSTEM_PROBE_ENABLED
       value: {{ true | quote }}
     {{- end }}
-    {{- if .Values.datadog.networkConfig.enabled }}
+    {{- if .Values.datadog.networkMonitoring.enabled }}
     - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
-      value: {{ .Values.datadog.networkConfig.enabled | quote }}
+      value: {{ .Values.datadog.networkMonitoring.enabled | quote }}
     {{- end }}
     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
       value: {{ .Values.datadog.orchestratorExplorer.enabled | quote }}

--- a/charts/datadog/templates/containers-init-linux.yaml
+++ b/charts/datadog/templates/containers-init-linux.yaml
@@ -37,7 +37,7 @@
       mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled }}
+    {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkMonitoring.enabled }}
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml

--- a/charts/datadog/templates/containers-init-linux.yaml
+++ b/charts/datadog/templates/containers-init-linux.yaml
@@ -37,7 +37,7 @@
       mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled }}
+    {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled }}
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml

--- a/charts/datadog/templates/containers-init-linux.yaml
+++ b/charts/datadog/templates/containers-init-linux.yaml
@@ -37,7 +37,7 @@
       mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkMonitoring.enabled }}
+    {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml

--- a/charts/datadog/templates/daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/daemonset-volumes-linux.yaml
@@ -24,7 +24,7 @@
   configMap:
     name: {{ template "datadog.fullname" . }}-confd
 {{- end }}
-{{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled}}
+{{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkConfig.enabled }}
 - name: sysprobe-config
   configMap:
     name: {{ template "datadog.fullname" . }}-system-probe-config
@@ -50,7 +50,7 @@
   name: src
 {{- end }}
 {{- end }}
-{{- if or .Values.datadog.processAgent.enabled .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.runtime.enabled }}
+{{- if or .Values.datadog.processAgent.enabled .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkConfig.enabled }}
 - hostPath:
     path: /etc/passwd
   name: passwd

--- a/charts/datadog/templates/daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/daemonset-volumes-linux.yaml
@@ -24,7 +24,7 @@
   configMap:
     name: {{ template "datadog.fullname" . }}-confd
 {{- end }}
-{{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkConfig.enabled }}
+{{- if eq (include "should-enable-system-probe" .) "true" }}
 - name: sysprobe-config
   configMap:
     name: {{ template "datadog.fullname" . }}-system-probe-config
@@ -50,7 +50,7 @@
   name: src
 {{- end }}
 {{- end }}
-{{- if or .Values.datadog.processAgent.enabled .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkConfig.enabled }}
+{{- if or .Values.datadog.processAgent.enabled .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.runtime.enabled }}
 - hostPath:
     path: /etc/passwd
   name: passwd

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         {{- if .Values.agents.customAgentConfig }}
         checksum/agent-config: {{ tpl (toYaml .Values.agents.customAgentConfig) . | sha256sum }}
         {{- end }}
-        {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled }}
+        {{- if eq  (include "should-enable-system-probe" .) "true" }}
         {{- if .Values.agents.podSecurity.apparmor.enabled }}
         container.apparmor.security.beta.kubernetes.io/system-probe: {{ .Values.datadog.systemProbe.apparmor }}
         {{- end }}
@@ -93,7 +93,7 @@ spec:
         {{- if .Values.datadog.processAgent.enabled }}
           {{- include "container-process-agent" . | nindent 6 }}
         {{- end }}
-        {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled }}
+        {{- if eq (include "should-enable-system-probe" .) "true" }}
           {{- include "container-system-probe" . | nindent 6 }}
         {{- end }}
         {{- if or .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.runtime.enabled}}
@@ -106,7 +106,7 @@ spec:
         {{- if eq .Values.targetSystem "linux" }}
           {{ include "containers-init-linux" . | nindent 6 }}
         {{- end }}
-        {{- if and (or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled)  (eq .Values.datadog.systemProbe.seccomp "localhost/system-probe") }}
+        {{- if and (eq (include "should-enable-system-probe" .) "true")  (eq .Values.datadog.systemProbe.seccomp "localhost/system-probe") }}
           {{ include "system-probe-init" . | nindent 6 }}
         {{- end }}
       volumes:

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         {{- if .Values.agents.customAgentConfig }}
         checksum/agent-config: {{ tpl (toYaml .Values.agents.customAgentConfig) . | sha256sum }}
         {{- end }}
-        {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled}}
+        {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled }}
         {{- if .Values.agents.podSecurity.apparmor.enabled }}
         container.apparmor.security.beta.kubernetes.io/system-probe: {{ .Values.datadog.systemProbe.apparmor }}
         {{- end }}
@@ -93,7 +93,7 @@ spec:
         {{- if .Values.datadog.processAgent.enabled }}
           {{- include "container-process-agent" . | nindent 6 }}
         {{- end }}
-        {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled }}
+        {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled }}
           {{- include "container-system-probe" . | nindent 6 }}
         {{- end }}
         {{- if or .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.runtime.enabled}}
@@ -106,7 +106,7 @@ spec:
         {{- if eq .Values.targetSystem "linux" }}
           {{ include "containers-init-linux" . | nindent 6 }}
         {{- end }}
-        {{- if and (or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled)  (eq .Values.datadog.systemProbe.seccomp "localhost/system-probe") }}
+        {{- if and (or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled)  (eq .Values.datadog.systemProbe.seccomp "localhost/system-probe") }}
           {{ include "system-probe-init" . | nindent 6 }}
         {{- end }}
       volumes:

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   system-probe.yaml: |
     system_probe_config:
-      enabled: {{ or $.Values.datadog.systemProbe.enabled $.Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkMonitoring.enabled }}
+      enabled: true
       debug_port:  {{ $.Values.datadog.systemProbe.debugPort }}
       sysprobe_socket: /var/run/sysprobe/sysprobe.sock
       enable_conntrack: {{ $.Values.datadog.systemProbe.enableConntrack }}

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkConfig.enabled }}
+{{- if eq (include "should-enable-system-probe" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled}}
+{{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkConfig.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,7 +13,7 @@ metadata:
 data:
   system-probe.yaml: |
     system_probe_config:
-      enabled: {{ or $.Values.datadog.systemProbe.enabled $.Values.datadog.securityAgent.runtime.enabled }}
+      enabled: {{ or $.Values.datadog.systemProbe.enabled $.Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled }}
       debug_port:  {{ $.Values.datadog.systemProbe.debugPort }}
       sysprobe_socket: /var/run/sysprobe/sysprobe.sock
       enable_conntrack: {{ $.Values.datadog.systemProbe.enableConntrack }}
@@ -21,6 +21,10 @@ data:
       enable_tcp_queue_length: {{ $.Values.datadog.systemProbe.enableTCPQueueLength }}
       enable_oom_kill: {{ $.Values.datadog.systemProbe.enableOOMKill }}
       collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
+    {{- if $.Values.datadog.networkConfig.enabled }}
+    network_config:
+      enabled: true
+    {{- end }}
     runtime_security_config:
       enabled: {{ $.Values.datadog.securityAgent.runtime.enabled }}
       debug: false

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   system-probe.yaml: |
     system_probe_config:
-      enabled: {{ or $.Values.datadog.systemProbe.enabled $.Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkConfig.enabled }}
+      enabled: {{ or $.Values.datadog.systemProbe.enabled $.Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkMonitoring.enabled }}
       debug_port:  {{ $.Values.datadog.systemProbe.debugPort }}
       sysprobe_socket: /var/run/sysprobe/sysprobe.sock
       enable_conntrack: {{ $.Values.datadog.systemProbe.enableConntrack }}
@@ -21,7 +21,7 @@ data:
       enable_tcp_queue_length: {{ $.Values.datadog.systemProbe.enableTCPQueueLength }}
       enable_oom_kill: {{ $.Values.datadog.systemProbe.enableOOMKill }}
       collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
-    {{- if $.Values.datadog.networkConfig.enabled }}
+    {{- if $.Values.datadog.networkMonitoring.enabled }}
     network_config:
       enabled: true
     {{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -283,8 +283,8 @@ datadog:
     ## ref: TODO - add doc link
     enabled: false
 
-  networkConfig:
-    # datadog.networkConfig.enabled -- Enable network performance monitoring.
+  neworkMonitoring:
+    # datadog.networkMonitoring.enabled -- Enable network performance monitoring.
     enabled: false
 
     # datadog.orchestratorExplorer.container_scrubbing -- Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -245,7 +245,7 @@ datadog:
 
   ## Enable systemProbe agent and provide custom configs
   systemProbe:
-    # datadog.systemProbe.enabled -- Enable the system-probe agent. DEPRECATED: use networkConfig or securityAgent blocks.
+    # datadog.systemProbe.enabled -- Enable the system-probe agent.
     enabled: false
 
     # datadog.systemProbe.debugPort -- Specify the port to expose pprof and expvar for system-probe agent

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -245,7 +245,7 @@ datadog:
 
   ## Enable systemProbe agent and provide custom configs
   systemProbe:
-    # datadog.systemProbe.enabled -- Set this to true to enable system-probe agent
+    # datadog.systemProbe.enabled -- Enable the system-probe agent. DEPRECATED: use networkConfig or securityAgent blocks.
     enabled: false
 
     # datadog.systemProbe.debugPort -- Specify the port to expose pprof and expvar for system-probe agent
@@ -281,6 +281,10 @@ datadog:
     # datadog.orchestratorExplorer.enabled -- Set this to true to enable the orchestrator explorer
     ## This requires processAgent.enabled and clusterAgent.enabled to be set to true
     ## ref: TODO - add doc link
+    enabled: false
+
+  networkConfig:
+    # datadog.networkConfig.enabled -- Enable network performance monitoring.
     enabled: false
 
     # datadog.orchestratorExplorer.container_scrubbing -- Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -291,7 +291,7 @@ datadog:
       enabled: true
 
   networkMonitoring:
-    # datadog.networkMonitoring.enabled -- Enable network performance monitoring.
+    # datadog.networkMonitoring.enabled -- Enable network performance monitoring
     enabled: false
 
   ## Enable security agent and provide custom configs

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -245,7 +245,7 @@ datadog:
 
   ## Enable systemProbe agent and provide custom configs
   systemProbe:
-    # datadog.systemProbe.enabled -- Enable the system-probe agent.
+    # datadog.systemProbe.enabled -- Set this to true to enable system-probe agent
     enabled: false
 
     # datadog.systemProbe.debugPort -- Specify the port to expose pprof and expvar for system-probe agent
@@ -283,16 +283,16 @@ datadog:
     ## ref: TODO - add doc link
     enabled: false
 
-  neworkMonitoring:
-    # datadog.networkMonitoring.enabled -- Enable network performance monitoring.
-    enabled: false
-
     # datadog.orchestratorExplorer.container_scrubbing -- Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information
     ## The container scrubbing is taking significant resources during data collection.
     ## If you notice that the cluster-agent uses too much CPU in larger clusters
     ## turning this option off will improve the situation.
     container_scrubbing:
       enabled: true
+
+  networkMonitoring:
+    # datadog.networkMonitoring.enabled -- Enable network performance monitoring.
+    enabled: false
 
   ## Enable security agent and provide custom configs
   securityAgent:


### PR DESCRIPTION

#### What this PR does / why we need it:


To preserve backwards compatibility, there is some special behavior when systemProbe.enabled=true.

Please see the following truth table for what behaviors should be
available when different values are set:

```
systemProbe.enabled     runtimeSecurity.enabled        networkConfig.enabled  agent features
no                      no                             no                     nothing enabled
no                      no                             yes                    system probe enabled, network config enabled
no                      yes                            no                     system probe enabled, network config disabled
no                      yes                            yes                    system probe enabled, network config enabled
yes                     no                             no                     system probe enabled, network config enabled
yes                     no                             yes                    system probe enabled, networkConfig enabled
yes                     yes                            no                     system probe enabled, network config disabled
yes                     yes                            yes                    system probe enabled, network config enabled
```

This PR does a few things to make this work correctly:
* add a new networkConfig block that can be used to disable/enable
  network performance monitoring
* set systemProbe.enabled=true based on networkConfig
* use networkConfig.enabled when deciding whether or not to render
  system-probe-manifests

Additionally, this exposed a bug in agent 7.23.0 where
DD_SYSTEM_PROBE_ENABLED must be set to true for the connection check to
run, which is fixed as part of this PR. This was an impossible situation
before this PR, but now might happen if the system probe is enabled
without network performance monitoring.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
