### PR TITLE
Add Service Account Annotations and Template Agent Pod Annotations

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 2.14.1
+
+* Add parameter `clusterAgent.rbac.serviceAccountAnnotations` for specifying annotations for dedicated ServiceAccount for Cluster Agent.
+* Add parameter `agents.rbac.serviceAccountAnnotations` for specifying annotations for dedicated ServiceAccount for Agents.
+* Support template expansion for `agents.podAnnotations`
+
 ## 2.14.0
 
 * Improve resources labels with kubermetes/helm standard labels.

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -371,6 +371,7 @@ helm install --name <RELEASE_NAME> \
 | agents.podSecurity.volumes | list | `["configMap","downwardAPI","emptyDir","hostPath","secret"]` | Allowed volumes types |
 | agents.priorityClassName | string | `nil` | Sets PriorityClassName if defineds |
 | agents.rbac.create | bool | `true` | If true, create & use RBAC resources |
+| agents.rbac.serviceAccountAnnotations | object | `{}` | Annotations to add to the ServiceAccount if agents.rbac.create is true |
 | agents.rbac.serviceAccountName | string | `"default"` | Specify service account name to use (usually pre-existing, created if create is true) |
 | agents.tolerations | list | `[]` | Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes >= 1.6) |
 | agents.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":"10%"},"type":"RollingUpdate"}` | Allow the DaemonSet to perform a rolling update on helm update |
@@ -412,6 +413,7 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.podSecurity.securityContextConstraints.create | bool | `false` | If true, create a SCC resource for Cluster Agent pods |
 | clusterAgent.priorityClassName | string | `nil` | Name of the priorityClass to apply to the Cluster Agent |
 | clusterAgent.rbac.create | bool | `true` | If true, create & use RBAC resources |
+| clusterAgent.rbac.serviceAccountAnnotations | object | `{}` | Annotations to add to the ServiceAccount if clusterAgent.rbac.create is true |
 | clusterAgent.rbac.serviceAccountName | string | `"default"` | Specify service account name to use (usually pre-existing, created if create is true) |
 | clusterAgent.readinessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent readiness probe settings |
 | clusterAgent.replicas | int | `1` | Specify the of cluster agent replicas, if > 1 it allow the cluster agent to work in HA mode. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.15.0](https://img.shields.io/badge/Version-2.15.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.15.1](https://img.shields.io/badge/Version-2.15.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/ci/agent-with-dynamic-annotations.yaml
+++ b/charts/datadog/ci/agent-with-dynamic-annotations.yaml
@@ -1,0 +1,8 @@
+agents:
+  enabled: true
+  podAnnotations:
+    pod-annotation: "{{.Values.agents.enabled}}"
+  rbac:
+    enabled: true
+    serviceAccountAnnotations:
+      "eks.amazonaws.com/role-arn": "arn:aws:iam::123456789012:role/datadog"

--- a/charts/datadog/ci/cluster-agent-and-worker-with-dedicated-rbac-values.yaml
+++ b/charts/datadog/ci/cluster-agent-and-worker-with-dedicated-rbac-values.yaml
@@ -7,6 +7,10 @@ datadog:
 
 clusterAgent:
   enabled: true
+  rbac:
+    create: true
+    serviceAccountAnnotations:
+      "eks.amazonaws.com/role-arn": "arn:aws:iam::123456789012:role/datadog-cluster-agent"
 
 clusterChecksRunner:
   enabled: true

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -298,6 +298,9 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 {{ include "datadog.labels" . | indent 4 }}
+{{- if .Values.clusterAgent.rbac.serviceAccountAnnotations }}
+  annotations: {{ toYaml .Values.clusterAgent.rbac.serviceAccountAnnotations | nindent 4}}
+{{- end }}
   name: {{ template "datadog.fullname" . }}-cluster-agent
   namespace: {{ .Release.Namespace }}
 {{- if .Values.clusterAgent.admissionController.enabled }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
         container.seccomp.security.alpha.kubernetes.io/system-probe: {{ .Values.datadog.systemProbe.seccomp }}
         {{- end }}
       {{- if .Values.agents.podAnnotations }}
-{{ toYaml .Values.agents.podAnnotations | indent 8 }}
+{{ tpl (toYaml .Values.agents.podAnnotations) . | indent 8 }}
       {{- end }}
     spec:
       {{- if .Values.datadog.securityContext }}

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -123,6 +123,9 @@ kind: ServiceAccount
 metadata:
   name: {{ template "datadog.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.agents.rbac.serviceAccountAnnotations }}
+  annotations: {{ tpl (toYaml .Values.agents.rbac.serviceAccountAnnotations) . | nindent 4}}
+  {{- end }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -486,6 +486,9 @@ clusterAgent:
     # clusterAgent.rbac.serviceAccountName -- Specify service account name to use (usually pre-existing, created if create is true)
     serviceAccountName: default
 
+    # clusterAgent.rbac.serviceAccountAnnotations -- Annotations to add to the ServiceAccount if clusterAgent.rbac.create is true
+    serviceAccountAnnotations: {}
+
   ## Provide Cluster Agent pod security configuration
   podSecurity:
     podSecurityPolicy:
@@ -709,6 +712,10 @@ agents:
 
     # agents.rbac.serviceAccountName -- Specify service account name to use (usually pre-existing, created if create is true)
     serviceAccountName: default
+
+    # agents.rbac.serviceAccountAnnotations -- Annotations to add to the ServiceAccount if agents.rbac.create is true
+    serviceAccountAnnotations: {}
+
 
   ## Provide Daemonset PodSecurityPolicy configuration
   podSecurity:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -716,7 +716,6 @@ agents:
     # agents.rbac.serviceAccountAnnotations -- Annotations to add to the ServiceAccount if agents.rbac.create is true
     serviceAccountAnnotations: {}
 
-
   ## Provide Daemonset PodSecurityPolicy configuration
   podSecurity:
     podSecurityPolicy:


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds Annotations to the Cluster Agent and Agent Service Accounts. Required for using IAM Roles for Service Accounts in EKS.
Update the Agent Pod Annotations to accept variables defined in a values.yaml.

#### Which issue this PR fixes
 - fixes #263 
 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
