### PR TITLE
Update CODEOWNERS for network team split

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 *.md             @DataDog/documentation @DataDog/container-integrations
 
 # Charts
-charts/datadog/templates/container-system-probe.yaml @DataDog/networks @DataDog/container-integrations
-charts/datadog/templates/system-probe-configmap.yaml @DataDog/networks @DataDog/container-integrations
-charts/datadog/templates/system-probe-init.yaml      @DataDog/networks @DataDog/container-integrations
+charts/datadog/templates/container-system-probe.yaml @DataDog/agent-network @DataDog/container-integrations
+charts/datadog/templates/system-probe-configmap.yaml @DataDog/agent-network @DataDog/container-integrations
+charts/datadog/templates/system-probe-init.yaml      @DataDog/agent-network @DataDog/container-integrations
 charts/synthetics-private-location/*                 @Datadog/synthetics @DataDog/container-integrations


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the CODEOWNERS since the new network-agent team will own the Helm charts for NPM.


