### PR TITLE
[examples] rm unneeded image config

### DIFF
--- a/examples/datadog/agent_with_cluster_agent_values.yaml
+++ b/examples/datadog/agent_with_cluster_agent_values.yaml
@@ -31,10 +31,6 @@ agents:
     serviceAccountName: default
 clusterChecksRunner:
   enabled: true
-  image:
-    repository: gcr.io/datadoghq/agent
-    tag: 7.24.1
-    pullPolicy: IfNotPresent
   rbac:
     create: true
     serviceAccountName: default


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove unneeded and outdated image configuration for cluster checks runner in an example file

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
