### PR TITLE
[datadog-agent] fix agent container volumeMounts

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 2.6.3
+## 2.6.4
 
 * Fix agent container volumeMounts when oom kill check or tcp queue length check is enabled.
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.6.3
 
+* Fix agent container volumeMounts when oom kill check or tcp queue length check is enabled.
+
+## 2.6.3
+
 * Add a new field `datadog.dogstatsd.tags` to configure `DD_DOGSTATSD_TAGS`.
 
 ## 2.6.2

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.6.3
+version: 2.6.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.6.3](https://img.shields.io/badge/Version-2.6.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.4](https://img.shields.io/badge/Version-2.6.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/container-agent.yaml
+++ b/charts/datadog/templates/container-agent.yaml
@@ -116,7 +116,7 @@
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
     {{- end }}
-    {{- if .Values.datadog.systemProbe.enabled }}
+    {{- if or .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
       readOnly: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Following https://github.com/DataDog/helm-charts/pull/101 the proper agent volumeMounts need to be set if the oom kill or tcp queue length checks are enabled.

#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
