### PR TITLE
cluster-agent-deployment: always enable cluster checks

### DIFF
--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -155,14 +155,12 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
             value: {{ template "datadog.fullname" . }}-cluster-agent-admission-controller
           {{- end }}
-          {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED
-            value: {{ .Values.datadog.clusterChecks.enabled | quote }}
+            value: "true"
           - name: DD_EXTRA_CONFIG_PROVIDERS
             value: "kube_endpoints kube_services"
           - name: DD_EXTRA_LISTENERS
             value: "kube_endpoints kube_services"
-          {{- end }}
           {{- if .Values.datadog.clusterName }}
           {{- template "check-cluster-name" . }}
           - name: DD_CLUSTER_NAME

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -118,7 +118,7 @@ datadog:
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
   ## Autodiscovery via Kube Service annotations is automatically enabled
   clusterChecks:
-    # datadog.clusterChecks.enabled -- Enable the Cluster Checks feature on both the cluster-agents and the daemonset
+    # datadog.clusterChecks.enabled -- Enable the Cluster Checks feature on the daemonset. Daemonset agents will participate in cluster checks.
     enabled: true
 
   # datadog.nodeLabelsAsTags -- Provide a mapping of Kubernetes Node Labels to Datadog Tags


### PR DESCRIPTION
Not sure I understand the original thinking here.  Proposing this change so that cluster agent is always deployed in an enabled state.  Why would we deploy cluster-agent in a disabled state?

Related to issue https://github.com/DataDog/helm-charts/issues/464