### PR TITLE
Update the `update-crds.sh` script for `yq` 4

### DIFF
--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -14,26 +14,28 @@ download_crd() {
     outFile=datadoghq.com_$2_$version.yaml
     path=$ROOT/charts/datadog-crds/templates/$outFile
     echo "Download CRD \"$inFile\" version \"$version\" from tag \"$1\""
-    curl --silent --show-error --fail --location --output $path https://raw.githubusercontent.com/DataDog/datadog-operator/$1/config/crd/bases/$version/$inFile
+    curl --silent --show-error --fail --location --output "$path" "https://raw.githubusercontent.com/DataDog/datadog-operator/$1/config/crd/bases/$version/$inFile"
 
     ifCondition="{{- if and .Values.crds.$3 (not (.Capabilities.APIVersions.Has \"apiextensions.k8s.io/v1/CustomResourceDefinition\")) }}"
     if [ "$version" = "v1" ]; then
         ifCondition="{{- if and .Values.crds.$3 (.Capabilities.APIVersions.Has \"apiextensions.k8s.io/v1/CustomResourceDefinition\") }}"
-        cp $path $ROOT/crds/datadoghq.com_$2.yaml
+        cp "$path" "$ROOT/crds/datadoghq.com_$2.yaml"
     fi
-    
-    yq w -i $path 'metadata.labels."helm.sh/chart"' '{{ include "datadog-crds.chart" . }}'
-    yq w -i $path 'metadata.labels."app.kubernetes.io/managed-by"' '{{ .Release.Service }}'
-    yq w -i $path 'metadata.labels."app.kubernetes.io/name"' '{{ include "datadog-crds.name" . }}'
-    yq w -i $path 'metadata.labels."app.kubernetes.io/instance"' '{{ .Release.Name }}'
-    
-    { echo "$ifCondition"; cat $path; } > tmp.file
-    mv tmp.file $path
-    echo '{{- end }}' >> $path
+
+    VALUE="'{{ include \"datadog-crds.chart\" . }}'" \
+    yq eval '.metadata.labels."helm.sh/chart" = env(VALUE)'                              -i "$path"
+    yq eval '.metadata.labels."app.kubernetes.io/managed-by" = "{{ .Release.Service }}"' -i "$path"
+    VALUE="'{{ include \"datadog-crds.name\" . }}'" \
+    yq eval '.metadata.labels."app.kubernetes.io/name" = env(VALUE)'                     -i "$path"
+    yq eval '.metadata.labels."app.kubernetes.io/instance" = "{{ .Release.Name }}"'      -i "$path"
+
+    { echo "$ifCondition"; cat "$path"; } > tmp.file
+    mv tmp.file "$path"
+    echo '{{- end }}' >> "$path"
 }
 
-mkdir -p $ROOT/crds
-download_crd $TAG datadogmetrics datadogMetrics v1beta1
-download_crd $TAG datadogmetrics datadogMetrics v1
-download_crd $TAG datadogagents datadogAgents v1beta1
-download_crd $TAG datadogagents datadogAgents v1
+mkdir -p "$ROOT/crds"
+download_crd "$TAG" datadogmetrics datadogMetrics v1beta1
+download_crd "$TAG" datadogmetrics datadogMetrics v1
+download_crd "$TAG" datadogagents datadogAgents v1beta1
+download_crd "$TAG" datadogagents datadogAgents v1


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the `update-crds.sh` script.

* `brew` now installs `yq` 4 which isn’t compatible with `yq` 3;
* Fix `shellcheck` warnings.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
