### PR TITLE
Add missing toFQDNs for agent-http-intake to CilumNetworkPolicy

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.27.3
+
+* Fix CiliumNetworkPolicy: Update toFQDNs policy to include `agent-http-intake` endpoint.
+* Fix CiliumNetworkPolicy: Update toFQDNs to include `api` endpoint.
+
 ## 2.27.2
 
 * Expose the `labels_as_tags` parameter of the KSM core check.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.27.2
+version: 2.27.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.27.2](https://img.shields.io/badge/Version-2.27.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.27.3](https://img.shields.io/badge/Version-2.27.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-cilium-network-policy.yaml
+++ b/charts/datadog/templates/agent-cilium-network-policy.yaml
@@ -85,11 +85,14 @@ specs:
           {{- end}}
           {{- if $.Values.datadog.site}}
           - matchPattern: "*-app.agent.{{ $.Values.datadog.site }}"
+          - matchName: "api.{{ $.Values.datadog.site }}"
           - matchName: "agent-intake.logs.{{ $.Values.datadog.site }}"
+          - matchName: "agent-http-intake.logs.{{ $.Values.datadog.site }}"
           - matchName: "process.{{ $.Values.datadog.site }}"
           - matchName: "orchestrator.{{ $.Values.datadog.site }}"
           {{- else}}
           - matchPattern: "*-app.agent.datadoghq.com"
+          - matchName: "api.datadoghq.com"
           - matchName: "agent-intake.logs.datadoghq.com"
           - matchName: "process.datadoghq.com"
           - matchName: "orchestrator.datadoghq.com"

--- a/charts/datadog/templates/agent-cilium-network-policy.yaml
+++ b/charts/datadog/templates/agent-cilium-network-policy.yaml
@@ -94,6 +94,7 @@ specs:
           - matchPattern: "*-app.agent.datadoghq.com"
           - matchName: "api.datadoghq.com"
           - matchName: "agent-intake.logs.datadoghq.com"
+          - matchName: "agent-http-intake.logs.datadoghq.com"
           - matchName: "process.datadoghq.com"
           - matchName: "orchestrator.datadoghq.com"
           {{- end}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds missing FQDN rules to the agent Cilium network policy.
Resolves `Unable to validate API Key` and `You are currently sending logs to Datadog through TCP...` messages in agent status. 

#### Which issue this PR fixes
  - fixes #456

#### Special notes for your reviewer:
I didn't find that the `unable to validate API key` message was breaking anything in the agent, but came across it while investigating Cilium network drops caused #456 so thought I would include the fix for that too.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
