### PR TITLE
[datadog] Support Service Topology for apm and dsd

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.8.6
+
+* Add support for Service Topology to target the Datadog Agent via a kubernetes service instead of host ports. This will allow sending traces and custom metrics without using host ports. Note: Service Topology is a new Kubernetes feature, it's still in alpha and disabled by default.
+
 ## 2.8.5
 
 * Allow `namespaces` in RBAC for `kubernetes_namespace_labels_as_tags`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.8.5
+version: 2.8.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.8.5](https://img.shields.io/badge/Version-2.8.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.8.6](https://img.shields.io/badge/Version-2.8.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -501,6 +501,9 @@ helm install --name <RELEASE_NAME> \
 | datadog.securityAgent.runtime.policies.configMap | string | `nil` | Contains policies that will be used |
 | datadog.securityAgent.runtime.syscallMonitor.enabled | bool | `false` | Set to true to enable the Syscall monitoring. |
 | datadog.securityContext | object | `{}` | Allows you to overwrite the default PodSecurityContext on the Daemonset or Deployment |
+| datadog.serviceTopology | object | `{"enabled":false,"serviceName":"datadog-agent"}` | Configure service topology to send custom metrics and traces without using host ports Important notes: - The Service Topology feature in Kubernetes is still in alpha and disabled by default, please make sure it's enabled in your cluster configuration - The environment variable DD_AGENT_HOST in your application pod template must be configured to reach the topology service |
+| datadog.serviceTopology.enabled | bool | `false` | Enabling this will allow sending custom metrics and APM traces to the Datadog Agent on the same node without using a host port Important note: Enabling this option without enabling Service Topology in the cluster will result in wrong tagging for traces and custom metrics |
+| datadog.serviceTopology.serviceName | string | `"datadog-agent"` | Configure the name of the service responsible for routing the custom metrics and/or traces to the Datadog Agent Important note: DD_AGENT_HOST must be configured in your app to target this service. Example using DNS record: DD_AGENT_HOST=datadog-agent.<datadog-namespace>.svc.cluster.local |
 | datadog.site | string | `nil` | The site of the Datadog intake to send Agent data to |
 | datadog.systemProbe.apparmor | string | `"unconfined"` | Specify a apparmor profile for system-probe |
 | datadog.systemProbe.bpfDebug | bool | `false` | Enable logging for kernel debug |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -202,3 +202,14 @@ More information about this change: https://github.com/DataDog/helm-charts/pull/
 You are using datadog.orchestratorExplorer.enabled but you disabled the cluster agent. This configuration is unsupported and Kubernetes resource monitoring has been turned off.
 To enable it please set clusterAgent.enabled to 'true'.
 {{- end }}
+
+{{- if .Values.datadog.serviceTopology.enabled }}
+
+#################################################################
+####               NOTE: Configuration notice             ####
+#################################################################
+
+datadog.serviceTopology.enabled is enabled. Please make sure the Service Topology feature is enabled in your Kubernetes cluster.
+Enabling datadog.serviceTopology.enabled without enabling the Service Topology in the cluster will result in wrong tagging for traces and custom metrics.
+Ref: https://kubernetes.io/docs/concepts/services-networking/service-topology/
+{{- end }}

--- a/charts/datadog/templates/agent-services.yaml
+++ b/charts/datadog/templates/agent-services.yaml
@@ -68,3 +68,37 @@ spec:
   - port: 443
     targetPort: 8000
 {{ end }}
+
+{{- if .Values.datadog.serviceTopology.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.datadog.serviceTopology.serviceName | quote }}
+  labels:
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+spec:
+  selector:
+    app: {{ template "datadog.fullname" . }}
+  ports:
+    - protocol: UDP
+      port: {{ .Values.datadog.dogstatsd.port }}
+      targetPort: {{ .Values.datadog.dogstatsd.port }}
+      name: dogstatsd
+{{- if .Values.datadog.apm.enabled }}
+    - protocol: TCP
+      port: {{ .Values.datadog.apm.port }}
+      targetPort: {{ .Values.datadog.apm.port }}
+      name: apm
+{{- end }}
+  topologyKeys:
+    - "kubernetes.io/hostname"
+{{ end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -256,6 +256,22 @@ datadog:
   # datadog.criSocketPath -- Path to the container runtime socket (if different from Docker)
   criSocketPath:  # /var/run/containerd/containerd.sock
 
+  # datadog.serviceTopology -- Configure service topology to send custom metrics and traces without using host ports
+  # Important notes:
+  # - The Service Topology feature in Kubernetes is still in alpha and disabled by default, please make sure it's enabled in your cluster configuration
+  # - The environment variable DD_AGENT_HOST in your application pod template must be configured to reach the topology service
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service-topology/
+  serviceTopology:
+
+    # datadog.serviceTopology.enabled -- Enabling this will allow sending custom metrics and APM traces to the Datadog Agent on the same node without using a host port
+    # Important note: Enabling this option without enabling Service Topology in the cluster will result in wrong tagging for traces and custom metrics
+    enabled: false
+
+    # datadog.serviceTopology.serviceName -- Configure the name of the service responsible for routing the custom metrics and/or traces to the Datadog Agent
+    # Important note: DD_AGENT_HOST must be configured in your app to target this service.
+    # Example using DNS record: DD_AGENT_HOST=datadog-agent.<datadog-namespace>.svc.cluster.local
+    serviceName: datadog-agent
+
   ## Enable process agent and provide custom configs
   processAgent:
     # datadog.processAgent.enabled -- Set this to true to enable live process monitoring agent


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

Add support for Service Topology to target the Datadog Agent via a kubernetes service instead of host ports. This will allow sending traces and custom metrics without using host ports. Note: Service Topology is a new Kubernetes feature, it's still in alpha and disabled by default.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
