### PR TITLE
[datadog-operator] watch all namespaces by default

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.2
+
+* Add `watchNamespaces` option to configure the namespaces watched by the operator.
+
 ## 0.7.1
 
 * Add missing RBAC to the operator to enable the admission controller in the cluster-agent.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.7.1
+version: 0.7.2
 appVersion: 0.7.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 ## Values
 
@@ -38,3 +38,23 @@
 | serviceAccount.name | string | `nil` | The name of the service account to use. If not set name is generated using the fullname template |
 | supportExtendedDaemonset | string | `"false"` | If true, supports using ExtendedDeamonSet CRD |
 | tolerations | list | `[]` | Allows to schedule Datadog Operator on tainted nodes |
+| watchNamespaces | list | `[]` | Restrics the Operator to watch its managed resources on specific namespaces |
+
+## How to configure which namespaces are watched by the Operator.
+
+By default, the Operator only watches resources (`DatadogAgent`, `DatadogMonitor`) that are present in the same namespace.
+
+It is possible to configure the Operator to watch resources that are present in one or several specific namespaces.
+
+```yaml
+watchNamespaces:
+- "default"
+- "datadog"
+```
+
+To watch all namespaces, the following configuration needs to be used:
+
+```yaml
+watchNamespaces:
+- ""
+```

--- a/charts/datadog-operator/README.md.gotmpl
+++ b/charts/datadog-operator/README.md.gotmpl
@@ -3,3 +3,22 @@
 {{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
 
 {{ template "chart.valuesSection" . }}
+
+## How to configure which namespaces are watched by the Operator.
+
+By default, the Operator only watches resources (`DatadogAgent`, `DatadogMonitor`) that are present in the same namespace.
+
+It is possible to configure the Operator to watch resources that are present in one or several specific namespaces.
+
+```yaml
+watchNamespaces:
+- "default"
+- "datadog"
+```
+
+To watch all namespaces, the following configuration needs to be used:
+
+```yaml
+watchNamespaces:
+- ""
+```

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -50,9 +50,13 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: WATCH_NAMESPACE
+            {{- if .Values.watchNamespaces }}
+              value: {{ .Values.watchNamespaces | join "," }}
+            {{- else }}
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -97,3 +97,14 @@ podLabels: {}
 
 # collectOperatorMetrics -- Configures an openmetrics check to collect operator metrics
 collectOperatorMetrics: true
+
+# watchNamespaces -- Restrics the Operator to watch its managed resources on specific namespaces
+watchNamespaces: []
+# example: watch only two namespaces:
+# watchNamespaces:
+# - "default"
+# - "datadog"
+#
+# to watch all namespaces
+# watchNamespaces:
+# - ""


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add `watchNamespace` option to limit on which namespace the operator can watch resources.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
