### PR TITLE
[synthetics-private-location] Use secret in stead of configMap

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+### 0.6.0
+
+* Use secret instead of Config Map for `configFile`.
+* Added `configSecret` to support passing the json config using a Secret.
+
 ### 0.5.0
 
 * Update private location image version to `1.11.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.5.0
+version: 0.6.0
 appVersion: 1.4.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -28,6 +28,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | affinity | object | `{}` | Allows to specify affinity for Datadog Synthetics Private Location PODs |
 | configConfigMap | string | `""` | Config Map that stores the configuration of the private location worked for the deployment |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
+| configSecret | string | `""` | Secret that stores the configuration of the private location worker for the deployment |
 | env | list | `[]` | Set environment variables |
 | envFrom | list | `[]` | Set environment variables from configMaps and/or secrets |
 | fullnameOverride | string | `""` | Override the full qualified app name |

--- a/charts/synthetics-private-location/templates/NOTES.txt
+++ b/charts/synthetics-private-location/templates/NOTES.txt
@@ -6,3 +6,21 @@
 
 You provided configConfigMap and configFile. The config map provided by configConfigMap takes precedence over configFile, so configFile was ignored.
 {{- end }}
+
+{{- if and ( ne .Values.configFile "{}" ) .Values.configSecret }}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+You provided configSecret and configFile. The secret provided by configSecret takes precedence over configFile, so configFile was ignored.
+{{- end }}
+
+{{- if and .Values.configConfigMap .Values.configSecret }}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+You provided configConfigMap and configSecret. The config map provided by configConfigMap takes precedence over configSecret, so configSecret was ignored.
+{{- end }}

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -68,9 +68,14 @@ spec:
       {{- end }}
       volumes:
       - name: worker-config
-        configMap:
         {{- if .Values.configConfigMap }}
+        configMap:
           name: {{ .Values.configConfigMap | quote }}
         {{- else }}
-          name: {{ include "synthetics-private-location.fullname" . }}-config
+        secret:
+        {{- if .Values.configSecret }}
+          secretName: {{ .Values.configSecret | quote }}
+        {{- else }}
+          secretName: {{ include "synthetics-private-location.fullname" . }}-config
+        {{- end }}
         {{- end }}

--- a/charts/synthetics-private-location/templates/secret.yaml
+++ b/charts/synthetics-private-location/templates/secret.yaml
@@ -1,13 +1,12 @@
-{{- if not .Values.configConfigMap }}
+{{- if and (not .Values.configConfigMap) (not .Values.configSecret) }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ include "synthetics-private-location.fullname" . }}-config
   labels:
     {{- include "synthetics-private-location.labels" . | nindent 4 }}
 data:
-  synthetics-check-runner.json: |-
-{{ .Values.configFile | indent 4 }}
+  synthetics-check-runner.json: {{ .Values.configFile | b64enc | quote }}
 ---
 {{- end }}
 

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -68,6 +68,9 @@ configFile: "{}"
 # configConfigMap -- Config Map that stores the configuration of the private location worked for the deployment
 configConfigMap: ""
 
+# configSecret -- Secret that stores the configuration of the private location worker for the deployment
+configSecret: ""
+
 # envFrom -- Set environment variables from configMaps and/or secrets
 envFrom: []
 #   - configMapRef:


### PR DESCRIPTION
#### What this PR does / why we need it:
Store configuration in a secret instead of a configMap.

The configuration contains credentials. Therefore it's better to store it in a secret.

This PR changes the following:

- store configFile value in secret instead of configMap
- keep supporting configConfigMap value for backwards compatibility
- add configSecret value


#### Checklist

- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`