### PR TITLE
Support for Multiple Static OpenMetrics Checks

### DIFF
--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -135,6 +135,10 @@
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+    {{- if .Values.datadog.openmetricsd }}
+    - name: {{ template "datadog.fullname" . }}-openmetricsd
+      mountPath: /etc/datadog-agent/conf.d/openmetrics.d/
+    {{- end }}
     {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
     - name: pointerdir
       mountPath: /opt/datadog-agent/run

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -41,6 +41,9 @@ spec:
         checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}
         checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
         checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
+        {{- if .Values.datadog.openmetricsd }}
+        checksum/openmetricsd-config: {{ tpl (toYaml .Values.datadog.openmetricsd) . | sha256sum }}
+        {{- end }}
         {{- if .Values.agents.customAgentConfig }}
         checksum/agent-config: {{ tpl (toYaml .Values.agents.customAgentConfig) . | sha256sum }}
         {{- end }}
@@ -145,6 +148,11 @@ spec:
       {{- end }}
       {{- if eq .Values.targetSystem "linux" }}
         {{ include "daemonset-volumes-linux" . | nindent 6 }}
+      {{- end }}
+      {{- if .Values.datadog.openmetricsd }}
+      - name: {{ template "datadog.fullname" . }}-openmetricsd
+        configMap:
+          name: {{ template "datadog.fullname" . }}-openmetricsd
       {{- end }}
 {{- if .Values.agents.volumes }}
 {{ toYaml .Values.agents.volumes | indent 6 }}

--- a/charts/datadog/templates/openmetricsd-configmap.yaml
+++ b/charts/datadog/templates/openmetricsd-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.datadog.openmetricsd }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "datadog.fullname" . }}-openmetricsd
+  labels:
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+  annotations:
+    checksum/openmetricsd-config: {{ tpl (toYaml .Values.datadog.openmetricsd) . | sha256sum }}
+data:
+  {{- tpl (toYaml .Values.datadog.openmetricsd) . | nindent 2 }}
+{{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -238,6 +238,11 @@ datadog:
   # datadog.criSocketPath -- Path to the container runtime socket (if different from Docker)
   criSocketPath:  # /var/run/containerd/containerd.sock
 
+  # datadog.openmetrics -- Provide multiple additional OpenMetrics checks
+  # Each key becomes a file in /conf.d/openmetrics.d
+  openmetricsd: {}
+  #   custom-openmetrics-check: |-
+
   ## Enable process agent and provide custom configs
   processAgent:
     # datadog.processAgent.enabled -- Set this to true to enable live process monitoring agent


### PR DESCRIPTION
#### What this PR does / why we need it:

When defining OpenMetrics checks on an agent in conf.d/openmetrics.d, you can specify an `ad_identifier` for autodiscovery of the containers/namespace/hosts the check applies to. Or you might even have a hardcoded IP for a remote host you want your installation to scrape.

We ran into an issue once we wanted to define multiple openmetrics checks with different `ad_identifiers`. The openmetrics check format doesn't really expect multiple checks in one file so putting them into a single `openmetrics.d` file did not work.

However, we were able to get it work by mounting multiple config files to conf.d/openmetrics.d as a folder instead. The issue we are encountering now is our daemonset doesn't get re-deployed whenever these checks are updated, so we thought we'd contribute upstream to see if:

1. does our approach to multiple openmetrics checks make sense?
2. If so, is it a feature the upstream chart might want? If not, are there any other ways to add a checksum annotation to the pods for a configmap we provide?

#### Which issue this PR fixes

I couldn't find an issues related to triggering a rollout/re-deploy for extra configmaps that are mounted.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
