### PR TITLE
[datadog-crds] Fix typo in datadogmetrics

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1
+
+* Fix typo in DatadogMetrics CRD
+
 ## 0.3.0
 
 * Update all the CRDs from operator v0.6.0 tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/crds/datadoghq.com_datadogmetrics.yaml
+++ b/crds/datadoghq.com_datadogmetrics.yaml
@@ -53,7 +53,7 @@ spec:
             description: DatadogMetricSpec defines the desired state of DatadogMetric
             properties:
               externalMetricName:
-                description: ExternalMetricName is reversed for internal use
+                description: ExternalMetricName is reserved for internal use
                 type: string
               maxAge:
                 description: MaxAge provides the max age for the metric query (overrides


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix type in `DatadogMetrics` CRD definition:
*  `reversed` -> `reserved`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [X] Variables are documented in the `README.md`
