### PR TITLE
Add advanced confd setup

### DIFF
--- a/charts/datadog/templates/cluster-agent-advanced-confd-configmap.yaml
+++ b/charts/datadog/templates/cluster-agent-advanced-confd-configmap.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.clusterAgent.advancedConfd }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "datadog.fullname" . }}-cluster-agent-advanced-confd
+  labels:
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+  annotations:
+    checksum/confd-config: {{ tpl (toYaml .Values.clusterAgent.advancedConfd) . | sha256sum }}
+data:
+{{- range $integration, $configs := $.Values.clusterAgent.advancedConfd }}
+{{- range $name, $config := $configs }}
+  {{ printf "%s.d--%s: |" $integration $name }}
+    {{ $config | indent 4 | trim }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -243,6 +243,11 @@ spec:
             mountPath: /conf.d
             readOnly: true
 {{- end }}
+{{- if .Values.clusterAgent.advancedConfd }}
+          - name: advanced-confd
+            mountPath: /conf.d
+            readOnly: true
+{{- end }}
 {{- if .Values.clusterAgent.datadog_cluster_yaml }}
           - name: cluster-agent-yaml
             mountPath: /etc/datadog-agent/datadog-cluster.yaml
@@ -264,6 +269,18 @@ spec:
         - name: confd
           configMap:
             name: {{ template "datadog.fullname" . }}-cluster-agent-confd
+{{- end }}
+{{- if .Values.clusterAgent.advancedConfd }}
+        - name: advanced-confd
+          configMap:
+            name: {{ template "datadog.fullname" . }}-cluster-agent-advanced-confd
+            items:
+{{- range $integration, $configs := $.Values.clusterAgent.advancedConfd }}
+{{- range $name, $config := $configs }}
+            - key: {{ printf "%s.d--%s" $integration $name | quote }}
+              path: {{ printf "%s.d/%s" $integration $name | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if .Values.clusterAgent.datadog_cluster_yaml }}
         - name: cluster-agent-yaml

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -493,6 +493,26 @@ clusterAgent:
   #         user: datadog
   #         pass: '<YOUR_CHOSEN_PASSWORD>'
 
+  # clusterAgent.advancedConfd -- Provide additional cluster check configurations
+  ## Each key is an integration containing several config files, it replaces clusterAgent.confd if set
+  ## ref: https://docs.datadoghq.com/agent/autodiscovery/
+  advancedConfd: {}
+  #  mysql:
+  #    1.yaml: |-
+  #      cluster_check: true
+  #      instances:
+  #        - server: '<EXTERNAL_IP>'
+  #          port: 3306
+  #          user: datadog
+  #          pass: '<YOUR_CHOSEN_PASSWORD>'
+  #    2.yaml:  |-
+  #      cluster_check: true
+  #      instances:
+  #        - server: '<EXTERNAL_IP>'
+  #          port: 3306
+  #          user: datadog
+  #          pass: '<YOUR_CHOSEN_PASSWORD>'
+
   # clusterAgent.resources -- Datadog cluster-agent resource requests and limits.
   resources: {}
   # requests:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR aims to propose an alternative `confd` configuration format to allow several configs on the same check in order to benefit from the cluster check dispatching.

It requires a recent image of the cluster-agent because of a tweak in the entrypoint 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
