### PR TITLE
Fix bug regarding using "Metric collection with Prometheus annotations"

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.10.7
+
+* Fix bug regarding using "Metric collection with Prometheus annotations".
+
 ## 2.10.6
 
 * Add provider labels on pods, warning on dogstatsd with UDS on GKE Autopilot.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.10.6
+version: 2.10.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.10.6](https://img.shields.io/badge/Version-2.10.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.10.7](https://img.shields.io/badge/Version-2.10.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -218,12 +218,12 @@ spec:
           - name: DD_COMPLIANCE_CONFIG_CHECK_INTERVAL
             value: {{ .Values.datadog.securityAgent.compliance.checkInterval | quote }}
           {{- end }}
+          {{- end }}
           {{- if .Values.datadog.prometheusScrape.enabled }}
           - name: DD_PROMETHEUS_SCRAPE_ENABLED
             value: "true"
           - name: DD_PROMETHEUS_SCRAPE_SERVICE_ENDPOINTS
             value: {{ .Values.datadog.prometheusScrape.serviceEndpoints | quote }}
-          {{- end }}
           {{- end }}
 {{- if .Values.clusterAgent.env }}
 {{ toYaml .Values.clusterAgent.env | indent 10 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Without this, one cannot use "Metric collection with Prometheus annotations" feature.


#### Checklist
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated

