### PR TITLE
[datadog] always disable UDS socket on GKE autopilot

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.21.1
+
+* Disable by default UDS socket for dogstastd and apm on GKE autopilot.
+
 ## 2.21.0
 
 * Enable APM by default with using a Unix Domain socket for communication.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.21.0
+version: 2.21.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.21.0](https://img.shields.io/badge/Version-2.21.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.21.1](https://img.shields.io/badge/Version-2.21.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -37,7 +37,7 @@
       value: "true"
     - name: DD_APM_RECEIVER_PORT
       value: {{ .Values.datadog.apm.port | quote }}
-  {{- if eq  (include "trace-agent-use-uds" .) "true" }}
+  {{- if eq (include "trace-agent-use-uds" .) "true" }}
     - name: DD_APM_RECEIVER_SOCKET
       value: {{ .Values.datadog.apm.socketPath | quote }}
   {{- end }}
@@ -64,7 +64,7 @@
       readOnly: false
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-    {{- if and .Values.datadog.apm.useSocketVolume (ne (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath)) }}
+    {{- if and (eq (include "trace-agent-use-uds" .) "true") (ne (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath)) }}
     - name: apmsocket
       mountPath: {{ (dir .Values.datadog.apm.socketPath) }}
     {{- end }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -9,7 +9,7 @@
 - hostPath:
     path: /sys/fs/cgroup
   name: cgroups
-{{- if .Values.datadog.dogstatsd.useSocketVolume }}
+{{- if eq (include "should-mount-hostPath-for-dsd-socket" .) "true" }}
 - hostPath:
     path: {{ .Values.datadog.dogstatsd.hostSocketPath }}
     type: DirectoryOrCreate
@@ -24,7 +24,7 @@
     type: File
   name: kubelet-ca
 {{- end }}
-{{- if eq  (include "trace-agent-use-uds" .) "true" }}
+{{- if eq (include "trace-agent-use-uds" .) "true" }}
 - hostPath:
     path: {{ .Values.datadog.apm.hostSocketPath }}
     type: DirectoryOrCreate

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -365,9 +365,26 @@ false
 {{- end -}}
 
 {{/*
-Return true if a APM over UDS is configured.
+Return true hostPath should be use for DSD socket. Return always false on GKE autopilot.
+*/}}
+{{- define "should-mount-hostPath-for-dsd-socket" -}}
+{{- if .Values.providers.gke.autopilot -}}
+false
+{{- end -}}
+{{- if .Values.datadog.dogstatsd.useSocketVolume -}}
+false
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a APM over UDS is configured. Return always false on GKE autopilot.
 */}}
 {{- define "trace-agent-use-uds" -}}
+{{- if .Values.providers.gke.autopilot -}}
+false
+{{- end -}}
 {{- if or .Values.datadog.apm.socketEnabled .Values.datadog.apm.useSocketVolume -}}
 true
 {{- else -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -368,7 +368,7 @@ false
 Return true hostPath should be use for DSD socket. Return always false on GKE autopilot.
 */}}
 {{- define "should-mount-hostPath-for-dsd-socket" -}}
-{{- if .Values.providers.gke.autopilot -}}
+{{- if or .Values.providers.gke.autopilot (eq .Values.targetSystem "windows") -}}
 false
 {{- end -}}
 {{- if .Values.datadog.dogstatsd.useSocketVolume -}}
@@ -382,7 +382,7 @@ true
 Return true if a APM over UDS is configured. Return always false on GKE autopilot.
 */}}
 {{- define "trace-agent-use-uds" -}}
-{{- if .Values.providers.gke.autopilot -}}
+{{- if or .Values.providers.gke.autopilot (eq .Values.targetSystem "windows") -}}
 false
 {{- end -}}
 {{- if or .Values.datadog.apm.socketEnabled .Values.datadog.apm.useSocketVolume -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

* Disable by default UDS sockets support for dogstastd and apm on GKE autopilot.

#### Which issue this PR fixes
  - fixes #182

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
