### PR TITLE
Propagate agents volume mounts to all agent containers

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.4.32
+
+* The `agents.volumeMounts` option is now properly propagated to all agent containers.
+
 ## 2.4.31
 
 * Support adding labels to the Agent pods and daemonset via `agents.additionalLabels`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.31
+version: 2.4.32
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.4.31](https://img.shields.io/badge/Version-2.4.31-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.4.32](https://img.shields.io/badge/Version-2.4.32-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -358,7 +358,7 @@ helm install --name <RELEASE_NAME> \
 | agents.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":"10%"},"type":"RollingUpdate"}` | Allow the DaemonSet to perform a rolling update on helm update |
 | agents.useConfigMap | string | `nil` | Configures a configmap to provide the agent configuration. Use this in combination with the `agents.customAgentConfig` parameter. |
 | agents.useHostNetwork | bool | `false` | Bind ports on the hostNetwork |
-| agents.volumeMounts | list | `[]` | Specify additional volumes to mount in the dd-agent container |
+| agents.volumeMounts | list | `[]` | Specify additional volumes to mount in all containers of the agent pod |
 | agents.volumes | list | `[]` | Specify additional volumes to mount in the dd-agent container |
 | clusterAgent.additionalLabels | object | `{}` | Adds labels to the Cluster Agent deployment and pods |
 | clusterAgent.admissionController.enabled | bool | `false` | Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods |

--- a/charts/datadog/templates/container-process-agent.yaml
+++ b/charts/datadog/templates/container-process-agent.yaml
@@ -76,4 +76,7 @@
       subPath: system-probe.yaml
     {{- end }}
     {{- end }}
+{{- if .Values.agents.volumeMounts }}
+{{ toYaml .Values.agents.volumeMounts | indent 4 }}
+{{- end }}
 {{- end -}}

--- a/charts/datadog/templates/container-security-agent.yaml
+++ b/charts/datadog/templates/container-security-agent.yaml
@@ -108,4 +108,7 @@
       subPath: system-probe.yaml
     {{- end }}
     {{- end }}
+{{- if .Values.agents.volumeMounts }}
+{{ toYaml .Values.agents.volumeMounts | indent 4 }}
+{{- end }}
 {{- end -}}

--- a/charts/datadog/templates/container-system-probe.yaml
+++ b/charts/datadog/templates/container-system-probe.yaml
@@ -47,4 +47,7 @@
       mountPath: /etc/datadog-agent/runtime-security.d
       readOnly: true
 {{- end }}
+{{- if .Values.agents.volumeMounts }}
+{{ toYaml .Values.agents.volumeMounts | indent 4 }}
+{{- end }}
 {{- end -}}

--- a/charts/datadog/templates/container-trace-agent.yaml
+++ b/charts/datadog/templates/container-trace-agent.yaml
@@ -58,6 +58,9 @@
     - name: apmsocket
       mountPath: {{ (dir .Values.datadog.apm.socketPath) }}
     {{- end }}
+{{- if .Values.agents.volumeMounts }}
+{{ toYaml .Values.agents.volumeMounts | indent 4 }}
+{{- end }}
   livenessProbe:
 {{- $live := .Values.agents.containers.traceAgent.livenessProbe }}
 {{ include "probe.tcp" (dict "port" .Values.datadog.apm.port "settings" $live ) | indent 4 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -734,7 +734,7 @@ agents:
   #       path: <HOST_PATH>
   #     name: <VOLUME_NAME>
 
-  # agents.volumeMounts -- Specify additional volumes to mount in the dd-agent container
+  # agents.volumeMounts -- Specify additional volumes to mount in all containers of the agent pod
   volumeMounts: []
   #   - name: <VOLUME_NAME>
   #     mountPath: <CONTAINER_PATH>


### PR DESCRIPTION
#### What this PR does / why we need it:

Propagate agents volume mounts to all agent containers

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes AKS certificate issue with the process-agent as the crt volume is not mounted

#### Special notes for your reviewer:

#### Checklist
- [x] Documentation has been updated with helm-docs (run: .github/helm-docs.sh)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
