### PR TITLE
Agent additional initcontainers

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.19.5
+
+* Support template expansion for `agents.containers.initContainers.additional`
+
 ## 2.19.4
 
 * Fix `runtimesocket` volumeMount for the `trace-agent` on windows deployment.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.19.4
+version: 2.19.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.19.4](https://img.shields.io/badge/Version-2.19.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.19.5](https://img.shields.io/badge/Version-2.19.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -326,7 +326,8 @@ helm install --name <RELEASE_NAME> \
 | agents.containers.agent.readinessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent readiness probe settings |
 | agents.containers.agent.resources | object | `{}` | Resource requests and limits for the agent container. |
 | agents.containers.agent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the agent container. |
-| agents.containers.initContainers.resources | object | `{}` | Resource requests and limits for the init containers |
+| agents.containers.initContainers.additional | list | `[]` | Additional initContainers to execute before agent containers run |
+| agents.containers.initContainers.resources | object | `{}` | Resource requests and limits for the default init containers |
 | agents.containers.processAgent.env | list | `[]` | Additional environment variables for the process-agent container |
 | agents.containers.processAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
 | agents.containers.processAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -88,9 +88,7 @@ spec:
           {{- end }}
         resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 10 }}
-      {{- with .Values.agents.containers.initContainers.additional }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+{{ toYaml .Values.agents.containers.initContainers.additional | indent 8 }}
       containers:
       - name: agent
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterChecksRunner.image) }}"

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -88,7 +88,9 @@ spec:
           {{- end }}
         resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 10 }}
+{{- if .Values.agents.containers.initContainers.additional }}
 {{ toYaml .Values.agents.containers.initContainers.additional | indent 8 }}
+{{- end }}
       containers:
       - name: agent
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterChecksRunner.image) }}"

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -88,6 +88,9 @@ spec:
           {{- end }}
         resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 10 }}
+      {{- with .Values.agents.containers.initContainers.additional }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       containers:
       - name: agent
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterChecksRunner.image) }}"

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -123,9 +123,7 @@ spec:
         {{- if and (eq (include "should-enable-system-probe" .) "true")  (eq .Values.datadog.systemProbe.seccomp "localhost/system-probe") }}
           {{ include "system-probe-init" . | nindent 6 }}
         {{- end }}
-        {{- with .Values.agents.containers.initContainers.additional }}
-        {{- toYaml . | nindent 6 }}
-        {{- end }}
+{{ toYaml .Values.agents.containers.initContainers.additional | indent 8 }}
       volumes:
       - name: installinfo
         configMap:

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -123,7 +123,9 @@ spec:
         {{- if and (eq (include "should-enable-system-probe" .) "true")  (eq .Values.datadog.systemProbe.seccomp "localhost/system-probe") }}
           {{ include "system-probe-init" . | nindent 6 }}
         {{- end }}
-{{ toYaml .Values.agents.containers.initContainers.additional | indent 8 }}
+        {{- if .Values.agents.containers.initContainers.additional }}
+          {{ toYaml .Values.agents.containers.initContainers.additional | nindent 6 }}
+        {{- end }}
       volumes:
       - name: installinfo
         configMap:

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -123,6 +123,9 @@ spec:
         {{- if and (eq (include "should-enable-system-probe" .) "true")  (eq .Values.datadog.systemProbe.seccomp "localhost/system-probe") }}
           {{ include "system-probe-init" . | nindent 6 }}
         {{- end }}
+        {{- with .Values.agents.containers.initContainers.additional }}
+        {{- toYaml . | nindent 6 }}
+        {{- end }}
       volumes:
       - name: installinfo
         configMap:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -950,7 +950,7 @@ agents:
       ports: []
 
     initContainers:
-      # agents.containers.initContainers.resources -- Resource requests and limits for the init containers
+      # agents.containers.initContainers.resources -- Resource requests and limits for the default init containers
       resources: {}
       #  requests:
       #    cpu: 100m
@@ -958,6 +958,12 @@ agents:
       #  limits:
       #    cpu: 100m
       #    memory: 200Mi
+
+      # agents.containers.initContainers.additional -- Additional initContainers to execute before agent containers run
+      additional: []
+      #   - name: busybox
+      #     image: busybox:1.31.1
+      #     command: ["sh", "-c", "echo"]
 
   # agents.volumes -- Specify additional volumes to mount in the dd-agent container
   volumes: []


### PR DESCRIPTION
#### What this PR does / why we need it:
From #286: 
> I need to run an initContainer before datadog containers run.
>
> My use case is to run an authorization request before execution.
>
> Currently there is only a way of editing datadog initContainer resources via agents.containers.initContainers.resources. This map only affects those initContainers that are preset by default by the Chart's template files for different host operating systems.

#### Which issue this PR fixes
Fixes #286 

#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
