### PR TITLE
Add missing RBAC when the DCA admission controller is enabled

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.7.1
+
+* Add missing RBAC to the operator to enable the admission controller in the cluster-agent.
+
+## 0.7.0
+
+* Update chart to support the operation version `v0.7.0`
+
 ## 0.6.3
 
 * Add missing `poddisruptionbudgets` RBAC when the compliance feature is enabled.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.7.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -444,6 +444,14 @@ rules:
 - apiGroups:
   - datadoghq.com
   resources:
+  - extendeddaemonsetreplicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
   - watermarkpodautoscalers
   verbs:
   - get


### PR DESCRIPTION
#### What this PR does / why we need it:

Add RBAC to the operator to allow the creation of the cluster-agent rbac
when the admission controller is enabled

```
- apiGroups:
  - datadoghq.com
  resources:
  - extendeddaemonsetreplicasets
  verbs:
  - get
  - list
  - watch
```


#### Which issue this PR fixes
  - fixes https://github.com/DataDog/datadog-operator/issues/382 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
