### PR TITLE
Use an EmptyDir volume shared between all the agents for logs so that `agent flare` can gather the logs of all of them.

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.10.2
+
+* Use an EmptyDir volume shared between all the agents for logs so that `agent flare` can gather the logs of all of them.
+
 ## 2.10.1
 
 * Remove the cluster-id configmap mount for process-agent. (Requires Datadog Agent 7.26+ and Datadog Cluster Agent 1.11+, otherwise collection of pods for the Kubernetes Resources page will fail).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.10.1
+version: 2.10.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.10.1](https://img.shields.io/badge/Version-2.10.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.10.2](https://img.shields.io/badge/Version-2.10.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -100,6 +100,8 @@
       subPath: install_info
       mountPath: /etc/datadog-agent/install_info
       readOnly: true
+    - name: logdatadog
+      mountPath: /var/log/datadog
     - name: tmpdir
       mountPath: /tmp
       readOnly: false

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -50,6 +50,8 @@
       mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+    - name: logdatadog
+      mountPath: /var/log/datadog
     - name: tmpdir
       mountPath: /tmp
       readOnly: false

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -47,6 +47,8 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
     {{- if eq .Values.targetSystem "linux" }}
+    - name: logdatadog
+      mountPath: /var/log/datadog
     - name: tmpdir
       mountPath: /tmp
       readOnly: false

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -23,6 +23,8 @@
   resources:
 {{ toYaml .Values.agents.containers.systemProbe.resources | indent 4 }}
   volumeMounts:
+    - name: logdatadog
+      mountPath: /var/log/datadog
     - name: tmpdir
       mountPath: /tmp
       readOnly: false

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -53,6 +53,8 @@
       subPath: datadog.yaml
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
+    - name: logdatadog
+      mountPath: /var/log/datadog
     - name: tmpdir
       mountPath: /tmp
       readOnly: false

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -17,6 +17,8 @@
   args:
     - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
   volumeMounts:
+    - name: logdatadog
+      mountPath: /var/log/datadog
     - name: config
       mountPath: /etc/datadog-agent
     {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -1,4 +1,6 @@
 {{- define "daemonset-volumes-linux" -}}
+- name: logdatadog
+  emptyDir: {}
 - name: tmpdir
   emptyDir: {}
 - hostPath:


### PR DESCRIPTION
#### What this PR does / why we need it:

Use an EmptyDir volume shared between all the agents for logs so that `agent flare` can gather the logs of all of them.

#### Which issue this PR fixes


#### Special notes for your reviewer:

I tested `agent flare` on a Windows pod and it happened to already contain the log files for all the agents.
So, nothing to be done on Windows.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
