### PR TITLE
Enable the orchestrator explorer by default

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.8.0
+
+* Enable the orchestrator explorer by default.
+
 ## 2.7.0
 
 * Changes default values to activate a maximum of built-in features to ease configuration.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.7.0
+version: 2.8.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -380,7 +380,7 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.createPodDisruptionBudget | bool | `false` | Create pod disruption budget for Cluster Agent deployments |
 | clusterAgent.datadog_cluster_yaml | object | `{}` | Specify custom contents for the datadog cluster agent config (datadog-cluster.yaml) |
 | clusterAgent.dnsConfig | object | `{}` | Specify dns configuration options for datadog cluster agent containers e.g ndots |
-| clusterAgent.enabled | bool | `true` | Set this to true to enable Datadog Cluster Agent |
+| clusterAgent.enabled | bool | `true` | Set this to false to disable Datadog Cluster Agent |
 | clusterAgent.env | list | `[]` | Set environment variables specific to Cluster Agent |
 | clusterAgent.healthPort | int | `5555` | Port number to use in the Cluster Agent for the healthz endpoint |
 | clusterAgent.image.name | string | `"cluster-agent"` | Cluster Agent image name to use (relative to `registry`) |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -487,7 +487,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.networkPolicy.flavor | string | `"kubernetes"` | Flavor of the network policy to use. Can be: * kubernetes for networking.k8s.io/v1/NetworkPolicy * cilium     for cilium.io/v2/CiliumNetworkPolicy |
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
 | datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
-| datadog.orchestratorExplorer.enabled | bool | `false` | Set this to true to enable the orchestrator explorer |
+| datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
 | datadog.podAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Annotations to Datadog Tags |
 | datadog.podLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Labels to Datadog Tags |
 | datadog.processAgent.enabled | bool | `true` | Set this to true to enable live process monitoring agent |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -192,3 +192,13 @@ You are using datadog.systemProbe.enabled which has been deprecated in favor usi
 More information about this change: https://github.com/DataDog/helm-charts/pull/101
 
 {{- end }}
+
+{{- if (and .Values.datadog.orchestratorExplorer.enabled (not .Values.clusterAgent.enabled ))}}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+You are using datadog.orchestratorExplorer.enabled but you disabled the cluster agent. This configuration is unsupported and Kubernetes resource monitoring has been turned off.
+To enable it please set clusterAgent.enabled to 'true'.
+{{- end }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -38,8 +38,8 @@
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}
     {{- end }}
     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-      value: {{ .Values.datadog.orchestratorExplorer.enabled | quote }}
-    {{- if .Values.datadog.orchestratorExplorer.enabled }}
+      value: {{ (include "should-enable-k8s-resource-monitoring" .) | quote }}
+    {{- if eq (include "should-enable-k8s-resource-monitoring" .) "true" }}
     - name: DD_ORCHESTRATOR_CLUSTER_ID
       valueFrom:
         configMapKeyRef:

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -208,3 +208,14 @@ Return a remote image path based on `.Values` (passed as root) and `.` (any `.im
 {{ .root.registry }}/{{ .image.name }}:{{ .image.tag }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return true if Kubernetes resource monitoring (orchestrator explorer) should be enabled.
+*/}}
+{{- define "should-enable-k8s-resource-monitoring" -}}
+{{- if and .Values.datadog.orchestratorExplorer.enabled .Values.clusterAgent.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -200,8 +200,8 @@ spec:
           - name: DD_KUBE_RESOURCES_NAMESPACE
             value: {{ .Release.Namespace }}
           - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-            value: {{ .Values.datadog.orchestratorExplorer.enabled | quote }}
-          {{- if  .Values.datadog.orchestratorExplorer.enabled }}
+            value: {{ (include "should-enable-k8s-resource-monitoring" .) | quote }}
+          {{- if eq (include "should-enable-k8s-resource-monitoring" .) "true" }}
           - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
             value: {{ .Values.datadog.orchestratorExplorer.container_scrubbing.enabled | quote }}
           {{- end }}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -90,7 +90,7 @@ rules:
   - "get"
   - "watch"
 {{- end }}
-{{- if .Values.datadog.orchestratorExplorer.enabled }}
+{{- if eq (include "should-enable-k8s-resource-monitoring" .) "true" }}
 - apiGroups:  # to get the kube-system namespace UID and generate a cluster ID
   - ""
   resources:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -289,10 +289,10 @@ datadog:
     collectDNSStats: false
 
   orchestratorExplorer:
-    # datadog.orchestratorExplorer.enabled -- Set this to true to enable the orchestrator explorer
+    # datadog.orchestratorExplorer.enabled -- Set this to false to disable the orchestrator explorer
     ## This requires processAgent.enabled and clusterAgent.enabled to be set to true
     ## ref: TODO - add doc link
-    enabled: false
+    enabled: true
 
     # datadog.orchestratorExplorer.container_scrubbing -- Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information
     ## The container scrubbing is taking significant resources during data collection.

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -354,7 +354,7 @@ datadog:
 ## the external metrics API so you can autoscale HPAs based on datadog metrics
 ## ref: https://docs.datadoghq.com/agent/kubernetes/cluster/
 clusterAgent:
-  # clusterAgent.enabled -- Set this to true to enable Datadog Cluster Agent
+  # clusterAgent.enabled -- Set this to false to disable Datadog Cluster Agent
   enabled: true
 
   ## Define the Datadog Cluster-Agent image to work with


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR enables the orchestrator explorer by default.
#### Special notes:

The important point of that PR is that it shouldn't introduce major incompatibilities for users, upgrading the helm chart shouldn't make the agent fail. As many variables comes into play, let's list the various scenarios.

Pre-requisites:
- Up to agent 7.24.x, the pod check on the process-agent requires that the `DD_ORCHESTRATOR_CLUSTER_ID` env variable is set. This is taken care of by our helm chart here: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/templates/_container-process-agent.yaml#L38-L44
- With the next agent release (7.25.x), the pod check is now able to query the cluster agent to get the cluster_id. As long as the cluster agent is recent enough (future release 1.11), agent 7.25.x is able to live without the `DD_ORCHESTRATOR_CLUSTER_ID` env var.
- In the short-term, the helm chart will stop populating this environment variable: https://github.com/DataDog/helm-charts/pull/124 so the current PR should be able to work with this future change.

Decision tree:
![Enable orchestration](https://user-images.githubusercontent.com/22912273/104334748-0b66ba80-54f3-11eb-923f-65b0a1e86afa.jpg)


In this diagram:

- `Config #1`: is when the user is explicitly defining both `clusterAgent.enabled` and `orchestratorExplorer.enabled`. In that case nothing happens with this PR and the values used are the ones provided by the user. Note that this can lead to enabling the orchestrator without the clusterAgent but that was already the case before.
- `Config #2`: is when the user explicitly sets `clusterAgent.enabled` to false and `orchestratorExplorer.enabled` is enabled (either via explicit configuration or via the new default). This is a new scenario where the orchestrator is enabled but can't work because `clusterAgent` is disabled. In that specific scenario, the helm chart disables the orchestrator explorer and logs a warning. Otherwise, the process-agent container would fail to start
- `Config #3`: is any other config basically.
- The red box `pod check is failing` means that on the process-agent container, the pod check will fail to get the cluster id and won't be able to run. In the end the orchestrator explorer page won't work at all for pods but the process-agent will continue to run.

#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
