### PR TITLE
Remove chart label from datadog chart

### DIFF
--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -215,7 +215,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "{{ template "datadog.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -233,7 +232,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: "{{ template "datadog.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"


### PR DESCRIPTION
#### What this PR does / why we need it:
We deploy datadog chart by pull request review and GitOps flow. When we update the chart version, there are many diff lines in a pull request. We patch `helm.sh/chart` label to reduce the diff, like:

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - vendor/generated-datadog.yaml
commonLabels:
  helm.sh/chart: datadog
```

In datadog chart, most of resources use `helm.sh/chart` label but still some resources use `chart` label. This PR will remove `chart` label.

#### Which issue this PR fixes
No.

#### Special notes for your reviewer:
Please make sure `datadog-cluster-agent` does not depend on `chart` label.

#### Checklist
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
