### PR TITLE
Bump KSM chart version to use rbac.authorization.k8s.io/v1

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,6 +1,6 @@
 chart-repos:
-  - stable=https://charts.helm.sh/stable
   - datadog=https://helm.datadoghq.com
+  - kube-state-metrics=https://kubernetes.github.io/kube-state-metrics
 helm-extra-args: --timeout 300s
 check-version-increment: true
 debug: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,10 +64,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Add default helm repo
-        run: helm repo add stable https://charts.helm.sh/stable && helm repo update
       - name: Add datadog helm repo
         run: helm repo add datadog https://helm.datadoghq.com && helm repo update
+      - name: Add KSM helm repo
+        run: helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics
       - name: Run kubeval
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,8 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Add repo
         run: |
-          helm repo add stable https://charts.helm.sh/stable
           helm repo add datadog https://helm.datadoghq.com
+          helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.0
         env:

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.10.3
+
+* Bump version of KSM chart to get rid of `rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1` warnings
+
 ## 2.10.2
 
 * Use an EmptyDir volume shared between all the agents for logs so that `agent flare` can gather the logs of all of them.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.10.2
+version: 2.10.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.10.2](https://img.shields.io/badge/Version-2.10.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.10.3](https://img.shields.io/badge/Version-2.10.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -28,8 +28,8 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.helm.sh/stable | kube-state-metrics | =2.8.11 |
 | https://helm.datadoghq.com | datadog-crds | =0.1.1 |
+| https://kubernetes.github.io/kube-state-metrics | kube-state-metrics | =2.13.0 |
 
 ## Quick start
 

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: =0.1.1
+  version: 0.1.1
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
-  version: =2.13.0
+  version: 2.13.0
 digest: sha256:61a1e728bd39540b0c24d51ee00122228405d4af0d5c320b4fb42d9152f63317
 generated: "2021-03-15T20:44:10.8139+01:00"

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: https://helm.datadoghq.com
   version: 0.1.1
 - name: kube-state-metrics
-  repository: https://charts.helm.sh/stable
-  version: 2.8.11
-digest: sha256:35c5ec4a7c5610cf2ff63bcd609293f8d2f8ac4bbc6e07462b9d66251b81b069
-generated: "2020-11-16T14:56:38.28858+01:00"
+  repository: https://kubernetes.github.io/kube-state-metrics
+  version: 2.13.0
+digest: sha256:b827463203e4d1ee45fb1f7f4aec3f24b4115da73fd106ddfee5fa100b3572b3
+generated: "2021-03-15T15:58:44.189206+01:00"

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 0.1.1
+  version: =0.1.1
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
-  version: 2.13.0
-digest: sha256:b827463203e4d1ee45fb1f7f4aec3f24b4115da73fd106ddfee5fa100b3572b3
-generated: "2021-03-15T15:58:44.189206+01:00"
+  version: =2.13.0
+digest: sha256:61a1e728bd39540b0c24d51ee00122228405d4af0d5c320b4fb42d9152f63317
+generated: "2021-03-15T20:44:10.8139+01:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -6,6 +6,6 @@ dependencies:
     tags:
     - install-crds
   - name: kube-state-metrics
-    version: "=2.8.11"
-    repository: https://charts.helm.sh/stable
+    version: "=2.13.0"
+    repository: https://kubernetes.github.io/kube-state-metrics
     condition: datadog.kubeStateMetricsEnabled

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -218,3 +218,21 @@ Ref: https://kubernetes.io/docs/concepts/services-networking/service-topology/
 
 {{- end }}
 {{- end }}
+
+{{- if and (not (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1")) .Values.datadog.kubeStateMetricsEnabled }}
+
+########################################################################################
+####  WARNING: latest version of kube-state-metrics isn’t supported on your cluster ####
+########################################################################################
+
+datadog.kubeStateMetricsEnabled is true, meaning that KSM is required.
+
+The target Kubernetes cluster {{ .Capabilities.KubeVersion }} doesn’t support API "rbac.authorization.k8s.io/v1"
+which is used by KSM.
+
+The recommended way to go forward is to disable KSM deployment from the datadog chart and to manually deploy an older version of KSM.
+The last version of the KSM chart using "rbac.authorization.k8s.io/v1beta1" is 2.9.1 which can be installed with:
+
+helm install ksm https://charts.helm.sh/stable/packages/kube-state-metrics-2.9.1.tgz
+
+{{- end }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -93,7 +93,7 @@ Return secret name to be used based on provided values.
 Return the appropriate apiVersion for RBAC APIs.
 */}}
 {{- define "rbac.apiVersion" -}}
-{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
 "rbac.authorization.k8s.io/v1"
 {{- else -}}
 "rbac.authorization.k8s.io/v1beta1"


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump the version of the KSM chart.

#### Which issue this PR fixes

When we install the datadog chart, Helm produces the following warnings:
```
W0315 15:51:01.542249   64621 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W0315 15:51:01.594559   64621 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W0315 15:51:01.647086   64621 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W0315 15:51:02.684250   64621 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0315 15:51:02.739027   64621 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0315 15:51:02.792100   64621 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
```

These errors are coming from the `kube-state-metrics` chart.
Whereas the `datadog` chart is able to automatically choose the right version of the RBAC API to use, the KSM chart switched from `v1beta1` to `v1` at [this commit](https://github.com/helm/charts/commit/84c5b81602b839bcca9ff59f42230bb6594e22d3).

* Fixes #153 

#### Special notes for your reviewer:

Whereas there is a mechanism to include or not a dependency based on a `.Value.…` value, I couldn’t find a way to include a dependency based on a `.Capabilities.…` object.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
