### PR TITLE
feat/fix: defined expvarPort, set containerPort for agentmetrics

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+# 2.23.6
+
+* Add `datadog.expvarPort` parameter to customize the default expvar default port to not conflict with the default clusteragent metrics port if running in hostNetwork mode.
+* Defined cluster-agent containerPort `agentmetrics` to expose the default port, which is set to 5000 and already defined in the `NetworkPolicy` for the cluster-agent.
+
 # 2.23.5
 
 Change OpenShift SCC priorities from 10 to 8 to avoid conflicts with OpenShift Auth operator.
@@ -68,7 +73,7 @@ Change OpenShift SCC priorities from 10 to 8 to avoid conflicts with OpenShift A
 ## 2.22.8
 
 * Add a service with local [internal traffic policy](https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/) for traces and dogstatsd.
-  This works only on Kubernetes 1.22 or more recent. 
+  This works only on Kubernetes 1.22 or more recent.
 
 ## 2.22.7
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.23.5
+version: 2.23.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.23.5](https://img.shields.io/badge/Version-2.23.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.23.6](https://img.shields.io/badge/Version-2.23.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -564,6 +564,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.env | list | `[]` | Set environment variables for all Agents |
 | datadog.envFrom | list | `[]` | Set environment variables for all Agents directly from configMaps and/or secrets |
 | datadog.excludePauseContainer | bool | `true` | Exclude pause containers from the Agent Autodiscovery. |
+| datadog.expvarPort | int | `6000` | Specify the port to expose pprof and expvar to not interfer with the agentmetrics port from the cluster-agent, which defaults to 5000 |
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.ignoreAutoConfig | list | `[]` | List of integration to ignore auto_conf.yaml. |
 | datadog.kubeStateMetricsCore.collectSecretMetrics | bool | `true` | Enable watching secret objects and collecting their corresponding metrics kubernetes_state.secret.* |

--- a/charts/datadog/ci/cluster-agent-values.yaml
+++ b/charts/datadog/ci/cluster-agent-values.yaml
@@ -5,6 +5,7 @@ datadog:
   kubeStateMetricsEnabled: false
   clusterChecks:
     enabled: true
+  expvarPort: 6001
 
 clusterAgent:
   enabled: true

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -107,6 +107,8 @@
     - name: DD_CHECKS_TAG_CARDINALITY
       value: {{ .Values.datadog.checksCardinality | quote }}
     {{- end }}
+    - name: DD_EXPVAR_PORT
+      value: {{ .Values.datadog.expvarPort | quote }}
 {{- if .Values.agents.containers.agent.env }}
 {{ toYaml .Values.agents.containers.agent.env | indent 4 }}
 {{- end }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -97,6 +97,9 @@ spec:
         - containerPort: 5005
           name: agentport
           protocol: TCP
+        - containerPort: 5000
+          name: agentmetrics
+          protocol: TCP
         {{- if .Values.clusterAgent.metricsProvider.enabled }}
         - containerPort: {{ template "clusterAgent.metricsProvider.port" . }}
           name: metricsapi

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -152,6 +152,9 @@ datadog:
     # @default -- /var/run/host-kubelet-ca.crt if hostCAPath else /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     agentCAPath:
 
+  # datadog.expvarPort -- Specify the port to expose pprof and expvar to not interfer with the agentmetrics port from the cluster-agent, which defaults to 5000
+  expvarPort: 6000
+
   ## dogstatsd configuration
   ## ref: https://docs.datadoghq.com/agent/kubernetes/dogstatsd/
   ## To emit custom metrics from your Kubernetes application, use DogStatsD.


### PR DESCRIPTION
**What this PR does / why we need it:**
feat/fix: defined expvarPort, set containerPort for agentmetrics

* Add `datadog.expvarPort` parameter to customize the default 
expvar default port to not conflict with the default clusteragent 
metrics port.

* Defined cluster-agent containerPort `agentmetrics` to expose the 
default port, which is set to 5000 and already defined in the 
`NetworkPolicy` for the cluster-agent.

**Special notes for your reviewer:**
See also 
https://github.com/DataDog/datadog-agent/blob/4f63274038167c7487aa44e0126d42cd6b27fba0/pkg/config/config.go#L659-L660
https://github.com/DataDog/datadog-agent/blob/4f63274038167c7487aa44e0126d42cd6b27fba0/pkg/config/config.go#L576-L585

Closes: #264

**Checklist**
- [x] Documentation has been updated with helm-docs (run: .github/helm-docs.sh)
- [x] Chart Version bumped
- [x] CHANGELOG.md has beed updated
- [x] Variables are documented in the README.md