### PR TITLE
[networks] Fix system-probe version check

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.10.10
+
+* Fix system-probe version check when using `datadog.networkMonitoring.enabled`
+
 ## 2.10.9
 
 * Add the possibility to specify a priority class name for the cluster checks runner pods.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.10.9
+version: 2.10.10
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.10.9](https://img.shields.io/badge/Version-2.10.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.10.10](https://img.shields.io/badge/Version-2.10.10-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -3,8 +3,8 @@
 {{- $version := (.Values.agents.image.tag | toString | trimSuffix "-jmx") }}
 {{- $length := len (split "." $version ) -}}
 {{- if (gt $length 1) }}
-{{- if not (semverCompare "^6.23.0-0 || ^7.23.0-0" $version) -}}
-{{- fail "datadog.networkMonitoring.enabled requires agent >= 7.23.0" }}
+{{- if not (semverCompare "^6.24.1-0 || ^7.24.1-0" $version) -}}
+{{- fail "datadog.networkMonitoring.enabled requires agent >= 7.24.1" }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix system-probe version check when using networkMonitoring.enabled

#### Special notes for your reviewer:

#### Checklist

- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
