### PR TITLE
Use existing helper to determine whether to mount system-probe socket & config

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 2.21.4
+
+* Fix condition for including `sysprobe-socket-dir` and `sysprobe-config` volume mounts for `agent`.
 ## 2.21.3
 
 * Default Datadog Agent image to 7.30.1.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.21.3
+version: 2.21.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.21.3](https://img.shields.io/badge/Version-2.21.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.21.4](https://img.shields.io/badge/Version-2.21.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -142,7 +142,7 @@
     {{- if eq .Values.targetSystem "linux" }}
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-    {{- if or .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill }}
+    {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
       readOnly: true


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR changes the condition for including the system probe socket & config mount in the `agent` container to use the existing `should-enable-system-probe` helper that is defined in `charts/datadog/templates/_helpers.tpl`. This fixes the case where before, certain system probe modules (such as network monitoring) being enabled wouldn't cause the socket/config to get mounted in the agent container (because they weren't included in the condition).

Moreover, this PR is part of a fix (along with https://github.com/DataDog/datadog-agent/pull/9110) to `datadog-agent status` and `datadog-agent flare` to have them correctly report the status of the system probe when it is running. Without the system probe socket & config being mounted, it won't report the status of the system probe when running `datadog-agent status` for an agent deployed using this helm chart.

<!-- #### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer: -->

#### Testing notes

To test this PR, I used an agent development container image (generated with the changes in https://github.com/DataDog/datadog-agent/pull/9110 included) and deployed it via the helm chart (with the agent & network monitoring enabled) to a test cluster. After the change in this PR, getting the status from a running agent prints out the status of the system probe as expected:

```
$ kubectl exec -it datadog-dr2jt -c agent -- agent status | grep "System Probe"
System Probe
System Probe is running
```

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
<!-- - [ ] Variables are documented in the `README.md` -->
