### PR TITLE
[datadog] Expose the `labels_as_tags` parameter of the KSM core check

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.27.2
+
+* Expose the `labels_as_tags` parameter of the KSM core check.
+  This parameter exists only in agent 7.32.0 and above and cluster-agent 1.16.0 and above.
+
 # 2.27.1
 
 * Update README.md to clarify Helm 2 vs. Helm 3 instructions.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.27.1
+version: 2.27.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.27.1](https://img.shields.io/badge/Version-2.27.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.27.2](https://img.shields.io/badge/Version-2.27.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -652,6 +652,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.kubeStateMetricsCore.collectSecretMetrics | bool | `true` | Enable watching secret objects and collecting their corresponding metrics kubernetes_state.secret.* |
 | datadog.kubeStateMetricsCore.enabled | bool | `false` | Enable the kubernetes_state_core check in the Cluster Agent (Requires Cluster Agent 1.12.0+) |
 | datadog.kubeStateMetricsCore.ignoreLegacyKSMCheck | bool | `true` | Disable the auto-configuration of legacy kubernetes_state check (taken into account only when datadog.kubeStateMetricsCore.enabled is true) |
+| datadog.kubeStateMetricsCore.labelsAsTags | object | `{}` | Extra labels to collect from resources and to turn into datadog tag. |
 | datadog.kubeStateMetricsCore.useClusterCheckRunners | bool | `false` | For large clusters where the Kubernetes State Metrics Check Core needs to be distributed on dedicated workers. |
 | datadog.kubeStateMetricsEnabled | bool | `true` | If true, deploys the kube-state-metrics deployment |
 | datadog.kubeStateMetricsNetworkPolicy.create | bool | `false` | If true, create a NetworkPolicy for kube state metrics |

--- a/charts/datadog/templates/cluster-agent-confd-configmap.yaml
+++ b/charts/datadog/templates/cluster-agent-confd-configmap.yaml
@@ -43,5 +43,7 @@ data:
         - poddisruptionbudgets
         - storageclasses
         - volumeattachments
+        labels_as_tags:
+{{ .Values.datadog.kubeStateMetricsCore.labelsAsTags | toYaml | indent 10 }}
 {{- end }}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -104,6 +104,9 @@ datadog:
     ##     <label2>: <tag2>
     ##   <resource2>:
     ##     <label3>: <tag3>
+    ##
+    ## Warning: the label must match the transformation done by kube-state-metrics,
+    ## example:  tags.datadoghq.com/version becomes label_tags_datadoghq_com_version 
     labelsAsTags: {}
     #  pod:
     #    app: app

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -96,6 +96,21 @@ datadog:
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/clusterchecksrunner?tab=helm
     useClusterCheckRunners: false
 
+    # datadog.kubeStateMetricsCore.labelsAsTags -- Extra labels to collect from resources and to turn into datadog tag.
+    ## It has the following structure:
+    ## labelsAsTags:
+    ##   <resource1>:        # can be pod, deployment, node, etc.
+    ##     <label1>: <tag1>  # where <label1> is the kubernetes label and <tag1> is the datadog tag
+    ##     <label2>: <tag2>
+    ##   <resource2>:
+    ##     <label3>: <tag3>
+    labelsAsTags: {}
+    #  pod:
+    #    app: app
+    #  node:
+    #    zone: zone
+    #    team: team
+
   ## Manage Cluster checks feature
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
   ## Autodiscovery via Kube Service annotations is automatically enabled

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -106,7 +106,7 @@ datadog:
     ##     <label3>: <tag3>
     ##
     ## Warning: the label must match the transformation done by kube-state-metrics,
-    ## example:  tags.datadoghq.com/version becomes label_tags_datadoghq_com_version 
+    ## for example tags.datadoghq.com/version becomes label_tags_datadoghq_com_version.
     labelsAsTags: {}
     #  pod:
     #    app: app


### PR DESCRIPTION
#### What this PR does / why we need it:

Expose the `labels_as_tags` setting of the KSM core check introduced by DataDog/datadog-agent#9214 in the Helm chart.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [X] Variables are documented in the `README.md`
