### PR TITLE
fix: running ksm core as cluster check

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.27.5
+
+* Fix bugs that prevented running the ksm core check as a cluster check.
+
 ## 2.27.4
 
 * Do not allow unsupported configs with the security agent in windows environments. 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.27.4
+version: 2.27.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.27.4](https://img.shields.io/badge/Version-2.27.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.27.5](https://img.shields.io/badge/Version-2.27.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -45,7 +45,7 @@ spec:
 {{ toYaml .Values.clusterChecksRunner.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.clusterChecksRunner.rbac.dedicated }}
+      {{- if or (eq (include "should-enable-cluster-check-workers" .) "true") .Values.clusterChecksRunner.rbac.dedicated }}
       serviceAccountName: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}-cluster-checks{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}
       {{- else }}
       serviceAccountName: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}

--- a/charts/datadog/templates/agent-clusterchecks-rbac.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterChecksRunner.rbac.create (eq (include "should-deploy-cluster-agent" .) "true") (eq (include "should-enable-cluster-check-workers" .) "true") .Values.clusterChecksRunner.rbac.dedicated -}}
+{{- if or (eq (include "should-enable-cluster-check-workers" .) "true") .Values.clusterChecksRunner.rbac.dedicated -}}
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:

--- a/charts/datadog/templates/cluster-agent-confd-configmap.yaml
+++ b/charts/datadog/templates/cluster-agent-confd-configmap.yaml
@@ -15,7 +15,7 @@ data:
 {{- if .Values.datadog.kubeStateMetricsCore.enabled }}
   kubernetes_state_core.yaml.default: |-
 {{- if .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners }}
-    cluster_checks: true
+    cluster_check: true
 {{- end }}
     init_config:
     instances:
@@ -43,6 +43,9 @@ data:
         - poddisruptionbudgets
         - storageclasses
         - volumeattachments
+{{- if .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners }}
+        skip_leader_election: true
+{{- end }}
         labels_as_tags:
 {{ .Values.datadog.kubeStateMetricsCore.labelsAsTags | toYaml | indent 10 }}
 {{- end }}

--- a/charts/datadog/templates/kube-state-metrics-core-rbac.yaml
+++ b/charts/datadog/templates/kube-state-metrics-core-rbac.yaml
@@ -22,6 +22,7 @@ rules:
   - persistentvolumes
   - namespaces
   - endpoints
+  - events
   verbs:
   - list
   - watch


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix bugs that prevented running the ksm core check as a cluster check.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes https://github.com/DataDog/helm-charts/issues/460

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
