### PR TITLE
Deprecate systemProbe.enabled and avoid incorrectly enabling NPM  

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -7,7 +7,6 @@
 ## 2.5.4
 
 * Supports `clusterChecksRunner` pod annotations
->>>>>>> origin/master
 
 ## 2.5.3
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.6.0
 
-* deprecates `systemProbe.enabled` in favor of `networkMonitoring.enabled`, `securityAgent.runtime.enabled`, 'systemProbe.enableOOMKill', and `systemProbe.enableTCPQueueLength`.
+* deprecates `systemProbe.enabled` in favor of `networkMonitoring.enabled`, `securityAgent.runtime.enabled`, `systemProbe.enableOOMKill`, and `systemProbe.enableTCPQueueLength`.
 * fixes a bug where network performance monitoring would be enabled if any systemProbe feature was enabled.
 
 ## 2.5.4

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * deprecates `systemProbe.enabled` in favor of `networkMonitoring.enabled`, `securityAgent.runtime.enabled`, 'systemProbe.enableOOMKill', and `systemProbe.enableTCPQueueLength`.
 * fixes a bug where network performance monitoring would be enabled if any systemProbe feature was enabled.
+
 ## 2.5.4
 
 * Supports `clusterChecksRunner` pod annotations

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.6.0
+
+* deprecates `systemProbe.enabled` in favor of `networkMonitoring.enabled`, `securityAgent.runtime.enabled`, 'systemProbe.enableOOMKill', and `systemProbe.enableTCPQueueLength`.
+* fixes a bug where network performance monitoring would be enabled if any systemProbe feature was enabled.
+
 ## 2.5.3
 
 * Add "datadog-crds" chart as dependency. It is used to install the `DatadogMetrics` CRD if needed.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.5.3
