### PR TITLE
Fix a bug related to datadog.leaderElection

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.9.2
+
+* Fixed a bug where `datadog.leaderElection` would not configure the cluster-agent environment variable `DD_LEADER_ELECTION` correctly.
+
 ## 2.9.1
 
 * add `datadog.systemProbe.conntrackMaxStateSize` and  `datadog.systemProbe.maxTrackedConnections`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.9.1
+version: 2.9.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.9.2](https://img.shields.io/badge/Version-2.9.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -178,7 +178,7 @@ spec:
             value: {{ .Values.datadog.logLevel | quote }}
           {{- end }}
           - name: DD_LEADER_ELECTION
-            value: {{ default "true" .Values.datadog.leaderElection | quote}}
+            value: {{ .Values.datadog.leaderElection | quote}}
           {{- if .Values.datadog.leaderLeaseDuration }}
           - name: DD_LEADER_LEASE_DURATION
             value: {{ .Values.datadog.leaderLeaseDuration | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Make `datadog.leaderElection` works properly. This boolean variable is used in the following way in the template.

```
{{ default "true" .Values.datadog.leaderElection | quote}}
```

If `datadog.leaderElection` is set to `false` (boolean) , the left side will be evaluated as false, so the default value of `"true"` will be set, and `"false"` (string) will not be set.

In addition, the default value of `datadog.leaderElection` is written in values.yaml, so no need to describe it here.

#### Which issue this PR fixes

  - fixes #170 

#### Special notes for your reviewer:

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] ~Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)~
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] ~Variables are documented in the `README.md`~
