### PR TITLE
Pass the proper Kubernetes version to `helm template`

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -20,5 +20,5 @@ tar -xf /tmp/kubeval.tar.gz kubeval
 # validate charts
 for CHART_DIR in ${CHART_DIRS}; do
   echo "Running kubeval for folder: '$CHART_DIR'"
-  helm dep up "${CHART_DIR}" && helm template --values "${CHART_DIR}"/ci/kubeval.yaml "${CHART_DIR}" | ./kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
+  helm dep up "${CHART_DIR}" && helm template --kube-version "${KUBERNETES_VERSION#v}" --values "${CHART_DIR}"/ci/kubeval.yaml "${CHART_DIR}" | ./kubeval --strict --ignore-missing-schemas --kubernetes-version "${KUBERNETES_VERSION#v}" --schema-location "${SCHEMA_LOCATION}"
 done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,8 +77,9 @@ jobs:
         # When changing versions here, check that the version exists at: https://github.com/instrumenta/kubernetes-json-schema
         k8s:
           - v1.14.10
-          - v1.16.4
-          - v1.18.1
+          - v1.16.9
+          - v1.18.4
+          - v1.22.4
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -106,6 +107,7 @@ jobs:
           - v1.14.10
           - v1.16.9
           - v1.18.4
+          - v1.22.4
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+## 0.4.6
+
+* Nothing
+
 ## 0.4.5
 
-Reduce DatadogAgent CRD size by removing description.
+* Reduce DatadogAgent CRD size by removing description.
 
 ## 0.4.4
 
-Update CRDs from Datadog Operator v0.7.2.
+* Update CRDs from Datadog Operator v0.7.2.
 
 ## 0.4.3
 

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.4.5
+version: 0.4.6
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.6
+
+* Nothing
+
 ## 0.7.5
 
 * Add a configuration field `containerSecurityContext` to configure a security context for a Container

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.7.5
+version: 0.7.6
 appVersion: 0.7.2
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.27.7
+
+* Nothing
+
 ## 2.27.6
 
 * Default Datadog Agent image to `7.32.2`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.27.6
+version: 2.27.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.27.6](https://img.shields.io/badge/Version-2.27.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.27.7](https://img.shields.io/badge/Version-2.27.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/extended-daemon-set/CHANGELOG.md
+++ b/charts/extended-daemon-set/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.2
+
+* Nothing
+
 ## 0.2.1
 
 * Add ExtendedDaemonset CRDs directly inside this chart.

--- a/charts/extended-daemon-set/Chart.yaml
+++ b/charts/extended-daemon-set/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.7.0
 description: Extended Daemonset Controller
 name: extendeddaemonset
-version: v0.2.1
+version: v0.2.2
 keywords:
 - monitoring
 - alerting

--- a/charts/extended-daemon-set/README.md
+++ b/charts/extended-daemon-set/README.md
@@ -1,6 +1,6 @@
 # Extended DaemonSet
 
-![Version: v0.2.1](https://img.shields.io/badge/Version-v0.2.1-informational?style=flat-square) ![AppVersion: v0.7.0](https://img.shields.io/badge/AppVersion-v0.7.0-informational?style=flat-square)
+![Version: v0.2.2](https://img.shields.io/badge/Version-v0.2.2-informational?style=flat-square) ![AppVersion: v0.7.0](https://img.shields.io/badge/AppVersion-v0.7.0-informational?style=flat-square)
 
 This chart installs the Extended DaemonSet (EDS). It aims to provide a new implementation of the Kubernetes DaemonSet resource with key features:
 - Canary Deployment: Deploy a new DaemonSet version with only a few nodes.

--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+### 0.9.1
+
+* Nothing
+
 ### 0.9.0
 
 * Update private location image version to `1.16.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.9.0
+version: 0.9.1
 appVersion: 1.16.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

Fix the following error:
```
WARN - datadog/templates/agent-services.yaml contains an invalid Service (default.RELEASE-NAME-datadog) - internalTrafficPolicy: Additional property internalTrafficPolicy is not allowed
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has beed updated
- [ ] Variables are documented in the `README.md`
