### PR TITLE
Enforcing clustername maximum helm limit

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.4.33
+
+* Introduce overall cluster-name limit of 80
+* Remove character limit of single parts of the cluster-name
+
 ## 2.4.32
 
 * The `agents.volumeMounts` option is now properly propagated to all agent containers.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.32
+version: 2.4.33
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.4.32](https://img.shields.io/badge/Version-2.4.32-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.4.33](https://img.shields.io/badge/Version-2.4.33-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/ci/cluster-agent-values.yaml
+++ b/charts/datadog/ci/cluster-agent-values.yaml
@@ -1,5 +1,5 @@
 datadog:
-  clusterName: kubernetes-cluster.example.com
+  clusterName: kubernetes-cluster.example.comkubernetes-cluster.example.com.kube.rnetes-80chars
   apiKey: "00000000000000000000000000000000"
   appKey: "0000000000000000000000000000000000000000"
   kubeStateMetricsEnabled: false

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -19,6 +19,16 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "check-cluster-name" }}
+{{- $length := len .Values.datadog.clusterName -}}
+{{- if (gt $length 80)}}
+{{- fail "Your `clusterName` isn’t valid it has to be below 81 chars." -}}
+{{- end}}
+{{- if not (regexMatch "^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$" .Values.datadog.clusterName) -}}
+{{- fail "Your `clusterName` isn’t valid. It must be dot-separated tokens where a token start with a lowercase letter followed by lowercase letters, numbers, or hyphens, can only end with a with [a-z0-9] and has to be below 80 chars." -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -132,7 +132,7 @@ spec:
           - name: DD_EXTERNAL_METRICS_PROVIDER_USE_DATADOGMETRIC_CRD
             value: {{ .Values.clusterAgent.metricsProvider.useDatadogMetrics | quote }}
           - name: DD_EXTERNAL_METRICS_AGGREGATOR
-            value: {{ .Values.clusterAgent.metricsProvider.aggregator | quote }}            
+            value: {{ .Values.clusterAgent.metricsProvider.aggregator | quote }}
           {{- end }}
           {{- if .Values.clusterAgent.admissionController.enabled }}
           - name: DD_ADMISSION_CONTROLLER_ENABLED
@@ -151,9 +151,7 @@ spec:
             value: "kube_endpoints kube_services"
           {{- end }}
           {{- if .Values.datadog.clusterName }}
-          {{- if not (regexMatch "^([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?)$" .Values.datadog.clusterName) }}
-          {{- fail "Your `clusterName` isn’t valid. It must be dot-separated tokens where a token start with a lowercase letter followed by up to 39 lowercase letters, numbers, or hyphens and cannot end with a hyphen."}}
-          {{- end}}
+          {{- template "check-cluster-name" . }}
           - name: DD_CLUSTER_NAME
             value: {{ .Values.datadog.clusterName | quote }}
           {{- end }}
@@ -212,7 +210,7 @@ spec:
         readinessProbe:
 {{- $ready := .Values.clusterAgent.readinessProbe }}
 {{ include "probe.http" (dict "path" "/ready" "port" $healthPort "settings" $ready) | indent 10 }}
-        volumeMounts: 
+        volumeMounts:
           - name: installinfo
             subPath: install_info
             {{- if eq .Values.targetSystem "windows" }}

--- a/charts/datadog/templates/containers-common-env.yaml
+++ b/charts/datadog/templates/containers-common-env.yaml
@@ -13,9 +13,7 @@
       fieldPath: status.hostIP
 {{- end }}
 {{- if .Values.datadog.clusterName }}
-{{- if not (regexMatch "^([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?)$" .Values.datadog.clusterName) }}
-{{- fail "Your `clusterName` isn’t valid. It must be dot-separated tokens where a token start with a lowercase letter followed by up to 39 lowercase letters, numbers, or hyphens and cannot end with a hyphen."}}
-{{- end}}
+{{- template "check-cluster-name" . }}
 - name: DD_CLUSTER_NAME
   value: {{ .Values.datadog.clusterName | quote }}
 {{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -42,10 +42,11 @@ datadog:
   hostVolumeMountPropagation: None
 
   # datadog.clusterName -- Set a unique cluster name to allow scoping hosts and Cluster Checks easily
-  ## The name must be unique and must be dot-separated tokens where a token can be up to 40 characters with the following restrictions:
+  ## The name must be unique and must be dot-separated tokens with the following restrictions:
   ## * Lowercase letters, numbers, and hyphens only.
   ## * Must start with a letter.
   ## * Must end with a number or a letter.
+  ## * Overall length should not be higher than 80 characters.
   ## Compared to the rules of GKE, dots are allowed whereas they are not allowed on GKE:
   ## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
   clusterName:  # <CLUSTER_NAME>


### PR DESCRIPTION
#### What this PR does / why we need it:
After merging https://github.com/DataDog/datadog-agent/pull/6400 we decided to increase the enforced limits of 40 characters to 80.
This PR addresses this by enforcing an overall limit of 80 characters because with HELM we cannot make sure that `hostname+cluster-name` < 255. With the limit of 80 we can catch most of the cases.
Additionally, we can remove the enforcement of parts being maximum 40 chars: `<part>.<part>`

#### Special notes for your reviewer:
- test with the given cluster-name from `cluster-agent-values.yaml`
```
helm template ./charts/datadog --debug -f ./charts/datadog/ci/cluster-agent-values.yaml  > /dev/null
```
- change the cluster-name in `cluster-agent-values.yaml` to be higher than 81 chars
```
helm template ./charts/datadog --debug -f ./charts/datadog/ci/cluster-agent-values.yaml  > /dev/null
```
will throw the updated exception. 

Feel free to change the values to match cases (multiple dots, longer than 80 char, parts being longer than 80 chars ect.)
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
