### PR TITLE
:wrench: Add configurable init timeout conntrack_init_timeout

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 2.22.11
+
+* Add configurable conntrack_init_timeout to sysprobe config.
+
 ## 2.22.10
 
 * Default Datadog Agent image to `7.31.1`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.22.10
+version: 2.22.11
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -584,7 +584,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.systemProbe.apparmor | string | `"unconfined"` | Specify a apparmor profile for system-probe |
 | datadog.systemProbe.bpfDebug | bool | `false` | Enable logging for kernel debug |
 | datadog.systemProbe.collectDNSStats | bool | `true` | Enable DNS stat collection |
-| datadog.systemProbe.conntrackInitTimeout | int | `10` | the time to wait in seconds for conntrack to initialize before failing |
+| datadog.systemProbe.conntrackInitTimeout | string | `"10s"` | the time to wait for conntrack to initialize before failing |
 | datadog.systemProbe.conntrackMaxStateSize | int | `131072` | the maximum size of the userspace conntrack cache |
 | datadog.systemProbe.debugPort | int | `0` | Specify the port to expose pprof and expvar for system-probe agent |
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.22.10](https://img.shields.io/badge/Version-2.22.10-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.22.11](https://img.shields.io/badge/Version-2.22.11-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -584,6 +584,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.systemProbe.apparmor | string | `"unconfined"` | Specify a apparmor profile for system-probe |
 | datadog.systemProbe.bpfDebug | bool | `false` | Enable logging for kernel debug |
 | datadog.systemProbe.collectDNSStats | bool | `true` | Enable DNS stat collection |
+| datadog.systemProbe.conntrackInitTimeout | int | `10` | the time to wait in seconds for conntrack to initialize before failing |
 | datadog.systemProbe.conntrackMaxStateSize | int | `131072` | the maximum size of the userspace conntrack cache |
 | datadog.systemProbe.debugPort | int | `0` | Specify the port to expose pprof and expvar for system-probe agent |
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -32,6 +32,7 @@ data:
       collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
       max_tracked_connections: {{ $.Values.datadog.systemProbe.maxTrackedConnections }}
       conntrack_max_state_size: {{ $.Values.datadog.systemProbe.conntrackMaxStateSize }}
+      conntrack_init_timeout: {{ $.Values.datadog.systemProbe.conntrackInitTimeout }}
     network_config:
       enabled: {{ $.Values.datadog.networkMonitoring.enabled }}
     runtime_security_config:

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -32,9 +32,9 @@ data:
       collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
       max_tracked_connections: {{ $.Values.datadog.systemProbe.maxTrackedConnections }}
       conntrack_max_state_size: {{ $.Values.datadog.systemProbe.conntrackMaxStateSize }}
-      conntrack_init_timeout: {{ $.Values.datadog.systemProbe.conntrackInitTimeout }}
     network_config:
       enabled: {{ $.Values.datadog.networkMonitoring.enabled }}
+      conntrack_init_timeout: {{ $.Values.datadog.systemProbe.conntrackInitTimeout }}
     runtime_security_config:
       enabled: {{ $.Values.datadog.securityAgent.runtime.enabled }}
       debug: false

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -340,6 +340,8 @@ datadog:
     # datadog.systemProbe.conntrackMaxStateSize -- the maximum size of the userspace conntrack cache
     conntrackMaxStateSize: 131072  # 2 * maxTrackedConnections by default, per  https://github.com/DataDog/datadog-agent/blob/d1c5de31e1bba72dfac459aed5ff9562c3fdcc20/pkg/process/config/config.go#L229
 
+    # datadog.systemProbe.conntrackInitTimeout -- the time to wait in seconds for conntrack to initialize before failing
+    conntrackInitTimeout: 10
 
   orchestratorExplorer:
     # datadog.orchestratorExplorer.enabled -- Set this to false to disable the orchestrator explorer

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -340,8 +340,8 @@ datadog:
     # datadog.systemProbe.conntrackMaxStateSize -- the maximum size of the userspace conntrack cache
     conntrackMaxStateSize: 131072  # 2 * maxTrackedConnections by default, per  https://github.com/DataDog/datadog-agent/blob/d1c5de31e1bba72dfac459aed5ff9562c3fdcc20/pkg/process/config/config.go#L229
 
-    # datadog.systemProbe.conntrackInitTimeout -- the time to wait in seconds for conntrack to initialize before failing
-    conntrackInitTimeout: 10
+    # datadog.systemProbe.conntrackInitTimeout -- the time to wait for conntrack to initialize before failing
+    conntrackInitTimeout: 10s
 
   orchestratorExplorer:
     # datadog.orchestratorExplorer.enabled -- Set this to false to disable the orchestrator explorer


### PR DESCRIPTION
#### What this PR does / why we need it:
When a node has a large number of processes, the system probe container fails. A fix was applied to the agent in https://github.com/DataDog/datadog-agent/issues/8181. This PR will allow you to configure the value, with a default of 10s (default of agent).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
