### PR TITLE
Enable to configure `spec.containers[*].securityContext` of operator

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.4
+
+* Add a configuration field `containerSecurityContext` to configure a security context for a Container
+
 ## 0.6.3
 
 * Add missing `poddisruptionbudgets` RBAC when the compliance feature is enabled.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.6.3
+version: 0.6.4
 appVersion: 0.6.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 ## Values
 
@@ -12,6 +12,7 @@
 | appKey | string | `nil` | Your Datadog APP key |
 | appKeyExistingSecret | string | `nil` | Use existing Secret which stores APP key instead of creating a new one |
 | collectOperatorMetrics | bool | `true` | Configures an openmetrics check to collect operator metrics |
+| containerSecurityContext | object | `{}` | A security context defines privilege and access control settings for a Container. |
 | datadog-crds.crds.datadogAgents | bool | `true` | Set to true to deploy the DatadogAgents CRD |
 | datadog-crds.crds.datadogMetrics | bool | `true` | Set to true to deploy the DatadogMetrics CRD |
 | datadog-crds.crds.datadogMonitors | bool | `true` | Set to true to deploy the DatadogMonitors CRD |

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -6,22 +6,22 @@
 replicaCount: 1
 
 # apiKey -- Your Datadog API key
-apiKey:  # <DATADOG_API_KEY>
+apiKey: # <DATADOG_API_KEY>
 
 # apiKeyExistingSecret -- Use existing Secret which stores API key instead of creating a new one
 ## If set, this parameter takes precedence over "apiKey".
-apiKeyExistingSecret:  # <DATADOG_API_KEY_SECRET>
+apiKeyExistingSecret: # <DATADOG_API_KEY_SECRET>
 
 # appKey -- Your Datadog APP key
-appKey:  # <DATADOG_APP_KEY>
+appKey: # <DATADOG_APP_KEY>
 
 # dd_url -- The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL
 ## Overrides the site setting defined in "site".
-dd_url:  # <DATADOG_API_ENDPOINT>
+dd_url: # <DATADOG_API_ENDPOINT>
 
 # appKeyExistingSecret -- Use existing Secret which stores APP key instead of creating a new one
 ## If set, this parameter takes precedence over "appKey".
-appKeyExistingSecret:  # <DATADOG_APP_KEY_SECRET>
+appKeyExistingSecret: # <DATADOG_APP_KEY_SECRET>
 
 image:
   # image.repository -- Repository to use for Datadog Operator image
@@ -97,3 +97,6 @@ podLabels: {}
 
 # collectOperatorMetrics -- Configures an openmetrics check to collect operator metrics
 collectOperatorMetrics: true
+
+# containerSecurityContext -- A security context defines privilege and access control settings for a Container.
+containerSecurityContext: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

I've added `containerSecurityContext` to `values.yaml` of datadog operator to configure `spec.containers[*].securityContext` because of security reason.

#### Special notes for your reviewer:

The motivation of this PR is to meet [pod security baseline](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline).

#### Checklist

- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
