### PR TITLE
Fix process-agent, trace-agent communication with DCA for tagging purpose.

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Datadog changelog
 
+
+## 2.6.1
+
+* Fix `process-agent` and `trace-agent` communication with the `cluster-agent`: When the `cluster-agent` is activated,
+  the agents should communicated with the `cluster-agent` to retrived tags like `kube_service` instead of communicating
+  directly with the Kubernetes API-Server.
+
 ## 2.6.0
 
 * deprecates `systemProbe.enabled` in favor of `networkMonitoring.enabled`, `securityAgent.runtime.enabled`, `systemProbe.enableOOMKill`, and `systemProbe.enableTCPQueueLength`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.6.0
+version: 2.6.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.6.0](https://img.shields.io/badge/Version-2.6.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.1](https://img.shields.io/badge/Version-2.6.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -116,16 +116,8 @@ spec:
           - name: DD_HEALTH_PORT
           {{- $healthPort := .Values.clusterChecksRunner.healthPort }}
             value: {{ $healthPort | quote }}
-          # Cluster checks
-          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
-            value: {{ template "datadog.fullname" . }}-cluster-agent
-          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "clusterAgent.tokenSecretName" . }}
-                key: token
-          - name: DD_CLUSTER_AGENT_ENABLED
-            value: {{ .Values.clusterAgent.enabled | quote }}
+          # Cluster checks (cluster-agent communication)
+          {{- include "containers-cluster-agent-env" . | nindent 10 }}
           # Safely run alongside the daemonset
           - name: DD_ENABLE_METADATA_COLLECTION
             value: "false"

--- a/charts/datadog/templates/container-agent.yaml
+++ b/charts/datadog/templates/container-agent.yaml
@@ -54,15 +54,7 @@
       value: {{.Values.datadog.collectEvents | quote}}
     {{- end }}
     {{- else }}
-    - name: DD_CLUSTER_AGENT_ENABLED
-      value: {{ .Values.clusterAgent.enabled | quote }}
-    - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
-      value: {{ template "datadog.fullname" . }}-cluster-agent
-    - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: {{ template "clusterAgent.tokenSecretName" . }}
-          key: token
+    {{- include "containers-cluster-agent-env" . | nindent 4 }}
     {{- end }}
     - name: DD_APM_ENABLED
       value: "false"

--- a/charts/datadog/templates/container-process-agent.yaml
+++ b/charts/datadog/templates/container-process-agent.yaml
@@ -20,6 +20,7 @@
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}
+    {{- include "containers-cluster-agent-env" . | nindent 4 }}
     {{- if .Values.datadog.processAgent.processCollection }}
     - name: DD_PROCESS_AGENT_ENABLED
       value: "true"

--- a/charts/datadog/templates/container-security-agent.yaml
+++ b/charts/datadog/templates/container-security-agent.yaml
@@ -23,17 +23,7 @@
       value: {{ .Values.datadog.securityAgent.compliance.checkInterval | quote }}
     - name: HOST_ROOT
       value: /host/root
-    - name: DD_CLUSTER_AGENT_ENABLED
-      value: {{ .Values.clusterAgent.enabled | quote }}
-    {{- if .Values.clusterAgent.enabled }}
-    - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
-      value: {{ template "datadog.fullname" . }}-cluster-agent
-    - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: {{ template "clusterAgent.tokenSecretName" . }}
-          key: token
-    {{- end }}
+    {{- include "containers-cluster-agent-env" . | nindent 4 }}
     {{- end }}
     - name: DD_RUNTIME_SECURITY_CONFIG_ENABLED
       value:  {{ .Values.datadog.securityAgent.runtime.enabled | quote }}

--- a/charts/datadog/templates/container-trace-agent.yaml
+++ b/charts/datadog/templates/container-trace-agent.yaml
@@ -25,6 +25,7 @@
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}
+    {{- include "containers-cluster-agent-env" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.traceAgent.logLevel | default .Values.datadog.logLevel | quote }}
     - name: DD_APM_ENABLED

--- a/charts/datadog/templates/containers-common-env.yaml
+++ b/charts/datadog/templates/containers-common-env.yaml
@@ -91,3 +91,21 @@
 {{- end }}
 {{- end }}
 {{- end -}}
+
+
+{{/*
+Return a list of env-vars if the cluster-agent is enabled
+*/}}
+{{- define "containers-cluster-agent-env" -}}
+- name: DD_CLUSTER_AGENT_ENABLED
+  value: {{ .Values.clusterAgent.enabled | quote }}
+{{- if .Values.clusterAgent.enabled }}
+- name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+  value: {{ template "datadog.fullname" . }}-cluster-agent
+- name: DD_CLUSTER_AGENT_AUTH_TOKEN
+  valueFrom:
+    secretKeyRef:
+        name: {{ template "clusterAgent.tokenSecretName" . }}
+        key: token
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix `process-agent`, `trace-agent` communication with DCA for tagging purpose.
    
When the `cluster-agent` is enabled, the agents should communicated with the
`cluster-agent` to retrieved tags like `kube_service` instead of communicating
directly with the Kubernetes API-Server.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
