### PR TITLE
Remove ref to readonly for socket mounts in trace agent container for Windows

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.19.3
+
+* Fix `runtimesocket` volumeMount for the `trace-agent` on windows deployment.
+
 ## 2.19.2
 
 * Fix `dsdsocket` volumeMount for the `trace-agent` on windows deployment.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.19.2
+
+* Fix `dsdsocket` volumeMount for the `trace-agent` on windows deployment.
+
 ## 2.19.1
 
 * Fix chart release process after updating the `kube-state-metrics` chart registry.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.19.2
+version: 2.19.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.19.3
+version: 2.19.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.19.1
+version: 2.19.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.19.1](https://img.shields.io/badge/Version-2.19.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.19.2](https://img.shields.io/badge/Version-2.19.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.19.2](https://img.shields.io/badge/Version-2.19.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.19.3](https://img.shields.io/badge/Version-2.19.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -64,17 +64,23 @@
       readOnly: false
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
+    {{- if not .Values.datadog.apm.useSocketVolume }}
+      readOnly: true
+    {{- else if and .Values.datadog.apm.useSocketVolume (ne (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath)) }}
+      readOnly: true
+    {{- end }}
     - name: runtimesocketdir
       mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+    {{- if .Values.datadog.apm.useSocketVolume }}
+    - name: apmsocket
+      mountPath: {{ (dir .Values.datadog.apm.socketPath) }}
+    {{- end }}
     {{- end }}
     {{- if eq .Values.targetSystem "windows" }}
     - name: runtimesocket
       mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
-    {{- end }}
-    - name: apmsocket
-      mountPath: {{ (dir .Values.datadog.apm.socketPath) }}
     {{- end }}
     {{- if .Values.datadog.kubelet.hostCAPath }}
 {{ include "datadog.kubelet.volumeMount" . | indent 4 }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -62,6 +62,8 @@
     - name: tmpdir
       mountPath: /tmp
       readOnly: false
+    - name: dsdsocket
+      mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
     - name: runtimesocketdir
       mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
@@ -71,8 +73,6 @@
     - name: runtimesocket
       mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
     {{- end }}
-    - name: dsdsocket
-      mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
     {{- if not .Values.datadog.apm.useSocketVolume }}
       readOnly: true
     {{- else if and .Values.datadog.apm.useSocketVolume (ne (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath)) }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -69,14 +69,14 @@
     {{- else if and .Values.datadog.apm.useSocketVolume (ne (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath)) }}
       readOnly: true
     {{- end }}
-    - name: runtimesocketdir
-      mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- if .Values.datadog.apm.useSocketVolume }}
     - name: apmsocket
       mountPath: {{ (dir .Values.datadog.apm.socketPath) }}
     {{- end }}
+    - name: runtimesocketdir
+      mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "windows" }}
     - name: runtimesocket

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -73,10 +73,6 @@
     - name: runtimesocket
       mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
     {{- end }}
-    {{- if not .Values.datadog.apm.useSocketVolume }}
-      readOnly: true
-    {{- else if and .Values.datadog.apm.useSocketVolume (ne (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath)) }}
-      readOnly: true
     - name: apmsocket
       mountPath: {{ (dir .Values.datadog.apm.socketPath) }}
     {{- end }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -64,7 +64,7 @@
       readOnly: false
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-    {{- if .Values.datadog.apm.useSocketVolume }}
+    {{- if and .Values.datadog.apm.useSocketVolume (ne (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath)) }}
     - name: apmsocket
       mountPath: {{ (dir .Values.datadog.apm.socketPath) }}
     {{- end }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -64,11 +64,6 @@
       readOnly: false
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-    {{- if not .Values.datadog.apm.useSocketVolume }}
-      readOnly: true
-    {{- else if and .Values.datadog.apm.useSocketVolume (ne (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath)) }}
-      readOnly: true
-    {{- end }}
     {{- if .Values.datadog.apm.useSocketVolume }}
     - name: apmsocket
       mountPath: {{ (dir .Values.datadog.apm.socketPath) }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes the trace agent container by removing the reference to socket read only mounts on Windows.
Pipes cannot be mounted as read only on windows and this PR introduced a read only mounts by mistake: https://github.com/DataDog/helm-charts/pull/313 for the runtimesocket mount.

#### Special notes for your reviewer:
Maybe I overlooked a logic introduced by https://github.com/DataDog/helm-charts/pull/300 for the readonly mounts, but I think this should not be there anyway.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
