### PR TITLE
[datadog] Fix Dogstatsd UDS hostVolume configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,13 @@ jobs:
       charts: ${{ steps.list-changed.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.1
+          version: v3.6.3
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
@@ -43,7 +45,9 @@ jobs:
       - changed
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
@@ -58,7 +62,9 @@ jobs:
       - changed
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Run helm-docs
         run: .github/helm-docs.sh
 
@@ -75,7 +81,9 @@ jobs:
           - v1.18.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Add datadog helm repo
         run: helm repo add datadog https://helm.datadoghq.com && helm repo update
       - name: Add KSM helm repo
@@ -100,7 +108,9 @@ jobs:
           - v1.18.4
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Create kind ${{ matrix.k8s }} cluster
         uses: helm/kind-action@main
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.21.2
+
+* Fix Dogstatsd UDS socket configuration with a HostVolume when `useSocketVolume: true`.
+
 ## 2.21.1
 
 * Disable by default UDS socket for dogstastd and apm on GKE autopilot.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.21.1
+version: 2.21.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.21.1](https://img.shields.io/badge/Version-2.21.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.21.2](https://img.shields.io/badge/Version-2.21.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -372,9 +372,9 @@ Return true hostPath should be use for DSD socket. Return always false on GKE au
 false
 {{- end -}}
 {{- if .Values.datadog.dogstatsd.useSocketVolume -}}
-false
-{{- else -}}
 true
+{{- else -}}
+false
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the Dogstatsd UDS hostVolume configuration when `useSocketVolume:true`. 
The PR #357 has introduced a bug that reverse the logic about create an `hostVolume` or an `EmptyDir`.

The wanted behaviour is:
* If `useSocketVolume:true` => use an `hostVolume`.
* If `useSocketVolume:false` => use an `emptyDir`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
