### PR TITLE
Allow for external secrets references

### DIFF
--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -112,17 +112,25 @@ spec:
           {{- $healthPort := .Values.clusterAgent.healthPort }}
             value: {{ $healthPort | quote }}
           - name: DD_API_KEY
+          {{- if .Values.apiKeyExternalSecret }}
+            value: {{ .Values.apiKeyExternalSecret }}
+          {{- else }}
             valueFrom:
               secretKeyRef:
                 name: {{ template "datadog.apiSecretName" . }}
                 key: api-key
                 optional: true
+          {{- end }}
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
+          {{- if not .Values.appKeyExternalSecret }}
+            value: {{ .Values.appKeyExternalSecret }}
+          {{- else }}
             valueFrom:
               secretKeyRef:
                 name: {{ template "datadog.appKeySecretName" . }}
                 key: app-key
+          {{- end }}
           - name: DD_EXTERNAL_METRICS_PROVIDER_ENABLED
             value: {{ .Values.clusterAgent.metricsProvider.enabled | quote }}
           - name: DD_EXTERNAL_METRICS_PROVIDER_PORT
@@ -132,7 +140,7 @@ spec:
           - name: DD_EXTERNAL_METRICS_PROVIDER_USE_DATADOGMETRIC_CRD
             value: {{ .Values.clusterAgent.metricsProvider.useDatadogMetrics | quote }}
           - name: DD_EXTERNAL_METRICS_AGGREGATOR
-            value: {{ .Values.clusterAgent.metricsProvider.aggregator | quote }}            
+            value: {{ .Values.clusterAgent.metricsProvider.aggregator | quote }}
           {{- end }}
           {{- if .Values.clusterAgent.admissionController.enabled }}
           - name: DD_ADMISSION_CONTROLLER_ENABLED

--- a/charts/datadog/templates/containers-common-env.yaml
+++ b/charts/datadog/templates/containers-common-env.yaml
@@ -2,10 +2,14 @@
 # variables required to operate dedicated containers in the daemonset
 {{- define "containers-common-env" -}}
 - name: DD_API_KEY
+{{- if .Values.apiKeyExternalSecret }}
+  value: {{ .Values.apiKeyExternalSecret }}
+{{- else }}
   valueFrom:
     secretKeyRef:
       name: {{ template "datadog.apiSecretName" . }}
       key: api-key
+{{- end }}
 {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
 - name: DD_KUBERNETES_KUBELET_HOST
   valueFrom:

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- template "check-version" . }}
 {{- if .Values.agents.enabled }}
-{{- if (or (.Values.datadog.apiKeyExistingSecret) (.Values.datadog.apiKey)) }}
+{{- if (or (.Values.datadog.apiKeyExistingSecret) (.Values.datadog.apiKey) (.Values.datadog.apiKeyExternalSecret)) }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/charts/datadog/templates/secrets.yaml
+++ b/charts/datadog/templates/secrets.yaml
@@ -1,5 +1,5 @@
 # API Key
-{{- if not .Values.datadog.apiKeyExistingSecret }}
+{{- if (or (not .Values.datadog.apiKeyExistingSecret) (not .Values.datadog.apiKeyExternalSecret)) }}
 
 apiVersion: v1
 kind: Secret
@@ -18,7 +18,7 @@ data:
 {{- end }}
 
 # APP Key
-{{- if not .Values.datadog.appKeyExistingSecret }}
+{{- if (or (not .Values.datadog.appKeyExistingSecret) (not .Values.datadog.appKeyExternalSecret)) }}
 {{- if and .Values.clusterAgent.enabled .Values.clusterAgent.metricsProvider.enabled }}
 ---
 apiVersion: v1

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -20,6 +20,10 @@ datadog:
   ## If set, this parameter takes precedence over "apiKey".
   apiKeyExistingSecret:  # <DATADOG_API_KEY_SECRET>
 
+  # datadog.apiKeyNoSecret -- Add a reference to an external secret to be injected into the environment.
+  # If set, this parameter takes precedence over "apiKey" and "apiKeyExistingSecret".
+  apiKeyExternalSecret:  # <EXTERNAL_SECRET_REFERENCE>
+
   # datadog.appKey -- Datadog APP key required to use metricsProvider
   ## If you are using clusterAgent.metricsProvider.enabled = true, you must set
   ## a Datadog application key for read access to your metrics.
@@ -28,6 +32,10 @@ datadog:
   # datadog.appKeyExistingSecret -- Use existing Secret which stores APP key instead of creating a new one
   ## If set, this parameter takes precedence over "appKey".
   appKeyExistingSecret:  # <DATADOG_APP_KEY_SECRET>
+
+  # datadog.appKeyAvoidSecret -- Don't reference a k8s Secret for storing the APP key and avoid creating a new
+  # one. If set, this parameter takes precedence over "appKey" and "appKeyExistingSecret".
+  appKeyExternalSecret: # <EXTERNAL_SECRET_REFERENCE>
 
   # datadog.securityContext -- Allows you to overwrite the default securityContext applied to the container
   securityContext: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

New patterns in K8s are emerging to move away from K8s-based secrets, and into third party application like Hashicorp's Vault accompanied by [Banzai's bank-vaults](https://github.com/banzaicloud/bank-vaults). This pattern allows the operator to set a reference to a secret via environment variable, then have a hook mutate the environment variable, and populate the container and pod with secrets at runtime (as opposed to storing them in the K8s secrets). Allowing the user to set an "external secret" (arbitrary string) as an environment variable enables bank-vaults to perform its preferred duty of examining each pod definition for Vault references, then giving that pod access to these secrets.


#### Special notes for your reviewer:

Here's what it looks like in practice.

On Vault, a secret exists in a path like the following:

```
path/to/this/datadog/secret
```

Inside of the daemonset, pod, or deployment definition, an env var is created

```yaml
   env:
    - name: DD_API_KEY
      value: vault:path/to/this/datadog/secret#DD_API_KEY
```

When the pod starts up, a hook mutates the entrypoint, and injects a Vault secretes fetching binary called `vault-env` which:
 
1. reads the values from the environment as `DD_API_KEY=vault:path/to/this/datadog/secret#DD_API_KEY`
1. connects to vault to read the secret at the described path
1. overrides the environment variable's value with the secret from Vault
1. executes the original command with arguments

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
