### PR TITLE
[datadog] Add a default required anti-affinity for the cluster agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Datadog changelog
 
+## 2.22.7
+
+* Add a default required pod anti-affinity for the cluster agent.
+
 ## 2.22.6
 
-* Adds missing configuration option for `DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS`
+* Adds missing configuration option for `DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS`.
 
 ## 2.22.5
 
-* Add support for using `envFrom` on all container definitions
+* Add support for using `envFrom` on all container definitions.
 
 ## 2.22.4
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.22.6
+version: 2.22.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.22.6](https://img.shields.io/badge/Version-2.22.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.22.7](https://img.shields.io/badge/Version-2.22.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -322,10 +322,19 @@ spec:
       tolerations:
 {{ toYaml .Values.clusterAgent.tolerations | indent 8 }}
       {{- end }}
-      {{- if .Values.clusterAgent.affinity }}
       affinity:
+{{- if .Values.clusterAgent.affinity }}
 {{ toYaml .Values.clusterAgent.affinity | indent 8 }}
-      {{- end }}
+{{- else }}
+        # Force scheduling the cluster agents on different nodes
+        # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: {{ template "datadog.fullname" . }}-cluster-agent
+            topologyKey: kubernetes.io/hostname
+{{- end }}
       nodeSelector:
         {{ template "label.os" . }}: {{ .Values.targetSystem }}
       {{- if .Values.clusterAgent.nodeSelector }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -646,6 +646,7 @@ clusterAgent:
   nodeSelector: {}
 
   # clusterAgent.affinity -- Allow the Cluster Agent Deployment to schedule using affinity rules
+  ## By default, Cluster Agent Deployment Pods are forced to run on different Nodes.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
 
@@ -1198,7 +1199,7 @@ clusterChecksRunner:
   #   memory: 500Mi
 
   # clusterChecksRunner.affinity -- Allow the ClusterChecks Deployment to schedule using affinity rules.
-  ## By default, ClusterChecks Deployment Pods are forced to run on different Nodes.
+  ## By default, ClusterChecks Deployment Pods are preferred to run on different Nodes.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a default required pod anti-affinity for the cluster agent.
When there are several DCA, one is elected the leader and is in charge of doing all the work about dispatching cluster checks.
The non-leader ones are in standby and are waiting for the leader to crash to take the lead.
If the standby instances can run on the same node as the leader, this defeats the purpose.

#### Which issue this PR fixes

#### Special notes for your reviewer:

`datadog-operator` counter-part: DataDog/datadog-operator#381.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [X] Variables are documented in the `README.md`
