### PR TITLE
Fix `networkMonitoring.enabled` behavior when set to `false`

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Datadog changelog
 
-## 2.8.6
+## 2.9.0
 
+* Remove `systemProbe.enabled` config param in favor of `networkMonitoring.enabled`, `securityAgent.runtime.enabled`, `systemProbe.enableOOMKill`, and `systemProbe.enableTCPQueueLength`.
 * Fix bug preventing network monitoring to be disabled by setting `datadog.networkMonitoring.enabled` to `false`.
 
 ## 2.8.5

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.8.5
+
+* Fix bug preventing network monitoring to be disabled by setting `datadog.networkMonitoring.enabled` to `false`.
+
 ## 2.8.4
 
 * Grant access to the `Lease` objects.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.8.4
+version: 2.8.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.8.6
+version: 2.9.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.8.6](https://img.shields.io/badge/Version-2.8.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -483,7 +483,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
-| datadog.networkMonitoring.enabled | bool | `nil` | Enable network performance monitoring |
+| datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
 | datadog.networkPolicy.cilium.dnsSelector | object | kube-dns in namespace kube-system | Cilium selector of the DNS server entity |
 | datadog.networkPolicy.create | bool | `false` | If true, create NetworkPolicy for all the components |
 | datadog.networkPolicy.flavor | string | `"kubernetes"` | Flavor of the network policy to use. Can be: * kubernetes for networking.k8s.io/v1/NetworkPolicy * cilium     for cilium.io/v2/CiliumNetworkPolicy |
@@ -532,7 +532,6 @@ Some options above are not working/not available on Windows, here is the list of
 | `datadog.dogstatsd.useSocketVolume`      | Unix sockets not supported on Windows            |
 | `datadog.dogstatsd.socketPath`           | Unix sockets not supported on Windows            |
 | `datadog.processAgent.processCollection` | Unable to access host/other containers processes |
-| `datadog.systemProbe.enabled`            | System probe is not available for Windows        |
 | `datadog.systemProbe.seccomp`            | System probe is not available for Windows        |
 | `datadog.systemProbe.seccompRoot`        | System probe is not available for Windows        |
 | `datadog.systemProbe.debugPort`          | System probe is not available for Windows        |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.8.4](https://img.shields.io/badge/Version-2.8.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.8.5](https://img.shields.io/badge/Version-2.8.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -483,7 +483,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
-| datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
+| datadog.networkMonitoring.enabled | bool | `nil` | Enable network performance monitoring |
 | datadog.networkPolicy.cilium.dnsSelector | object | kube-dns in namespace kube-system | Cilium selector of the DNS server entity |
 | datadog.networkPolicy.create | bool | `false` | If true, create NetworkPolicy for all the components |
 | datadog.networkPolicy.flavor | string | `"kubernetes"` | Flavor of the network policy to use. Can be: * kubernetes for networking.k8s.io/v1/NetworkPolicy * cilium     for cilium.io/v2/CiliumNetworkPolicy |

--- a/charts/datadog/README.md.gotmpl
+++ b/charts/datadog/README.md.gotmpl
@@ -312,7 +312,6 @@ Some options above are not working/not available on Windows, here is the list of
 | `datadog.dogstatsd.useSocketVolume`      | Unix sockets not supported on Windows            |
 | `datadog.dogstatsd.socketPath`           | Unix sockets not supported on Windows            |
 | `datadog.processAgent.processCollection` | Unable to access host/other containers processes |
-| `datadog.systemProbe.enabled`            | System probe is not available for Windows        |
 | `datadog.systemProbe.seccomp`            | System probe is not available for Windows        |
 | `datadog.systemProbe.seccompRoot`        | System probe is not available for Windows        |
 | `datadog.systemProbe.debugPort`          | System probe is not available for Windows        |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -183,7 +183,7 @@ More information about this change: https://github.com/DataDog/helm-charts/pull/
 {{- end }}
 
 {{- if .Values.datadog.systemProbe.enabled }}
-{{- fail "You are using datadog.systemProbe.enabled which has been superseded by networkMonitoring.enabled, systemProbe.enableTCPQueueLength, systemProbe.enableOOMKill, and securityAgent.runtime.enabled" }}
+{{- fail "You are using datadog.systemProbe.enabled which has been superseded by networkMonitoring.enabled, systemProbe.enableTCPQueueLength, systemProbe.enableOOMKill, and securityAgent.runtime.enabled. These options provide a more granular control of which features should be activated." }}
 {{- end }}
 
 {{- if (and .Values.datadog.orchestratorExplorer.enabled (not .Values.clusterAgent.enabled ))}}

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -183,14 +183,7 @@ More information about this change: https://github.com/DataDog/helm-charts/pull/
 {{- end }}
 
 {{- if .Values.datadog.systemProbe.enabled }}
-
-#################################################################
-####               WARNING: Deprecation notice               ####
-#################################################################
-
-You are using datadog.systemProbe.enabled which has been deprecated in favor using one of networkMonitoring.enabled, systemProbe.enableTCPQueueLength, systemProbe.enableOOMKill, or securityAgent.runtime.enabled.
-More information about this change: https://github.com/DataDog/helm-charts/pull/101
-
+{{- fail "You are using datadog.systemProbe.enabled which has been superseded by networkMonitoring.enabled, systemProbe.enableTCPQueueLength, systemProbe.enableOOMKill, and securityAgent.runtime.enabled" }}
 {{- end }}
 
 {{- if (and .Values.datadog.orchestratorExplorer.enabled (not .Values.clusterAgent.enabled ))}}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -32,7 +32,7 @@
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.processAgent.logLevel | default .Values.datadog.logLevel | quote }}
     - name: DD_SYSTEM_PROBE_ENABLED
