### PR TITLE
Only deploy PodDisruptionBudget when replicaCount > 1

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3
+
+* Only deploy a `PodDisruptionBudget` when `replicaCount` is greater than `1`
+
 ## 0.5.2
 
 * Support configuring the secret backend command arguments (requires Datadog Operator v0.5.0+)

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.5.2
+version: 0.5.3
 appVersion: 0.5.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/pod_disruption_budget.yaml
+++ b/charts/datadog-operator/templates/pod_disruption_budget.yaml
@@ -1,3 +1,4 @@
+{{- if gt .Values.replicaCount 1.0 -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -10,3 +11,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "datadog-operator.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently with the default replica as 1 and the default deployment of the pod disruption budget requiring 1, means that when performing a node drain / upgrade will timeout:
> Drain did not complete pods [datadog-operator-55dc4888bf-94x5j] within 10m0s on vm *****. Check Pod Disruption Budgets

This simply disables deployment of the `PodDisruptionBudget` until the `replicaCount` is set to something greater than 1. Otherwise by default, users that use this operator won't be able to upgrade without manual intervention. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
