### PR TITLE
[datadog] ✨ New! ✨ Support running Datadog Agent on GKE Autopilot ✨

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.9.3
+
+* Enable support for GKE Autopilot.
+
 ## 2.9.2
 
 * Fixed a bug where `datadog.leaderElection` would not configure the cluster-agent environment variable `DD_LEADER_ELECTION` correctly.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.9.2
+version: 2.9.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.9.2](https://img.shields.io/badge/Version-2.9.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.9.3](https://img.shields.io/badge/Version-2.9.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -524,6 +524,7 @@ helm install --name <RELEASE_NAME> \
 | kube-state-metrics.serviceAccount.create | bool | `true` | If true, create ServiceAccount, require rbac kube-state-metrics.rbac.create true |
 | kube-state-metrics.serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. |
 | nameOverride | string | `nil` | Override name of app |
+| providers.gke.autopilot | bool | `false` | Enables Datadog Agent deployment on GKE Autopilot |
 | registry | string | `"gcr.io/datadoghq"` | Registry to use for all Agent images (default gcr.io) |
 | targetSystem | string | `"linux"` | Target OS for this deployment (possible values: linux, windows) |
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -205,4 +205,23 @@ To enable it please set clusterAgent.enabled to 'true'.
 datadog.serviceTopology.enabled is enabled. Please make sure the Service Topology feature is enabled in your Kubernetes cluster.
 Enabling datadog.serviceTopology.enabled without enabling the Service Topology in the cluster will result in wrong tagging for traces and custom metrics.
 Ref: https://kubernetes.io/docs/concepts/services-networking/service-topology/
+
+{{- end }}
+
+{{- if .Values.providers.gke.autopilot}}
+{{- if eq (include "system-probe-feature" .) "true" }}
+
+##################################################################################
+####               WARNING: System Probe is not supported on GKE Autopilot    ####
+##################################################################################
+
+{{- end }}
+
+{{- if or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.securityAgent.compliance.enabled }}
+
+###################################################################################
+####               WARNING: Security Agent is not supported on GKE Autopilot   ####
+###################################################################################
+
+{{- end }}
 {{- end }}

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -80,9 +80,9 @@
 - name: DD_CONTAINER_EXCLUDE_LOGS
   value: {{ .Values.datadog.containerExcludeLogs | quote }}
 {{- end }}
-{{- if .Values.datadog.criSocketPath }}
+{{- if or .Values.providers.gke.autopilot .Values.datadog.criSocketPath }}
 - name: DD_CRI_SOCKET_PATH
-  value: {{ print "/host/" .Values.datadog.criSocketPath | clean }}
+  value: {{ print "/host/" (include "datadog.dockerOrCriSocketPath" .) | clean }}
 {{- else }}
 - name: DOCKER_HOST
 {{- if eq .Values.targetSystem "linux" }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -52,11 +52,12 @@
   name: src
 {{- end }}
 {{- end }}
-{{- if or .Values.datadog.processAgent.enabled .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.runtime.enabled }}
+{{- if or .Values.datadog.processAgent.enabled (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true") }}
 - hostPath:
     path: /etc/passwd
   name: passwd
 {{- end }}
+{{- if eq  (include "should-enable-security-agent" .) "true" }}
 {{- if .Values.datadog.securityAgent.compliance.enabled }}
 - hostPath:
     path: /etc/group
@@ -75,9 +76,10 @@
   configMap:
     name: {{ .Values.datadog.securityAgent.runtime.policies.configMap }}
 {{- end }}
+{{- end }}
 {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
 - hostPath:
-    path: "/var/lib/datadog-agent/logs"
+    path: {{ template "datadog.hostMountRoot" . }}/logs
   name: pointerdir
 - hostPath:
     path: /var/log/pods

--- a/charts/datadog/templates/agent-psp.yaml
+++ b/charts/datadog/templates/agent-psp.yaml
@@ -24,7 +24,7 @@ spec:
   - min: 8125
     max: 8126
   {{- end }}
-  hostPID: {{ or .Values.datadog.securityAgent.compliance.enabled .Values.datadog.dogstatsd.useHostPID }}
+  hostPID: {{ or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID }}
   allowedCapabilities: 
 {{ toYaml .Values.agents.podSecurity.capabilites | indent 4 }}
   volumes:

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -205,11 +205,13 @@ spec:
           - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
             value: {{ .Values.datadog.orchestratorExplorer.container_scrubbing.enabled | quote }}
           {{- end }}
+          {{- if eq  (include "should-enable-security-agent" .) "true" }}
           - name: DD_COMPLIANCE_CONFIG_ENABLED
             value:  {{ .Values.datadog.securityAgent.compliance.enabled | quote }}
           {{- if .Values.datadog.securityAgent.compliance.enabled }}
           - name: DD_COMPLIANCE_CONFIG_CHECK_INTERVAL
             value: {{ .Values.datadog.securityAgent.compliance.checkInterval | quote }}
+          {{- end }}
           {{- end }}
 {{- if .Values.clusterAgent.env }}
 {{ toYaml .Values.clusterAgent.env | indent 10 }}
@@ -243,10 +245,12 @@ spec:
             subPath: datadog-cluster.yaml
             readOnly: true
 {{- end}}
+{{- if eq  (include "should-enable-security-agent" .) "true" }}
 {{- if and .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.compliance.configMap }}
           - name: complianceconfigdir
             mountPath: /etc/datadog-agent/compliance.d
             readOnly: true
+{{- end}}
 {{- end}}
       volumes:
         - name: installinfo
@@ -262,10 +266,12 @@ spec:
           configMap:
             name: {{ template "datadog.fullname" . }}-cluster-agent-config
 {{- end}}
+{{- if eq  (include "should-enable-security-agent" .) "true" }}
 {{- if  and .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.compliance.configMap }}
         - name: complianceconfigdir
           configMap:
             name: {{ .Values.datadog.securityAgent.compliance.configMap }}
+{{- end}}
 {{- end}}
 
 {{- if .Values.clusterAgent.volumes }}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -153,6 +153,7 @@ rules:
   resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
   verbs: ["get"]
 {{- end }}
+{{- if eq  (include "should-enable-security-agent" .) "true" }}
 {{- if .Values.datadog.securityAgent.compliance.enabled }}
 - apiGroups:
   - ""
@@ -182,6 +183,7 @@ rules:
   - networkpolicies
   verbs:
   - list
+{{- end }}
 {{- end }}
 - apiGroups:
   - policy

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -80,7 +80,7 @@ spec:
       dnsConfig:
 {{ toYaml .Values.agents.dnsConfig | indent 8 }}
       {{- end }}
-      {{- if or .Values.datadog.securityAgent.compliance.enabled .Values.datadog.dogstatsd.useHostPID }}
+      {{- if or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID }}
       hostPID: true
       {{- end }}
       {{- if .Values.agents.image.pullSecrets }}
@@ -101,7 +101,7 @@ spec:
         {{- if eq (include "should-enable-system-probe" .) "true" }}
           {{- include "container-system-probe" . | nindent 6 }}
         {{- end }}
-        {{- if or .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.runtime.enabled}}
+        {{- if eq  (include "should-enable-security-agent" .) "true" }}
           {{- include "container-security-agent" . | nindent 6 }}
         {{- end }}
       initContainers:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1131,3 +1131,8 @@ kube-state-metrics:
   # kube-state-metrics.nodeSelector -- Node selector for KSM. KSM only supports Linux.
   nodeSelector:
     kubernetes.io/os: linux
+
+providers:
+  gke:
+    # providers.gke.autopilot -- Enables Datadog Agent deployment on GKE Autopilot
+    autopilot: false


### PR DESCRIPTION
#### What this PR does / why we need it:

- Support [running Datadog Agent](https://www.datadoghq.com/blog/gke-autopilot-monitoring/) on [GKE Autopilot](https://cloud.google.com/blog/products/containers-kubernetes/introducing-gke-autopilot) 🚀 
- Introduce a new section in the chart configuration values for easy setup of cloud provider options.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
