### PR TITLE
Fix datadog apiKey and appKey secret name reminder

### DIFF
--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -5,7 +5,7 @@ minutes, you should see your agents starting in your event stream:
 
   {{- if .Values.datadog.apiKeyExistingSecret }}
 You disabled creation of Secret containing API key, therefore it is expected
-that you create Secret named '{{ .Values.datadog.apiKeyExistingSecret }}' which includes a key called 'api-key' containing the API key.
+that you create Secret named '{{ .Values.datadog.apiKeyExistingSecret }}' which includes a key called 'apiKey' containing the API key.
   {{- else if not (eq .Values.datadog.apiKey "<DATADOG_API_KEY>") }}
   {{- end }}
 
@@ -53,7 +53,7 @@ Node Agent readiness probe port ({{ $readiness.port }}) is different from the co
   {{- if .Values.clusterAgent.metricsProvider.enabled }}
     {{- if .Values.datadog.appKeyExistingSecret }}
 You disabled creation of Secret containing APP key, therefore it is expected
-that you create a Secret named '{{ .Values.datadog.appKeyExistingSecret }}' which includes a key called 'app-key' containing the APP key.
+that you create a Secret named '{{ .Values.datadog.appKeyExistingSecret }}' which includes a key called 'appKey' containing the APP key.
     {{- else if (.Values.datadog.appKey) }}
     {{- else }}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
This fix clarifies the helm chart output when an already created kubernetes secret is used instead (properties apiKeyExistingSecret and appKeyExistingSecret) of the plain text properties for apiKey and appKey
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
