### PR TITLE
[datadog-agent] update agent to 7.24.1

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.6.7
+
+* Change the default agent version to `7.24.1`
+
 ## 2.6.6
 
 * Add `agents.containers.systemProbe.securityContext` option.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.6.6
+version: 2.6.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.6.6](https://img.shields.io/badge/Version-2.6.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.7](https://img.shields.io/badge/Version-2.6.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -342,7 +342,7 @@ helm install --name <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `"gcr.io/datadoghq/agent"` | Datadog Agent image repository to use |
-| agents.image.tag | string | `"7.23.1"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.24.1"` | Define the Agent version to use |
 | agents.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the agents. DEPRECATED. Use datadog.networkPolicy.create instead |
 | agents.nodeSelector | object | `{}` | Allow the DaemonSet to schedule on selected nodes |
 | agents.podAnnotations | object | `{}` | Annotations to add to the DaemonSet's Pods |
@@ -415,7 +415,7 @@ helm install --name <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `"gcr.io/datadoghq/agent"` | Datadog Agent image repository to use |
-| clusterChecksRunner.image.tag | string | `"7.23.1"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.24.1"` | Define the Agent version to use |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterChecksRunner.nodeSelector | object | `{}` | Allow the ClusterChecks Deployment to schedule on selected nodes |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -558,7 +558,7 @@ agents:
 
     # agents.image.tag -- Define the Agent version to use
     ## Use 7-jmx to enable jmx fetch collection
-    tag: 7.23.1
+    tag: 7.24.1
 
     # agents.image.doNotCheckTag -- Skip the version<>chart compatibility check
     ## By default, the version passed in agents.image.tag is checked
@@ -888,7 +888,7 @@ clusterChecksRunner:
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
     ## Use 7-jmx to enable jmx fetch collection
-    tag: 7.23.1
+    tag: 7.24.1
 
     # clusterChecksRunner.image.pullPolicy -- Datadog Agent image pull policy
     pullPolicy: IfNotPresent

--- a/examples/datadog/agent_basic_values.yaml
+++ b/examples/datadog/agent_basic_values.yaml
@@ -33,5 +33,5 @@ agents:
   enabled: true
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.23.1
+    tag: 7.24.1
     pullPolicy: IfNotPresent

--- a/examples/datadog/agent_on_openshift_values.yaml
+++ b/examples/datadog/agent_on_openshift_values.yaml
@@ -44,5 +44,5 @@ agents:
   enabled: true
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.23.1
+    tag: 7.24.1
     pullPolicy: IfNotPresent

--- a/examples/datadog/agent_on_rancher_values.yaml
+++ b/examples/datadog/agent_on_rancher_values.yaml
@@ -33,7 +33,7 @@ agents:
   enabled: true
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.23.1
+    tag: 7.24.1
     pullPolicy: IfNotPresent
   tolerations:
     # These tolerations are needed to run the agent on master nodes

--- a/examples/datadog/agent_with_cluster_agent_values.yaml
+++ b/examples/datadog/agent_with_cluster_agent_values.yaml
@@ -34,7 +34,7 @@ agents:
   enabled: true
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.23.1
+    tag: 7.24.1
   rbac:
     create: true
     serviceAccountName: default
@@ -42,7 +42,7 @@ clusterChecksRunner:
   enabled: true
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.23.1
+    tag: 7.24.1
     pullPolicy: IfNotPresent
   rbac:
     create: true

--- a/examples/datadog/agent_with_containerd_values.yaml
+++ b/examples/datadog/agent_with_containerd_values.yaml
@@ -14,5 +14,5 @@ agents:
   enabled: true
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.23.1
+    tag: 7.24.1
     pullPolicy: IfNotPresent


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the default agent image to 7.24.1

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [X] Variables are documented in the `README.md`
