### PR TITLE
Address Cluster Agent deployment issues on secure clusters

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Datadog changelog
 
-## 2.6.14
-
-* Adds PodSecurityPolicy support for Cluster Agents.
-
 ## 2.6.13
 
 * Opens ports 6443/TCP and 53/UDP for egress on cluster agent.
+* Adds PodSecurityPolicy support for Cluster Agents.
 
 ## 2.6.12
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.6.14
+
+* Adds PodSecurityPolicy support for Cluster Agents.
+
 ## 2.6.13
 
 * Opens ports 6443/TCP and 53/UDP for egress on cluster agent.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.6.13
+
+* Opens ports 6443/TCP and 53/UDP for egress on cluster agent.
+
 ## 2.6.12
 
 * Mount `/etc/passwd` as `readOnly` in the `process-agent`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.6.12
+version: 2.6.13
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.6.14
+version: 2.6.13
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.6.13
+version: 2.6.14
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.6.14](https://img.shields.io/badge/Version-2.6.14-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.13](https://img.shields.io/badge/Version-2.6.13-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.6.12](https://img.shields.io/badge/Version-2.6.12-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.13](https://img.shields.io/badge/Version-2.6.13-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.6.13](https://img.shields.io/badge/Version-2.6.13-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.6.14](https://img.shields.io/badge/Version-2.6.14-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -392,6 +392,7 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster agent. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterAgent.nodeSelector | object | `{}` | Allow the Cluster Agent Deployment to be scheduled on selected nodes |
 | clusterAgent.podAnnotations | object | `{}` | Annotations to add to the cluster-agents's pod(s) |
+| clusterAgent.podSecurity.podSecurityPolicy.create | bool | `false` | If true, create a PodSecurityPolicy resource for Cluster Agent pods |
 | clusterAgent.priorityClassName | string | `nil` | Name of the priorityClass to apply to the Cluster Agent |
 | clusterAgent.rbac.create | bool | `true` | If true, create & use RBAC resources |
 | clusterAgent.rbac.serviceAccountName | string | `"default"` | Specify service account name to use (usually pre-existing, created if create is true) |

--- a/charts/datadog/templates/cluster-agent-network-policy.yaml
+++ b/charts/datadog/templates/cluster-agent-network-policy.yaml
@@ -42,6 +42,10 @@ spec:
     - # Egress to
       # * Datadog intake
       # * Kube API server
+      # * DNS
       ports:
         - port: 443
+        - port: 6443
+        - port: 53
+          protocol: UDP
 {{- end}}

--- a/charts/datadog/templates/cluster-agent-psp.yaml
+++ b/charts/datadog/templates/cluster-agent-psp.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.clusterAgent.podSecurity.podSecurityPolicy.create }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "datadog.fullname" . }}-cluster-agent
+  labels:
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+spec:
+  volumes:
+    - configMap
+    - hostPath
+    - secret
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+{{- end }}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -182,6 +182,14 @@ rules:
   verbs:
   - list
 {{- end }}
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - {{ template "datadog.fullname" . }}-cluster-agent
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -387,6 +387,12 @@ clusterAgent:
     # clusterAgent.rbac.create -- If true, create & use RBAC resources
     create: true
 
+  ## Provide Cluster Agent PodSecurityPolicy configuration
+  podSecurity:
+    podSecurityPolicy:
+      # clusterAgent.podSecurity.podSecurityPolicy.create -- If true, create a PodSecurityPolicy resource for Cluster Agent pods
+      create: false
+
     # clusterAgent.rbac.serviceAccountName -- Specify service account name to use (usually pre-existing, created if create is true)
     serviceAccountName: default
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -387,14 +387,14 @@ clusterAgent:
     # clusterAgent.rbac.create -- If true, create & use RBAC resources
     create: true
 
+    # clusterAgent.rbac.serviceAccountName -- Specify service account name to use (usually pre-existing, created if create is true)
+    serviceAccountName: default
+
   ## Provide Cluster Agent PodSecurityPolicy configuration
   podSecurity:
     podSecurityPolicy:
       # clusterAgent.podSecurity.podSecurityPolicy.create -- If true, create a PodSecurityPolicy resource for Cluster Agent pods
       create: false
-
-    # clusterAgent.rbac.serviceAccountName -- Specify service account name to use (usually pre-existing, created if create is true)
-    serviceAccountName: default
 
   # Enable the metricsProvider to be able to scale based on metrics in Datadog
   metricsProvider:


### PR DESCRIPTION
- 53/UDP - Cluster Agent clusters were not able to resolve hostnames 
- 6443/TCP - When Orchestrator is enabled, Cluster Agent would fail to start with message "Error: unable to read authentication token file: open /etc/datadog-agent/auth_token: no such file or directory"
- The chart does not create PSPs for Cluster Agents.

#### What this PR does / why we need it:
Deploying a Cluster Agent with Network Policies fails.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ x] Chart Version bumped
- [ x] `CHANGELOG.md` has beed updated
- [ x] Variables are documented in the `README.md`
