### PR TITLE
Fix should-enable-system-probe helper function to support helm2

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Datadog changelog
 
+## 2.4.36
+
+* Fix `should-enable-system-probe` helper function to support `helm2`.
+
+## 2.4.35
+
+* Add options to set pod and container securityContext
+
 ## 2.4.34
 
 * Add `datadog.networkMonitoring` section to allow the system-probe to be run without network performance monitoring. Deprecates `systemProbe.enabled`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.35
+version: 2.4.36
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.4.35](https://img.shields.io/badge/Version-2.4.35-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.4.36](https://img.shields.io/badge/Version-2.4.36-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -191,7 +191,7 @@ Accepts a map with `port` (default port) and `settings` (probe settings).
 Return true if the system-probe container should be created.
 */}}
 {{- define "should-enable-system-probe" -}}
-{{- if (or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled $.Values.datadog.networkMonitoring.enabled)  -}}
+{{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkMonitoring.enabled -}}
 true
 {{- else -}}
 false


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix `should-enable-system-probe` helper function to support helm2 builded with a buggy golang version ([issue](https://github.com/golang/go/issues/30948))

in the [template function](https://github.com/DataDog/helm-charts/blob/67b9149a9dfa69ada69c5c98d16d2df3799d4c27/charts/datadog/templates/_helpers.tpl#L194) an extra blank character was present, which trigger the golang lexer bug. 

#### Which issue this PR fixes
 - fixes #84

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
