### PR TITLE
[datadog] add disableClusterNameTagKey to values.yaml

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Datadog changelog
 
+## 2.31.1
+
+* Add `datadog.disableClusterNameTagKey` parameter to chose wether to not add tag key `cluster_name` to submit the orchestrator cluster name tag.
+
 ## 2.31.0
 
-* Add `datadog.prometheusScrape.version` parameter to choose the version of the openmetrics check that the Prometheus auto-discovery should instantiate by default.
+* Add `datadog.prometheusScrape.version` parameter to choose the version of the OpenMetrics check that the Prometheus auto-discovery should instantiate by default.
   It now defaults to `2`, which requires an agent 7.34+.
-  It can be explicitely set to `1` to restore the behaviour of previous versions.
+  It can be explicitly set to `1` to restore the behaviour of previous versions.
 
 ## 2.30.21
 
@@ -73,7 +77,7 @@
 
 ## 2.30.5
 
-* Add a new note to recommand to the Cluster Agent in HA mode when the `admission-controller` or the `metrics provider` are enabled.
+* Add a new note to recommend to the Cluster Agent in HA mode when the `admission-controller` or the `metrics provider` are enabled.
 
 ## 2.30.4
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -640,6 +640,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.containerRuntimeSupport.enabled | bool | `true` | Set this to false to disable agent access to container runtime. |
 | datadog.criSocketPath | string | `nil` | Path to the container runtime socket (if different from Docker) |
 | datadog.dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
+| datadog.disableClusterNameTagKey | bool | `false` | Disable using the 'cluster_name' tag key to submit the orchestrator cluster name tag. |
 | datadog.dockerSocketPath | string | `nil` | Path to the docker socket |
 | datadog.dogstatsd.hostSocketPath | string | `"/var/run/datadog/"` | Host path to the DogStatsD socket |
 | datadog.dogstatsd.nonLocalTraffic | bool | `true` | Enable this to make each node accept non-local statsd traffic (from outside of the pod) |

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -42,6 +42,10 @@
 - name: DD_CLUSTER_NAME
   value: {{ .Values.datadog.clusterName | quote }}
 {{- end }}
+{{- if .Values.datadog.disableClusterNameTagKey }}
+- name: DD_DISABLE_CLUSTER_NAME_TAG_KEY
+  value: "true"
+{{- end }}
 {{- if eq .Values.targetSystem "linux" }}
 {{- if .Values.providers.eks.ec2.useHostnameFromFile }}
 - name: DD_HOSTNAME_FILE

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -73,6 +73,11 @@ datadog:
   ## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
   clusterName:  # <CLUSTER_NAME>
 
+
+  # datadog.disableClusterNameTagKey -- Disable using the 'cluster_name' tag key to submit the orchestrator cluster name tag.
+  ## The Agent will continue sending the cluster name tag with 'kube|ecs_cluster_name' key regardless of the value of this parameter.
+  disableClusterNameTagKey: false
+
   # datadog.site -- The site of the Datadog intake to send Agent data to
   ## Set to 'datadoghq.eu' to send data to the EU site.
   site:  # datadoghq.com


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds `disableClusterNameTagKey` to be able easily to use the feature introduced in https://github.com/DataDog/datadog-agent/pull/5500 to get rid of redundant tags.

#### Special notes for your reviewer:

I think that ideally it should be set to `true` by default for Helm to not use this way for new installations. On the other hand, people may rely on this `cluster_name` tag in their Datadog configuration so updating the Helm Chart version shouldn't break their setup. Hence I decided to have `false` as a default value.

#### Checklist

- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
