### PR TITLE
[datadog-agent] add datadog.kubelet params

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.7.1
 
-* Add a new field `datadog.kubelet.kubelet_host` to override `DD_KUBERNETES_KUBELET_HOST`
+* Add a new fields `datadog.kubelet.host` (to override `DD_KUBERNETES_KUBELET_HOST`) and `datadog.kubelet.tlsVerify` (to toggle kubelet TLS verification)
 
 ## 2.7.0
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.7.1
+
+* Add a new field `datadog.kubelet.kubelet_host` to override `DD_KUBERNETES_KUBELET_HOST`
+
 ## 2.7.0
 
 * Changes default values to activate a maximum of built-in features to ease configuration.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.7.1
+version: 2.7.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.7.0
+version: 2.7.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.7.1](https://img.shields.io/badge/Version-2.7.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -475,6 +475,8 @@ helm install --name <RELEASE_NAME> \
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.kubeStateMetricsEnabled | bool | `true` | If true, deploys the kube-state-metrics deployment |
 | datadog.kubeStateMetricsNetworkPolicy.create | bool | `false` | If true, create a NetworkPolicy for kube state metrics |
+| datadog.kubelet.host | object | `{"valueFrom":{"fieldRef":{"fieldPath":"status.hostIP"}}}` | Override kubelet IP |
+| datadog.kubelet.tlsVerify | bool | `true` | Toggle kubelet TLS verification |
 | datadog.leaderElection | bool | `true` | Enables leader election mechanism for event collection |
 | datadog.leaderLeaseDuration | string | `nil` | Set the lease time for leader election in second |
 | datadog.logLevel | string | `"INFO"` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, off |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.7.1](https://img.shields.io/badge/Version-2.7.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.7.2](https://img.shields.io/badge/Version-2.7.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/ci/kubeval.yaml
+++ b/charts/datadog/ci/kubeval.yaml
@@ -1,6 +1,8 @@
 datadog:
   apiKey: "00000000000000000000000000000000"
   appKey: "0000000000000000000000000000000000000000"
+  kubelet:
+    kubelet_host: spec.nodeName
   env:
   - name: "DD_KUBELET_TLS_VERIFY"
     value: "false"

--- a/charts/datadog/ci/kubeval.yaml
+++ b/charts/datadog/ci/kubeval.yaml
@@ -2,7 +2,10 @@ datadog:
   apiKey: "00000000000000000000000000000000"
   appKey: "0000000000000000000000000000000000000000"
   kubelet:
-    kubelet_host: spec.nodeName
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
   env:
   - name: "DD_KUBELET_TLS_VERIFY"
     value: "false"

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -6,7 +6,12 @@
     secretKeyRef:
       name: {{ template "datadog.apiSecretName" . }}
       key: api-key
-{{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if .Values.datadog.kubelet.kubelet_host }}
+- name: DD_KUBERNETES_KUBELET_HOST
+  valueFrom:
+    fieldRef:
+      fieldPath: {{ .Values.datadog.kubelet.kubelet_host }}
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
 - name: DD_KUBERNETES_KUBELET_HOST
   valueFrom:
     fieldRef:

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -6,16 +6,13 @@
     secretKeyRef:
       name: {{ template "datadog.apiSecretName" . }}
       key: api-key
-{{- if .Values.datadog.kubelet.kubelet_host }}
+{{- if .Values.datadog.kubelet.host }}
 - name: DD_KUBERNETES_KUBELET_HOST
-  valueFrom:
-    fieldRef:
-      fieldPath: {{ .Values.datadog.kubelet.kubelet_host }}
-{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
-- name: DD_KUBERNETES_KUBELET_HOST
-  valueFrom:
-    fieldRef:
-      fieldPath: status.hostIP
+{{ toYaml .Values.datadog.kubelet.host | indent 2 }}
+{{- end }}
+{{- if .Values.datadog.kubelet.tlsVerify }}
+- name: DD_KUBELET_TLS_VERIFY
+  value: {{ .Values.datadog.kubelet.tlsVerify | quote }}
 {{- end }}
 {{- if .Values.datadog.clusterName }}
 {{- template "check-cluster-name" . }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -107,6 +107,11 @@ datadog:
   #   - "<KEY_1>:<VALUE_1>"
   #   - "<KEY_2>:<VALUE_2>"
 
+  # kubelet configuration
+  kubelet:
+    # datadog.kubelet.kubelet_host -- Override kubelet IP
+    kubelet_host:  # spec.nodeName
+
   ## dogstatsd configuration
   ## ref: https://docs.datadoghq.com/agent/kubernetes/dogstatsd/
   ## To emit custom metrics from your Kubernetes application, use DogStatsD.

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -109,8 +109,13 @@ datadog:
 
   # kubelet configuration
   kubelet:
-    # datadog.kubelet.kubelet_host -- Override kubelet IP
-    kubelet_host:  # spec.nodeName
+    # datadog.kubelet.host -- Override kubelet IP
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    # datadog.kubelet.tlsVerify -- Toggle kubelet TLS verification
+    tlsVerify: true
 
   ## dogstatsd configuration
   ## ref: https://docs.datadoghq.com/agent/kubernetes/dogstatsd/

--- a/examples/datadog/agent_basic_values.yaml
+++ b/examples/datadog/agent_basic_values.yaml
@@ -28,9 +28,3 @@ datadog:
     enableTCPQueueLength: false
     enableOOMKill: true
     collectDNSStats: false
-agents:
-  enabled: true
-  image:
-    repository: gcr.io/datadoghq/agent
-    tag: 7.24.1
-    pullPolicy: IfNotPresent

--- a/examples/datadog/agent_basic_values.yaml
+++ b/examples/datadog/agent_basic_values.yaml
@@ -9,11 +9,10 @@ datadog:
   appKeyExistingSecret: <DATADOG_APP_KEY_SECRET>
   clusterName: <CLUSTER_NAME>
   tags: []
-  env:
-    # DD_KUBELET_TLS_VERIFY should be false on kind and minikube
-    # to establish communication with the kubelet
-    # - name: "DD_KUBELET_TLS_VERIFY"
-    #   value: "false"
+  # datadog.kubelet.tlsVerify should be `false` on kind and minikube
+  # to establish communication with the kubelet
+  # kubelet:
+    # tlsVerify: "false"
   logs:
     enabled: true
     containerCollectAll: false

--- a/examples/datadog/agent_on_aks_values.yaml
+++ b/examples/datadog/agent_on_aks_values.yaml
@@ -1,4 +1,6 @@
 # Datadog Agent with Logs, APM, Processes, and System Probe enabled
+# with specific configuration to work on AKS.
+
 
 targetSystem: "linux"
 datadog:
@@ -9,11 +11,8 @@ datadog:
   appKeyExistingSecret: <DATADOG_APP_KEY_SECRET>
   clusterName: <CLUSTER_NAME>
   tags: []
-  env:
-    # DD_KUBELET_TLS_VERIFY should be false on kind and minikube
-    # to establish communication with the kubelet
-    # - name: "DD_KUBELET_TLS_VERIFY"
-    #   value: "false"
+  kubelet:
+    kubelet_host: spec.nodeName
   logs:
     enabled: true
     containerCollectAll: false

--- a/examples/datadog/agent_on_aks_values.yaml
+++ b/examples/datadog/agent_on_aks_values.yaml
@@ -16,6 +16,7 @@ datadog:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    tlsVerify: "false"
   logs:
     enabled: true
     containerCollectAll: false

--- a/examples/datadog/agent_on_aks_values.yaml
+++ b/examples/datadog/agent_on_aks_values.yaml
@@ -31,9 +31,3 @@ datadog:
     enableTCPQueueLength: false
     enableOOMKill: true
     collectDNSStats: false
-agents:
-  enabled: true
-  image:
-    repository: gcr.io/datadoghq/agent
-    tag: 7.24.1
-    pullPolicy: IfNotPresent

--- a/examples/datadog/agent_on_aks_values.yaml
+++ b/examples/datadog/agent_on_aks_values.yaml
@@ -12,7 +12,10 @@ datadog:
   clusterName: <CLUSTER_NAME>
   tags: []
   kubelet:
-    kubelet_host: spec.nodeName
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
   logs:
     enabled: true
     containerCollectAll: false

--- a/examples/datadog/agent_on_openshift_values.yaml
+++ b/examples/datadog/agent_on_openshift_values.yaml
@@ -39,9 +39,3 @@ datadog:
     enableTCPQueueLength: false
     enableOOMKill: true
     collectDNSStats: false
-agents:
-  enabled: true
-  image:
-    repository: gcr.io/datadoghq/agent
-    tag: 7.24.1
-    pullPolicy: IfNotPresent

--- a/examples/datadog/agent_on_openshift_values.yaml
+++ b/examples/datadog/agent_on_openshift_values.yaml
@@ -16,10 +16,9 @@ datadog:
   clusterName: <CLUSTER_NAME>
   tags: []
   criSocketPath: /var/run/crio/crio.sock
-  env:
-    # DD_KUBELET_TLS_VERIFY should be false to establish communication with the kubelet
-    - name: "DD_KUBELET_TLS_VERIFY"
-      value: "false"
+  # datadog.kubelet.tlsVerify should be `false` to establish communication with the kubelet
+  kubelet:
+    tlsVerify: "false"
   confd:
     cri.yaml: |-
       init_config:

--- a/examples/datadog/agent_on_rancher_values.yaml
+++ b/examples/datadog/agent_on_rancher_values.yaml
@@ -29,11 +29,6 @@ datadog:
     enableOOMKill: true
     collectDNSStats: false
 agents:
-  enabled: true
-  image:
-    repository: gcr.io/datadoghq/agent
-    tag: 7.24.1
-    pullPolicy: IfNotPresent
   tolerations:
     # These tolerations are needed to run the agent on master nodes
     - effect: NoSchedule

--- a/examples/datadog/agent_on_rancher_values.yaml
+++ b/examples/datadog/agent_on_rancher_values.yaml
@@ -10,10 +10,9 @@ datadog:
   appKeyExistingSecret: <DATADOG_APP_KEY_SECRET>
   clusterName: <CLUSTER_NAME>
   tags: []
-  env:
-    # DD_KUBELET_TLS_VERIFY should be false to establish communication with the kubelet
-    - name: "DD_KUBELET_TLS_VERIFY"
-      value: "false"
+  # datadog.kubelet.tlsVerify should be `false` to establish communication with the kubelet
+  kubelet:
+    tlsVerify: "false"
   logs:
     enabled: true
     containerCollectAll: false

--- a/examples/datadog/agent_with_cluster_agent_values.yaml
+++ b/examples/datadog/agent_with_cluster_agent_values.yaml
@@ -14,11 +14,6 @@ datadog:
   orchestratorExplorer:
     enabled: true
 clusterAgent:
-  enabled: true
-  image:
-    repository: gcr.io/datadoghq/cluster-agent
-    tag: 1.9.1
-    pullPolicy: IfNotPresent
   replicas: 2
   rbac:
     create: true
@@ -31,10 +26,6 @@ clusterAgent:
       type: ClusterIP
       port: 8443
 agents:
-  enabled: true
-  image:
-    repository: gcr.io/datadoghq/agent
-    tag: 7.24.1
   rbac:
     create: true
     serviceAccountName: default

--- a/examples/datadog/agent_with_containerd_values.yaml
+++ b/examples/datadog/agent_with_containerd_values.yaml
@@ -10,9 +10,3 @@ datadog:
   clusterName: <CLUSTER_NAME>
   tags: []
   criSocketPath: /var/run/containerd/containerd.sock
-agents:
-  enabled: true
-  image:
-    repository: gcr.io/datadoghq/agent
-    tag: 7.24.1
-    pullPolicy: IfNotPresent


### PR DESCRIPTION
#### What this PR does / why we need it:

Add a new field `datadog.kubelet.host` to override `DD_KUBERNETES_KUBELET_HOST` when set
Add a new field `datadog.kubelet.tlsVerify` to toggle `DD_KUBELET_TLS_VERIFY`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [X] Variables are documented in the `README.md`
