### PR TITLE
Add datadog.dogstatsd.tags field

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.6.3
+
+* Add a new field `datadog.dogstatsd.tags` to configure `DD_DOGSTATSD_TAGS`.
+
 ## 2.6.2
 
 * Make sure KSM deploys on Linux nodes

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.6.2
+version: 2.6.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.6.2](https://img.shields.io/badge/Version-2.6.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.3](https://img.shields.io/badge/Version-2.6.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -455,6 +455,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.dogstatsd.port | int | `8125` | Override the Agent DogStatsD port |
 | datadog.dogstatsd.socketPath | string | `"/var/run/datadog/dsd.socket"` | Path to the DogStatsD socket |
 | datadog.dogstatsd.tagCardinality | string | `"low"` | Sets the tag cardinality relative to the origin detection |
+| datadog.dogstatsd.tags | list | `[]` | List of static tags to attach to every custom metric, event and service check collected by Dogstatsd. |
 | datadog.dogstatsd.useHostPID | bool | `false` | Run the agent in the host's PID namespace |
 | datadog.dogstatsd.useHostPort | bool | `false` | Sets the hostPort to the same value of the container port |
 | datadog.dogstatsd.useSocketVolume | bool | `false` | Enable dogstatsd over Unix Domain Socket |

--- a/charts/datadog/templates/container-agent.yaml
+++ b/charts/datadog/templates/container-agent.yaml
@@ -40,6 +40,10 @@
     - name: DD_DOGSTATSD_TAG_CARDINALITY
       value: {{ .Values.datadog.dogstatsd.tagCardinality | quote }}
     {{- end }}
+    {{- if .Values.datadog.dogstatsd.tags }}
+    - name: DD_DOGSTATSD_TAGS
+      value: {{ tpl (.Values.datadog.dogstatsd.tags | join " " | quote) . }}
+    {{- end }}
     {{- if not .Values.clusterAgent.enabled }}
     {{- if .Values.datadog.leaderElection }}
     - name: DD_LEADER_ELECTION

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -112,6 +112,12 @@ datadog:
     ## https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
     originDetection: false
 
+    # datadog.dogstatsd.tags -- List of static tags to attach to every custom metric, event and service check collected by Dogstatsd.
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    tags: []
+    #   - "<KEY_1>:<VALUE_1>"
+    #   - "<KEY_2>:<VALUE_2>"
+
     # datadog.dogstatsd.tagCardinality -- Sets the tag cardinality relative to the origin detection
     ## https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
     tagCardinality: low


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add a new field `datadog.dogstatsd.tags` to configure `DD_DOGSTATSD_TAGS`.

#### Which issue this PR fixes
  - fixes #111 

#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
