### PR TITLE
Remove note about --recreate-pods

### DIFF
--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -133,7 +133,7 @@ As a best practice, a YAML file that specifies the values for the chart paramete
 3. Upgrade the Datadog Helm chart with the new `datadog-values.yaml` file:
 
 ```bash
-helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog --recreate-pods
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
 See the [All configuration options](#all-configuration-options) section to discover all possibilities offered by the Datadog chart.
@@ -153,7 +153,7 @@ datadog:
 then upgrade your Datadog Helm chart:
 
 ```bash
-helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog --recreate-pods
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
 ### Enabling Process Collection
@@ -171,7 +171,7 @@ datadog:
 then upgrade your Datadog Helm chart:
 
 ```bash
-helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog --recreate-pods
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
 ### Enabling System Probe Collection
@@ -191,7 +191,7 @@ datadog:
 then upgrade your Datadog Helm chart:
 
 ```bash
-helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog --recreate-pods
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
 ### Kubernetes event collection
@@ -234,7 +234,7 @@ datadog:
 then upgrade your Datadog Helm chart:
 
 ```bash
-helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog --recreate-pods
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
 For more details, please refer to [the documentation](https://docs.datadoghq.com/agent/kubernetes/integrations/).
@@ -263,7 +263,7 @@ podLabelsAsTags:
 then upgrade your Datadog Helm chart:
 
 ```bash
-helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog --recreate-pods
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
 ### CRI integration

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -93,8 +93,6 @@ The Leader Election is enabled by default in the chart for the Cluster Agent. On
 
 You can specify the Datadog Cluster Agent token used to secure the communication between the Cluster Agent(s) and the Agents with `clusterAgent.token`.
 
-**If you don't specify a token, a random one is generated at each deployment so you must use `--recreate-pods` to ensure all pod use the same token.** see[Datadog Chart notes](https://github.com/helm/charts/blob/57d3030941ad2ec2d6f97c86afdf36666658a884/datadog/datadog/templates/NOTES.txt#L49-L59) to learn more.
-
 ### Upgrading
 
 #### From 1.x to 2.x


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding the flag (`--recreate-pods`) to the helm install command is not necessary anymore, and it has been deprecated in Helm 3. This line should be removed because customers are attempting to run this flag with helm 3, or are looking for workarounds to achieve the same result.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
