### PR TITLE
Enable template expansion for Cluster Agent Annotations and Service Account

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.16.6
+
+* Support template expansion for `clusterAgent.podAnnotations`
+* Support template expansion for `clusterAgent.rbac.serviceAccountAnnotations`
+
 ## 2.16.5
 
 * Remove other way of detecting OpenShift cluster as it's not supported by Helm2.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.16.5
+version: 2.16.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.16.5](https://img.shields.io/badge/Version-2.16.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.16.6](https://img.shields.io/badge/Version-2.16.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/ci/cluster-agent-with-dynamic-annotations.yaml
+++ b/charts/datadog/ci/cluster-agent-with-dynamic-annotations.yaml
@@ -1,0 +1,13 @@
+datadog:
+  clusterName: kubernetes-cluster.example.comkubernetes-cluster.example.com.kube.rnetes-80chars
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  kubeStateMetricsEnabled: false
+  clusterChecks:
+    enabled: true
+
+clusterAgent:
+  enabled: true
+  wpaController: true
+  podAnnotations:
+    pod-annotation: "{{.Values.datadog.clusterName}}"

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -71,7 +71,7 @@ spec:
             ]
           }]
       {{- if .Values.clusterAgent.podAnnotations }}
-{{ toYaml .Values.clusterAgent.podAnnotations | indent 8 }}
+{{ tpl (toYaml .Values.clusterAgent.podAnnotations) . | indent 8 }}
       {{- end }}
 
     spec:

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -310,7 +310,7 @@ metadata:
     release: {{ .Release.Name | quote }}
 {{ include "datadog.labels" . | indent 4 }}
 {{- if .Values.clusterAgent.rbac.serviceAccountAnnotations }}
-  annotations: {{ toYaml .Values.clusterAgent.rbac.serviceAccountAnnotations | nindent 4}}
+  annotations: {{ tpl (toYaml .Values.clusterAgent.rbac.serviceAccountAnnotations) . | nindent 4}}
 {{- end }}
   name: {{ template "datadog.fullname" . }}-cluster-agent
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds template expansion to Annotations and Service Accounts for the ClusterAgent.
This allows variables defined in a values.yaml to be evaluated in the ServiceAccount and PodAnnotations sections of the Cluster Agent config. 
Useful for avoiding hard-coding parameters for different clusters/environments.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
