### PR TITLE
fix(datadog-operator): fix Operator RBACs (for VPA)

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.10
+
+* Sync operator RBACs from `datadog-operator` repo to add missing `verticalpodautoscalers` RBACs.
+
 ## 0.7.9
 
 * Add missing `datadogmetrics` RBACs.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.7.9
+version: 0.7.10
 appVersion: 0.7.2
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.7.9](https://img.shields.io/badge/Version-0.7.9-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 0.7.10](https://img.shields.io/badge/Version-0.7.10-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -331,6 +331,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - batch
   resources:
   - cronjobs
@@ -352,6 +359,18 @@ rules:
   - certificatesigningrequests
   verbs:
   - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - coordination.k8s.io
@@ -400,6 +419,21 @@ rules:
 - apiGroups:
   - datadoghq.com
   resources:
+  - datadogmetrics
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadogmetrics/status
+  verbs:
+  - update
+- apiGroups:
+  - datadoghq.com
+  resources:
   - datadogmonitors
   verbs:
   - create
@@ -432,18 +466,9 @@ rules:
 - apiGroups:
   - datadoghq.com
   resources:
-  - datadogmetrics
+  - extendeddaemonsetreplicasets
   verbs:
-  - create
-  - delete
-  - list
-  - watch
-- apiGroups:
-  - datadoghq.com
-  resources:
-  - datadogmetrics/status
-  verbs:
-  - update
+  - get
 - apiGroups:
   - datadoghq.com
   resources:
@@ -455,14 +480,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - datadoghq.com
-  resources:
-  - extendeddaemonsetreplicasets
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - datadoghq.com


### PR DESCRIPTION
#### What this PR does / why we need it:

* Sync operator RBACs from `datadog-operator` repo to add missing `verticalpodautoscalers` RBACs.
* It adds also the RBAC for `ciliumnetworkpolicies` resources. 

#### Which issue this PR fixes

When testing the lastest operator binary with `kubernetes_state_core` check enable, the following error is returned by
the API-server to the operator:


```
{"level":"ERROR","ts":"2022-02-09T09:18:31Z","logger":"controller-runtime.manager.controller.datadogagent","msg":"Reconciler error","reconciler group":"datadoghq.com","reconciler kind":"DatadogAgent","name":"datadog","namespace":"default","error":"clusterroles.rbac.authorization.k8s.io \"default-datadog-ksm-core-dca\" is forbidden: user \"system:serviceaccount:default:my-datadog-operator\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:default\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"autoscaling.k8s.io\"], Resources:[\"verticalpodautoscalers\"], Verbs:[\"list\" \"watch\"]}"}
```


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
