### PR TITLE
[datadog] move to the new kube-state-metrics chart registry

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,6 +1,6 @@
 chart-repos:
   - datadog=https://helm.datadoghq.com
-  - kube-state-metrics=https://kubernetes.github.io/kube-state-metrics
+  - kube-state-metrics=https://prometheus-community.github.io/helm-charts
 helm-extra-args: --timeout 300s
 check-version-increment: true
 debug: true

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.19.0
+
+* Move to the new `kube-state-metrics` chart registry, but keep the version `2.13.2`.
+
 ## 2.18.2
 
 * Update `kube-state-metrics` requirement chart documentation.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.18.3
+version: 2.19.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.18.3](https://img.shields.io/badge/Version-2.18.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.19.0](https://img.shields.io/badge/Version-2.19.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -29,7 +29,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 | Repository | Name | Version |
 |------------|------|---------|
 | https://helm.datadoghq.com | datadog-crds | =0.1.1 |
-| https://kubernetes.github.io/kube-state-metrics | kube-state-metrics | =2.13.2 |
+| https://prometheus-community.github.io/helm-charts | kube-state-metrics | =2.13.2 |
 
 ## Quick start
 

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: https://helm.datadoghq.com
   version: 0.1.1
 - name: kube-state-metrics
-  repository: https://kubernetes.github.io/kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
-digest: sha256:561cb4a9b77471828d50f8bbcf3b093639b881ebddbd0d8c42336732a4f50bf2
-generated: "2021-04-28T21:35:59.027064+02:00"
+digest: sha256:088c89099b7107e78a1394f8a089223e60b594aaf21593e75362d4c351d3e18e
+generated: "2021-07-08T12:52:38.907313+02:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -7,5 +7,5 @@ dependencies:
     - install-crds
   - name: kube-state-metrics
     version: "=2.13.2"
-    repository: https://kubernetes.github.io/kube-state-metrics
+    repository: https://prometheus-community.github.io/helm-charts
     condition: datadog.kubeStateMetricsEnabled


### PR DESCRIPTION
#### What this PR does / why we need it:

* Move to `https://prometheus-community.github.io/helm-charts` helm chart registry for the `kube-state-metrics` dependency in the `datadog` chart.

#### Which issue this PR fixes

  - fixes #307

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
