### PR TITLE
Add 'datadog-crds' chart as 'datadog' dependency

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,5 +1,6 @@
 chart-repos:
   - stable=https://charts.helm.sh/stable
+  - datadog=https://helm.datadoghq.com
 helm-extra-args: --timeout 300s
 check-version-increment: true
 debug: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/checkout@v1
       - name: Add default helm repo
         run: helm repo add stable https://charts.helm.sh/stable && helm repo update
+      - name: Add datadog helm repo
+        run: helm repo add datadog https://helm.datadoghq.com && helm repo update
       - name: Run kubeval
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Datadog changelog
 
+## 2.5.3
+
+* Add "datadog-crds" chart as dependency. It is used to install the `DatadogMetrics` CRD if needed.
+
 ## 2.5.2
+
 * Change `datadog.tags` to a `tpl` value
 
 ## 2.5.0

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.5.2
+version: 2.5.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.5.2](https://img.shields.io/badge/Version-2.5.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.5.3](https://img.shields.io/badge/Version-2.5.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -29,6 +29,7 @@ Kubernetes 1.4+ or OpenShift 3.4+, note that:
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.helm.sh/stable | kube-state-metrics | =2.8.11 |
+| https://helm.datadoghq.com | datadog-crds | =0.1.1 |
 
 ## Quick start
 
@@ -429,6 +430,7 @@ helm install --name <RELEASE_NAME> \
 | clusterChecksRunner.tolerations | list | `[]` | Tolerations for pod assignment |
 | clusterChecksRunner.volumeMounts | list | `[]` | Specify additional volumes to mount in the cluster checks container |
 | clusterChecksRunner.volumes | list | `[]` | Specify additional volumes to mount in the cluster checks container |
+| datadog-crds.crds.datadogMetrics | bool | `true` | Set to true to deploy the DatadogMetrics CRD |
 | datadog.apiKey | string | `"<DATADOG_API_KEY>"` | Your Datadog API key ref: https://app.datadoghq.com/account/settings#agent/kubernetes |
 | datadog.apiKeyExistingSecret | string | `nil` | Use existing Secret which stores API key instead of creating a new one |
 | datadog.apm.enabled | bool | `false` | Enable this to enable APM and tracing, on port 8126 |

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,6 +1,9 @@
 dependencies:
+- name: datadog-crds
+  repository: https://helm.datadoghq.com
+  version: 0.1.1
 - name: kube-state-metrics
   repository: https://charts.helm.sh/stable
   version: 2.8.11
-digest: sha256:e72aef3e78bbdd838ec25870ee899db9c2500b7da8c0ca8ec435d02880c47366
-generated: "2020-11-05T15:20:36.9037656Z"
+digest: sha256:35c5ec4a7c5610cf2ff63bcd609293f8d2f8ac4bbc6e07462b9d66251b81b069
+generated: "2020-11-16T14:56:38.28858+01:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -1,4 +1,10 @@
 dependencies:
+  - name: datadog-crds
+    version: "=0.1.1"
+    repository: https://helm.datadoghq.com
+    condition: clusterAgent.metricsProvider.useDatadogMetrics
+    tags:
+    - install-crds
   - name: kube-state-metrics
     version: "=2.8.11"
     repository: https://charts.helm.sh/stable

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -991,6 +991,11 @@ clusterChecksRunner:
   # clusterChecksRunner.securityContext -- Allows you to overwrite the default PodSecurityContext on the clusterchecks pods.
   securityContext: {}
 
+datadog-crds:
+  crds:
+    # datadog-crds.crds.datadogMetrics -- Set to true to deploy the DatadogMetrics CRD
+    datadogMetrics: true
+
 kube-state-metrics:
   rbac:
     # kube-state-metrics.rbac.create -- If true, create & use RBAC resources


### PR DESCRIPTION
#### What this PR does / why we need it:

Add the `datadog-crds` chart as dependency of the `datadog` chart, to ease the `DatadogMetrics` CRD installation.

Now, when someone set  `clusterAgent.metricsProvider.useDatadogMetrics=true`, the CRD `DatadogMetrics` is installed.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
