### PR TITLE
[Private-Synthetics] Conditionally create configMap and docs

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+### 0.2.1
+
+* Conditionally create the configMap
+* Allow the configMap name to be configurable
+
 ### 0.2.0
 
 * Use `gcr.io` instead of `Dockerhub`

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.4.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -27,6 +27,8 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Allows to specify affinity for Datadog Synthetics Private Location PODs |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
+| configMap.enabled | bool | `true` | Conditionally create configMap containing configuration for Synthetics |
+| configMap.name | string | `""` | Name of the configMap. If not set name is generated using the fullname template |
 | fullnameOverride | string | `""` | Override the full qualified app name |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Synthetics Private Location image |
 | image.repository | string | `"gcr.io/datadoghq/synthetics-private-location-worker"` | Repository to use for Datadog Synthetics Private Location image |

--- a/charts/synthetics-private-location/templates/_helpers.tpl
+++ b/charts/synthetics-private-location/templates/_helpers.tpl
@@ -64,6 +64,6 @@ Create the name of the service account to use
 {{/*
 Determine name of the configmap
 */}}
-{{- define "synthetics-privatet-location.configMapName" -}}
+{{- define "synthetics-private-location.configMapName" -}}
 {{- default ( printf "%s-config" (include "synthetics-private-location.fullname" .)) .Values.configMap.name }}
 {{- end }}

--- a/charts/synthetics-private-location/templates/_helpers.tpl
+++ b/charts/synthetics-private-location/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Determine name of the configmap
+*/}}
+{{- define "synthetics-privatet-location.configMapName" -}}
+{{- default ( printf "%s-config" (include "synthetics-private-location.fullname" .)) .Values.configMap.name }}
+{{- end }}

--- a/charts/synthetics-private-location/templates/configmap.yaml
+++ b/charts/synthetics-private-location/templates/configmap.yaml
@@ -1,11 +1,12 @@
+{{- if .Values.configMap.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "synthetics-private-location.fullname" . }}-config
+  name: {{ include "synthetics-privatet-location.configMapName" . }}
   labels:
     {{- include "synthetics-private-location.labels" . | nindent 4 }}
 data:
   synthetics-check-runner.json: |-
 {{ .Values.configFile | indent 4 }}
-
+{{- end}}
 ---

--- a/charts/synthetics-private-location/templates/configmap.yaml
+++ b/charts/synthetics-private-location/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "synthetics-privatet-location.configMapName" . }}
+  name: {{ include "synthetics-private-location.configMapName" . }}
   labels:
     {{- include "synthetics-private-location.labels" . | nindent 4 }}
 data:

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -61,4 +61,4 @@ spec:
       volumes:
       - name: worker-config
         configMap:
-          name: {{ include "synthetics-private-location.fullname" . }}-config
+          name: {{ include "synthetics-privatet-location.configMapName" . }}

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -61,4 +61,4 @@ spec:
       volumes:
       - name: worker-config
         configMap:
-          name: {{ include "synthetics-privatet-location.configMapName" . }}
+          name: {{ include "synthetics-private-location.configMapName" . }}

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -64,3 +64,9 @@ affinity: {}
 
 # configFile -- JSON string containing the configuration of the private location worker
 configFile: "{}"
+
+configMap:
+  # configMap.enabled -- Conditionally create configMap containing configuration for Synthetics
+  enabled: true
+  # configMap.name -- Name of the configMap. If not set name is generated using the fullname template
+  name: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows specifying whether the configMap should be created and allows specifying the name. This allows the configMap to be created out of band and passing the name of the configMap in to the chart. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #103 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
