### PR TITLE
[datadog] Fix release process after kube-state-metrics registry update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Add datadog helm repo
         run: helm repo add datadog https://helm.datadoghq.com && helm repo update
       - name: Add KSM helm repo
-        run: helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics
+        run: helm repo add kube-state-metrics https://prometheus-community.github.io/helm-charts
       - name: Run kubeval
         env:
           KUBERNETES_VERSION: ${{ matrix.k8s }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Add repo
         run: |
           helm repo add datadog https://helm.datadoghq.com
-          helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics
+          helm repo add kube-state-metrics https://prometheus-community.github.io/helm-charts
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.0
         env:

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.19.1
+
+* Fix chart release process after updating the `kube-state-metrics` chart registry.
+
 ## 2.19.0
 
 * Move to the new `kube-state-metrics` chart registry, but keep the version `2.13.2`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.19.0
+version: 2.19.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.19.0](https://img.shields.io/badge/Version-2.19.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.19.1](https://img.shields.io/badge/Version-2.19.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 


### PR DESCRIPTION
#### What this PR does / why we need it:

the helm chart registries are defined in several files. In previous #309 PR, I forgot to update the `kube-state-metrics` registry in the release workflow configuration. 

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
