### PR TITLE
[datadog-operator] Support GKE Autopilot in the operator

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.2
+
+* Enable operator configuration for GKE Autopilot (requires operator v0.6).
+
 ## 0.4.1
 
 * Added support for `podAnnotations` and `podLabels` values

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.4.1
+version: 0.4.2
 appVersion: 0.4.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 ## Values
 
@@ -21,6 +21,7 @@
 | nodeSelector | object | `{}` | Allows to schedule Datadog Operator on specific nodes |
 | podAnnotations | object | `{}` | Allows setting additional annotations for Datadog Operator PODs |
 | podLabels | object | `{}` | Allows setting additional labels for for Datadog Operator PODs |
+| providers.gke.autopilot | bool | `false` | Enables Datadog Agent deployment on GKE Autopilot |
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |
 | replicaCount | int | `1` | Number of instances of Datadog Operator |
 | resources | object | `{}` | Set resources requests/limits for Datadog Operator PODs |
@@ -29,3 +30,15 @@
 | serviceAccount.name | string | `nil` | The name of the service account to use. If not set name is generated using the fullname template |
 | supportExtendedDaemonset | string | `"false"` | If true, supports using ExtendedDeamonSet CRD |
 | tolerations | list | `[]` | Allows to schedule Datadog Operator on tainted nodes |
+
+## Configuration options for cloud providers
+
+Datadog Operator can be configured to enforce settings applicable to public cloud environments.
+
+The sections below document how to configure this chart to enable these features.
+
+### Google GKE
+
+To enable restrictions applicable to Google GKE Autopilot environments, please enable the `providers.gke.autopilot` setting.
+
+Note that certain Datadog Agent features are not supported on GKE Autopilot, notably the System Probe and Security Agent cannot be enabled in the `DatadogAgent` resource.

--- a/charts/datadog-operator/README.md.gotmpl
+++ b/charts/datadog-operator/README.md.gotmpl
@@ -3,3 +3,15 @@
 {{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
 
 {{ template "chart.valuesSection" . }}
+
+## Configuration options for cloud providers
+
+Datadog Operator can be configured to enforce settings applicable to public cloud environments.
+
+The sections below document how to configure this chart to enable these features.
+
+### Google GKE
+
+To enable restrictions applicable to Google GKE Autopilot environments, please enable the `providers.gke.autopilot` setting.
+
+Note that certain Datadog Agent features are not supported on GKE Autopilot, notably the System Probe and Security Agent cannot be enabled in the `DatadogAgent` resource.

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -50,12 +50,17 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
           args:
-            - "-supportExtendedDaemonset={{ .Values.supportExtendedDaemonset }}"
+            - "-supportExtendedDaemonset={{ and .Values.supportExtendedDaemonset (not .Values.providers.gke.autopilot) }}"
             - "-logEncoder=json"
             - "-metrics-addr=:{{ .Values.metricsPort }}"
             - "-loglevel={{ .Values.logLevel }}"
           {{- if .Values.secretBackend.command }}
             - "-secretBackendCommand={{ .Values.secretBackend.command }}"
+          {{- end }}
+          {{- if .Values.providers.gke.autopilot }}
+            - "-allowedRegistries=gcr.io/datadoghq.com"
+            - "-disallowedFeatures=system-probe,runtime-security,compliance"
+            - "-hostStoragePath=/var/autopilot/addon/datadog"
           {{- end }}
           ports:
             - name: metrics

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -68,3 +68,8 @@ datadog-crds:
 podAnnotations: {}
 # podLabels -- Allows setting additional labels for for Datadog Operator PODs
 podLabels: {}
+
+providers:
+  gke:
+    # providers.gke.autopilot -- Enables Datadog Agent deployment on GKE Autopilot
+    autopilot: false


### PR DESCRIPTION
#### What this PR does / why we need it:

- Support [running Datadog Agent via operator](https://www.datadoghq.com/blog/gke-autopilot-monitoring/) on [GKE Autopilot](https://cloud.google.com/blog/products/containers-kubernetes/introducing-gke-autopilot) 🚀 
- Introduce a new section in the chart configuration values for easy setup of cloud provider options.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

This requires changes in [this PR](https://github.com/DataDog/datadog-operator/pull/238) which will be released in `v0.6`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
