### PR TITLE
[datadog] Add windows containerd support

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 2.22.16
+
+* Support containerd on windows node with logs enabled.
+
 # 2.22.15
 
 * Add a new configuration field `datadog.kubeStateMetricsCore.collectSecretMetrics` to allow disabling the collection of `kubernetes_state.secret.*` metrics by the `kubernetes_state_core` check.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.22.15
+version: 2.22.16
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.22.15](https://img.shields.io/badge/Version-2.22.15-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.22.16](https://img.shields.io/badge/Version-2.22.16-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -124,16 +124,7 @@
     {{- end }}
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
-    {{- if eq .Values.targetSystem "linux" }}
-    - name: runtimesocketdir
-      mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
-    {{- end }}
-    {{- if eq .Values.targetSystem "windows" }}
-    - name: runtimesocket
-      mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
-    {{- end }}
+    {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: {{ template "datadog.fullname" . }}-datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
@@ -186,7 +177,7 @@
       mountPath: C:/var/log/pods
       readOnly: true
     - name: logdockercontainerpath
-      mountPath: C:/ProgramData/docker/containers
+      mountPath: C:/ProgramData
       readOnly: true
     {{- end }}
     {{- end }}

--- a/charts/datadog/templates/_container-cri-volumemounts.yaml
+++ b/charts/datadog/templates/_container-cri-volumemounts.yaml
@@ -1,0 +1,16 @@
+{{- define "container-crisocket-volumemounts" -}}
+{{- if eq .Values.targetSystem "linux" }}
+- name: runtimesocketdir
+  mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
+  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+  readOnly: true
+{{- end }}
+{{- if eq .Values.targetSystem "windows" }}
+- name: runtimesocket
+  mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
+{{- if not .Values.datadog.criSocketPath }}
+- name: containerdsocket 
+  mountPath: \\.\pipe\containerd-containerd
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -54,20 +54,13 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
     {{- if eq .Values.targetSystem "linux" }}
-    - name: runtimesocketdir
-      mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog
     - name: tmpdir
       mountPath: /tmp
       readOnly: false
     {{- end }}
-    {{- if eq .Values.targetSystem "windows" }}
-    - name: runtimesocket
-      mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
-    {{- end }}
+    {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: {{ template "datadog.fullname" . }}-datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -58,17 +58,11 @@
     - name: tmpdir
       mountPath: /tmp
       readOnly: false
-    - name: runtimesocketdir
-      mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
-      readOnly: true
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: true
     {{- end }}
-    {{- if eq .Values.targetSystem "windows" }}
-    - name: runtimesocket
-      mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
-    {{- end }}
+    {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: {{ template "datadog.fullname" . }}-datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
@@ -88,11 +82,6 @@
     - name: hostroot
       mountPath: /host/root
       readOnly: true
-    {{- if eq .Values.targetSystem "linux" }}
-    - name: runtimesocketdir
-      mountPath: {{ print "/host/root" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
-      readOnly: true
-    {{- end }}
     - name: procdir
       mountPath: /host/proc
       readOnly: true

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -68,15 +68,8 @@
     - name: apmsocket
       mountPath: {{ (dir .Values.datadog.apm.socketPath) }}
     {{- end }}
-    - name: runtimesocketdir
-      mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- end }}
-    {{- if eq .Values.targetSystem "windows" }}
-    - name: runtimesocket
-      mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
-    {{- end }}
+    {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- if .Values.datadog.kubelet.hostCAPath }}
 {{ include "datadog.kubelet.volumeMount" . | indent 4 }}
     {{- end }}

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -35,10 +35,7 @@
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    - name: runtimesocketdir
-      mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
+    {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml

--- a/charts/datadog/templates/_containers-init-windows.yaml
+++ b/charts/datadog/templates/_containers-init-windows.yaml
@@ -33,8 +33,7 @@
       mountPath: C:/checks.d
       readOnly: true
     {{- end }}
-    - name: runtimesocket
-      mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
+    {{- include "container-crisocket-volumemounts" . | nindent 4 }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}
   resources:

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -109,4 +109,7 @@
   name: logdockercontainerpath
 {{- end }}
 {{- end }}
+- hostPath:
+    path: {{ dir (include "datadog.dockerOrCriSocketPath" .) }}
+  name: runtimesocketdir
 {{- end -}}

--- a/charts/datadog/templates/_daemonset-volumes-windows.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-windows.yaml
@@ -13,7 +13,18 @@
     path: C:/var/log/pods
   name: logpodpath
 - hostPath:
-    path: C:/ProgramData/docker/containers
+    path: C:/ProgramData
   name: logdockercontainerpath
+{{- end }}
+- hostPath:
+    path: {{ template "datadog.dockerOrCriSocketPath" . }}
+  name: runtimesocket
+{{- if not .Values.datadog.criSocketPath }}
+# if the CRI or is not provived we should try to mount the default containerd pipe.
+# by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+# so with this additional hostPath, by default both are mounted.
+- hostPath:
+    path: \\.\pipe\containerd-containerd
+  name: containerdsocket
 {{- end }}
 {{- end -}}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -129,16 +129,6 @@ spec:
           name: {{ template "datadog.fullname" . }}-installinfo
       - name: config
         emptyDir: {}
-      {{- if eq .Values.targetSystem "linux" }}
-      - hostPath:
-          path: {{ dir (include "datadog.dockerOrCriSocketPath" .) }}
-        name: runtimesocketdir
-      {{- end }}
-      {{- if eq .Values.targetSystem "windows" }}
-      - hostPath:
-          path: {{ template "datadog.dockerOrCriSocketPath" . }}
-        name: runtimesocket
-      {{- end }}
       {{- if .Values.datadog.checksd }}
       - name: checksd
         configMap:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allow to deploy the agent on containerd windows nodes with a minimum configuration.

Thanks to this change, it is possible to use the same helm chart installation for docker and containerd windows nodes. 🥳 

* mount 2 levels higher the docker logs volumes to also works with containerd node.
* create and helper to refactor how volumeMount are managed for CRI sockets.
* If the CRI socket is not provided, on windows mount also the containerd pipe.

#### Which issue this PR fixes

Until now on windows, when `datadog.logs.enabled:true` the hostVolume:

```yaml
    - name: logdockercontainerpath
      mountPath: C:/ProgramData/docker/containers
      readOnly: true
```

was always mounted.

#### Special notes for your reviewer:

testing configuration

```yaml
targetSystem: windows

datadog:
  logs:
    enabled: true
    containerCollectAll: true
  kubeStateMetricsEnabled: false

existingClusterAgent:
  join: true
  serviceName: "dd-datadog-cluster-agent" # from the other datadog helm chart release (linux)
  tokenSecretName: "dd-datadog-cluster-agent" # from the other datadog helm chart release (linux)

```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
