### PR TITLE
Fix port number for datadog.apm.portEnabled option

### DIFF
--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -527,7 +527,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.apm.enabled | bool | `false` | Enable this to enable APM and tracing, on port 8126 DEPRECATED. Use datadog.apm.portEnabled instead |
 | datadog.apm.hostSocketPath | string | `"/var/run/datadog/"` | Host path to the trace-agent socket |
 | datadog.apm.port | int | `8126` | Override the trace Agent port |
-| datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (port 8216 by default |
+| datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (port 8126 by default) |
 | datadog.apm.socketEnabled | bool | `true` | Enable APM over Socket (Unix Socket or windows named pipe) |
 | datadog.apm.socketPath | string | `"/var/run/datadog/apm.socket"` | Path to the trace-agent socket |
 | datadog.apm.useSocketVolume | bool | `false` | Enable APM over Unix Domain Socket DEPRECATED. Use datadog.apm.socketEnabled instead |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -232,7 +232,7 @@ datadog:
     ## ref: https://docs.datadoghq.com/agent/kubernetes/apm/
     socketEnabled: true
 
-    # datadog.apm.portEnabled -- Enable APM over TCP communication (port 8216 by default
+    # datadog.apm.portEnabled -- Enable APM over TCP communication (port 8126 by default)
     ## ref: https://docs.datadoghq.com/agent/kubernetes/apm/
     portEnabled: false
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes a port number typo for the `datadog.apm.portEnabled` option from 8216 to 8126.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
