### PR TITLE
move kube-state-metrics sub-chart from google registry to charts.helm.sh

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,5 +1,5 @@
 chart-repos:
-  - stable=https://kubernetes-charts.storage.googleapis.com
+  - stable=https://charts.helm.sh/stable
 helm-extra-args: --timeout 300s
 check-version-increment: true
 debug: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Add default helm repo
-        run: helm repo add stable https://kubernetes-charts.storage.googleapis.com && helm repo update
+        run: helm repo add stable https://charts.helm.sh/stable && helm repo update
       - name: Run kubeval
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.4.38
+
+* Move the kube-state-metrics subchart from google's helm registry to charts.helm.sh/stable.
+
 ## 2.4.37
 
 * Fix incorrect link for Event Collection in `values.yaml`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.4.37
+version: 2.4.38
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -28,7 +28,7 @@ Kubernetes 1.4+ or OpenShift 3.4+, note that:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://kubernetes-charts.storage.googleapis.com/ | kube-state-metrics | =2.8.11 |
+| https://charts.helm.sh/stable/ | kube-state-metrics | =2.8.11 |
 
 ## Quick start
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -28,7 +28,7 @@ Kubernetes 1.4+ or OpenShift 3.4+, note that:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.helm.sh/stable/ | kube-state-metrics | =2.8.11 |
+| https://charts.helm.sh/stable | kube-state-metrics | =2.8.11 |
 
 ## Quick start
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.4.37](https://img.shields.io/badge/Version-2.4.37-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.4.38](https://img.shields.io/badge/Version-2.4.38-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://charts.helm.sh/stable/
-  version: =2.8.11
-digest: sha256:d372a5a447b9bac65504ad41a7201c5e5a51a43aed27133712608ca3d6558bf7
-generated: "2020-11-05T13:30:35.0560537Z"
+  repository: https://charts.helm.sh/stable
+  version: 2.8.11
+digest: sha256:e72aef3e78bbdd838ec25870ee899db9c2500b7da8c0ca8ec435d02880c47366
+generated: "2020-11-05T15:20:36.9037656Z"

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.8.11
-digest: sha256:ca16dbfb025e4fdd4f5665fc5adfd8f8cf62100cae882d1d94e32efd2e9ce156
-generated: "2020-10-19T18:49:38.132849+02:00"
+  repository: https://charts.helm.sh/stable/
+  version: =2.8.11
+digest: sha256:d372a5a447b9bac65504ad41a7201c5e5a51a43aed27133712608ca3d6558bf7
+generated: "2020-11-05T13:30:35.0560537Z"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kube-state-metrics
     version: "=2.8.11"
-    repository: https://charts.helm.sh/stable/
+    repository: https://charts.helm.sh/stable
     condition: datadog.kubeStateMetricsEnabled

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kube-state-metrics
     version: "=2.8.11"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: datadog.kubeStateMetricsEnabled


### PR DESCRIPTION


#### What this PR does / why we need it:

https://kubernetes-charts.storage.googleapis.com is moving to https://charts.helm.sh/stable and on Nov 13, 2020, the chart downloads will be redirected to the read-only archive GitHub Pages of helm charts (Please see: https://helm.sh/blog/charts-repo-deprecation/). This redirection can possibly cause some disruption. Given that the upstream resolution at https://github.com/kubernetes/kube-state-metrics/issues/1153 might not happen before Nov 13, moving to https://charts.helm.sh/stable might be a safer option in the interim

#### Which issue this PR fixes
  - fixes https://github.com/DataDog/helm-charts/issues/75

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
