### PR TITLE
[charts/datadog] Support additional labels

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 2.4.31
+
+* Support adding labels to the Agent pods and daemonset via `agents.additionalLabels`.
+* Support adding labels to the Cluster Agent pods and deployment via `clusterAgent.additionalLabels`.
+* Support adding labels to the Cluster Checks Runner pods and deployment via `clusterChecksRunner.additionalLabels`.
+
 ## 2.4.30
 
 * Refactor liveness and readiness probes with helpers to allow user overrides with other types of probes or disabling

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.30
+version: 2.4.31
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.4.30](https://img.shields.io/badge/Version-2.4.30-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.4.31](https://img.shields.io/badge/Version-2.4.31-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -308,6 +308,7 @@ helm install --name <RELEASE_NAME> \
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| agents.additionalLabels | object | `{}` | Adds labels to the Agent daemonset and pods |
 | agents.affinity | object | `{}` | Allow the DaemonSet to schedule using affinity rules |
 | agents.containers.agent.env | list | `[]` | Additional environment variables for the agent container |
 | agents.containers.agent.healthPort | int | `5555` | Port number to use in the node agent for the healthz endpoint |
@@ -340,7 +341,7 @@ helm install --name <RELEASE_NAME> \
 | agents.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the agents |
 | agents.nodeSelector | object | `{}` | Allow the DaemonSet to schedule on selected nodes |
 | agents.podAnnotations | object | `{}` | Annotations to add to the DaemonSet's Pods |
-| agents.podLabels | object | `{}` | Sets podLabels if defined |
+| agents.podLabels | object | `{}` | Sets podLabels if defined Note: These labels are also used as label selectors so they are immutable. |
 | agents.podSecurity.apparmor.enabled | bool | `true` | If true, enable apparmor enforcement |
 | agents.podSecurity.apparmorProfiles | list | `["runtime/default"]` | Allowed apparmor profiles |
 | agents.podSecurity.capabilites | list | `["SYS_ADMIN","SYS_RESOURCE","SYS_PTRACE","NET_ADMIN","NET_BROADCAST","IPC_LOCK","AUDIT_CONTROL","AUDIT_READ"]` | Allowed capabilites |
@@ -359,6 +360,7 @@ helm install --name <RELEASE_NAME> \
 | agents.useHostNetwork | bool | `false` | Bind ports on the hostNetwork |
 | agents.volumeMounts | list | `[]` | Specify additional volumes to mount in the dd-agent container |
 | agents.volumes | list | `[]` | Specify additional volumes to mount in the dd-agent container |
+| clusterAgent.additionalLabels | object | `{}` | Adds labels to the Cluster Agent deployment and pods |
 | clusterAgent.admissionController.enabled | bool | `false` | Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods |
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |
 | clusterAgent.affinity | object | `{}` | Allow the Cluster Agent Deployment to schedule using affinity rules |
@@ -397,6 +399,7 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.useHostNetwork | string | `nil` | Bind ports on the hostNetwork |
 | clusterAgent.volumeMounts | list | `[]` | Specify additional volumes to mount in the cluster-agent container |
 | clusterAgent.volumes | list | `[]` | Specify additional volumes to mount in the cluster-agent container |
+| clusterChecksRunner.additionalLabels | object | `{}` | Adds labels to the cluster checks runner deployment and pods |
 | clusterChecksRunner.affinity | object | `{}` | Allow the ClusterChecks Deployment to schedule using affinity rules. |
 | clusterChecksRunner.createPodDisruptionBudget | bool | `false` | Create the pod disruption budget to apply to the cluster checks agents |
 | clusterChecksRunner.dnsConfig | object | `{}` | specify dns configuration options for datadog cluster agent containers e.g ndots |

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- if .Values.clusterChecksRunner.additionalLabels }}
+{{ toYaml .Values.clusterChecksRunner.additionalLabels | indent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.clusterChecksRunner.replicas }}
   strategy:
@@ -20,6 +23,9 @@ spec:
     metadata:
       labels:
         app: {{ template "datadog.fullname" . }}-clusterchecks
+        {{- if .Values.clusterChecksRunner.additionalLabels }}
+{{ toYaml .Values.clusterChecksRunner.additionalLabels | indent 8 }}
+        {{- end }}
       name: {{ template "datadog.fullname" . }}-clusterchecks
       annotations:
         checksum/clusteragent_token: {{ include (print $.Template.BasePath "/agent-secret.yaml") . | sha256sum }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- if .Values.clusterAgent.additionalLabels }}
+{{ toYaml .Values.clusterAgent.additionalLabels | indent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.clusterAgent.replicas }}
   strategy:
@@ -32,6 +35,9 @@ spec:
         app: {{ template "datadog.fullname" . }}-cluster-agent
         {{- if .Values.clusterAgent.podLabels }}
 {{ toYaml .Values.clusterAgent.podLabels | indent 8 }}
+        {{- end }}
+        {{- if .Values.clusterAgent.additionalLabels }}
+{{ toYaml .Values.clusterAgent.additionalLabels | indent 8 }}
         {{- end }}
       name: {{ template "datadog.fullname" . }}-cluster-agent
       annotations:

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    {{- if .Values.agents.additionalLabels }}
+{{ toYaml .Values.agents.additionalLabels | indent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -24,6 +27,9 @@ spec:
         app: {{ template "datadog.fullname" . }}
         {{- if .Values.agents.podLabels }}
 {{ toYaml .Values.agents.podLabels | indent 8 }}
+        {{- end }}
+        {{- if .Values.agents.additionalLabels }}
+{{ toYaml .Values.agents.additionalLabels | indent 8 }}
         {{- end }}
       name: {{ template "datadog.fullname" . }}
       annotations:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -502,6 +502,10 @@ clusterAgent:
     # clusterAgent.networkPolicy.create -- If true, create a NetworkPolicy for the cluster agent
     create: false
 
+  # clusterAgent.additionalLabels -- Adds labels to the Cluster Agent deployment and pods
+  additionalLabels: {}
+    # key: "value"
+
 agents:
   # agents.enabled -- You should keep Datadog DaemonSet enabled!
   ## The exceptional case could be a situation when you need to run
@@ -778,7 +782,12 @@ agents:
   priorityClassName:
 
   # agents.podLabels -- Sets podLabels if defined
+  # Note: These labels are also used as label selectors so they are immutable.
   podLabels: {}
+
+  # agents.additionalLabels -- Adds labels to the Agent daemonset and pods
+  additionalLabels: {}
+    # key: "value"
 
   # agents.useConfigMap -- Configures a configmap to provide the agent configuration. Use this in combination with the `agents.customAgentConfig` parameter.
   useConfigMap:  # false
@@ -957,6 +966,10 @@ clusterChecksRunner:
   networkPolicy:
     # clusterChecksRunner.networkPolicy.create -- If true, create a NetworkPolicy for the cluster checks runners
     create: false
+
+  # clusterChecksRunner.additionalLabels -- Adds labels to the cluster checks runner deployment and pods
+  additionalLabels: {}
+    # key: "value"
 
 kube-state-metrics:
   rbac:


### PR DESCRIPTION
#### What this PR does / why we need it:

* Support adding labels to the Agent pods and daemonset via `agents.additionalLabels`.
* Support adding labels to the Cluster Agent pods and deployment via `clusterAgent.additionalLabels`.
* Support adding labels to the Cluster Checks Runner pods and deployment via `clusterChecksRunner.additionalLabels`.

#### Which issue this PR fixes
  - fixes #43 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
