### PR TITLE
[synthetics-private-location] Use gcr.io instead of Dockerhub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,9 @@
 
 # Documentation
 *.md             @DataDog/documentation @DataDog/container-integrations
+
+# Charts
 charts/datadog/templates/container-system-probe.yaml @DataDog/networks @DataDog/container-integrations
 charts/datadog/templates/system-probe-configmap.yaml @DataDog/networks @DataDog/container-integrations
 charts/datadog/templates/system-probe-init.yaml      @DataDog/networks @DataDog/container-integrations
+charts/synthetics-private-location/*                 @Datadog/synthetics @DataDog/container-integrations

--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+### 0.2.0
+
+* Use `gcr.io` instead of `Dockerhub`
+
 ### 0.1.0
 
 * Initial version

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.1.0
+version: 0.2.0
 appVersion: 1.4.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -29,7 +29,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
 | fullnameOverride | string | `""` | Override the full qualified app name |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Synthetics Private Location image |
-| image.repository | string | `"datadog/synthetics-private-location-worker"` | Repository to use for Datadog Synthetics Private Location image |
+| image.repository | string | `"gcr.io/datadoghq/synthetics-private-location-worker"` | Repository to use for Datadog Synthetics Private Location image |
 | image.tag | string | `"1.4.0"` | Define the Datadog Synthetics Private Location version to use |
 | imagePullSecrets | list | `[]` | Datadog Synthetics Private Location repository pullSecret (ex: specify docker registry credentials) |
 | nameOverride | string | `""` | Override name of app |

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   # image.repository -- Repository to use for Datadog Synthetics Private Location image
-  repository: datadog/synthetics-private-location-worker
+  repository: gcr.io/datadoghq/synthetics-private-location-worker
   # image.pullPolicy -- Define the pullPolicy for Datadog Synthetics Private Location image
   pullPolicy: IfNotPresent
   # image.tag -- Define the Datadog Synthetics Private Location version to use


### PR DESCRIPTION
#### What this PR does / why we need it:

* Update default docker image from dockerhub to gcr.io
* Update `CODEOWNERS` file to assign automatically to the `synthetics` team,  PRs releated to `synthetics-private-location` 

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
