### PR TITLE
Process Agent: Replace deprecated arg "-config" with supported arg "--config"

### DIFF
--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -3,7 +3,7 @@
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
   {{- if eq .Values.targetSystem "linux" }}
-  command: ["process-agent", "-config={{ template "datadog.confPath" . }}/datadog.yaml"]
+  command: ["process-agent", "--config={{ template "datadog.confPath" . }}/datadog.yaml"]
   {{- end }}
   {{- if eq .Values.targetSystem "windows" }}
   command: ["process-agent", "-foreground", "-config={{ template "datadog.confPath" . }}/datadog.yaml"]


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR addresses the following warning log line from the process agent:
```
datadog-thxjm process-agent WARNING: `-config` argument is deprecated and will be removed in a future version. Please use `--config` instead.
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
