### PR TITLE
fix(datadog): environments variables quoted correctly

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.28.7
+
+* Fix environment variables to be quoted correct with a loop and `quote` instead of `toYaml`.
+
 ## 2.28.6
 
 * Update `PodDisruptionBudget` api version to get rid of `policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget` warning.
@@ -58,7 +62,7 @@
 
 ## 2.27.4
 
-* Do not allow unsupported configs with the security agent in windows environments. 
+* Do not allow unsupported configs with the security agent in windows environments.
 * Ensure autoconf/extra config files are mounted in windows environments.
 
 ## 2.27.3
@@ -77,7 +81,7 @@
 * Fix typos in README.md in `How to join a Cluster Agent from another helm chart deployment (Linux)`.
 * Fixes a port number typo for the `datadog.apm.portEnabled` option from 8216 to 8126.
 
-# 2.27.0 
+# 2.27.0
 
 * Introduce `processAgent.processDiscovery` to configure `DD_PROCESS_AGENT_DISCOVERY_ENABLED`
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.28.6
+version: 2.28.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.28.6](https://img.shields.io/badge/Version-2.28.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.28.7](https://img.shields.io/badge/Version-2.28.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/ci/cluster-agent-values.yaml
+++ b/charts/datadog/ci/cluster-agent-values.yaml
@@ -6,14 +6,143 @@ datadog:
   clusterChecks:
     enabled: true
   expvarPort: 6001
+  env:
+    - name: DD_FOOBAR
+      value: 7500
+    - name: DD_BATZ
+      value: true
+    - name: DD_TEXT
+      value: TEST_TEXT
+    - name: DD_QUOTED
+      value: "quoted_text_in_env"
+    - name: DD_SINGLE_QUOTED
+      value: "\"double_quoted_text_in_env\" 'single_quoted_second_text_in_env'"
+    - name: DD_VALUE_VALUE_FROM
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+
+agents:
+  containers:
+    agent:
+      env:
+        - name: DD_AGENT_FOOBAR
+          value: 7500
+        - name: DD_AGENT_BATZ
+          value: true
+        - name: DD_AGENT_TEXT
+          value: TEST_TEXT
+        - name: DD_AGENT_QUOTED
+          value: "quoted_text_in_env"
+        - name: DD_AGENT_SINGLE_QUOTED
+          value: "\"double_quoted_text_in_env\" 'single_quoted_second_text_in_env'"
+        - name: DD_AGENT_VALUE_FROM
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+    processAgent:
+      env:
+        - name: DD_PROCESS_AGENT_FOOBAR
+          value: 7500
+        - name: DD_PROCESS_AGENT_BATZ
+          value: true
+        - name: DD_PROCESS_AGENT_TEXT
+          value: TEST_TEXT
+        - name: DD_PROCESS_AGENT_QUOTED
+          value: "quoted_text_in_env"
+        - name: DD_PROCESS_AGENT_SINGLE_QUOTED
+          value: "\"double_quoted_text_in_env\" 'single_quoted_second_text_in_env'"
+        - name: DD_PROCESS_VALUE_FROM
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+    securityAgent:
+      env:
+        - name: DD_SECURITY_AGENT_FOOBAR
+          value: 7500
+        - name: DD_SECURITY_AGENT_BATZ
+          value: true
+        - name: DD_SECURITY_AGENT_TEXT
+          value: TEST_TEXT
+        - name: DD_SECURITY_AGENT_QUOTED
+          value: "quoted_text_in_env"
+        - name: DD_SECURITY_AGENT_SINGLE_QUOTED
+          value: "\"double_quoted_text_in_env\" 'single_quoted_second_text_in_env'"
+        - name: DD_SECURITY_AGENT_VALUE_FROM
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+    systemProbe:
+      env:
+        - name: DD_SYSTEM_PROBE_AGENT_FOOBAR
+          value: 7500
+        - name: DD_SYSTEM_PROBE_AGENT_BATZ
+          value: true
+        - name: DD_SYSTEM_PROBE_AGENT_TEXT
+          value: TEST_TEXT
+        - name: DD_SYSTEM_PROBE_AGENT_QUOTED
+          value: "quoted_text_in_env"
+        - name: DD_SYSTEM_PROBE_AGENT_SINGLE_QUOTED
+          value: "\"double_quoted_text_in_env\" 'single_quoted_second_text_in_env'"
+        - name: DD_SYSTEM_PROBE_AGENT_VALUE_FROM
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+    traceAgent:
+      env:
+        - name: DD_TRACE_AGENT_FOOBAR
+          value: 7500
+        - name: DD_TRACE_AGENT_BATZ
+          value: true
+        - name: DD_TRACE_AGENT_TEXT
+          value: TEST_TEXT
+        - name: DD_TRACE_AGENT_QUOTED
+          value: "quoted_text_in_env"
+        - name: DD_TRACE_AGENT_SINGLE_QUOTED
+          value: "\"double_quoted_text_in_env\" 'single_quoted_second_text_in_env'"
+        - name: DD_TRACE_AGENT_VALUE_FROM
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+
 
 clusterAgent:
   enabled: true
   wpaController: true
+  env:
+    - name: DD_CLUSTER_AGENT_FOOBAR
+      value: 7500
+    - name: DD_CLUSTER_AGENT_BATZ
+      value: true
+    - name: DD_CLUSTER_AGENT_TEXT
+      value: TEST_TEXT
+    - name: DD_CLUSTER_AGENT_QUOTED
+      value: "quoted_text_in_env"
+    - name: DD_CLUSTER_AGENT_SINGLE_QUOTED
+      value: "\"double_quoted_text_in_env\" 'single_quoted_second_text_in_env'"
+    - name: DD_CLUSTER_AGENT_VALUE_FROM
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
 
 clusterChecksRunner:
   enabled: true
   replicas: 1
+  env:
+    - name: DD_CLUSTER_CHECKS_AGENT_FOOBAR
+      value: 7500
+    - name: DD_CLUSTER_CHECKS_AGENT_BATZ
+      value: true
+    - name: DD_CLUSTER_CHECKS_AGENT_TEXT
+      value: TEST_TEXT
+    - name: DD_CLUSTER_CHECKS_AGENT_QUOTED
+      value: "quoted_text_in_env"
+    - name: DD_CLUSTER_CHECKS_AGENT_SINGLE_QUOTED
+      value: "\"double_quoted_text_in_env\" 'single_quoted_second_text_in_env'"
+    - name: DD_CLUSTER_CHECKS_AGENT_VALUE_FROM
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
 
   volumes:
     - name: tmp

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -109,9 +109,7 @@
     {{- end }}
     - name: DD_EXPVAR_PORT
       value: {{ .Values.datadog.expvarPort | quote }}
-{{- if .Values.agents.containers.agent.env }}
-{{ toYaml .Values.agents.containers.agent.env | indent 4 }}
-{{- end }}
+    {{- include "additional-env-entries" .Values.agents.containers.agent.env | indent 4 }}
   volumeMounts:
     {{- if eq .Values.targetSystem "linux" }}
     - name: installinfo

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -49,9 +49,7 @@
     {{- end }}
     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
       value: {{ (include "should-enable-k8s-resource-monitoring" .) | quote }}
-{{- if .Values.agents.containers.processAgent.env }}
-{{ toYaml .Values.agents.containers.processAgent.env | indent 4 }}
-{{- end }}
+    {{- include "additional-env-entries" .Values.agents.containers.processAgent.env | indent 4 }}
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -45,10 +45,7 @@
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
     {{- end }}
-  {{- range $value := .Values.agents.containers.securityAgent.env }}
-    - name: {{ $value.name }}
-      value: {{ $value.value | quote }}
-  {{- end }}
+    {{- include "additional-env-entries" .Values.agents.containers.securityAgent.env | indent 4 }}
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -17,13 +17,11 @@
     {{- include "containers-common-env" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.systemProbe.logLevel | default .Values.datadog.logLevel | quote }}
-{{- if .Values.datadog.serviceMonitoring.enabled }}
+    {{- if .Values.datadog.serviceMonitoring.enabled }}
     - name: HOST_ROOT
       value: "/host/root"
-{{- end }}
-{{- if .Values.agents.containers.systemProbe.env }}
-{{ toYaml .Values.agents.containers.systemProbe.env | indent 4 }}
-{{- end }}
+    {{- end }}
+    {{- include "additional-env-entries" .Values.agents.containers.systemProbe.env | indent 4 }}
   resources:
 {{ toYaml .Values.agents.containers.systemProbe.resources | indent 4 }}
   volumeMounts:

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -39,17 +39,15 @@
       value: "true"
     - name: DD_APM_RECEIVER_PORT
       value: {{ .Values.datadog.apm.port | quote }}
-  {{- if eq (include "trace-agent-use-uds" .) "true" }}
+    {{- if eq (include "trace-agent-use-uds" .) "true" }}
     - name: DD_APM_RECEIVER_SOCKET
       value: {{ .Values.datadog.apm.socketPath | quote }}
-  {{- end }}
-  {{- if eq .Values.targetSystem "linux" }}
+    {{- end }}
+    {{- if eq .Values.targetSystem "linux" }}
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
-  {{- end }}
-{{- if .Values.agents.containers.traceAgent.env }}
-{{ toYaml .Values.agents.containers.traceAgent.env | indent 4 }}
-{{- end }}
+    {{- end }}
+    {{- include "additional-env-entries" .Values.agents.containers.traceAgent.env | indent 4 }}
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -78,9 +78,7 @@
 - name: DD_DD_URL
   value: {{ .Values.datadog.dd_url | quote }}
 {{- end }}
-{{- if .Values.datadog.env }}
-{{ toYaml .Values.datadog.env }}
-{{- end }}
+{{- include "additional-env-entries" .Values.datadog.env }}
 {{- if .Values.datadog.acInclude }}
 - name: DD_AC_INCLUDE
   value: {{ .Values.datadog.acInclude | quote }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -549,3 +549,19 @@ true
 false
 {{- end -}}
 {{- end -}}
+
+Returns env vars correctly quoted and valueFrom respected
+*/}}
+{{- define "additional-env-entries" -}}
+{{- if . -}}
+{{- range . }}
+- name: {{ .name }}
+{{- if .value }}
+  value: {{ .value | quote }}
+{{- else }}
+  valueFrom:
+{{ toYaml .valueFrom | indent 4 }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -172,9 +172,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-{{- if .Values.clusterChecksRunner.env }}
-{{ toYaml .Values.clusterChecksRunner.env | indent 10 }}
-{{- end }}
+          {{- include "additional-env-entries" .Values.clusterChecksRunner.env | indent 10 }}
         resources:
 {{ toYaml .Values.clusterChecksRunner.resources | indent 10 }}
         volumeMounts:

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -238,9 +238,7 @@ spec:
             value: {{ .Values.datadog.prometheusScrape.additionalConfigs | toJson | quote }}
           {{- end }}
           {{- end }}
-{{- if .Values.clusterAgent.env }}
-{{ toYaml .Values.clusterAgent.env | indent 10 }}
-{{- end }}
+          {{- include "additional-env-entries" .Values.clusterAgent.env | indent 10 }}
         livenessProbe:
 {{- $live := .Values.clusterAgent.livenessProbe }}
 {{ include "probe.http" (dict "path" "/live" "port" $healthPort "settings" $live) | indent 10 }}


### PR DESCRIPTION
fix(datadog): environments variables quoted correctly

Fix environment variables to be quoted with a loop and `quote` instead of
`toYaml`.

**Checklist**

- [x] Documentation has been updated with helm-docs (run: .github/helm-docs.sh)
- [x] Chart Version bumped
- [x] CHANGELOG.md has been updated