### PR TITLE
Fix typo on `charts/datadog/README.md`

### DIFF
--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -591,8 +591,8 @@ targetSystem: windows
 
 existingClusterAgent:
   join: true
-  serviceName: "<EXISTING_DCA_SECRET_NAME>" # from the other datadog helm chart release
-  tokenSecretName: "<EXISTING_DCA_SERVICE_NAME>" # from the other datadog helm chart release
+  serviceName: "<EXISTING_DCA_SERVICE_NAME>" # from the other datadog helm chart release
+  tokenSecretName: "<EXISTING_DCA_SECRET_NAME>" # from the other datadog helm chart release
 
 # Disabled datadogMetrics deployment since it should have been already deployed with the other chart release.
 datadog-crds:

--- a/charts/datadog/README.md.gotmpl
+++ b/charts/datadog/README.md.gotmpl
@@ -339,8 +339,8 @@ targetSystem: windows
 
 existingClusterAgent:
   join: true
-  serviceName: "<EXISTING_DCA_SECRET_NAME>" # from the other datadog helm chart release
-  tokenSecretName: "<EXISTING_DCA_SERVICE_NAME>" # from the other datadog helm chart release
+  serviceName: "<EXISTING_DCA_SERVICE_NAME>" # from the other datadog helm chart release
+  tokenSecretName: "<EXISTING_DCA_SECRET_NAME>" # from the other datadog helm chart release
 
 # Disabled datadogMetrics deployment since it should have been already deployed with the other chart release.
 datadog-crds:


### PR DESCRIPTION
Fix typos in `How to join a Cluster Agent from another helm chart deployment (Linux)` of `charts/datadog/README.md`.