### PR TITLE
Lower OpenShift SCC priorities to avoid conflicts with OpenShift Auth Operator

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 2.23.5
+
+Change OpenShift SCC priorities from 10 to 8 to avoid conflicts with OpenShift Auth operator.
+
 # 2.23.4
 
 * Add a new configuration field `datadog.providers.eks.ec2.useHostnameFromFile` to allow use of host's `/var/lib/cloud/data/instance-id` for hostname detection.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.23.4
+version: 2.23.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.23.4](https://img.shields.io/badge/Version-2.23.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.23.5](https://img.shields.io/badge/Version-2.23.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-scc.yaml
+++ b/charts/datadog/templates/agent-scc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "datadog.labels" . | indent 4 }}
 users:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ template "datadog.fullname" . }}
-priority: 10
+priority: 8
 # Allow host ports for dsd / trace intake
 allowHostPorts: {{ or .Values.datadog.dogstatsd.useHostPort .Values.datadog.apm.enabled .Values.datadog.apm.portEnabled .Values.agents.useHostNetwork }}
 # Allow host PID for dogstatsd origin detection

--- a/charts/datadog/templates/cluster-agent-scc.yaml
+++ b/charts/datadog/templates/cluster-agent-scc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "datadog.labels" . | indent 4 }}
 users:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ template "datadog.fullname" . }}-cluster-agent
-priority: 10
+priority: 8
 # Allow host ports if hostNetwork
 allowHostPorts: {{ .Values.clusterAgent.useHostNetwork }}
 allowHostNetwork: {{ .Values.clusterAgent.useHostNetwork}}


### PR DESCRIPTION
#### What this PR does / why we need it:

After installing the Agent with SCC creation, updating an OpenShift cluster will fail. See https://access.redhat.com/solutions/4727461 (requires access)

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
