### PR TITLE
feat(synthetics-private-location): add support for adding hostaliases

### DIFF
--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.11.0
+version: 0.12.0
 appVersion: 1.18.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![AppVersion: 1.18.0](https://img.shields.io/badge/AppVersion-1.18.0-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![AppVersion: 1.18.0](https://img.shields.io/badge/AppVersion-1.18.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -32,6 +32,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | env | list | `[]` | Set environment variables |
 | envFrom | list | `[]` | Set environment variables from configMaps and/or secrets |
 | fullnameOverride | string | `""` | Override the full qualified app name |
+| hostAliases | list | `[]` | Add entries to Datadog Synthetics Private Location PODs' /etc/hosts |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Synthetics Private Location image |
 | image.repository | string | `"gcr.io/datadoghq/synthetics-private-location-worker"` | Repository to use for Datadog Synthetics Private Location image |
 | image.tag | string | `"1.18.0"` | Define the Datadog Synthetics Private Location version to use |

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "synthetics-private-location.serviceAccountName" . }}
+      hostAliases:
+        {{- .Values.hostAliases | toYaml | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -82,3 +82,9 @@ envFrom: []
 env: []
 #   - name: <ENV_VAR_NAME>
 #     value: <ENV_VAR_VALUE>
+
+# hostAliases -- Add entries to Datadog Synthetics Private Location PODs' /etc/hosts
+hostAliases: []
+#  - ip: "10.0.0.1"
+#    hostnames:
+#    - "host.domain.com"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds support for adding entries to the Synthetics Private Location PODs' `/etc/hosts` with HostAliases.

This is useful because provides Pod-level override of hostname resolution when DNS and other options are not applicable in the private location network environment. 

See also: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

I need this to solve a real problem in my environment. Better here that in a fork.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
