### PR TITLE
Improve CI and add /tmp as an empty dir to prepare for VOLUME removal in Dockerfile

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
 set -euo pipefail
 
-CHART_DIRS="$(git diff --find-renames --name-only "$(git rev-parse --abbrev-ref HEAD)" remotes/origin/master -- charts | grep '[cC]hart.yaml' | sed -e 's#/[Cc]hart.yaml##g')"
 KUBEVAL_VERSION="0.15.0"
 SCHEMA_LOCATION="https://kubernetesjsonschema.dev/"
+OS=$(uname)
+
+CHANGED_CHARTS=${CHANGED_CHARTS:-${1:-}}
+if [ -n "$CHANGED_CHARTS" ];
+then
+  CHART_DIRS=$CHANGED_CHARTS
+else
+  CHART_DIRS=$(ls -d charts/*)
+fi
 
 # install kubeval
-curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz https://github.com/instrumenta/kubeval/releases/download/"${KUBEVAL_VERSION}"/kubeval-linux-amd64.tar.gz
+curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz https://github.com/instrumenta/kubeval/releases/download/"${KUBEVAL_VERSION}"/kubeval-${OS}-amd64.tar.gz
 tar -xf /tmp/kubeval.tar.gz kubeval
 
 # validate charts
 for CHART_DIR in ${CHART_DIRS}; do
+  echo "Running kubeval for folder: '$CHART_DIR'"
   helm dep up "${CHART_DIR}" && helm template --values "${CHART_DIR}"/ci/kubeval.yaml "${CHART_DIR}" | ./kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
 done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,20 +6,44 @@ on:
       - "charts/**"
 
 jobs:
-  lint-chart:
+  changed:
     runs-on: ubuntu-latest
+    outputs:
+      charts: ${{ steps.list-changed.outputs.changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo -n "Charts changed:"
+            echo "$changed"
+            echo "::set-output name=changed::$changed"
+          else
+            echo "PR without any chart changes - failing"
+            exit 1
+          fi
+
+  lint-chart:
+    runs-on: ubuntu-latest
+    needs:
+      - changed
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
       - name: Run chart-testing (lint)
-        uses: helm/chart-testing-action@master
-        with:
-          image: quay.io/helmpack/chart-testing:v3.0.0
-          command: lint
-          config: .github/ct.yaml
+        run: ct lint --config .github/ct.yaml
 
   lint-docs:
     runs-on: ubuntu-latest
+    needs:
+      - changed
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -28,6 +52,8 @@ jobs:
 
   kubeval-chart:
     runs-on: ubuntu-latest
+    needs:
+      - changed
     strategy:
       matrix:
         # When changing versions here, check that the version exists at: https://github.com/instrumenta/kubernetes-json-schema
@@ -45,6 +71,7 @@ jobs:
       - name: Run kubeval
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}
+          CHANGED_CHARTS: ${{needs.changed.outputs.charts}}
         run: .github/kubeval.sh
 
   install-chart:
@@ -66,11 +93,10 @@ jobs:
         uses: helm/kind-action@master
         with:
           node_image: kindest/node:${{ matrix.k8s }}
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.1.0
-        with:
-          command: install
-          config: .github/ct.yaml
+        run: ct install --config .github/ct.yaml
 
   pr-validated:
     name: pr-validated

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 charts/*/charts
 helm-docs
+kubeval

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,5 +9,6 @@ We aim to follow high quality standards, thus your PR must follow some rules:
 - Make sure to describe your change in the corresponding chart's `CHANGELOG.md`.
 - Make sure any new feature is tested by modifying or adding a file in `ci/`
 - Make sure your changes are compatible (or protected) with older Kubernetes version (CI will validate this down to 1.14)
+- Make sure you updated documentation (after bumping `Chart.yaml`) by running `.github/helm-docs.sh`
 
 Our team will then happily review and merge contributions!

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.6.9
+
+* Add `/tmp` in Agent POD as an emptyDir to allow VOLUME removal from Agent Dockerfile
+* Clarify documentation of `datadog.dogstatsd.nonLocalTraffic`
+
 ## 2.6.8
 
 * Fix `helm lint` by renaming YAML files lacking metadata info.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.6.8
+version: 2.6.9
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.6.8](https://img.shields.io/badge/Version-2.6.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.9](https://img.shields.io/badge/Version-2.6.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -451,7 +451,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | datadog.dockerSocketPath | string | `nil` | Path to the docker socket |
 | datadog.dogstatsd.hostSocketPath | string | `"/var/run/datadog/"` | Host path to the DogStatsD socket |
-| datadog.dogstatsd.nonLocalTraffic | bool | `false` | Enable this to make each node accept non-local statsd traffic |
+| datadog.dogstatsd.nonLocalTraffic | bool | `false` | Enable this to make each node accept non-local statsd traffic (from outside of the pod) |
 | datadog.dogstatsd.originDetection | bool | `false` | Enable origin detection for container tagging |
 | datadog.dogstatsd.port | int | `8125` | Override the Agent DogStatsD port |
 | datadog.dogstatsd.socketPath | string | `"/var/run/datadog/dsd.socket"` | Path to the DogStatsD socket |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -93,6 +93,9 @@
       subPath: install_info
       mountPath: /etc/datadog-agent/install_info
       readOnly: true
+    - name: tmpdir
+      mountPath: /tmp
+      readOnly: false
     {{- end }}
     - name: config
       mountPath: {{ template "datadog.confPath" . }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -53,6 +53,9 @@
       mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+    - name: tmpdir
+      mountPath: /tmp
+      readOnly: false
     {{- end }}
     {{- if eq .Values.targetSystem "windows" }}
     - name: runtimesocket

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -43,6 +43,9 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
     {{- if eq .Values.targetSystem "linux" }}
+    - name: tmpdir
+      mountPath: /tmp
+      readOnly: false
     - name: runtimesocketdir
       mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
       readOnly: true

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -19,6 +19,9 @@
   resources:
 {{ toYaml .Values.agents.containers.systemProbe.resources | indent 4 }}
   volumeMounts:
+    - name: tmpdir
+      mountPath: /tmp
+      readOnly: false
     - name: debugfs
       mountPath: /sys/kernel/debug
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -50,6 +50,9 @@
       subPath: datadog.yaml
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
+    - name: tmpdir
+      mountPath: /tmp
+      readOnly: false
     - name: runtimesocketdir
       mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -1,4 +1,6 @@
 {{- define "daemonset-volumes-linux" -}}
+- name: tmpdir
+  emptyDir: {}
 - hostPath:
     path: /proc
   name: procdir

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -233,7 +233,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-  name: {{ template "datadog.fullname" . }}-cluster-agent:system:auth-delegator
+  name: {{ template "datadog.fullname" . }}-cluster-agent-system-auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -145,7 +145,7 @@ datadog:
     ## See https://docs.datadoghq.com/developers/dogstatsd/unix_socket/
     useHostPID: false
 
-    # datadog.dogstatsd.nonLocalTraffic -- Enable this to make each node accept non-local statsd traffic
+    # datadog.dogstatsd.nonLocalTraffic -- Enable this to make each node accept non-local statsd traffic (from outside of the pod)
     ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
     nonLocalTraffic: false
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Improve Helm CI
Mount `/tmp` as an empty dir in all Agent containers

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
