### PR TITLE
Add site option to change the Datadog intake site

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.3
+
+* Add `site` option to change the Datadog intake site.
+
 ## 0.7.2
 
 * Add `watchNamespaces` option to configure the namespaces watched by the operator.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.7.2
+version: 0.7.3
 appVersion: 0.7.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 ## Values
 
@@ -36,6 +36,7 @@
 | secretBackend.command | string | `""` | Specifies the path to the command that implements the secret backend api |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. If not set name is generated using the fullname template |
+| site | string | `nil` | The site of the Datadog intake to send data to |
 | supportExtendedDaemonset | string | `"false"` | If true, supports using ExtendedDeamonSet CRD |
 | tolerations | list | `[]` | Allows to schedule Datadog Operator on tainted nodes |
 | watchNamespaces | list | `[]` | Restrics the Operator to watch its managed resources on specific namespaces |

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -75,6 +75,10 @@ spec:
                   name: {{ template "datadog-operator.appKeySecretName" . }}
                   key: app-key
             {{- end }}
+            {{- if .Values.site }}
+            - name: DD_SITE
+              value: {{ .Values.site }}
+            {{- end }}
             {{- if .Values.dd_url }}
             - name: DD_URL
               value: {{ .Values.dd_url }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -16,6 +16,7 @@ apiKeyExistingSecret:  # <DATADOG_API_KEY_SECRET>
 appKey:  # <DATADOG_APP_KEY>
 
 # site -- The site of the Datadog intake to send data to
+## Set to 'datadoghq.com' to send data to the US1 site (default).
 ## Set to 'datadoghq.eu' to send data to the EU site.
 ## Set to 'us3.datadoghq.com' to send data to the US3 site.
 ## Set to 'us5.datadoghq.com' to send data to the US5 site.

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -15,6 +15,13 @@ apiKeyExistingSecret:  # <DATADOG_API_KEY_SECRET>
 # appKey -- Your Datadog APP key
 appKey:  # <DATADOG_APP_KEY>
 
+# site -- The site of the Datadog intake to send data to
+## Set to 'datadoghq.eu' to send data to the EU site.
+## Set to 'us3.datadoghq.com' to send data to the US3 site.
+## Set to 'us5.datadoghq.com' to send data to the US5 site.
+## Set to 'ddog-gov.com' to send data to the US1-FED site.
+site:  # datadoghq.com
+
 # dd_url -- The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL
 ## Overrides the site setting defined in "site".
 dd_url:  # <DATADOG_API_ENDPOINT>


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows `site` to be set in the operator helm chart.

#### Special notes for your reviewer:
Requires https://github.com/DataDog/datadog-operator/pull/395 for the operator to use the `site` value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
