### PR TITLE
[datadog] Fix Helm check scheduling

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.30.10
+
+* Fix scheduling of Helm check. It's no longer scheduled on a daemonset agent.
+
 ## 2.30.9
 
 * Add RBAC rules for Roles, RoleBindings, ClusterRoles, ClusterRoleBindings and ServiceAccounts in order to collect them in the Orchestrator Explorer from the Cluster-agent.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.30.9
+version: 2.30.10
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.30.9](https://img.shields.io/badge/Version-2.30.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.30.10](https://img.shields.io/badge/Version-2.30.10-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_helm_check_config.yaml
+++ b/charts/datadog/templates/_helm_check_config.yaml
@@ -1,6 +1,6 @@
 {{- define "helmCheck-config" -}}
 helm.yaml: |-
-{{- if .Values.datadog.clusterChecks.enabled }}
+{{- if and .Values.datadog.clusterChecks.enabled .Values.clusterChecksRunner.enabled }}
   cluster_check: true
 {{- end }}
   init_config:

--- a/charts/datadog/templates/helm-check-rbac.yaml
+++ b/charts/datadog/templates/helm-check-rbac.yaml
@@ -28,7 +28,7 @@ roleRef:
   name: {{ template "datadog.fullname" . }}-helm-check
 subjects:
   - kind: ServiceAccount
-    {{- if .Values.datadog.clusterChecks.enabled }}
+    {{- if and .Values.datadog.clusterChecks.enabled .Values.clusterChecksRunner.enabled }}
     name: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}-cluster-checks{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}
     {{- else }}
     name: {{ if .Values.clusterAgent.rbac.create }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.rbac.serviceAccountName }}"{{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes scheduling of Helm check. It's no longer scheduled on a daemonset agent.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
