### PR TITLE
Replace status.hostIP by spec.nodeName as default kubelet host to be used by the agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.30.6
+
+* Update the default value of `datadog.kubelet.host` to use `spec.nodeName` instead of `status.hostIP`
+
 ## 2.30.5
 
 * Add a new note to recommand to the Cluster Agent in HA mode when the `admission-controller` or the `metrics provider` are enabled.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.30.5
+version: 2.30.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.30.5](https://img.shields.io/badge/Version-2.30.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.30.6](https://img.shields.io/badge/Version-2.30.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -661,7 +661,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.kubeStateMetricsEnabled | bool | `true` | If true, deploys the kube-state-metrics deployment |
 | datadog.kubeStateMetricsNetworkPolicy.create | bool | `false` | If true, create a NetworkPolicy for kube state metrics |
 | datadog.kubelet.agentCAPath | string | /var/run/host-kubelet-ca.crt if hostCAPath else /var/run/secrets/kubernetes.io/serviceaccount/ca.crt | Path (inside Agent containers) where the Kubelet CA certificate is stored |
-| datadog.kubelet.host | object | `{"valueFrom":{"fieldRef":{"fieldPath":"status.hostIP"}}}` | Override kubelet IP |
+| datadog.kubelet.host | object | `{"valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}` | Override kubelet IP |
 | datadog.kubelet.hostCAPath | string | None (no mount from host) | Path (on host) where the Kubelet CA certificate is stored |
 | datadog.kubelet.tlsVerify | string | true | Toggle kubelet TLS verification |
 | datadog.leaderElection | bool | `true` | Enables leader election mechanism for event collection |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -173,7 +173,7 @@ datadog:
     host:
       valueFrom:
         fieldRef:
-          fieldPath: status.hostIP
+          fieldPath: spec.nodeName
     # datadog.kubelet.tlsVerify -- Toggle kubelet TLS verification
     # @default -- true
     tlsVerify:  # false


### PR DESCRIPTION
#### What this PR does / why we need it:
We have a couple of k8s clusters running on the 1.19 version (on AWS, provisioned via kops), Datadog agent running perfectly fine there. however we have a new cluster version 1.21 and the dd-agent are throwing a lot of errors because unable to connect to the kubelet server running on the host node.

After investigation, it turns out the read-only server running in the Kubelet was deactivated by default since 1.20, and I assume dd-agent switch the secure server instead if we pass the option `datadog.kubelet.tlsVerify=false` to the agent then it starts working fine.
Furthermore if we change the `datadog.kubelet.host` to use `{"valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}` instead of `{"valueFrom":{"fieldRef":{"fieldPath":"status.hostIP"}}}` this also worked better and clean way than `tlsVerify=false`.

Here is the description of the new configs loaded to kubelet where `readOnlyPort` was deactivated by default: 
https://v1-20.docs.kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/


#### Special notes for your reviewer:
I hope this is clear enough for the issue we faced and the fix we found.
Thanks for the great effort here.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
