### PR TITLE
:sparkles: Allow for envFrom per container instead of exclusively global

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.22.5
+
+* Add support for using `envFrom` on all container definitions
+
 ## 2.22.4
 
 * Cluster Agent: `DD_TAGS` are included even when Datadog is not set as metrics provider.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.22.4
+
+* Cluster Agent: `DD_TAGS` are included even when Datadog is not set as metrics provider.
+
 ## 2.22.3
 
 * CiliumNetworkPolicy: Grant access to the agent to ECS container agent via localhost.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.22.3
+version: 2.22.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.22.4
+version: 2.22.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.22.3](https://img.shields.io/badge/Version-2.22.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.22.4](https://img.shields.io/badge/Version-2.22.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.22.4](https://img.shields.io/badge/Version-2.22.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.22.5](https://img.shields.io/badge/Version-2.22.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -356,7 +356,7 @@ helm install --name <RELEASE_NAME> \
 | agents.additionalLabels | object | `{}` | Adds labels to the Agent daemonset and pods |
 | agents.affinity | object | `{}` | Allow the DaemonSet to schedule using affinity rules |
 | agents.containers.agent.env | list | `[]` | Additional environment variables for the agent container |
-| agents.containers.agent.envFrom | list | `[]` | Additional environment variables for the agent container |
+| agents.containers.agent.envFrom | list | `[]` | Set environment variables for the agent container directly from configMaps and/or secrets |
 | agents.containers.agent.healthPort | int | `5555` | Port number to use in the node agent for the healthz endpoint |
 | agents.containers.agent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | agents.containers.agent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
@@ -366,24 +366,24 @@ helm install --name <RELEASE_NAME> \
 | agents.containers.agent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the agent container. |
 | agents.containers.initContainers.resources | object | `{}` | Resource requests and limits for the init containers |
 | agents.containers.processAgent.env | list | `[]` | Additional environment variables for the process-agent container |
-| agents.containers.processAgent.envFrom | list | `[]` | Additional environment variables for the process-agent container |
+| agents.containers.processAgent.envFrom | list | `[]` | Set environment variables specific to process-agent from configMaps and/or secrets |
 | agents.containers.processAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
 | agents.containers.processAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.processAgent.resources | object | `{}` | Resource requests and limits for the process-agent container |
 | agents.containers.processAgent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the process-agent container. |
 | agents.containers.securityAgent.env | string | `nil` | Additional environment variables for the security-agent container |
-| agents.containers.securityAgent.envFrom | list | `[]` | Additional environment variables for the security-agent container |
+| agents.containers.securityAgent.envFrom | list | `[]` | Set environment variables specific to security-agent from configMaps and/or secrets |
 | agents.containers.securityAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
 | agents.containers.securityAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.securityAgent.resources | object | `{}` | Resource requests and limits for the security-agent container |
 | agents.containers.systemProbe.env | list | `[]` | Additional environment variables for the system-probe container |
-| agents.containers.systemProbe.envFrom | list | `[]` | Additional environment variables for the system-probe container |
+| agents.containers.systemProbe.envFrom | list | `[]` | Set environment variables specific to system-probe from configMaps and/or secrets |
 | agents.containers.systemProbe.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off. |
 | agents.containers.systemProbe.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.systemProbe.resources | object | `{}` | Resource requests and limits for the system-probe container |
 | agents.containers.systemProbe.securityContext | object | `{"capabilities":{"add":["SYS_ADMIN","SYS_RESOURCE","SYS_PTRACE","NET_ADMIN","NET_BROADCAST","NET_RAW","IPC_LOCK"]},"privileged":false}` | Allows you to overwrite the default container SecurityContext for the system-probe container. |
 | agents.containers.traceAgent.env | string | `nil` | Additional environment variables for the trace-agent container |
-| agents.containers.traceAgent.envFrom | list | `[]` | Additional environment variables for the trace-agent container |
+| agents.containers.traceAgent.envFrom | list | `[]` | Set environment variables specific to trace-agent from configMaps and/or secrets |
 | agents.containers.traceAgent.livenessProbe | object | Every 15s | Override default agent liveness probe settings |
 | agents.containers.traceAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
 | agents.containers.traceAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
@@ -435,7 +435,7 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.dnsConfig | object | `{}` | Specify dns configuration options for datadog cluster agent containers e.g ndots |
 | clusterAgent.enabled | bool | `true` | Set this to false to disable Datadog Cluster Agent |
 | clusterAgent.env | list | `[]` | Set environment variables specific to Cluster Agent |
-| clusterAgent.envFrom | list | `[]` | Set environment variables specific to Cluster Agent |
+| clusterAgent.envFrom | list | `[]` | Set environment variables specific to Cluster Agent from configMaps and/or secrets |
 | clusterAgent.healthPort | int | `5556` | Port number to use in the Cluster Agent for the healthz endpoint |
 | clusterAgent.image.name | string | `"cluster-agent"` | Cluster Agent image name to use (relative to `registry`) |
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -476,7 +476,7 @@ helm install --name <RELEASE_NAME> \
 | clusterChecksRunner.dnsConfig | object | `{}` | specify dns configuration options for datadog cluster agent containers e.g ndots |
 | clusterChecksRunner.enabled | bool | `false` | If true, deploys agent dedicated for running the Cluster Checks instead of running in the Daemonset's agents. |
 | clusterChecksRunner.env | list | `[]` | Environment variables specific to Cluster Checks Runner |
-| clusterChecksRunner.envFrom | list | `[]` | Set environment variables for all Agents directly from configMaps and/or secrets |
+| clusterChecksRunner.envFrom | list | `[]` | Set environment variables for the Cluster Checks Runner directly from configMaps and/or secrets |
 | clusterChecksRunner.healthPort | int | `5557` | Port number to use in the Cluster Checks Runner for the healthz endpoint |
 | clusterChecksRunner.image.name | string | `"agent"` | Datadog Agent image name to use (relative to `registry`) |
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -356,6 +356,7 @@ helm install --name <RELEASE_NAME> \
 | agents.additionalLabels | object | `{}` | Adds labels to the Agent daemonset and pods |
 | agents.affinity | object | `{}` | Allow the DaemonSet to schedule using affinity rules |
 | agents.containers.agent.env | list | `[]` | Additional environment variables for the agent container |
+| agents.containers.agent.envFrom | list | `[]` | Additional environment variables for the agent container |
 | agents.containers.agent.healthPort | int | `5555` | Port number to use in the node agent for the healthz endpoint |
 | agents.containers.agent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | agents.containers.agent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
@@ -365,20 +366,24 @@ helm install --name <RELEASE_NAME> \
 | agents.containers.agent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the agent container. |
 | agents.containers.initContainers.resources | object | `{}` | Resource requests and limits for the init containers |
 | agents.containers.processAgent.env | list | `[]` | Additional environment variables for the process-agent container |
+| agents.containers.processAgent.envFrom | list | `[]` | Additional environment variables for the process-agent container |
 | agents.containers.processAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
 | agents.containers.processAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.processAgent.resources | object | `{}` | Resource requests and limits for the process-agent container |
 | agents.containers.processAgent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the process-agent container. |
 | agents.containers.securityAgent.env | string | `nil` | Additional environment variables for the security-agent container |
+| agents.containers.securityAgent.envFrom | list | `[]` | Additional environment variables for the security-agent container |
 | agents.containers.securityAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
 | agents.containers.securityAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.securityAgent.resources | object | `{}` | Resource requests and limits for the security-agent container |
 | agents.containers.systemProbe.env | list | `[]` | Additional environment variables for the system-probe container |
+| agents.containers.systemProbe.envFrom | list | `[]` | Additional environment variables for the system-probe container |
 | agents.containers.systemProbe.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off. |
 | agents.containers.systemProbe.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.systemProbe.resources | object | `{}` | Resource requests and limits for the system-probe container |
 | agents.containers.systemProbe.securityContext | object | `{"capabilities":{"add":["SYS_ADMIN","SYS_RESOURCE","SYS_PTRACE","NET_ADMIN","NET_BROADCAST","NET_RAW","IPC_LOCK"]},"privileged":false}` | Allows you to overwrite the default container SecurityContext for the system-probe container. |
 | agents.containers.traceAgent.env | string | `nil` | Additional environment variables for the trace-agent container |
+| agents.containers.traceAgent.envFrom | list | `[]` | Additional environment variables for the trace-agent container |
 | agents.containers.traceAgent.livenessProbe | object | Every 15s | Override default agent liveness probe settings |
 | agents.containers.traceAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
 | agents.containers.traceAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
@@ -430,6 +435,7 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.dnsConfig | object | `{}` | Specify dns configuration options for datadog cluster agent containers e.g ndots |
 | clusterAgent.enabled | bool | `true` | Set this to false to disable Datadog Cluster Agent |
 | clusterAgent.env | list | `[]` | Set environment variables specific to Cluster Agent |
+| clusterAgent.envFrom | list | `[]` | Set environment variables specific to Cluster Agent |
 | clusterAgent.healthPort | int | `5556` | Port number to use in the Cluster Agent for the healthz endpoint |
 | clusterAgent.image.name | string | `"cluster-agent"` | Cluster Agent image name to use (relative to `registry`) |
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
@@ -470,6 +476,7 @@ helm install --name <RELEASE_NAME> \
 | clusterChecksRunner.dnsConfig | object | `{}` | specify dns configuration options for datadog cluster agent containers e.g ndots |
 | clusterChecksRunner.enabled | bool | `false` | If true, deploys agent dedicated for running the Cluster Checks instead of running in the Daemonset's agents. |
 | clusterChecksRunner.env | list | `[]` | Environment variables specific to Cluster Checks Runner |
+| clusterChecksRunner.envFrom | list | `[]` | Set environment variables for all Agents directly from configMaps and/or secrets |
 | clusterChecksRunner.healthPort | int | `5557` | Port number to use in the Cluster Checks Runner for the healthz endpoint |
 | clusterChecksRunner.image.name | string | `"agent"` | Datadog Agent image name to use (relative to `registry`) |
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -356,7 +356,7 @@ helm install --name <RELEASE_NAME> \
 | agents.additionalLabels | object | `{}` | Adds labels to the Agent daemonset and pods |
 | agents.affinity | object | `{}` | Allow the DaemonSet to schedule using affinity rules |
 | agents.containers.agent.env | list | `[]` | Additional environment variables for the agent container |
-| agents.containers.agent.envFrom | list | `[]` | Set environment variables for the agent container directly from configMaps and/or secrets |
+| agents.containers.agent.envFrom | list | `[]` | Set environment variables specific to agent container from configMaps and/or secrets |
 | agents.containers.agent.healthPort | int | `5555` | Port number to use in the node agent for the healthz endpoint |
 | agents.containers.agent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | agents.containers.agent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off |
@@ -476,7 +476,7 @@ helm install --name <RELEASE_NAME> \
 | clusterChecksRunner.dnsConfig | object | `{}` | specify dns configuration options for datadog cluster agent containers e.g ndots |
 | clusterChecksRunner.enabled | bool | `false` | If true, deploys agent dedicated for running the Cluster Checks instead of running in the Daemonset's agents. |
 | clusterChecksRunner.env | list | `[]` | Environment variables specific to Cluster Checks Runner |
-| clusterChecksRunner.envFrom | list | `[]` | Set environment variables for the Cluster Checks Runner directly from configMaps and/or secrets |
+| clusterChecksRunner.envFrom | list | `[]` | Set environment variables specific to Cluster Checks Runner from configMaps and/or secrets |
 | clusterChecksRunner.healthPort | int | `5557` | Port number to use in the Cluster Checks Runner for the healthz endpoint |
 | clusterChecksRunner.image.name | string | `"agent"` | Datadog Agent image name to use (relative to `registry`) |
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -19,9 +19,9 @@
 {{- if .Values.agents.containers.agent.ports }}
 {{ toYaml .Values.agents.containers.agent.ports | indent 2 }}
 {{- end }}
-{{- if .Values.datadog.envFrom }}
+{{- if or (.Values.datadog.envFrom) (.Values.agents.containers.agent.envFrom) }}
   envFrom:
-{{ toYaml .Values.datadog.envFrom | indent 4 }}
+{{ toYaml (concat .Values.datadog.envFrom .Values.agents.containers.agent.envFrom) | indent 4 }}
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -19,9 +19,9 @@
 {{- if .Values.agents.containers.agent.ports }}
 {{ toYaml .Values.agents.containers.agent.ports | indent 2 }}
 {{- end }}
-{{- if or (.Values.datadog.envFrom) (.Values.agents.containers.agent.envFrom) }}
+{{- if or .Values.datadog.envFrom .Values.agents.containers.agent.envFrom }}
   envFrom:
-{{ toYaml (concat .Values.datadog.envFrom .Values.agents.containers.agent.envFrom) | indent 4 }}
+{{ concat .Values.datadog.envFrom .Values.agents.containers.agent.envFrom | toYaml | indent 4 }}
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -18,9 +18,9 @@
 {{- end }}
   resources:
 {{ toYaml .Values.agents.containers.processAgent.resources | indent 4 }}
-{{- if .Values.datadog.envFrom }}
+{{- if or (.Values.datadog.envFrom) (.Values.agents.containers.processAgent.envFrom)  }}
   envFrom:
-{{ toYaml .Values.datadog.envFrom | indent 4 }}
+{{ toYaml (concat .Values.datadog.envFrom .Values.agents.containers.processAgent.envFrom) | indent 4 }}
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -18,7 +18,7 @@
 {{- end }}
   resources:
 {{ toYaml .Values.agents.containers.processAgent.resources | indent 4 }}
-{{- if or .Values.datadog.envFrom .Values.agents.containers.processAgent.envFrom  }}
+{{- if or .Values.datadog.envFrom .Values.agents.containers.processAgent.envFrom }}
   envFrom:
 {{ concat .Values.datadog.envFrom .Values.agents.containers.processAgent.envFrom | toYaml | indent 4 }}
 {{- end }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -18,9 +18,9 @@
 {{- end }}
   resources:
 {{ toYaml .Values.agents.containers.processAgent.resources | indent 4 }}
-{{- if or (.Values.datadog.envFrom) (.Values.agents.containers.processAgent.envFrom)  }}
+{{- if or .Values.datadog.envFrom .Values.agents.containers.processAgent.envFrom  }}
   envFrom:
-{{ toYaml (concat .Values.datadog.envFrom .Values.agents.containers.processAgent.envFrom) | indent 4 }}
+{{ concat .Values.datadog.envFrom .Values.agents.containers.processAgent.envFrom | toYaml | indent 4 }}
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -12,9 +12,9 @@
   ports:
 {{ toYaml .Values.agents.containers.securityAgent.ports | indent 2 }}
 {{- end }}
-{{- if .Values.datadog.envFrom }}
+{{- if or (.Values.datadog.envFrom) (.Values.agents.containers.securityAgent.envFrom)  }}
   envFrom:
-{{ toYaml .Values.datadog.envFrom | indent 4 }}
+{{ toYaml (concat .Values.datadog.envFrom .Values.agents.containers.securityAgent.envFrom) | indent 4 }}
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -12,9 +12,9 @@
   ports:
 {{ toYaml .Values.agents.containers.securityAgent.ports | indent 2 }}
 {{- end }}
-{{- if or (.Values.datadog.envFrom) (.Values.agents.containers.securityAgent.envFrom)  }}
+{{- if or .Values.datadog.envFrom .Values.agents.containers.securityAgent.envFrom }}
   envFrom:
-{{ toYaml (concat .Values.datadog.envFrom .Values.agents.containers.securityAgent.envFrom) | indent 4 }}
+{{ concat .Values.datadog.envFrom .Values.agents.containers.securityAgent.envFrom | toYaml  | indent 4 }}
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -9,9 +9,9 @@
   ports:
 {{ toYaml .Values.agents.containers.systemProbe.ports | indent 2 }}
 {{- end }}
-{{- if or (.Values.datadog.envFrom) (.Values.agents.containers.systemProbe.envFrom) }}
+{{- if or .Values.datadog.envFrom .Values.agents.containers.systemProbe.envFrom }}
   envFrom:
-{{ toYaml (concat .Values.datadog.envFrom .Values.agents.containers.systemProbe.envFrom) | indent 4 }}
+{{ concat .Values.datadog.envFrom .Values.agents.containers.systemProbe.envFrom | toYaml  | indent 4 }}
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -9,9 +9,9 @@
   ports:
 {{ toYaml .Values.agents.containers.systemProbe.ports | indent 2 }}
 {{- end }}
-{{- if .Values.datadog.envFrom }}
+{{- if or (.Values.datadog.envFrom) (.Values.agents.containers.systemProbe.envFrom) }}
   envFrom:
-{{ toYaml .Values.datadog.envFrom | indent 4 }}
+{{ toYaml (concat .Values.datadog.envFrom .Values.agents.containers.systemProbe.envFrom) | indent 4 }}
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -22,9 +22,9 @@
 {{- if .Values.agents.containers.traceAgent.ports }}
 {{ toYaml .Values.agents.containers.traceAgent.ports | indent 2 }}
 {{- end }}
-{{- if or (.Values.datadog.envFrom) (.Values.agents.containers.traceAgent.envFrom) }}
+{{- if or .Values.datadog.envFrom .Values.agents.containers.traceAgent.envFrom }}
   envFrom:
-{{ toYaml (concat .Values.datadog.envFrom .Values.agents.containers.traceAgent.envFrom) | indent 4 }}
+{{ concat .Values.datadog.envFrom .Values.agents.containers.traceAgent.envFrom | toYaml  | indent 4 }}
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -22,9 +22,9 @@
 {{- if .Values.agents.containers.traceAgent.ports }}
 {{ toYaml .Values.agents.containers.traceAgent.ports | indent 2 }}
 {{- end }}
-{{- if .Values.datadog.envFrom }}
+{{- if or (.Values.datadog.envFrom) (.Values.agents.containers.traceAgent.envFrom) }}
   envFrom:
-{{ toYaml .Values.datadog.envFrom | indent 4 }}
+{{ toYaml (concat .Values.datadog.envFrom .Values.agents.containers.traceAgent.envFrom) | indent 4 }}
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -56,7 +56,7 @@
 - name: DD_DD_URL
   value: {{ .Values.datadog.dd_url | quote }}
 {{- end }}
-{{- if .Values.datadog.env  }}
+{{- if .Values.datadog.env }}
 {{ toYaml .Values.datadog.env }}
 {{- end }}
 {{- if .Values.datadog.acInclude }}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -99,9 +99,9 @@ spec:
         ports:
 {{ toYaml .Values.clusterChecksRunner.ports | indent 10 }}
 {{- end }}
-{{- if .Values.datadog.envFrom }}
+{{- if or (.Values.datadog.envFrom) (.Values.clusterChecksRunner.envFrom)  }}
         envFrom:
-{{ toYaml .Values.datadog.envFrom | indent 10 }}
+{{ toYaml (concat .Values.datadog.envFrom .Values.clusterChecksRunner.envFrom) | indent 10 }}
 {{- end }}
         env:
           - name: DD_API_KEY

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -99,7 +99,7 @@ spec:
         ports:
 {{ toYaml .Values.clusterChecksRunner.ports | indent 10 }}
 {{- end }}
-{{- if or .Values.datadog.envFrom .Values.clusterChecksRunner.envFrom  }}
+{{- if or .Values.datadog.envFrom .Values.clusterChecksRunner.envFrom }}
         envFrom:
 {{ concat .Values.datadog.envFrom .Values.clusterChecksRunner.envFrom | toYaml  | indent 10 }}
 {{- end }}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -99,9 +99,9 @@ spec:
         ports:
 {{ toYaml .Values.clusterChecksRunner.ports | indent 10 }}
 {{- end }}
-{{- if or (.Values.datadog.envFrom) (.Values.clusterChecksRunner.envFrom)  }}
+{{- if or .Values.datadog.envFrom .Values.clusterChecksRunner.envFrom  }}
         envFrom:
-{{ toYaml (concat .Values.datadog.envFrom .Values.clusterChecksRunner.envFrom) | indent 10 }}
+{{ concat .Values.datadog.envFrom .Values.clusterChecksRunner.envFrom | toYaml  | indent 10 }}
 {{- end }}
         env:
           - name: DD_API_KEY

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -115,9 +115,9 @@ spec:
           name: metricsapi
           protocol: TCP
         {{- end }}
-{{- if or (.Values.datadog.envFrom) (.Values.clusterAgent.envFrom) }}
+{{- if or .Values.datadog.envFrom .Values.clusterAgent.envFrom }}
         envFrom:
-{{ toYaml (concat .Values.datadog.envFrom .Values.clusterAgent.envFrom) | indent 10 }}
+{{ concat .Values.datadog.envFrom .Values.clusterAgent.envFrom | toYaml | indent 10 }}
 {{- end }}
         env:
           - name: DD_HEALTH_PORT

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -115,9 +115,9 @@ spec:
           name: metricsapi
           protocol: TCP
         {{- end }}
-{{- if .Values.datadog.envFrom }}
+{{- if or (.Values.datadog.envFrom) (.Values.clusterAgent.envFrom) }}
         envFrom:
-{{ toYaml .Values.datadog.envFrom | indent 10 }}
+{{ toYaml (concat .Values.datadog.envFrom .Values.clusterAgent.envFrom) | indent 10 }}
 {{- end }}
         env:
           - name: DD_HEALTH_PORT

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -129,16 +129,16 @@ spec:
                 name: {{ template "datadog.apiSecretName" . }}
                 key: api-key
                 optional: true
+          {{- if .Values.datadog.tags }}
+          - name: DD_TAGS
+            value: {{ tpl (.Values.datadog.tags | join " " | quote) . }}
+          {{- end }}
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
             valueFrom:
               secretKeyRef:
                 name: {{ template "datadog.appKeySecretName" . }}
                 key: app-key
-          {{- if .Values.datadog.tags }}
-          - name: DD_TAGS
-            value: {{ tpl (.Values.datadog.tags | join " " | quote) . }}
-          {{- end }}
           - name: DD_EXTERNAL_METRICS_PROVIDER_ENABLED
             value: {{ .Values.clusterAgent.metricsProvider.enabled | quote }}
           - name: DD_EXTERNAL_METRICS_PROVIDER_PORT

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -575,6 +575,11 @@ clusterAgent:
   ## ref: https://docs.datadoghq.com/agent/cluster_agent/commands/#cluster-agent-options
   env: []
 
+  # clusterAgent.envFrom -- Set environment variables specific to Cluster Agent
+  ## The Cluster-Agent supports many additional environment variables
+  ## ref: https://docs.datadoghq.com/agent/cluster_agent/commands/#cluster-agent-options
+  envFrom: []
+
   admissionController:
     # clusterAgent.admissionController.enabled -- Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods
     enabled: false
@@ -846,6 +851,9 @@ agents:
       # agents.containers.agent.env -- Additional environment variables for the agent container
       env: []
 
+      # agents.containers.agent.envFrom -- Additional environment variables for the agent container
+      envFrom: []
+
       # agents.containers.agent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
       ## If not set, fall back to the value of datadog.logLevel.
       logLevel:  # INFO
@@ -890,6 +898,9 @@ agents:
       # agents.containers.processAgent.env -- Additional environment variables for the process-agent container
       env: []
 
+      # agents.containers.processAgent.envFrom -- Additional environment variables for the process-agent container
+      envFrom: []
+
       # agents.containers.processAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
       ## If not set, fall back to the value of datadog.logLevel.
       logLevel:  # INFO
@@ -912,6 +923,9 @@ agents:
     traceAgent:
       # agents.containers.traceAgent.env -- Additional environment variables for the trace-agent container
       env:
+
+      # agents.containers.traceAgent.envFrom -- Additional environment variables for the trace-agent container
+      envFrom: []
 
       # agents.containers.traceAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
       logLevel:  # INFO
@@ -942,6 +956,9 @@ agents:
       # agents.containers.systemProbe.env -- Additional environment variables for the system-probe container
       env: []
 
+      # agents.containers.systemProbe.envFrom -- Additional environment variables for the system-probe container
+      envFrom: []
+
       # agents.containers.systemProbe.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       ## If not set, fall back to the value of datadog.logLevel.
       logLevel:  # INFO
@@ -967,6 +984,9 @@ agents:
     securityAgent:
       # agents.containers.securityAgent.env -- Additional environment variables for the security-agent container
       env:
+
+      # agents.containers.securityAgent.envFrom -- Additional environment variables for the security-agent container
+      envFrom: []
 
       # agents.containers.securityAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
       ## If not set, fall back to the value of datadog.logLevel.
@@ -1225,6 +1245,17 @@ clusterChecksRunner:
   env: []
   #   - name: <ENV_VAR_NAME>
   #     value: <ENV_VAR_VALUE>
+
+  # clusterChecksRunner.envFrom -- Set environment variables for all Agents directly from configMaps and/or secrets
+  ## envFrom to pass configmaps or secrets as environment
+  ## ref: https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/agent#environment-variables
+  envFrom: []
+  #   - configMapRef:
+  #       name: <CONFIGMAP_NAME>
+  #   - secretRef:
+  #       name: <SECRET_NAME>
+
+
 
   # clusterChecksRunner.volumes -- Specify additional volumes to mount in the cluster checks container
   volumes: []

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1279,8 +1279,6 @@ clusterChecksRunner:
   #   - secretRef:
   #       name: <SECRET_NAME>
 
-
-
   # clusterChecksRunner.volumes -- Specify additional volumes to mount in the cluster checks container
   volumes: []
   #   - hostPath:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -575,10 +575,14 @@ clusterAgent:
   ## ref: https://docs.datadoghq.com/agent/cluster_agent/commands/#cluster-agent-options
   env: []
 
-  # clusterAgent.envFrom -- Set environment variables specific to Cluster Agent
+  # clusterAgent.envFrom --  Set environment variables specific to Cluster Agent from configMaps and/or secrets
   ## The Cluster-Agent supports many additional environment variables
   ## ref: https://docs.datadoghq.com/agent/cluster_agent/commands/#cluster-agent-options
   envFrom: []
+  #   - configMapRef:
+  #       name: <CONFIGMAP_NAME>
+  #   - secretRef:
+  #       name: <SECRET_NAME>
 
   admissionController:
     # clusterAgent.admissionController.enabled -- Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods
@@ -851,8 +855,12 @@ agents:
       # agents.containers.agent.env -- Additional environment variables for the agent container
       env: []
 
-      # agents.containers.agent.envFrom -- Additional environment variables for the agent container
+      # agents.containers.agent.envFrom -- Set environment variables for the agent container directly from configMaps and/or secrets
       envFrom: []
+      #   - configMapRef:
+      #       name: <CONFIGMAP_NAME>
+      #   - secretRef:
+      #       name: <SECRET_NAME>
 
       # agents.containers.agent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
       ## If not set, fall back to the value of datadog.logLevel.
@@ -898,8 +906,12 @@ agents:
       # agents.containers.processAgent.env -- Additional environment variables for the process-agent container
       env: []
 
-      # agents.containers.processAgent.envFrom -- Additional environment variables for the process-agent container
+      # agents.containers.processAgent.envFrom -- Set environment variables specific to process-agent from configMaps and/or secrets
       envFrom: []
+      #   - configMapRef:
+      #       name: <CONFIGMAP_NAME>
+      #   - secretRef:
+      #       name: <SECRET_NAME>
 
       # agents.containers.processAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
       ## If not set, fall back to the value of datadog.logLevel.
@@ -924,8 +936,12 @@ agents:
       # agents.containers.traceAgent.env -- Additional environment variables for the trace-agent container
       env:
 
-      # agents.containers.traceAgent.envFrom -- Additional environment variables for the trace-agent container
+      # agents.containers.traceAgent.envFrom -- Set environment variables specific to trace-agent from configMaps and/or secrets
       envFrom: []
+      #   - configMapRef:
+      #       name: <CONFIGMAP_NAME>
+      #   - secretRef:
+      #       name: <SECRET_NAME>
 
       # agents.containers.traceAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
       logLevel:  # INFO
@@ -956,8 +972,12 @@ agents:
       # agents.containers.systemProbe.env -- Additional environment variables for the system-probe container
       env: []
 
-      # agents.containers.systemProbe.envFrom -- Additional environment variables for the system-probe container
+      # agents.containers.systemProbe.envFrom -- Set environment variables specific to system-probe from configMaps and/or secrets
       envFrom: []
+      #   - configMapRef:
+      #       name: <CONFIGMAP_NAME>
+      #   - secretRef:
+      #       name: <SECRET_NAME>
 
       # agents.containers.systemProbe.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       ## If not set, fall back to the value of datadog.logLevel.
@@ -985,8 +1005,12 @@ agents:
       # agents.containers.securityAgent.env -- Additional environment variables for the security-agent container
       env:
 
-      # agents.containers.securityAgent.envFrom -- Additional environment variables for the security-agent container
+      # agents.containers.securityAgent.envFrom -- Set environment variables specific to security-agent from configMaps and/or secrets
       envFrom: []
+      #   - configMapRef:
+      #       name: <CONFIGMAP_NAME>
+      #   - secretRef:
+      #       name: <SECRET_NAME>
 
       # agents.containers.securityAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
       ## If not set, fall back to the value of datadog.logLevel.

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1270,7 +1270,7 @@ clusterChecksRunner:
   #   - name: <ENV_VAR_NAME>
   #     value: <ENV_VAR_VALUE>
 
-  # clusterChecksRunner.envFrom -- Set environment variables for all Agents directly from configMaps and/or secrets
+  # clusterChecksRunner.envFrom -- Set environment variables for the Cluster Checks Runner directly from configMaps and/or secrets
   ## envFrom to pass configmaps or secrets as environment
   ## ref: https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/agent#environment-variables
   envFrom: []

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -855,7 +855,7 @@ agents:
       # agents.containers.agent.env -- Additional environment variables for the agent container
       env: []
 
-      # agents.containers.agent.envFrom -- Set environment variables for the agent container directly from configMaps and/or secrets
+      # agents.containers.agent.envFrom -- Set environment variables specific to agent container from configMaps and/or secrets
       envFrom: []
       #   - configMapRef:
       #       name: <CONFIGMAP_NAME>
@@ -1270,7 +1270,7 @@ clusterChecksRunner:
   #   - name: <ENV_VAR_NAME>
   #     value: <ENV_VAR_VALUE>
 
-  # clusterChecksRunner.envFrom -- Set environment variables for the Cluster Checks Runner directly from configMaps and/or secrets
+  # clusterChecksRunner.envFrom -- Set environment variables specific to Cluster Checks Runner from configMaps and/or secrets
   ## envFrom to pass configmaps or secrets as environment
   ## ref: https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/agent#environment-variables
   envFrom: []

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           envFrom:
 {{ toYaml .Values.envFrom | indent 12 }}
 {{- end }}
-{{- if .Values.env  }}
+{{- if .Values.env }}
           env:
 {{ toYaml .Values.env | indent 12 }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Each container will be able to specify environment variables from a secret or configmap exclusively, therefore not requiring every container to share environment. When you apply the helm config, the dictionaries of `container.` and `datadog.envFrom` will be merged.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
I am happy to update the changelog, but I wasnt sure on the versioning, for when this gets approved as to avoid conflicts with other PRs.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