-      value: {{ (or .Values.datadog.systemProbe.enabled .Values.datadog.networkMonitoring.enabled) | quote }}
+      value: {{ .Values.datadog.networkMonitoring.enabled | quote }}
     {{- if .Values.datadog.networkMonitoring.enabled }}
     - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -52,7 +52,7 @@
   name: src
 {{- end }}
 {{- end }}
-{{- if or .Values.datadog.processAgent.enabled .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.runtime.enabled }}
+{{- if or .Values.datadog.processAgent.enabled .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.runtime.enabled }}
 - hostPath:
     path: /etc/passwd
   name: passwd

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -191,7 +191,7 @@ Accepts a map with `port` (default port) and `settings` (probe settings).
 Return true if the system-probe container should be created.
 */}}
 {{- define "should-enable-system-probe" -}}
-{{- if or .Values.datadog.systemProbe.enabled .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkMonitoring.enabled .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill -}}
+{{- if or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.networkMonitoring.enabled .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill -}}
 true
 {{- else -}}
 false

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -1,3 +1,16 @@
+{{- if .Values.datadog.networkMonitoring.enabled }}
+{{- if not .Values.agents.image.doNotCheckTag -}}
+{{- $version := (.Values.agents.image.tag | toString | trimSuffix "-jmx") }}
+{{- $length := len (split "." $version ) -}}
+{{- if (gt $length 1) }}
+{{- if not (semverCompare "^6.23.0-0 || ^7.23.0-0" $version) -}}
+{{- fail "datadog.networkMonitoring.enabled requires agent >= 7.23.0" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
 {{- if eq (include "should-enable-system-probe" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
@@ -21,10 +34,12 @@ data:
       enable_tcp_queue_length: {{ $.Values.datadog.systemProbe.enableTCPQueueLength }}
       enable_oom_kill: {{ $.Values.datadog.systemProbe.enableOOMKill }}
       collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
-    {{- if $.Values.datadog.networkMonitoring.enabled }}
     network_config:
-      enabled: true
-    {{- end }}
+      {{- if (eq ($.Values.datadog.networkMonitoring.enabled | toString) "<nil>") }}
+      enabled: {{ $.Values.datadog.systemProbe.enabled }}
+      {{- else }}
+      enabled: {{ $.Values.datadog.networkMonitoring.enabled }}
+      {{- end }}
     runtime_security_config:
       enabled: {{ $.Values.datadog.securityAgent.runtime.enabled }}
       debug: false

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -35,11 +35,7 @@ data:
       enable_oom_kill: {{ $.Values.datadog.systemProbe.enableOOMKill }}
       collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
     network_config:
-      {{- if (eq ($.Values.datadog.networkMonitoring.enabled | toString) "<nil>") }}
-      enabled: {{ $.Values.datadog.systemProbe.enabled }}
-      {{- else }}
       enabled: {{ $.Values.datadog.networkMonitoring.enabled }}
-      {{- end }}
     runtime_security_config:
       enabled: {{ $.Values.datadog.securityAgent.runtime.enabled }}
       debug: false

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -314,7 +314,7 @@ datadog:
 
   networkMonitoring:
     # datadog.networkMonitoring.enabled -- Enable network performance monitoring
-    enabled: false
+    enabled: null
 
   ## Enable security agent and provide custom configs
   securityAgent:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -313,7 +313,7 @@ datadog:
       enabled: true
 
   networkMonitoring:
-    # datadog.networkMonitoring.enabled -- Enable network performance monitoring
+    # datadog.networkMonitoring.enabled -- (bool) Enable network performance monitoring
     enabled: null
 
   ## Enable security agent and provide custom configs

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -313,8 +313,8 @@ datadog:
       enabled: true
 
   networkMonitoring:
-    # datadog.networkMonitoring.enabled -- (bool) Enable network performance monitoring
-    enabled: null
+    # datadog.networkMonitoring.enabled -- Enable network performance monitoring
+    enabled: false
 
   ## Enable security agent and provide custom configs
   securityAgent:


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently it is not possible to disable the network monitoring (while leaving system-probe enabled) by setting `datadog.networkMonitoring.enabled` to `false`. This PR fixes that.

#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
