### PR TITLE
Update example mysql confs

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 2.28.9
+* Update confd examples for the mysql integration
+
 ## 2.28.8
 
 * Fix `PodDisruptionBudget` api version definition when using `helm template`.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 2.28.9
+## 2.28.10
 * Update confd examples for the mysql integration
 
 ## 2.28.8

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.28.8
+version: 2.28.9
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.28.9
+version: 2.28.10
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.28.8](https://img.shields.io/badge/Version-2.28.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.28.10](https://img.shields.io/badge/Version-2.28.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.28.10](https://img.shields.io/badge/Version-2.28.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.28.10](https://img.shields.io/badge/Version-2.28.10-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-scc.yaml
+++ b/charts/datadog/templates/cluster-agent-scc.yaml
@@ -17,8 +17,6 @@ allowHostIPC: false
 allowHostPID: false
 allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
-allowedCapabilities: null
-defaultAddCapabilities: null
 fsGroup:
   type: MustRunAs
 readOnlyRootFilesystem: false

--- a/charts/datadog/templates/cluster-agent-scc.yaml
+++ b/charts/datadog/templates/cluster-agent-scc.yaml
@@ -17,6 +17,8 @@ allowHostIPC: false
 allowHostPID: false
 allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
 fsGroup:
   type: MustRunAs
 readOnlyRootFilesystem: false

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -664,10 +664,10 @@ clusterAgent:
   #   mysql.yaml: |-
   #     cluster_check: true
   #     instances:
-  #       - server: '<EXTERNAL_IP>'
+  #       - host: <EXTERNAL_IP>
   #         port: 3306
-  #         user: datadog
-  #         pass: '<YOUR_CHOSEN_PASSWORD>'
+  #         username: datadog
+  #         password: <YOUR_CHOSEN_PASSWORD>
 
   # clusterAgent.advancedConfd -- Provide additional cluster check configurations. Each key is an integration containing several config files.
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/
@@ -676,17 +676,17 @@ clusterAgent:
   #    1.yaml: |-
   #      cluster_check: true
   #      instances:
-  #        - server: '<EXTERNAL_IP>'
+  #        - host: <EXTERNAL_IP>
   #          port: 3306
-  #          user: datadog
-  #          pass: '<YOUR_CHOSEN_PASSWORD>'
+  #          username: datadog
+  #          password: <YOUR_CHOSEN_PASSWORD>
   #    2.yaml:  |-
   #      cluster_check: true
   #      instances:
-  #        - server: '<EXTERNAL_IP>'
+  #        - host: <EXTERNAL_IP>
   #          port: 3306
-  #          user: datadog
-  #          pass: '<YOUR_CHOSEN_PASSWORD>'
+  #          username: datadog
+  #          password: <YOUR_CHOSEN_PASSWORD>
 
   # clusterAgent.resources -- Datadog cluster-agent resource requests and limits.
   resources: {}


### PR DESCRIPTION
Update config examples for the mysql integration to match the current values accepted by the integration

#### What this PR does / why we need it:

Updates the examples of the mysql integration to correspond to the current values. For example replace the server parameter with the current host that is in the integration example. Also removed the "" around the server and password. This will hopefully help avoid customers using these in their setups and having issues.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] Documentation has been updated with helm-docs (run: .github/helm-docs.sh)
- [x] Chart Version bumped
- [x] CHANGELOG.md has been updated
- [x] Variables are documented in the README.md