### PR TITLE
fix: [datadog] Do not configure APM hostPort if portEnabled:false

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,22 +1,26 @@
 # Datadog changelog
 
-# 2.22.17
+## 2.22.18
+
+* Do not configure `trace-agent` hostPort if `datadog.apm.portEnabled: false`.
+
+## 2.22.17
 
 * Update general installation documentation and add how to disable APM.
 
-# 2.22.16
+## 2.22.16
 
 * Support containerd on windows node with logs enabled.
 
-# 2.22.15
+## 2.22.15
 
 * Add a new configuration field `datadog.kubeStateMetricsCore.collectSecretMetrics` to allow disabling the collection of `kubernetes_state.secret.*` metrics by the `kubernetes_state_core` check.
 
-# 2.22.14
+## 2.22.14
 
 * Apply security context capabilities to security-agent only if compliance is enabled.
 
-# 2.22.13
+## 2.22.13
 
 * Add configurable conntrack_init_timeout to sysprobe config.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.22.17
+version: 2.22.18
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.22.17](https://img.shields.io/badge/Version-2.22.17-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.22.18](https://img.shields.io/badge/Version-2.22.18-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -16,7 +16,9 @@
 {{ toYaml .Values.agents.containers.traceAgent.resources | indent 4 }}
   ports:
   - containerPort: {{ .Values.datadog.apm.port }}
+  {{- if .Values.datadog.apm.portEnabled }}
     hostPort: {{ .Values.datadog.apm.port }}
+  {{- end }}
     name: traceport
     protocol: TCP
 {{- if .Values.agents.containers.traceAgent.ports }}


### PR DESCRIPTION
#### What this PR does / why we need it:

* Do not configure `trace-agent` hostPort if `datadog.apm.portEnabled: false`.

#### Which issue this PR fixes

- fixes #423

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
