### PR TITLE
Add the possibility to specify a priorityClassName for the CLC

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.10.9
 
-* Add the possibility to specify a priority class name for the CLC pods.
+* Add the possibility to specify a priority class name for the cluster checks runner pods.
 
 ## 2.10.8
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.10.9
+
+* Add the possibility to specify a priority class name for the CLC pods.
+
 ## 2.10.8
 
 * When node agents are joining an existing DCA managed by another Helm release, we must control if they should be eligible to cluster checks dispatch or not depending on whether CLC have been deployed with the external DCA.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.10.8
+version: 2.10.9
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.10.8](https://img.shields.io/badge/Version-2.10.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.10.9](https://img.shields.io/badge/Version-2.10.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -432,6 +432,7 @@ helm install --name <RELEASE_NAME> \
 | clusterChecksRunner.nodeSelector | object | `{}` | Allow the ClusterChecks Deployment to schedule on selected nodes |
 | clusterChecksRunner.podAnnotations | object | `{}` | Annotations to add to the cluster-checks-runner's pod(s) |
 | clusterChecksRunner.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
+| clusterChecksRunner.priorityClassName | string | `nil` | Name of the priorityClass to apply to the Cluster checks runners |
 | clusterChecksRunner.rbac.create | bool | `true` | If true, create & use RBAC resources |
 | clusterChecksRunner.rbac.dedicated | bool | `false` | If true, use a dedicated RBAC resource for the cluster checks agent(s) |
 | clusterChecksRunner.rbac.serviceAccountAnnotations | object | `{}` | Annotations to add to the ServiceAccount if clusterChecksRunner.rbac.dedicated is true |

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -49,6 +49,9 @@ spec:
       {{- end }}
       imagePullSecrets:
 {{ toYaml .Values.clusterChecksRunner.image.pullSecrets | indent 8 }}
+      {{- if .Values.clusterChecksRunner.priorityClassName }}
+      priorityClassName: {{ .Values.clusterChecksRunner.priorityClassName }}
+      {{- end }}
       {{- if .Values.clusterChecksRunner.dnsConfig }}
       dnsConfig:
 {{ toYaml .Values.clusterChecksRunner.dnsConfig | indent 8 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1050,6 +1050,9 @@ clusterChecksRunner:
   #  - name: ndots
   #    value: "1"
 
+  # clusterChecksRunner.priorityClassName -- Name of the priorityClass to apply to the Cluster checks runners
+  priorityClassName:  # system-cluster-critical
+
   # clusterChecksRunner.nodeSelector -- Allow the ClusterChecks Deployment to schedule on selected nodes
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   #


### PR DESCRIPTION
#### What this PR does / why we need it:

Add the possibility to specify a `priorityClassName` for the CLC pods like it was already possible for the node agents and the DCA ones.

#### Which issue this PR fixes
  - fixes #203

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [X] Variables are documented in the `README.md`
