### PR TITLE
Fix releaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,9 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Add repo
+        run: |
+          helm repo add datadog https://helm.datadoghq.com
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.0
         env:


### PR DESCRIPTION
#### What this PR does / why we need it:

An attempt to fix this after bumping helm releaser version

```
Run helm/chart-releaser-action@v1.2.0
Looking up latest tag...
Discovering changed charts since 'datadog-2.9.11'...
Installing chart-releaser...
Adding cr directory to PATH...
Packaging chart 'charts/datadog-operator'...
Error: no repository definition for https://helm.datadoghq.com
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
