### PR TITLE
[datadog-operator] Add SB args 

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+* Support configuring the secret backend command arguments (requires Datadog Operator v0.5.0+)
+
 ## 0.5.0
 
 * Update chart for Operator release `v0.5.0`

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.5.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 ## Values
 
@@ -24,6 +24,7 @@
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |
 | replicaCount | int | `1` | Number of instances of Datadog Operator |
 | resources | object | `{}` | Set resources requests/limits for Datadog Operator PODs |
+| secretBackend.arguments | string | `""` | Specifies the space-separated arguments passed to the command that implements the secret backend api |
 | secretBackend.command | string | `""` | Specifies the path to the command that implements the secret backend api |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. If not set name is generated using the fullname template |

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           {{- if .Values.secretBackend.command }}
             - "-secretBackendCommand={{ .Values.secretBackend.command }}"
           {{- end }}
+          {{- if .Values.secretBackend.arguments }}
+            - "-secretBackendArgs={{ .Values.secretBackend.arguments }}"
+          {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -26,6 +26,8 @@ metricsPort: 8383
 secretBackend:
   # secretBackend.command -- Specifies the path to the command that implements the secret backend api
   command: ""
+  # secretBackend.arguments -- Specifies the space-separated arguments passed to the command that implements the secret backend api
+  arguments: ""
 rbac:
   # rbac.create -- Specifies whether the RBAC resources should be created
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

* Support configuring the secret backend command arguments (requires Datadog Operator v0.5.0+)

#### Special notes for your reviewer:

Related to https://github.com/DataDog/datadog-operator/pull/196

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
