### PR TITLE
Use a single entrypoint for the datadog agent docker image

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.17.0
+
+* Use a single entrypoint for the all agents containers.
+
 ## 2.16.5
 
 * Remove other way of detecting OpenShift cluster as it's not supported by Helm2.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.16.5
+version: 2.17.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -2,7 +2,6 @@
 - name: agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command: ["agent", "run"]
   {{- if .Values.agents.containers.agent.securityContext }}
   securityContext:
     {{ toYaml .Values.agents.containers.agent.securityContext | nindent 4 }}
@@ -24,6 +23,8 @@
 {{ toYaml .Values.datadog.envFrom | indent 4 }}
 {{- end }}
   env:
+    - name: ENTRYPOINT
+      value: agent
     {{- include "containers-common-env" . | nindent 4 }}
     {{- if .Values.datadog.logLevel }}
     - name: DD_LOG_LEVEL

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -2,12 +2,6 @@
 - name: process-agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  {{- if eq .Values.targetSystem "linux" }}
-  command: ["process-agent", "-config={{ template "datadog.confPath" . }}/datadog.yaml"]
-  {{- end }}
-  {{- if eq .Values.targetSystem "windows" }}
-  command: ["process-agent", "-foreground", "-config={{ template "datadog.confPath" . }}/datadog.yaml"]
-  {{- end }}
   {{- if .Values.agents.containers.processAgent.securityContext }}
   securityContext:
     {{ toYaml .Values.agents.containers.processAgent.securityContext | nindent 4 }}
@@ -23,6 +17,8 @@
 {{ toYaml .Values.datadog.envFrom | indent 4 }}
 {{- end }}
   env:
