### PR TITLE
Adding priorityClass for the DD daemonset in Autopilot environments

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.28.0
+
+* Create priority Class to better support environments such as GKE Autopilot.
+
 ## 2.27.8
 
 * Default Datadog Agent image to `7.32.3`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.27.8
+version: 2.28.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.27.8](https://img.shields.io/badge/Version-2.27.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.28.0](https://img.shields.io/badge/Version-2.28.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -514,7 +514,9 @@ helm install --name <RELEASE_NAME> \
 | agents.podSecurity.seccompProfiles | list | `["runtime/default","localhost/system-probe"]` | Allowed seccomp profiles |
 | agents.podSecurity.securityContextConstraints.create | bool | `false` | If true, create a SecurityContextConstraints resource for Agent pods |
 | agents.podSecurity.volumes | list | `["configMap","downwardAPI","emptyDir","hostPath","secret"]` | Allowed volumes types |
-| agents.priorityClassName | string | `nil` | Sets PriorityClassName if defineds |
+| agents.priorityClassCreate | bool | `false` | Creates a priorityClass for the Datadog Agent's Daemonset pods. |
+| agents.priorityClassName | string | `nil` | Sets PriorityClassName if defined |
+| agents.priorityClassValue | int | `1000000000` | Value used to specify the priority of the scheduling of Datadog Agent's Daemonset pods. |
 | agents.rbac.create | bool | `true` | If true, create & use RBAC resources |
 | agents.rbac.serviceAccountAnnotations | object | `{}` | Annotations to add to the ServiceAccount if agents.rbac.create is true |
 | agents.rbac.serviceAccountName | string | `"default"` | Specify a preexisting ServiceAccount to use if agents.rbac.create is false |

--- a/charts/datadog/templates/agent-priorityclass.yaml
+++ b/charts/datadog/templates/agent-priorityclass.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.agents.priorityClassCreate}}
+apiVersion: scheduling.k8s.io/v1
+description: Used for Datadog Agent Components to be scheduled with higher priority.
+kind: PriorityClass
+metadata:
+  name: {{ .Values.agents.priorityClassName | default (include "datadog.fullname" . ) }}
+preemptionPolicy: PreemptLowerPriority
+value: {{ .Values.agents.priorityClassValue }}
+{{- end }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -99,8 +99,8 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.agents.image.pullSecrets | indent 8 }}
       {{- end }}
-      {{- if .Values.agents.priorityClassName }}
-      priorityClassName: {{ .Values.agents.priorityClassName }}
+      {{- if or .Values.agents.priorityClassCreate .Values.agents.priorityClassName }}
+      priorityClassName: {{ .Values.agents.priorityClassName | default (include "datadog.fullname" . ) }}
       {{- end }}
       containers:
         {{- include "container-agent" . | nindent 6 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1135,8 +1135,15 @@ agents:
     rollingUpdate:
       maxUnavailable: "10%"
 
-  # agents.priorityClassName -- Sets PriorityClassName if defineds
+  # agents.priorityClassCreate -- Creates a priorityClass for the Datadog Agent's Daemonset pods.
+  priorityClassCreate: false
+
+  # agents.priorityClassName -- Sets PriorityClassName if defined
   priorityClassName:
+
+  # agents.priorityClassValue -- Value used to specify the priority of the scheduling of Datadog Agent's Daemonset pods.
+  ## The PriorityClass uses PreemptLowerPriority.
+  priorityClassValue: 1000000000
 
   # agents.podLabels -- Sets podLabels if defined
   # Note: These labels are also used as label selectors so they are immutable.


### PR DESCRIPTION
#### What this PR does / why we need it:

In Autopilot environments, the default NG is too small to accommodate applications and the agent in certain conditions. This ensures the agent is prioritized and let's Autopilot do the scale up as necessary.

#### Which issue this PR fixes

https://github.com/DataDog/helm-charts/issues/409

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has beed updated
- [x] Variables are documented in the `README.md`
