### PR TITLE
Add annotations to cluster-agent and agents

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 2.25.0
+
+* Adding the following `agents.daemonsetAnnotations`, `clusterAgent.deploymentAnnotation` and `clusterChecksRunner.deploymentAnnotations` parameters to allow custom annotations on the agent's deployments/daemonsets to be setup
+
 # 2.24.1
 
 * Fix typo in variable name : `agents.localService.forceLocalServiceEnabled`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.24.1
+version: 2.25.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.24.1](https://img.shields.io/badge/Version-2.24.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.25.0](https://img.shields.io/badge/Version-2.25.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -409,7 +409,7 @@ helm install --name <RELEASE_NAME> \
 | agents.containers.traceAgent.resources | object | `{}` | Resource requests and limits for the trace-agent container |
 | agents.containers.traceAgent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the trace-agent container. |
 | agents.customAgentConfig | object | `{}` | Specify custom contents for the datadog agent config (datadog.yaml) |
-| agents.daemonsetAnnotations | object | `{}` | Custom annotations for the agent daemonset to be set |
+| agents.daemonsetAnnotations | object | `{}` | Annotations to add to the DaemonSet |
 | agents.dnsConfig | object | `{}` | specify dns configuration options for datadog cluster agent containers e.g ndots |
 | agents.enabled | bool | `true` | You should keep Datadog DaemonSet enabled! |
 | agents.image.doNotCheckTag | string | `nil` | Skip the version<>chart compatibility check |
@@ -455,7 +455,7 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.containers.clusterAgent.securityContext | object | `{}` | Specify securityContext on the cluster-agent container. |
 | clusterAgent.createPodDisruptionBudget | bool | `false` | Create pod disruption budget for Cluster Agent deployments |
 | clusterAgent.datadog_cluster_yaml | object | `{}` | Specify custom contents for the datadog cluster agent config (datadog-cluster.yaml) |
-| clusterAgent.deploymentAnnotations | object | `{}` | Custom annotations for the Cluster Agent deployment to be set |
+| clusterAgent.deploymentAnnotations | object | `{}` | Annotations to add to the cluster-agents's deployment |
 | clusterAgent.dnsConfig | object | `{}` | Specify dns configuration options for datadog cluster agent containers e.g ndots |
 | clusterAgent.enabled | bool | `true` | Set this to false to disable Datadog Cluster Agent |
 | clusterAgent.env | list | `[]` | Set environment variables specific to Cluster Agent |
@@ -497,7 +497,7 @@ helm install --name <RELEASE_NAME> \
 | clusterChecksRunner.additionalLabels | object | `{}` | Adds labels to the cluster checks runner deployment and pods |
 | clusterChecksRunner.affinity | object | `{}` | Allow the ClusterChecks Deployment to schedule using affinity rules. |
 | clusterChecksRunner.createPodDisruptionBudget | bool | `false` | Create the pod disruption budget to apply to the cluster checks agents |
-| clusterChecksRunner.deploymentAnnotations | object | `{}` | Custom annotations for the ClusterChecks deployment to be set |
+| clusterChecksRunner.deploymentAnnotations | object | `{}` | Annotations to add to the cluster-checks-runner's Deployment |
 | clusterChecksRunner.dnsConfig | object | `{}` | specify dns configuration options for datadog cluster agent containers e.g ndots |
 | clusterChecksRunner.enabled | bool | `false` | If true, deploys agent dedicated for running the Cluster Checks instead of running in the Daemonset's agents. |
 | clusterChecksRunner.env | list | `[]` | Environment variables specific to Cluster Checks Runner |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -374,6 +374,7 @@ helm install --name <RELEASE_NAME> \
 |-----|------|---------|-------------|
 | agents.additionalLabels | object | `{}` | Adds labels to the Agent daemonset and pods |
 | agents.affinity | object | `{}` | Allow the DaemonSet to schedule using affinity rules |
+| agents.annotations | object | `{}` | Custom annotations for the agent daemonset to be set |
 | agents.containers.agent.env | list | `[]` | Additional environment variables for the agent container |
 | agents.containers.agent.envFrom | list | `[]` | Set environment variables specific to agent container from configMaps and/or secrets |
 | agents.containers.agent.healthPort | int | `5555` | Port number to use in the node agent for the healthz endpoint |
@@ -449,6 +450,7 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |
 | clusterAgent.advancedConfd | object | `{}` | Provide additional cluster check configurations |
 | clusterAgent.affinity | object | `{}` | Allow the Cluster Agent Deployment to schedule using affinity rules |
+| clusterAgent.annotations | object | `{}` | Custom annotations for the Cluster Agent deployment to be set |
 | clusterAgent.command | list | `[]` | Command to run in the Cluster Agent container as entrypoint |
 | clusterAgent.confd | object | `{}` | Provide additional cluster check configurations |
 | clusterAgent.containers.clusterAgent.securityContext | object | `{}` | Specify securityContext on the cluster-agent container. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -374,7 +374,6 @@ helm install --name <RELEASE_NAME> \
 |-----|------|---------|-------------|
 | agents.additionalLabels | object | `{}` | Adds labels to the Agent daemonset and pods |
 | agents.affinity | object | `{}` | Allow the DaemonSet to schedule using affinity rules |
-| agents.annotations | object | `{}` | Custom annotations for the agent daemonset to be set |
 | agents.containers.agent.env | list | `[]` | Additional environment variables for the agent container |
 | agents.containers.agent.envFrom | list | `[]` | Set environment variables specific to agent container from configMaps and/or secrets |
 | agents.containers.agent.healthPort | int | `5555` | Port number to use in the node agent for the healthz endpoint |
@@ -410,6 +409,7 @@ helm install --name <RELEASE_NAME> \
 | agents.containers.traceAgent.resources | object | `{}` | Resource requests and limits for the trace-agent container |
 | agents.containers.traceAgent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the trace-agent container. |
 | agents.customAgentConfig | object | `{}` | Specify custom contents for the datadog agent config (datadog.yaml) |
+| agents.daemonsetAnnotations | object | `{}` | Custom annotations for the agent daemonset to be set |
 | agents.dnsConfig | object | `{}` | specify dns configuration options for datadog cluster agent containers e.g ndots |
 | agents.enabled | bool | `true` | You should keep Datadog DaemonSet enabled! |
 | agents.image.doNotCheckTag | string | `nil` | Skip the version<>chart compatibility check |
@@ -450,12 +450,12 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |
 | clusterAgent.advancedConfd | object | `{}` | Provide additional cluster check configurations |
 | clusterAgent.affinity | object | `{}` | Allow the Cluster Agent Deployment to schedule using affinity rules |
-| clusterAgent.annotations | object | `{}` | Custom annotations for the Cluster Agent deployment to be set |
 | clusterAgent.command | list | `[]` | Command to run in the Cluster Agent container as entrypoint |
 | clusterAgent.confd | object | `{}` | Provide additional cluster check configurations |
 | clusterAgent.containers.clusterAgent.securityContext | object | `{}` | Specify securityContext on the cluster-agent container. |
 | clusterAgent.createPodDisruptionBudget | bool | `false` | Create pod disruption budget for Cluster Agent deployments |
 | clusterAgent.datadog_cluster_yaml | object | `{}` | Specify custom contents for the datadog cluster agent config (datadog-cluster.yaml) |
+| clusterAgent.deploymentAnnotations | object | `{}` | Custom annotations for the Cluster Agent deployment to be set |
 | clusterAgent.dnsConfig | object | `{}` | Specify dns configuration options for datadog cluster agent containers e.g ndots |
 | clusterAgent.enabled | bool | `true` | Set this to false to disable Datadog Cluster Agent |
 | clusterAgent.env | list | `[]` | Set environment variables specific to Cluster Agent |
@@ -497,6 +497,7 @@ helm install --name <RELEASE_NAME> \
 | clusterChecksRunner.additionalLabels | object | `{}` | Adds labels to the cluster checks runner deployment and pods |
 | clusterChecksRunner.affinity | object | `{}` | Allow the ClusterChecks Deployment to schedule using affinity rules. |
 | clusterChecksRunner.createPodDisruptionBudget | bool | `false` | Create the pod disruption budget to apply to the cluster checks agents |
+| clusterChecksRunner.deploymentAnnotations | object | `{}` | Custom annotations for the ClusterChecks deployment to be set |
 | clusterChecksRunner.dnsConfig | object | `{}` | specify dns configuration options for datadog cluster agent containers e.g ndots |
 | clusterChecksRunner.enabled | bool | `false` | If true, deploys agent dedicated for running the Cluster Checks instead of running in the Daemonset's agents. |
 | clusterChecksRunner.env | list | `[]` | Environment variables specific to Cluster Checks Runner |

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
 {{ toYaml .Values.clusterChecksRunner.additionalLabels | indent 4 }}
     {{- end }}
 {{ include "provider-labels" . | indent 4 }}
+  {{- if .Values.clusterChecksRunner.deploymentAnnotations }}
+  annotations: {{ toYaml .Values.clusterChecksRunner.deploymentAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.clusterChecksRunner.replicas }}
   strategy:

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -11,8 +11,8 @@ metadata:
 {{ toYaml .Values.clusterAgent.additionalLabels | indent 4 }}
     {{- end }}
 {{ include "provider-labels" . | indent 4 }}
-  {{- if .Values.clusterAgent.annotations }}
-  annotations: {{ toYaml .Values.clusterAgent.annotations | nindent 4 }}
+  {{- if .Values.clusterAgent.deploymentAnnotations }}
+  annotations: {{ toYaml .Values.clusterAgent.deploymentAnnotations | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.clusterAgent.replicas }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
 {{ toYaml .Values.clusterAgent.additionalLabels | indent 4 }}
     {{- end }}
 {{ include "provider-labels" . | indent 4 }}
+  {{- if .Values.clusterAgent.annotations }}
+  annotations: {{ toYaml .Values.clusterAgent.annotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.clusterAgent.replicas }}
   strategy:

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -13,6 +13,9 @@ metadata:
 {{ toYaml .Values.agents.additionalLabels | indent 4 }}
     {{- end }}
 {{ include "provider-labels" . | indent 4 }}
+  {{- if .Values.agents.annotations }}
+  annotations: {{ toYaml .Values.agents.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -13,8 +13,8 @@ metadata:
 {{ toYaml .Values.agents.additionalLabels | indent 4 }}
     {{- end }}
 {{ include "provider-labels" . | indent 4 }}
-  {{- if .Values.agents.annotations }}
-  annotations: {{ toYaml .Values.agents.annotations | nindent 4 }}
+  {{- if .Values.agents.daemonsetAnnotations }}
+  annotations: {{ toYaml .Values.agents.daemonsetAnnotations | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -682,8 +682,8 @@ clusterAgent:
       maxSurge: 1
       maxUnavailable: 0
 
-  # clusterAgent.annotations -- Annotations to add to the cluster-agents's deployment
-  annotations: {}
+  # clusterAgent.deploymentAnnotations -- Annotations to add to the cluster-agents's deployment
+  deploymentAnnotations: {}
   #   key: "value"
 
   # clusterAgent.podAnnotations -- Annotations to add to the cluster-agents's pod(s)
@@ -1082,8 +1082,8 @@ agents:
   #  - name: ndots
   #    value: "1"
 
-  # agents.annotations -- Annotations to add to the DaemonSet
-  annotations: {}
+  # agents.daemonsetAnnotations -- Annotations to add to the DaemonSet
+  daemonsetAnnotations: {}
   #   key: "value"
 
   # agents.podAnnotations -- Annotations to add to the DaemonSet's Pods
@@ -1288,6 +1288,10 @@ clusterChecksRunner:
     timeoutSeconds: 5
     successThreshold: 1
     failureThreshold: 6
+
+  # clusterChecksRunner.deploymentAnnotation -- Annotations to add to the cluster-checks-runner's Deployment
+  deploymentAnnotations: {}
+  #   key: "value"
 
   # clusterChecksRunner.podAnnotations -- Annotations to add to the cluster-checks-runner's pod(s)
   podAnnotations: {}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1289,7 +1289,7 @@ clusterChecksRunner:
     successThreshold: 1
     failureThreshold: 6
 
-  # clusterChecksRunner.deploymentAnnotation -- Annotations to add to the cluster-checks-runner's Deployment
+  # clusterChecksRunner.deploymentAnnotations -- Annotations to add to the cluster-checks-runner's Deployment
   deploymentAnnotations: {}
   #   key: "value"
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -682,6 +682,10 @@ clusterAgent:
       maxSurge: 1
       maxUnavailable: 0
 
+  # clusterAgent.annotations -- Annotations to add to the cluster-agents's deployment
+  annotations: {}
+  #   key: "value"
+
   # clusterAgent.podAnnotations -- Annotations to add to the cluster-agents's pod(s)
   podAnnotations: {}
   #   key: "value"
@@ -1077,6 +1081,10 @@ agents:
   #  options:
   #  - name: ndots
   #    value: "1"
+
+  # agents.annotations -- Annotations to add to the DaemonSet
+  annotations: {}
+  #   key: "value"
 
   # agents.podAnnotations -- Annotations to add to the DaemonSet's Pods
   podAnnotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
  - fixes #441 

#### Special notes for your reviewer:

This adds the ability to set custom annotations in the cluster-agent and also the daemonset for the DD agent. Things like reloader need apps to have annotations to they can monitor a secret. If the secret changes then it can do a rolling restart. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
