### PR TITLE
[datadog] DCA 1.12 + Support KSM core basic config

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.12.0
+
+* Update the Cluster Agent version to `1.12.0`
+* Support kube-state-metrics core check
+
 ## 2.11.6
 
 * Improve support for environment autodiscovery by removing explicit setting of `DOCKER_HOST` by default with Agent 7.27+.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.11.6
+version: 2.12.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.11.6](https://img.shields.io/badge/Version-2.11.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.12.0](https://img.shields.io/badge/Version-2.12.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -388,7 +388,7 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"1.11.0"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"1.12.0"` | Cluster Agent image tag to use |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
 | clusterAgent.metricsProvider.createReaderRbac | bool | `true` | Create `external-metrics-reader` RBAC automatically (to allow HPA to read data from Cluster Agent) |
@@ -477,6 +477,8 @@ helm install --name <RELEASE_NAME> \
 | datadog.env | list | `[]` | Set environment variables for all Agents |
 | datadog.envFrom | list | `[]` | Set environment variables for all Agents directly from configMaps and/or secrets |
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
+| datadog.kubeStateMetricsCore.enabled | bool | `false` | Enable the kubernetes_state_core check in the Cluster Agent (Requires Cluster Agent 1.12.0+) |
+| datadog.kubeStateMetricsCore.ignoreLegacyKSMCheck | bool | `true` | Disable the auto-configuration of lagacy kubernetes_state check (taken into account only when datadog.kubeStateMetricsCore.enabled is true) |
 | datadog.kubeStateMetricsEnabled | bool | `true` | If true, deploys the kube-state-metrics deployment |
 | datadog.kubeStateMetricsNetworkPolicy.create | bool | `false` | If true, create a NetworkPolicy for kube state metrics |
 | datadog.kubelet.agentCAPath | string | /var/run/host-kubelet-ca.crt if hostCAPath else /var/run/secrets/kubernetes.io/serviceaccount/ca.crt | Path (inside Agent containers) where the Kubelet CA certificate is stored |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -245,3 +245,13 @@ The last version of the KSM chart using "rbac.authorization.k8s.io/v1beta1" is 2
 helm install ksm https://charts.helm.sh/stable/packages/kube-state-metrics-2.9.1.tgz
 
 {{- end }}
+
+{{- if and .Values.datadog.kubeStateMetricsCore.enabled (eq (include "cluster-agent-enabled" .) "false")}}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+You are using datadog.kubeStateMetricsCore.enabled but you disabled the cluster agent. This configuration is unsupported and the kube-state-metrics core check can't be configured.
+To enable it please set clusterAgent.enabled to 'true'.
+{{- end }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -95,6 +95,10 @@
       value: {{ .Values.datadog.prometheusScrape.additionalConfigs | toJson | quote }}
     {{- end }}
     {{- end }}
+    {{- if and .Values.datadog.kubeStateMetricsCore.enabled .Values.datadog.kubeStateMetricsCore.ignoreLegacyKSMCheck }}
+    - name: DD_IGNORE_AUTOCONF
+      value: "kubernetes_state"
+    {{- end }}
 {{- if .Values.agents.containers.agent.env }}
 {{ toYaml .Values.agents.containers.agent.env | indent 4 }}
 {{- end }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -401,3 +401,14 @@ Return Kubelet volumeMount
   {{- end }}
   readOnly: true
 {{- end -}}
+
+{{/*
+Return true if the Cluster Agent needs a confd configmap
+*/}}
+{{- define "need-cluster-agent-confd" -}}
+{{- if (or (.Values.clusterAgent.confd) (.Values.datadog.kubeStateMetricsCore.enabled)) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/charts/datadog/templates/cluster-agent-confd-configmap.yaml
+++ b/charts/datadog/templates/cluster-agent-confd-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterAgent.confd }}
+{{- if eq (include "need-cluster-agent-confd" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,5 +12,34 @@ metadata:
   annotations:
     checksum/confd-config: {{ tpl (toYaml .Values.clusterAgent.confd) . | sha256sum }}
 data:
+{{- if .Values.clusterAgent.confd }}
 {{ tpl (toYaml .Values.clusterAgent.confd) . | indent 2 }}
+{{- end }}
+{{- if .Values.datadog.kubeStateMetricsCore.enabled }}
+  kubernetes_state_core.yaml.default: |-
+    init_config:
+    instances:
+      - collectors:
+        - secrets
+        - nodes
+        - pods
+        - services
+        - resourcequotas
+        - replicationcontrollers
+        - limitranges
+        - persistentvolumeclaims
+        - persistentvolumes
+        - namespaces
+        - endpoints
+        - daemonsets
+        - deployments
+        - replicasets
+        - statefulsets
+        - cronjobs
+        - jobs
+        - horizontalpodautoscalers
+        - poddisruptionbudgets
+        - storageclasses
+        - volumeattachments
+{{- end }}
 {{- end -}}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -254,7 +254,7 @@ spec:
 {{- if .Values.clusterAgent.volumeMounts }}
 {{ toYaml .Values.clusterAgent.volumeMounts | indent 10 }}
 {{- end }}
-{{- if .Values.clusterAgent.confd }}
+{{- if eq (include "need-cluster-agent-confd" .) "true" }}
           - name: confd
             mountPath: /conf.d
             readOnly: true
@@ -276,7 +276,7 @@ spec:
         - name: installinfo
           configMap:
             name: {{ template "datadog.fullname" . }}-installinfo
-{{- if .Values.clusterAgent.confd }}
+{{- if eq (include "need-cluster-agent-confd" .) "true" }}
         - name: confd
           configMap:
             name: {{ template "datadog.fullname" . }}-cluster-agent-confd

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -212,6 +212,74 @@ rules:
   - use
   resourceNames:
   - {{ template "datadog.fullname" . }}-cluster-agent
+{{- if .Values.datadog.kubeStateMetricsCore.enabled }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch
+{{- end }}
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -77,6 +77,13 @@ datadog:
     # datadog.kubeStateMetricsNetworkPolicy.create -- If true, create a NetworkPolicy for kube state metrics
     create: false
 
+  kubeStateMetricsCore:
+    # datadog.kubeStateMetricsCore.enabled -- Enable the kubernetes_state_core check in the Cluster Agent (Requires Cluster Agent 1.12.0+)
+    enabled: false
+
+    # datadog.kubeStateMetricsCore.ignoreLegacyKSMCheck -- Disable the auto-configuration of lagacy kubernetes_state check (taken into account only when datadog.kubeStateMetricsCore.enabled is true)
+    ignoreLegacyKSMCheck: true
+
   ## Manage Cluster checks feature
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
   ## Autodiscovery via Kube Service annotations is automatically enabled
@@ -425,7 +432,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 1.11.0
+    tag: 1.12.0
 
     # clusterAgent.image.repository -- Override default registry + image.name for Cluster Agent
     repository:


### PR DESCRIPTION
#### What this PR does / why we need it:

- Bump the DCA version
- Support configuring the ksm core check in the cluster agent

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
