### PR TITLE
[datadog] Update CNP to grant access to ECS agent on localhost

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Datadog changelog
 
+## 2.22.3
+
+* CiliumNetworkPolicy: Grant access to the agent to ECS container agent via localhost.
+
 ## 2.22.2
 
-* Bind mount host /etc/os-release in system probe container
+* Bind mount host /etc/os-release in system probe container.
 
 ## 2.22.1
 
-* Fix CiliumNetworkPolicy `port` field
+* Fix CiliumNetworkPolicy `port` field.
 
 ## 2.22.0
 
@@ -15,7 +19,7 @@
 
 ## 2.21.5
 
-* Update descriptions for securityAgent configuration
+* Update descriptions for securityAgent configuration.
 
 ## 2.21.4
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.22.2
+version: 2.22.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.22.2](https://img.shields.io/badge/Version-2.22.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.22.3](https://img.shields.io/badge/Version-2.22.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-cilium-network-policy.yaml
+++ b/charts/datadog/templates/agent-cilium-network-policy.yaml
@@ -15,6 +15,12 @@ specs:
         {{ toYaml .Values.agents.podLabels | indent 8 }}
         {{- end }}
     egress:
+      - toEntities:
+          - host
+        toPorts:
+          - ports:
+              - port: "51678"
+                protocol: TCP
       - toCIDR:
           - 169.254.0.0/16
         toPorts:


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the `CiliumNetworkPolicy` of the agent to allow outbound connections to the ECS container agent on `localhost`.

#### Which issue this PR fixes
  - fixes #387

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [X] Variables are documented in the `README.md`
