### PR TITLE
[datadog-crds] Fix instructions to run the update-crds script

### DIFF
--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.4.1
+version: 0.4.2
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -33,5 +33,5 @@ But the recommended Kubernetes versions are `1.16+`.
 ### How to update CRDs
 
 ```shell
-./update-crds.sh <datadog-operator-tag> <datadog-extended-daemonset-tag>
+./update-crds.sh <datadog-operator-tag>
 ```

--- a/charts/datadog-crds/README.md.gotmpl
+++ b/charts/datadog-crds/README.md.gotmpl
@@ -26,5 +26,5 @@ But the recommended Kubernetes versions are `1.16+`.
 ### How to update CRDs
 
 ```shell
-./update-crds.sh <datadog-operator-tag> <datadog-extended-daemonset-tag>
+./update-crds.sh <datadog-operator-tag>
 ```


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the instructions to run the script used to update the CRDs. The script no longer accepts a second parameter after merging https://github.com/DataDog/helm-charts/pull/382/


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