+version: 2.6.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -492,7 +492,6 @@ helm install --name <RELEASE_NAME> \
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
-| datadog.systemProbe.enabled | bool | `false` | DEPRECATED. Set this to true to enable system-probe agent. Prefer using `networkMonitoring.enabled`, `systemProbe.enableTCPQueueLength`, `systemProbe.enableOOMKill`, or `securityAgent.runtime.enabled` to enable specific features. |
 | datadog.systemProbe.seccomp | string | `"localhost/system-probe"` | Apply an ad-hoc seccomp profile to the system-probe agent to restrict its privileges |
 | datadog.systemProbe.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |
 | datadog.tags | list | `[]` | List of static tags to attach to every metric, event and service check collected by this Agent. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.5.3](https://img.shields.io/badge/Version-2.5.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.0](https://img.shields.io/badge/Version-2.6.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -470,8 +470,6 @@ helm install --name <RELEASE_NAME> \
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
 | datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
-| datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
-| datadog.orchestratorExplorer.enabled | bool | `false` | Set this to true to enable the orchestrator explorer |
 | datadog.podAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Annotations to Datadog Tags |
 | datadog.podLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Labels to Datadog Tags |
 | datadog.processAgent.enabled | bool | `true` | Set this to true to enable live process monitoring agent |
@@ -486,12 +484,12 @@ helm install --name <RELEASE_NAME> \
 | datadog.site | string | `nil` | The site of the Datadog intake to send Agent data to |
 | datadog.systemProbe.apparmor | string | `"unconfined"` | Specify a apparmor profile for system-probe |
 | datadog.systemProbe.bpfDebug | bool | `false` | Enable logging for kernel debug |
-| datadog.systemProbe.collectDNSStats | bool | `false` | Enable DNS stat collection |
+| datadog.systemProbe.container_scrubbing.enabled | bool | `true` |  |
 | datadog.systemProbe.debugPort | int | `0` | Specify the port to expose pprof and expvar for system-probe agent |
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
-| datadog.systemProbe.enabled | bool | `false` | Set this to true to enable system-probe agent |
+| datadog.systemProbe.enabled | bool | `false` | DEPRECATED. Set this to true to enable system-probe agent. Prefer using `networkMonitoring.enabled`, `systemProbe.enableTCPQueueLength`, `systemProbe.enableOOMKill`, or `securityAgent.runtime.enabled` to enable specific features. |
 | datadog.systemProbe.seccomp | string | `"localhost/system-probe"` | Apply an ad-hoc seccomp profile to the system-probe agent to restrict its privileges |
 | datadog.systemProbe.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |
 | datadog.tags | list | `[]` | List of static tags to attach to every metric, event and service check collected by this Agent. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -471,6 +471,8 @@ helm install --name <RELEASE_NAME> \
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
 | datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
+| datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
+| datadog.orchestratorExplorer.enabled | bool | `false` | Set this to true to enable the orchestrator explorer |
 | datadog.podAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Annotations to Datadog Tags |
 | datadog.podLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Labels to Datadog Tags |
 | datadog.processAgent.enabled | bool | `true` | Set this to true to enable live process monitoring agent |
@@ -485,7 +487,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.site | string | `nil` | The site of the Datadog intake to send Agent data to |
 | datadog.systemProbe.apparmor | string | `"unconfined"` | Specify a apparmor profile for system-probe |
 | datadog.systemProbe.bpfDebug | bool | `false` | Enable logging for kernel debug |
-| datadog.systemProbe.container_scrubbing.enabled | bool | `true` |  |
+| datadog.systemProbe.collectDNSStats | bool | `false` | Enable DNS stat collection |
 | datadog.systemProbe.debugPort | int | `0` | Specify the port to expose pprof and expvar for system-probe agent |
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |

--- a/charts/datadog/ci/disable-apparmor.yaml
+++ b/charts/datadog/ci/disable-apparmor.yaml
@@ -3,7 +3,7 @@ datadog:
   apiKey: "00000000000000000000000000000000"
   appKey: "0000000000000000000000000000000000000000"
   kubeStateMetricsEnabled: false
-  systemProbe:
+  networkMonitoring:
     enabled: true
 agents:
   podSecurity:

--- a/charts/datadog/ci/kubeval.yaml
+++ b/charts/datadog/ci/kubeval.yaml
@@ -12,8 +12,9 @@ datadog:
   processAgent:
     enabled: true
     processCollection: true
-  systemProbe:
+  networkMonitoring:
     enabled: true
+  systemProbe:
     enableConntrack: true
     enableTCPQueueLength: true
     enableOOMKill: true

--- a/charts/datadog/ci/no_hardened_seccomp-values.yaml
+++ b/charts/datadog/ci/no_hardened_seccomp-values.yaml
@@ -2,6 +2,7 @@ datadog:
   apiKey: "00000000000000000000000000000000"
   appKey: "0000000000000000000000000000000000000000"
   kubeStateMetricsEnabled: false
-  systemProbe:
+  networkMonitoring:
     enabled: true
+  systemProbe:
     seccomp: runtime/default

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -188,7 +188,7 @@ More information about this change: https://github.com/DataDog/helm-charts/pull/
 ####               WARNING: Deprecation notice               ####
 #################################################################
 
-You are using datadog.systemProbe.enabled which has been depreated in favor using one of networkMonitoring.enabled, systemProbe.enableTCPQueueLength, systemProbe.enableOOMKill, or securityAgent.runtime.enabled.
+You are using datadog.systemProbe.enabled which has been deprecated in favor using one of networkMonitoring.enabled, systemProbe.enableTCPQueueLength, systemProbe.enableOOMKill, or securityAgent.runtime.enabled.
 More information about this change: https://github.com/DataDog/helm-charts/pull/101
 
 {{- end }}

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -168,3 +168,14 @@ You are using the datadog.podSecurity.securityContext parameter, which has been 
 This version still supports datadog.podSecurity.securityContext, but it will be removed in the next major version of our Helm chart.
 More information about this change: https://github.com/DataDog/helm-charts/pull/46
 {{- end }}
+
+
+{{- if .Values.datadog.systemProbe }}
+
+#################################################################
+####               WARNING: Deprecation notice               ####
+#################################################################
+
+You are using datadog.systemProbe.enabled which has been depreated in favor using one of networkMonitoring.enabled, systemProbe.enableTCPQueueLength, systemProbe.enableOOMKill, or securityAgent.runtime.enabled.
+More information about this change: https://github.com/DataDog/helm-charts/pull/101
+{{- end }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -191,7 +191,7 @@ Accepts a map with `port` (default port) and `settings` (probe settings).
 Return true if the system-probe container should be created.
 */}}
 {{- define "should-enable-system-probe" -}}
-{{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkMonitoring.enabled -}}
+{{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkMonitoring.enabled .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill -}}
 true
 {{- else -}}
 false

--- a/charts/datadog/templates/container-process-agent.yaml
+++ b/charts/datadog/templates/container-process-agent.yaml
@@ -26,10 +26,8 @@
     {{- end }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.processAgent.logLevel | default .Values.datadog.logLevel | quote }}
-    {{- if or .Values.datadog.systemProbe.enabled .Values.datadog.networkMonitoring.enabled }}
     - name: DD_SYSTEM_PROBE_ENABLED
-      value: {{ true | quote }}
-    {{- end }}
+      value: {{ (or .Values.datadog.systemProbe.enabled .Values.datadog.networkMonitoring.enabled) | quote }}
     {{- if .Values.datadog.networkMonitoring.enabled }}
     - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -246,7 +246,7 @@ datadog:
 
   ## Enable systemProbe agent and provide custom configs
   systemProbe:
