### PR TITLE
Add an `agents.podSecurity.defaultApparmor` setting

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 2.23.2
+
+* Add an `agents.podSecurity.defaultApparmor` setting to allow customizing the default AppArmor profile used by all containers but `system-probe`.
+
 # 2.23.1
 
 * Fix APM reporting via `trace-agent` hostPort if `datadog.apm.enabled: true`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.23.1
+version: 2.23.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.23.1](https://img.shields.io/badge/Version-2.23.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.23.2](https://img.shields.io/badge/Version-2.23.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -425,6 +425,7 @@ helm install --name <RELEASE_NAME> \
 | agents.podSecurity.apparmor.enabled | bool | `true` | If true, enable apparmor enforcement |
 | agents.podSecurity.apparmorProfiles | list | `["runtime/default","unconfined"]` | Allowed apparmor profiles |
 | agents.podSecurity.capabilities | list | `["SYS_ADMIN","SYS_RESOURCE","SYS_PTRACE","NET_ADMIN","NET_BROADCAST","NET_RAW","IPC_LOCK","AUDIT_CONTROL","AUDIT_READ"]` | Allowed capabilities |
+| agents.podSecurity.defaultApparmor | string | `"runtime/default"` | Default AppArmor profile for all containers but system-probe |
 | agents.podSecurity.podSecurityPolicy.create | bool | `false` | If true, create a PodSecurityPolicy resource for Agent pods |
 | agents.podSecurity.privileged | bool | `false` | If true, Allow to run privileged containers |
 | agents.podSecurity.seLinuxContext | object | Must run as spc_t | Provide seLinuxContext configuration for PSP/SCC |

--- a/charts/datadog/templates/agent-psp.yaml
+++ b/charts/datadog/templates/agent-psp.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- if .Values.agents.podSecurity.apparmor.enabled }}
     apparmor.security.beta.kubernetes.io/allowedProfileNames: {{ join "," .Values.agents.podSecurity.apparmorProfiles | quote }}
-    apparmor.security.beta.kubernetes.io/defaultProfileName: "runtime/default"
+    apparmor.security.beta.kubernetes.io/defaultProfileName: {{ .Values.agents.podSecurity.defaultApparmor | default "runtime/default" }}
     {{- end }}
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: {{ join "," .Values.agents.podSecurity.seccompProfiles | quote }}
     seccomp.security.alpha.kubernetes.io/defaultProfileName: "runtime/default"

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -846,15 +846,18 @@ agents:
       - "runtime/default"
       - "localhost/system-probe"
 
+    apparmor:
+      # agents.podSecurity.apparmor.enabled -- If true, enable apparmor enforcement
+      ## see: https://kubernetes.io/docs/tutorials/clusters/apparmor/
+      enabled: true
+
     # agents.podSecurity.apparmorProfiles -- Allowed apparmor profiles
     apparmorProfiles:
       - "runtime/default"
       - "unconfined"
 
-    apparmor:
-      # agents.podSecurity.apparmor.enabled -- If true, enable apparmor enforcement
-      ## see: https://kubernetes.io/docs/tutorials/clusters/apparmor/
-      enabled: true
+    # agents.podSecurity.defaultApparmor -- Default AppArmor profile for all containers but system-probe
+    defaultApparmor: runtime/default
 
   containers:
     agent:


### PR DESCRIPTION
#### What this PR does / why we need it:

Add an `agents.podSecurity.defaultApparmor` setting to allow customising the default AppArmor profile used by all containers but `system-probe`.
For `system-probe`, there was already the `datadog.systemProbe.apparmor` setting.

Agents other than `system-probe` don’t need any AppArmor privileges so that the `runtime/default` default AppArmor profile should be enough in most cases.
On some setups, however, AppArmor is generating a lot of harmless messages. See DataDog/datadog-agent#6915 for more details.
In order to fix those messages, we can use a custom AppArmor profile as described [here](https://github.com/DataDog/datadog-agent/issues/6915#issuecomment-748077547).
This change adds a parameter in the `values.yaml` of the chart to allow specifying this custom profile.

#### Which issue this PR fixes
  - fixes #389

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has beed updated
- [X] Variables are documented in the `README.md`
