### PR TITLE
Fix unsupported config in windows envs

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.27.4
+
+* Do not allow unsupported configs with the security agent in windows environments. 
+* Ensure autoconf/extra config files are mounted in windows environments.
+
 ## 2.27.3
 
 * Fix CiliumNetworkPolicy: Update toFQDNs policy to include `agent-http-intake` endpoint.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.27.3
+version: 2.27.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.27.3](https://img.shields.io/badge/Version-2.27.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.27.4](https://img.shields.io/badge/Version-2.27.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -2,7 +2,7 @@
 - name: security-agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  {{- if .Values.datadog.securityAgent.compliance.enabled }}
+  {{- if eq  (include "should-enable-compliance" .) "true" }}
   securityContext:
     capabilities:
       add: ["AUDIT_CONTROL", "AUDIT_READ"]

--- a/charts/datadog/templates/_daemonset-volumes-windows.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-windows.yaml
@@ -5,6 +5,11 @@
     type: Directory
   name: kubelet-ca
 {{- end }}
+{{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
+- name: confd
+  configMap:
+    name: {{ template "datadog.fullname" . }}-confd
+{{- end }}
 {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
 - hostPath:
     path: C:/var/log

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -266,7 +266,7 @@ false
 Return true if the system-probe container should be created.
 */}}
 {{- define "should-enable-system-probe" -}}
-{{- if and (not .Values.providers.gke.autopilot) (eq (include "system-probe-feature" .) "true") -}}
+{{- if and (not .Values.providers.gke.autopilot) (eq (include "system-probe-feature" .) "true") (eq .Values.targetSystem "linux") -}}
 true
 {{- else -}}
 false
@@ -289,7 +289,7 @@ false
 Return true if the security-agent container should be created.
 */}}
 {{- define "should-enable-security-agent" -}}
-{{- if and (not .Values.providers.gke.autopilot) (eq (include "security-agent-feature" .) "true") -}}
+{{- if and (not .Values.providers.gke.autopilot) (eq .Values.targetSystem "linux") (eq (include "security-agent-feature" .) "true") -}}
 true
 {{- else -}}
 false
@@ -300,7 +300,7 @@ false
 Return true if the compliance features should be enabled.
 */}}
 {{- define "should-enable-compliance" -}}
-{{- if and (not .Values.providers.gke.autopilot) .Values.datadog.securityAgent.compliance.enabled -}}
+{{- if and (not .Values.providers.gke.autopilot) (eq .Values.targetSystem "linux") .Values.datadog.securityAgent.compliance.enabled -}}
 true
 {{- else -}}
 false


### PR DESCRIPTION
#### What this PR does / why we need it:

Right now you can't mount the custom files in windows pods and a specific config with the security/compliance that makes the pods crash.

#### Special notes for your reviewer:

Used this custom values file, for a chart named `datadog-windows-test`:

```
➜  datadog git:(charlyf/fix-security-agent-config-conflict) ✗ cat values-custom.yaml
#targetSystem: windows
#existingClusterAgent:
#  join: true
#  serviceName: "datadog-windows-test-cluster-agent" # from the other datadog helm chart release
#  tokenSecretName: "datadog-windows-test-cluster-agent" # from the other datadog helm chart release
datadog:
  collectEvents: true
  leaderElection: true
  logs:
    enabled: true
  apm:
    enabled: true
  processAgent:
    enabled: true
  clusterChecks:
    enabled: true
  networkMonitoring:
    enabled: true
  orchestratorExplorer:
    enabled: true
  securityAgent:
    compliance:
      enabled: true
    runtime:
      enabled: true
  kubeStateMetricsEnabled: false
  kubeStateMetricsCore:
    enabled: true
    useClusterCheckRunners: true
  confd:
    mongo.yaml: |-
      ad_identifiers:
        - redis
        - bitnami/redis
      init_config:
      instances:
        - host: "%%host%%"
          port: "%%port%%"
    jmx.yaml: |-
      ad_identifiers:
        - openjdk
      instance_config:
      instances:
        - host: "%%host%%"
          port: "%%port_0%%"
    redisdb.yaml: |-
      init_config:
      instances:
        - host: "outside-k8s.example.com"
          port: 6379
clusterAgent:
  enabled: true
  env:
   - name: DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED
     value: "true"
  metricsProvider:
    enabled: true
    useDatadogMetrics: true
clusterChecksRunner:
  enabled: true
  image:
    tag: 7.33.0
```

and added the same without the commented section (to have agents being scheduled on window nodes).

#### Checklist

- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