-    # datadog.systemProbe.enabled -- DEPRECATED, prefer setting .... Set this to true to enable system-probe agent
+    # datadog.systemProbe.enabled -- DEPRECATED. Set this to true to enable system-probe agent. Prefer using `networkMonitoring.enabled`, `systemProbe.enableTCPQueueLength`, `systemProbe.enableOOMKill`, or `securityAgent.runtime.enabled` to enable specific features.
     enabled: false
 
     # datadog.systemProbe.debugPort -- Specify the port to expose pprof and expvar for system-probe agent
@@ -274,17 +274,7 @@ datadog:
 
     # datadog.systemProbe.enableOOMKill -- Enable the OOM kill eBPF-based check
     enableOOMKill: false
-
-    # datadog.systemProbe.collectDNSStats -- Enable DNS stat collection
-    collectDNSStats: false
-
-  orchestratorExplorer:
-    # datadog.orchestratorExplorer.enabled -- Set this to true to enable the orchestrator explorer
-    ## This requires processAgent.enabled and clusterAgent.enabled to be set to true
-    ## ref: TODO - add doc link
-    enabled: false
-
-    # datadog.orchestratorExplorer.container_scrubbing -- Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information
+# datadog.systemProbe.collectDNSStats -- Enable DNS stat collection collectDNSStats: false orchestratorExplorer: # datadog.orchestratorExplorer.enabled -- Set this to true to enable the orchestrator explorer ## This requires processAgent.enabled and clusterAgent.enabled to be set to true ## ref: TODO - add doc link enabled: false # datadog.orchestratorExplorer.container_scrubbing -- Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information
     ## The container scrubbing is taking significant resources during data collection.
     ## If you notice that the cluster-agent uses too much CPU in larger clusters
     ## turning this option off will improve the situation.

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -274,7 +274,17 @@ datadog:
 
     # datadog.systemProbe.enableOOMKill -- Enable the OOM kill eBPF-based check
     enableOOMKill: false
-# datadog.systemProbe.collectDNSStats -- Enable DNS stat collection collectDNSStats: false orchestratorExplorer: # datadog.orchestratorExplorer.enabled -- Set this to true to enable the orchestrator explorer ## This requires processAgent.enabled and clusterAgent.enabled to be set to true ## ref: TODO - add doc link enabled: false # datadog.orchestratorExplorer.container_scrubbing -- Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information
+
+    # datadog.systemProbe.collectDNSStats -- Enable DNS stat collection
+    collectDNSStats: false
+
+  orchestratorExplorer:
+    # datadog.orchestratorExplorer.enabled -- Set this to true to enable the orchestrator explorer
+    ## This requires processAgent.enabled and clusterAgent.enabled to be set to true
+    ## ref: TODO - add doc link
+    enabled: false
+
+    # datadog.orchestratorExplorer.container_scrubbing -- Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information
     ## The container scrubbing is taking significant resources during data collection.
     ## If you notice that the cluster-agent uses too much CPU in larger clusters
     ## turning this option off will improve the situation.

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -246,7 +246,7 @@ datadog:
 
   ## Enable systemProbe agent and provide custom configs
   systemProbe:
-    # datadog.systemProbe.enabled -- Set this to true to enable system-probe agent
+    # datadog.systemProbe.enabled -- DEPRECATED, prefer setting .... Set this to true to enable system-probe agent
     enabled: false
 
     # datadog.systemProbe.debugPort -- Specify the port to expose pprof and expvar for system-probe agent

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -246,8 +246,6 @@ datadog:
 
   ## Enable systemProbe agent and provide custom configs
   systemProbe:
-    # datadog.systemProbe.enabled -- DEPRECATED. Set this to true to enable system-probe agent. Prefer using `networkMonitoring.enabled`, `systemProbe.enableTCPQueueLength`, `systemProbe.enableOOMKill`, or `securityAgent.runtime.enabled` to enable specific features.
-    enabled: false
 
     # datadog.systemProbe.debugPort -- Specify the port to expose pprof and expvar for system-probe agent
     debugPort: 0


### PR DESCRIPTION
#### What this PR does / why we need it:

* systemProbe.enabled is now implicitly true if oomKill or
  tcpQueueLength are enabled
* fixes a bug where DD_SYSTEM_PROBE_ENABLED environment variable was not
  explicitly set to "false" when neither the systemProbe.enabled nor
  networkMonitoring.enabled flags are flipped on. In those cases, the
  process-agent should explicitly disable the system-probe so the
  connections check does not get enabled.



#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
