### PR TITLE
[datadog] Rename DCA's Role && RoleBinding

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.16.4
+
+* Rename the `Role` and `RoleBinding` of the Datadog Cluster Agent to avoid edge cases where `helm upgrade` can fail because of object name conflict.
+
 ## 2.16.3
 
 * Add Daemonsets RBAC rules for the Cluster Agent in order to collect new resources in the Orchestrator Explorer.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.16.3
+version: 2.16.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.16.3](https://img.shields.io/badge/Version-2.16.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.16.4](https://img.shields.io/badge/Version-2.16.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -321,7 +321,7 @@ kind: Role
 metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
-  name: {{ template "datadog.fullname" . }}-cluster-agent
+  name: {{ template "datadog.fullname" . }}-cluster-agent-main
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: [""]
@@ -333,12 +333,12 @@ kind: RoleBinding
 metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
-  name: "{{ template "datadog.fullname" . }}-cluster-agent"
+  name: "{{ template "datadog.fullname" . }}-cluster-agent-main"
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "datadog.fullname" . }}-cluster-agent
+  name: {{ template "datadog.fullname" . }}-cluster-agent-main
 subjects:
   - kind: ServiceAccount
     name: {{ template "datadog.fullname" . }}-cluster-agent


### PR DESCRIPTION
#### What this PR does / why we need it:

* Rename the `RoleBinding` of the Datadog Cluster Agent to avoid edge cases where `helm upgrade` can fail because of object name conflict.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
