### PR TITLE
Fix DCA RBAC for the external metrics provider

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.10.11
+
+* Fix RBAC needed for the external metrics provider for the future release of the DCA.
+
 ## 2.10.10
 
 * Fix system-probe version check when using `datadog.networkMonitoring.enabled`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.10.10
+version: 2.10.11
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.10.10](https://img.shields.io/badge/Version-2.10.10-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.10.11](https://img.shields.io/badge/Version-2.10.11-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -64,11 +64,22 @@ rules:
   - datadog-leader-election  # Leader election token
 {{- if .Values.clusterAgent.metricsProvider.enabled }}
   - datadog-custom-metrics
-  - extension-apiserver-authentication
 {{- end }}
   verbs:
   - get
   - update
+{{- if .Values.clusterAgent.metricsProvider.enabled }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - extension-apiserver-authentication
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
 - apiGroups:  # To create the leader election token and hpa events
   - ""
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the DCA RBAC.
Since the migration of the DCA to the `go-client` 1.18, the DCA needs some additional permissions to register an external metrics provider.

#### Which issue this PR fixes

With the current version of the Helm chart and the `master` version of the cluster agent, the external metrics provider feature is broken and the DCA complains about the following errors:

```
2021-04-02 13:05:10 UTC | CLUSTER | ERROR | (/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/runtime/runtime.go:114 in logError) | pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125: Failed to list *v1.ConfigMap: configmaps "extension-apiserver-authentication" is forbidden: User "system:serviceaccount:default:datadog-agent-cluster-agent" cannot list resource "configmaps" in API group "" in the namespace "kube-system"
```
```
2021-04-02 13:07:51 UTC | CLUSTER | ERROR | (/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/runtime/runtime.go:114 in logError) | pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125: Failed to watch *v1.ConfigMap: unknown (get configmaps)
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
