### PR TITLE
Add agents.podSecurity.allowedUnsafeSysctls parameter to datadog chart

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.29.0
+
+* Add `agents.podSecurity.allowedUnsafeSysctls` parameter
+
 ## 2.28.11
 
 * Fix deprecation warning in examples caused by the `datadog.apm.enabled` parameter

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.28.11
+version: 2.29.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.28.11](https://img.shields.io/badge/Version-2.28.11-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.29.0](https://img.shields.io/badge/Version-2.29.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -504,6 +504,7 @@ helm install --name <RELEASE_NAME> \
 | agents.nodeSelector | object | `{}` | Allow the DaemonSet to schedule on selected nodes |
 | agents.podAnnotations | object | `{}` | Annotations to add to the DaemonSet's Pods |
 | agents.podLabels | object | `{}` | Sets podLabels if defined Note: These labels are also used as label selectors so they are immutable. |
+| agents.podSecurity.allowedUnsafeSysctls | list | `[]` | Allowed unsafe sysclts |
 | agents.podSecurity.apparmor.enabled | bool | `true` | If true, enable apparmor enforcement |
 | agents.podSecurity.apparmorProfiles | list | `["runtime/default","unconfined"]` | Allowed apparmor profiles |
 | agents.podSecurity.capabilities | list | `["SYS_ADMIN","SYS_RESOURCE","SYS_PTRACE","NET_ADMIN","NET_BROADCAST","NET_RAW","IPC_LOCK","CHOWN","AUDIT_CONTROL","AUDIT_READ"]` | Allowed capabilities |

--- a/charts/datadog/templates/agent-psp.yaml
+++ b/charts/datadog/templates/agent-psp.yaml
@@ -21,8 +21,10 @@ spec:
     max: 8126
   {{- end }}
   hostPID: {{ or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID }}
-  allowedCapabilities: 
+  allowedCapabilities:
 {{ toYaml .Values.agents.podSecurity.capabilities | indent 4 }}
+  allowedUnsafeSysctls:
+{{ toYaml .Values.agents.podSecurity.allowedUnsafeSysctls | indent 4 }}
   volumes:
 {{ toYaml .Values.agents.podSecurity.volumes | indent 4 }}
   fsGroup:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -899,6 +899,9 @@ agents:
       - AUDIT_CONTROL
       - AUDIT_READ
 
+    # agents.podSecurity.allowedUnsafeSysctls -- Allowed unsafe sysclts
+    allowedUnsafeSysctls: []
+
     # agents.podSecurity.volumes -- Allowed volumes types
     volumes:
       - configMap


### PR DESCRIPTION
#### What this PR does / why we need it:

This allows us to use unsafe sysctls as described here: https://docs.datadoghq.com/developers/dogstatsd/high_throughput/\#over-uds-unix-domain-socket


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
