### PR TITLE
[datadog] allow setting privileged securityContext for system-probe

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.7.0
 
-* Add `agents.containers.systemProbe.securityContext.privileged`.
+* Add `agents.containers.systemProbe.securityContext` option.
 
 ## 2.6.5
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 2.7.0
+## 2.6.6
 
 * Add `agents.containers.systemProbe.securityContext` option.
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.7.0
+
+* Add `agents.containers.systemProbe.securityContext.privileged`.
+
 ## 2.6.5
 
 * Make sure all agents are rolled out on API key update and the Cluster agents on Application key update.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.6.5
+version: 2.6.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -329,6 +329,7 @@ helm install --name <RELEASE_NAME> \
 | agents.containers.systemProbe.env | list | `[]` | Additional environment variables for the system-probe container |
 | agents.containers.systemProbe.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off. |
 | agents.containers.systemProbe.resources | object | `{}` | Resource requests and limits for the system-probe container |
+| agents.containers.systemProbe.securityContext.privileged | bool | `false` |  |
 | agents.containers.traceAgent.env | string | `nil` | Additional environment variables for the trace-agent container |
 | agents.containers.traceAgent.livenessProbe | object | Every 15s | Override default agent liveness probe settings |
 | agents.containers.traceAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -329,7 +329,7 @@ helm install --name <RELEASE_NAME> \
 | agents.containers.systemProbe.env | list | `[]` | Additional environment variables for the system-probe container |
 | agents.containers.systemProbe.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off. |
 | agents.containers.systemProbe.resources | object | `{}` | Resource requests and limits for the system-probe container |
-| agents.containers.systemProbe.securityContext.privileged | bool | `false` |  |
+| agents.containers.systemProbe.securityContext | object | `{"capabilities":{"add":["SYS_ADMIN","SYS_RESOURCE","SYS_PTRACE","NET_ADMIN","NET_BROADCAST","IPC_LOCK"]},"privileged":false}` | Allows you to overwrite the default container SecurityContext for the system-probe container. |
 | agents.containers.traceAgent.env | string | `nil` | Additional environment variables for the trace-agent container |
 | agents.containers.traceAgent.livenessProbe | object | Every 15s | Override default agent liveness probe settings |
 | agents.containers.traceAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.6.5](https://img.shields.io/badge/Version-2.6.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.6](https://img.shields.io/badge/Version-2.6.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/container-system-probe.yaml
+++ b/charts/datadog/templates/container-system-probe.yaml
@@ -3,9 +3,7 @@
   image: "{{ .Values.agents.image.repository }}:{{ .Values.agents.image.tag }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
   securityContext:
-    capabilities:
-      add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"]
-    privileged: {{ $.Values.agents.containers.systemProbe.securityContext.privileged }}
+{{ toYaml .Values.agents.containers.systemProbe.securityContext | indent 4 }}
   command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
 {{- if .Values.datadog.envFrom }}
   envFrom:

--- a/charts/datadog/templates/container-system-probe.yaml
+++ b/charts/datadog/templates/container-system-probe.yaml
@@ -5,6 +5,7 @@
   securityContext:
     capabilities:
       add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"]
+    privileged: {{ $.Values.agents.containers.systemProbe.securityContext.privileged }}
   command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
 {{- if .Values.datadog.envFrom }}
   envFrom:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -744,6 +744,10 @@ agents:
       #  limits:
       #    cpu: 100m
       #    memory: 200Mi
+
+      securityContext:
+        # agents.containers.securityContext.privileged -- Set the system-probe container to run in privileged mode.
+        privileged: false
     securityAgent:
       # agents.containers.securityAgent.env -- Additional environment variables for the security-agent container
       env:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -745,9 +745,11 @@ agents:
       #    cpu: 100m
       #    memory: 200Mi
 
+      # agents.containers.systemProbe.securityContext -- Allows you to overwrite the default container SecurityContext for the system-probe container.
       securityContext:
-        # agents.containers.securityContext.privileged -- Set the system-probe container to run in privileged mode.
         privileged: false
+        capabilities:
+          add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"]
     securityAgent:
       # agents.containers.securityAgent.env -- Additional environment variables for the security-agent container
       env:


### PR DESCRIPTION
#### What this PR does / why we need it:

Similar to other agents, this allows the system-probe to run with
privileged=true.

#### Special notes for your reviewer:

#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
