### PR TITLE
[EDS] Update to 0.7.0

### DIFF
--- a/charts/extended-daemon-set/CHANGELOG.md
+++ b/charts/extended-daemon-set/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+* Updated for EDS 0.7.0.
+
 ## 0.1.0
 
 * Initial version

--- a/charts/extended-daemon-set/Chart.yaml
+++ b/charts/extended-daemon-set/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.6.0
+appVersion: v0.7.0
 description: Extended Daemonset Controller
 name: extendeddaemonset
 version: v0.1.0

--- a/charts/extended-daemon-set/Chart.yaml
+++ b/charts/extended-daemon-set/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.7.0
 description: Extended Daemonset Controller
 name: extendeddaemonset
-version: v0.1.0
+version: v0.2.0
 keywords:
 - monitoring
 - alerting

--- a/charts/extended-daemon-set/README.md
+++ b/charts/extended-daemon-set/README.md
@@ -1,6 +1,6 @@
 # Extended DaemonSet
 
-![Version: v0.1.0](https://img.shields.io/badge/Version-v0.1.0-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
+![Version: v0.2.0](https://img.shields.io/badge/Version-v0.2.0-informational?style=flat-square) ![AppVersion: v0.7.0](https://img.shields.io/badge/AppVersion-v0.7.0-informational?style=flat-square)
 
 This chart installs the Extended DaemonSet (EDS). It aims to provide a new implementation of the Kubernetes DaemonSet resource with key features:
 - Canary Deployment: Deploy a new DaemonSet version with only a few nodes.
@@ -27,7 +27,7 @@ helm repo update
 | fullnameOverride | string | `""` | Overrides the full qualified app name |
 | image.pullPolicy | string | `"IfNotPresent"` | Defines the pullPolicy for the Extended DaemonSet image |
 | image.repository | string | `"datadog/extendeddaemonset"` | Repository to use for the Extended DaemonSet image |
-| image.tag | string | `"v0.6.0"` | Defines the Extended DaemonSet version to use |
+| image.tag | string | `"v0.7.0"` | Defines the Extended DaemonSet version to use |
 | imagePullSecrets | list | `[]` | Extended DaemonSet image repository pullSecret (ex: specify docker registry credentials) |
 | logLevel | string | `"info"` | Sets the log level (debug, info, error, panic, fatal) |
 | nameOverride | string | `""` | Overrides name of app |

--- a/charts/extended-daemon-set/requirements.lock
+++ b/charts/extended-daemon-set/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 0.3.4
-digest: sha256:d9bf1befc92cbf2572ed2fe02404ae71ef0590220937e0f519fae94bb2cc3839
-generated: "2021-08-04T10:58:57.57067+02:00"
+  version: 0.3.5
+digest: sha256:aafc4baa740a5aea5df7ce74d79fb7b163bf55c6e2530a510a4c45b397fb17f4
+generated: "2021-09-09T13:01:56.282732+02:00"

--- a/charts/extended-daemon-set/requirements.yaml
+++ b/charts/extended-daemon-set/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: datadog-crds
-    version: "=0.3.4"
+    version: "=0.3.5"
     repository: https://helm.datadoghq.com
     condition: true
     tags:

--- a/charts/extended-daemon-set/templates/role.yaml
+++ b/charts/extended-daemon-set/templates/role.yaml
@@ -35,6 +35,18 @@ rules:
   - get
   - watch
 - apiGroups:
+    - ""
+  resources:
+    - podtemplates
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
   - ""
   resources:
   - services

--- a/charts/extended-daemon-set/values.yaml
+++ b/charts/extended-daemon-set/values.yaml
@@ -8,7 +8,7 @@ image:
   # image.repository -- Repository to use for the Extended DaemonSet image
   repository: datadog/extendeddaemonset
   # image.tag -- Defines the Extended DaemonSet version to use
-  tag: v0.6.0
+  tag: v0.7.0
   # image.pullPolicy -- Defines the pullPolicy for the Extended DaemonSet image
   pullPolicy: IfNotPresent
 # imagePullSecrets -- Extended DaemonSet image repository pullSecret (ex: specify docker registry credentials)


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the EDS chart to support v0.7.0.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
