### PR TITLE
Update GH action versions and helm-docs

### DIFF
--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-HELM_DOCS_VERSION="0.15.0"
+HELM_DOCS_VERSION="1.5.0"
 OS=$(uname)
 
 # install helm-docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       charts: ${{ steps.list-changed.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
@@ -43,7 +43,7 @@ jobs:
       - changed
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
@@ -58,7 +58,7 @@ jobs:
       - changed
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Run helm-docs
         run: .github/helm-docs.sh
 
@@ -75,7 +75,7 @@ jobs:
           - v1.18.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Add datadog helm repo
         run: helm repo add datadog https://helm.datadoghq.com && helm repo update
       - name: Add KSM helm repo
@@ -100,7 +100,7 @@ jobs:
           - v1.18.4
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Create kind ${{ matrix.k8s }} cluster
         uses: helm/kind-action@main
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,6 @@ jobs:
           helm repo add datadog https://helm.datadoghq.com
           helm repo add kube-state-metrics https://prometheus-community.github.io/helm-charts
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
#### What this PR does / why we need it:

- Update actions/checkout to v2
- Update chart-releaser-action to 1.2.1
- Update helm-docs to 1.5.0

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

I ran helm-docs@1.5 locally and it didn't create any diff, and didn't notice any notable changes in their changelog

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
