### PR TITLE
[datadog] Add option to use EKS EC2 hostname from host filesystem

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 2.23.4
+
+* Add a new configuration field `datadog.providers.eks.ec2.useHostnameFromFile` to allow use of host's `/var/lib/cloud/data/instance-id` for hostname detection.
+
 # 2.23.3
 
 * Add `agents.localService` parameters to customize the internal traffic policy service name and force its creation of Kubernetes 1.21.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.23.3
+version: 2.23.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.23.3](https://img.shields.io/badge/Version-2.23.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.23.4](https://img.shields.io/badge/Version-2.23.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -630,6 +630,7 @@ helm install --name <RELEASE_NAME> \
 | kube-state-metrics.serviceAccount.create | bool | `true` | If true, create ServiceAccount, require rbac kube-state-metrics.rbac.create true |
 | kube-state-metrics.serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. |
 | nameOverride | string | `nil` | Override name of app |
+| providers.eks.ec2.useHostnameFromFile | bool | `false` | Use hostname from EC2 filesystem instead of fetching from metadata endpoint. |
 | providers.gke.autopilot | bool | `false` | Enables Datadog Agent deployment on GKE Autopilot |
 | registry | string | `"gcr.io/datadoghq"` | Registry to use for all Agent images (default gcr.io) |
 | targetSystem | string | `"linux"` | Target OS for this deployment (possible values: linux, windows) |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -125,6 +125,7 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
+    {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: {{ template "datadog.fullname" . }}-datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-cloudinit-volumemounts.yaml
+++ b/charts/datadog/templates/_container-cloudinit-volumemounts.yaml
@@ -1,0 +1,9 @@
+{{- define "container-cloudinit-volumemounts" -}}
+{{- if .Values.providers.eks.ec2.useHostnameFromFile }}
+{{- if eq .Values.targetSystem "linux" }}
+- name: cloudinit-instance-id-file
+  mountPath: /var/lib/cloud/data/instance-id
+  readOnly: true
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -61,6 +61,7 @@
       readOnly: false
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
+    {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: {{ template "datadog.fullname" . }}-datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -63,6 +63,7 @@
       readOnly: true
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
+    {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: {{ template "datadog.fullname" . }}-datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -33,6 +33,7 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
+    {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: {{ template "datadog.fullname" . }}-datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -72,6 +72,7 @@
     {{- end }}
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
+    {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.datadog.kubelet.hostCAPath }}
 {{ include "datadog.kubelet.volumeMount" . | indent 4 }}
     {{- end }}

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -30,6 +30,10 @@
 - name: DD_CLUSTER_NAME
   value: {{ .Values.datadog.clusterName | quote }}
 {{- end }}
+{{- if .Values.providers.eks.ec2.useHostnameFromFile }}
+- name: DD_HOSTNAME_FILE
+  value: /var/lib/cloud/data/instance-id
+{{- end }}
 {{- if .Values.datadog.tags }}
 - name: DD_TAGS
   value: {{ tpl (.Values.datadog.tags | join " " | quote) . }}

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -30,9 +30,11 @@
 - name: DD_CLUSTER_NAME
   value: {{ .Values.datadog.clusterName | quote }}
 {{- end }}
+{{- if eq .Values.targetSystem "linux" }}
 {{- if .Values.providers.eks.ec2.useHostnameFromFile }}
 - name: DD_HOSTNAME_FILE
   value: /var/lib/cloud/data/instance-id
+{{- end }}
 {{- end }}
 {{- if .Values.datadog.tags }}
 - name: DD_TAGS

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -18,6 +18,12 @@
 - emptyDir: {}
   name: dsdsocket
 {{- end }}
+{{- if .Values.providers.eks.ec2.useHostnameFromFile }}
+- hostPath:
+    path: /var/lib/cloud/data/instance-id
+    type: File
+  name: cloudinit-instance-id-file
+{{- end }}
 {{- if .Values.datadog.kubelet.hostCAPath }}
 - hostPath:
     path: {{ .Values.datadog.kubelet.hostCAPath }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1368,3 +1368,11 @@ providers:
   gke:
     # providers.gke.autopilot -- Enables Datadog Agent deployment on GKE Autopilot
     autopilot: false
+
+  eks:
+    ec2:
+      # providers.eks.ec2.useHostnameFromFile -- Use hostname from EC2 filesystem instead of fetching from metadata endpoint.
+      ## When deploying to EC2-backed EKS infrastructure, there are situations where the
+      ## IMDS metadata endpoint is not accesible to containers. This flag mounts the host's
+      ## `/var/lib/cloud/data/instance-id` and uses that for Agent's hostname instead.
+      useHostnameFromFile: false


### PR DESCRIPTION
#### What this PR does / why we need it:

In EKS backed by EC2, IMDS service may be disabled and hostname
detection will fail. This change allows us to mount the EC2 host's
filesystem and get the hostname through the cloud-init provided file
at `/var/lib/cloud/data/instance-id` through DD_HOSTNAME_FILE.

#### Which issue this PR fixes

Fixes #419 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
