### PR TITLE
Add `ports` options to all Agent containers

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.6.15
+
+* Add `ports` options to all Agent containers to allow users to add any binding they'd like for integrations
+
 ## 2.6.14
 
 * Opens port 6443/TCP on kube-state-metrics netpol.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.6.14
+version: 2.6.15
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.6.14](https://img.shields.io/badge/Version-2.6.14-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.15](https://img.shields.io/badge/Version-2.6.15-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -315,24 +315,29 @@ helm install --name <RELEASE_NAME> \
 | agents.containers.agent.healthPort | int | `5555` | Port number to use in the node agent for the healthz endpoint |
 | agents.containers.agent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | agents.containers.agent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
+| agents.containers.agent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.agent.readinessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent readiness probe settings |
 | agents.containers.agent.resources | object | `{}` | Resource requests and limits for the agent container. |
 | agents.containers.agent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the agent container. |
 | agents.containers.initContainers.resources | object | `{}` | Resource requests and limits for the init containers |
 | agents.containers.processAgent.env | list | `[]` | Additional environment variables for the process-agent container |
 | agents.containers.processAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
+| agents.containers.processAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.processAgent.resources | object | `{}` | Resource requests and limits for the process-agent container |
 | agents.containers.processAgent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the process-agent container. |
 | agents.containers.securityAgent.env | string | `nil` | Additional environment variables for the security-agent container |
 | agents.containers.securityAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
+| agents.containers.securityAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.securityAgent.resources | object | `{}` | Resource requests and limits for the security-agent container |
 | agents.containers.systemProbe.env | list | `[]` | Additional environment variables for the system-probe container |
 | agents.containers.systemProbe.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off. |
+| agents.containers.systemProbe.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.systemProbe.resources | object | `{}` | Resource requests and limits for the system-probe container |
 | agents.containers.systemProbe.securityContext | object | `{"capabilities":{"add":["SYS_ADMIN","SYS_RESOURCE","SYS_PTRACE","NET_ADMIN","NET_BROADCAST","IPC_LOCK"]},"privileged":false}` | Allows you to overwrite the default container SecurityContext for the system-probe container. |
 | agents.containers.traceAgent.env | string | `nil` | Additional environment variables for the trace-agent container |
 | agents.containers.traceAgent.livenessProbe | object | Every 15s | Override default agent liveness probe settings |
 | agents.containers.traceAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
+| agents.containers.traceAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.traceAgent.resources | object | `{}` | Resource requests and limits for the trace-agent container |
 | agents.containers.traceAgent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the trace-agent container. |
 | agents.customAgentConfig | object | `{}` | Specify custom contents for the datadog agent config (datadog.yaml) |
@@ -421,6 +426,7 @@ helm install --name <RELEASE_NAME> \
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterChecksRunner.nodeSelector | object | `{}` | Allow the ClusterChecks Deployment to schedule on selected nodes |
 | clusterChecksRunner.podAnnotations | object | `{}` | Annotations to add to the cluster-checks-runner's pod(s) |
+| clusterChecksRunner.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | clusterChecksRunner.rbac.create | bool | `true` | If true, create & use RBAC resources |
 | clusterChecksRunner.rbac.dedicated | bool | `false` | If true, use a dedicated RBAC resource for the cluster checks agent(s) |
 | clusterChecksRunner.rbac.serviceAccountAnnotations | object | `{}` | Annotations to add to the ServiceAccount if clusterChecksRunner.rbac.dedicated is true |

--- a/charts/datadog/ci/kubeval.yaml
+++ b/charts/datadog/ci/kubeval.yaml
@@ -50,3 +50,9 @@ agents:
   podSecurity:
     podSecurityPolicy:
       create: true
+  containers:
+    agent:
+      ports:
+      - containerPort: 6666
+        name: testport
+        protocol: UDP

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -16,6 +16,9 @@
     {{- end }}
     name: dogstatsdport
     protocol: UDP
+{{- if .Values.agents.containers.agent.ports }}
+{{ toYaml .Values.agents.containers.agent.ports | indent 2 }}
+{{- end }}
 {{- if .Values.datadog.envFrom }}
   envFrom:
 {{ toYaml .Values.datadog.envFrom | indent 4 }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -12,6 +12,10 @@
   securityContext:
     {{ toYaml .Values.agents.containers.processAgent.securityContext | nindent 4 }}
   {{- end }}
+{{- if .Values.agents.containers.processAgent.ports }}
+  ports:
+{{ toYaml .Values.agents.containers.processAgent.ports | indent 2 }}
+{{- end }}
   resources:
 {{ toYaml .Values.agents.containers.processAgent.resources | indent 4 }}
 {{- if .Values.datadog.envFrom }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -8,6 +8,10 @@
   command: ["security-agent", "start", "-c={{ template "datadog.confPath" . }}/datadog.yaml"]
   resources:
 {{ toYaml .Values.agents.containers.securityAgent.resources | indent 4 }}
+{{- if .Values.agents.containers.securityAgent.ports }}
+  ports:
+{{ toYaml .Values.agents.containers.securityAgent.ports | indent 2 }}
+{{- end }}
 {{- if .Values.datadog.envFrom }}
   envFrom:
 {{ toYaml .Values.datadog.envFrom | indent 4 }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -5,6 +5,10 @@
   securityContext:
 {{ toYaml .Values.agents.containers.systemProbe.securityContext | indent 4 }}
   command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+{{- if .Values.agents.containers.systemProbe.ports }}
+  ports:
+{{ toYaml .Values.agents.containers.systemProbe.ports | indent 2 }}
+{{- end }}
 {{- if .Values.datadog.envFrom }}
   envFrom:
 {{ toYaml .Values.datadog.envFrom | indent 4 }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -19,6 +19,9 @@
     hostPort: {{ .Values.datadog.apm.port }}
     name: traceport
     protocol: TCP
+{{- if .Values.agents.containers.traceAgent.ports }}
+{{ toYaml .Values.agents.containers.traceAgent.ports | indent 2 }}
+{{- end }}
 {{- if .Values.datadog.envFrom }}
   envFrom:
 {{ toYaml .Values.datadog.envFrom | indent 4 }}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -90,6 +90,10 @@ spec:
         args:
           - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run
         imagePullPolicy: {{ .Values.clusterChecksRunner.image.pullPolicy }}
+{{- if .Values.clusterChecksRunner.ports }}
+        ports:
+{{ toYaml .Values.clusterChecksRunner.ports | indent 10 }}
+{{- end }}
 {{- if .Values.datadog.envFrom }}
         envFrom:
 {{ toYaml .Values.datadog.envFrom | indent 10 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -689,6 +689,9 @@ agents:
       # agents.containers.agent.securityContext -- Allows you to overwrite the default container SecurityContext for the agent container.
       securityContext: {}
 
+      # agents.containers.agent.ports -- Allows to specify extra ports (hostPorts for instance) for this container
+      ports: []
+
     processAgent:
       # agents.containers.processAgent.env -- Additional environment variables for the process-agent container
       env: []
@@ -708,6 +711,9 @@ agents:
 
       # agents.containers.processAgent.securityContext -- Allows you to overwrite the default container SecurityContext for the process-agent container.
       securityContext: {}
+
+      # agents.containers.processAgent.ports -- Allows to specify extra ports (hostPorts for instance) for this container
+      ports: []
 
     traceAgent:
       # agents.containers.traceAgent.env -- Additional environment variables for the trace-agent container
@@ -735,6 +741,9 @@ agents:
       # agents.containers.traceAgent.securityContext -- Allows you to overwrite the default container SecurityContext for the trace-agent container.
       securityContext: {}
 
+      # agents.containers.traceAgent.ports -- Allows to specify extra ports (hostPorts for instance) for this container
+      ports: []
+
     systemProbe:
       # agents.containers.systemProbe.env -- Additional environment variables for the system-probe container
       env: []
@@ -757,6 +766,10 @@ agents:
         privileged: false
         capabilities:
           add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"]
+
+      # agents.containers.systemProbe.ports -- Allows to specify extra ports (hostPorts for instance) for this container
+      ports: []
+
     securityAgent:
       # agents.containers.securityAgent.env -- Additional environment variables for the security-agent container
       env:
@@ -773,6 +786,9 @@ agents:
       #  limits:
       #    cpu: 100m
       #    memory: 200Mi
+
+      # agents.containers.securityAgent.ports -- Allows to specify extra ports (hostPorts for instance) for this container
+      ports: []
 
     initContainers:
       # agents.containers.initContainers.resources -- Resource requests and limits for the init containers
@@ -1034,6 +1050,9 @@ clusterChecksRunner:
 
   # clusterChecksRunner.securityContext -- Allows you to overwrite the default PodSecurityContext on the clusterchecks pods.
   securityContext: {}
+
+  # clusterChecksRunner.ports -- Allows to specify extra ports (hostPorts for instance) for this container
+  ports: []
 
 datadog-crds:
   crds:


### PR DESCRIPTION
#### What this PR does / why we need it:
Add `ports` options to all Agent containers

#### Which issue this PR fixes
https://github.com/DataDog/helm-charts/issues/123

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
