### PR TITLE
Update datadoghq.com_datadogmetrics.yaml

### DIFF
--- a/crds/datadoghq.com_datadogmetrics.yaml
+++ b/crds/datadoghq.com_datadogmetrics.yaml
@@ -53,7 +53,7 @@ spec:
             description: DatadogMetricSpec defines the desired state of DatadogMetric
             properties:
               externalMetricName:
-                description: ExternalMetricName is reversed for internal use
+                description: ExternalMetricName is reserved for internal use
                 type: string
               maxAge:
                 description: MaxAge provides the max age for the metric query (overrides


### PR DESCRIPTION
Fix typo `reversed` -> `reserved`

#### What this PR does / why we need it:
Fixes a typo in a property description.

#### Which issue this PR fixes
*N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
