### PR TITLE
[chart/datadog] Update datadog-crds dependency to v0.3.2

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.19.8
+
+* Update `datadog-crds` to `0.3.2`.
+
 ## 2.19.7
 
 * Fix test value files in datadog/ci directory.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.19.7
+version: 2.19.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.19.7](https://img.shields.io/badge/Version-2.19.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.19.8](https://img.shields.io/badge/Version-2.19.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -28,7 +28,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://helm.datadoghq.com | datadog-crds | =0.1.1 |
+| https://helm.datadoghq.com | datadog-crds | =0.3.2 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | =2.13.2 |
 
 ## Quick start

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 0.1.1
+  version: 0.3.2
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
-digest: sha256:088c89099b7107e78a1394f8a089223e60b594aaf21593e75362d4c351d3e18e
-generated: "2021-07-08T12:52:38.907313+02:00"
+digest: sha256:fba58e151b8e26c07874746e72e17385da6e6e85883c3777397050bbb8fe4e32
+generated: "2021-07-28T17:51:46.994751+02:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: datadog-crds
-    version: "=0.1.1"
+    version: "=0.3.2"
     repository: https://helm.datadoghq.com
     condition: clusterAgent.metricsProvider.useDatadogMetrics
     tags:


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the datadog chart `datadog-crds` dependency to v0.3.2


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
