### PR TITLE
Skip KSM network policy creation when KSM creation is disabled

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.20.4
+
+* Skip KSM network policy creation when KSM creation is disabled.
+
 ## 2.20.3
 
 * Add `agents.image.tagSuffix` and `clusterChecksRunner.image.tagSuffix` to be able to request JMX or Windows servercore images without having to explicitly specify the full version.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.20.3
+version: 2.20.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.20.3](https://img.shields.io/badge/Version-2.20.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.20.4](https://img.shields.io/badge/Version-2.20.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/kube-state-metrics-cilium-network-policy.yaml
+++ b/charts/datadog/templates/kube-state-metrics-cilium-network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if and (or $.Values.datadog.networkPolicy.create $.Values.datadog.kubeStateMetricsNetworkPolicy.create) (eq $.Values.datadog.networkPolicy.flavor "cilium") -}}
+{{- if and $.Values.datadog.kubeStateMetricsEnabled (or $.Values.datadog.networkPolicy.create $.Values.datadog.kubeStateMetricsNetworkPolicy.create) (eq $.Values.datadog.networkPolicy.flavor "cilium") -}}
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:

--- a/charts/datadog/templates/kube-state-metrics-network-policy.yaml
+++ b/charts/datadog/templates/kube-state-metrics-network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if and (or $.Values.datadog.networkPolicy.create $.Values.datadog.kubeStateMetricsNetworkPolicy.create) (eq $.Values.datadog.networkPolicy.flavor "kubernetes") -}}
+{{- if and $.Values.datadog.kubeStateMetricsEnabled (or $.Values.datadog.networkPolicy.create $.Values.datadog.kubeStateMetricsNetworkPolicy.create) (eq $.Values.datadog.networkPolicy.flavor "kubernetes") -}}
 apiVersion: "networking.k8s.io/v1"
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

Skip KSM network policy creation when KSM creation is disabled.

#### Which issue this PR fixes
  - fixes #336

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [X] Variables are documented in the `README.md`