+    - name: ENTRYPOINT
+      value: process-agent
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
     {{- if .Values.datadog.processAgent.processCollection }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -5,7 +5,6 @@
   securityContext:
     capabilities:
       add: ["AUDIT_CONTROL", "AUDIT_READ"]
-  command: ["security-agent", "start", "-c={{ template "datadog.confPath" . }}/datadog.yaml"]
   resources:
 {{ toYaml .Values.agents.containers.securityAgent.resources | indent 4 }}
 {{- if .Values.agents.containers.securityAgent.ports }}
@@ -17,6 +16,8 @@
 {{ toYaml .Values.datadog.envFrom | indent 4 }}
 {{- end }}
   env:
+    - name: ENTRYPOINT
+      value: security-agent
     {{- include "containers-common-env" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.securityAgent.logLevel | default .Values.datadog.logLevel | quote }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -4,7 +4,6 @@
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
   securityContext:
 {{ toYaml .Values.agents.containers.systemProbe.securityContext | indent 4 }}
-  command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
 {{- if .Values.agents.containers.systemProbe.ports }}
   ports:
 {{ toYaml .Values.agents.containers.systemProbe.ports | indent 2 }}
@@ -14,6 +13,8 @@
 {{ toYaml .Values.datadog.envFrom | indent 4 }}
 {{- end }}
   env:
+    - name: ENTRYPOINT
+      value: system-probe
     {{- include "containers-common-env" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.systemProbe.logLevel | default .Values.datadog.logLevel | quote }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -2,12 +2,6 @@
 - name: trace-agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  {{- if eq .Values.targetSystem "linux" }}
-  command: ["trace-agent", "-config={{ template "datadog.confPath" . }}/datadog.yaml"]
-  {{- end }}
-  {{- if eq .Values.targetSystem "windows" }}
-  command: ["trace-agent", "-foreground", "-config={{ template "datadog.confPath" . }}/datadog.yaml"]
-  {{- end }}
   {{- if .Values.agents.containers.traceAgent.securityContext }}
   securityContext:
     {{ toYaml .Values.agents.containers.traceAgent.securityContext | nindent 4 }}
@@ -27,6 +21,8 @@
 {{ toYaml .Values.datadog.envFrom | indent 4 }}
 {{- end }}
   env:
+    - name: ENTRYPOINT
+      value: trace-agent
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
     - name: DD_LOG_LEVEL

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -2,9 +2,9 @@
 - name: init-volume
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command: ["bash", "-c"]
-  args:
-    - cp -r /etc/datadog-agent /opt
+  env:
+    - name: ENTRYPOINT
+      value: init-volume
   volumeMounts:
     - name: config
       mountPath: /opt/datadog-agent
@@ -13,9 +13,6 @@
 - name: init-config
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command: ["bash", "-c"]
-  args:
-    - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
   volumeMounts:
     - name: logdatadog
       mountPath: /var/log/datadog
@@ -45,6 +42,8 @@
       subPath: system-probe.yaml
     {{- end }}
   env:
+    - name: ENTRYPOINT
+      value: init-config
     {{- include "containers-common-env" . | nindent 4 }}
     {{- if and (eq (include "cluster-agent-enabled" .) "false") .Values.datadog.leaderElection }}
     - name: DD_LEADER_ELECTION

--- a/charts/datadog/templates/_containers-init-windows.yaml
+++ b/charts/datadog/templates/_containers-init-windows.yaml
@@ -2,11 +2,9 @@
 - name: init-volume
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command: ["pwsh", "-Command"]
-  args:
-    - |
-      Copy-Item -Recurse -Force {{ template "datadog.confPath" . }} C:/Temp
-      Copy-Item -Force C:/Temp/install_info/install_info C:/Temp/Datadog/install_info
+  env:
+    - name: ENTRYPOINT
+      value: init-volume
   volumeMounts:
     - name: config
       mountPath: C:/Temp/Datadog
@@ -17,9 +15,6 @@
 - name: init-config
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command: ["pwsh", "-Command"]
-  args:
-    - Get-ChildItem 'entrypoint-ps1' | ForEach-Object { & $_.FullName if (-Not $?) { exit 1 } }
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
@@ -36,6 +31,8 @@
     - name: runtimesocket
       mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
   env:
+    - name: ENTRYPOINT
+      value: init-config
     {{- include "containers-common-env" . | nindent 4 }}
   resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 4 }}

--- a/charts/datadog/templates/_system-probe-init.yaml
+++ b/charts/datadog/templates/_system-probe-init.yaml
@@ -1,10 +1,9 @@
 {{- define "system-probe-init" -}}
 - name: seccomp-setup
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
-  command:
-  - cp
-  - /etc/config/system-probe-seccomp.json
-  - /host/var/lib/kubelet/seccomp/system-probe
+  env:
+    - name: ENTRYPOINT
+      value: seccomp-setup
   volumeMounts:
   - name: datadog-agent-security
     mountPath: /etc/config

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -64,9 +64,9 @@ spec:
       - name: init-volume
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterChecksRunner.image) }}"
         imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-        command: ["bash", "-c"]
-        args:
-          - cp -r /etc/datadog-agent /opt
+        env:
+          - name: ENTRYPOINT
+            value: init-volume
         volumeMounts:
           - name: config
             mountPath: /opt/datadog-agent
@@ -75,9 +75,9 @@ spec:
       - name: init-config
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterChecksRunner.image) }}"
         imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-        command: ["bash", "-c"]
-        args:
-          - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+        env:
+          - name: ENTRYPOINT
+            value: init-config
         volumeMounts:
           - name: config
             mountPath: /etc/datadog-agent
@@ -91,9 +91,6 @@ spec:
       containers:
       - name: agent
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterChecksRunner.image) }}"
-        command: ["bash", "-c"]
-        args:
-          - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run
         imagePullPolicy: {{ .Values.clusterChecksRunner.image.pullPolicy }}
 {{- if .Values.clusterChecksRunner.ports }}
         ports:
@@ -104,6 +101,8 @@ spec:
 {{ toYaml .Values.datadog.envFrom | indent 10 }}
 {{- end }}
         env:
+          - name: ENTRYPOINT
+            value: clusterchecks-agent
           - name: DD_API_KEY
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
#### What this PR does / why we need it:

Use a single entrypoint for the datadog agent docker image.

#### Which issue this PR fixes

GKE auto-pilot requires to have a fixed entrypoint in the docker image.

#### Special notes for your reviewer:

This new version of the chart requires an agent docker image that includes DataDog/datadog-agent#8490.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
