### PR TITLE
Allow sending Agent Flares in CiliumNetworkPolicy

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.30.11
+
+* Fix CiliumNetworkPolicy: Allow sending support flares.
+
 ## 2.30.10
 
 * Fix scheduling of Helm check. It's no longer scheduled on a daemonset agent.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.30.10
+version: 2.30.11
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.30.10](https://img.shields.io/badge/Version-2.30.10-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.30.11](https://img.shields.io/badge/Version-2.30.11-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-cilium-network-policy.yaml
+++ b/charts/datadog/templates/agent-cilium-network-policy.yaml
@@ -85,6 +85,7 @@ specs:
           {{- end}}
           {{- if $.Values.datadog.site}}
           - matchPattern: "*-app.agent.{{ $.Values.datadog.site }}"
+          - matchName: "app.{{ $.Values.datadog.site }}"
           - matchName: "api.{{ $.Values.datadog.site }}"
           - matchName: "agent-intake.logs.{{ $.Values.datadog.site }}"
           - matchName: "agent-http-intake.logs.{{ $.Values.datadog.site }}"
@@ -92,6 +93,7 @@ specs:
           - matchName: "orchestrator.{{ $.Values.datadog.site }}"
           {{- else}}
           - matchPattern: "*-app.agent.datadoghq.com"
+          - matchName: "app.datadoghq.com"
           - matchName: "api.datadoghq.com"
           - matchName: "agent-intake.logs.datadoghq.com"
           - matchName: "agent-http-intake.logs.datadoghq.com"

--- a/charts/datadog/templates/agent-clusterchecks-cilium-network-policy.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-cilium-network-policy.yaml
@@ -41,8 +41,10 @@ specs:
           - matchName: {{ trimPrefix "https://" $.Values.datadog.dd_url }}
           {{- end}}
           {{- if $.Values.datadog.site}}
+          - matchName: "app.{{ $.Values.datadog.site }}"
           - matchPattern: "*-app.agent.{{ $.Values.datadog.site }}"
           {{- else}}
+          - matchName: "app.datadoghq.com"
           - matchPattern: "*-app.agent.datadoghq.com"
           {{- end}}
         toPorts:

--- a/charts/datadog/templates/cluster-agent-cilium-network-policy.yaml
+++ b/charts/datadog/templates/cluster-agent-cilium-network-policy.yaml
@@ -50,9 +50,11 @@ specs:
           - matchName: {{ trimPrefix "https://" $.Values.datadog.dd_url }}
           {{- end}}
           {{- if $.Values.datadog.site}}
-          - matchPattern: "*-app.agent.{{  $.Values.datadog.site }}"
+          - matchName: "app.{{ $.Values.datadog.site }}"
+          - matchPattern: "*-app.agent.{{ $.Values.datadog.site }}"
           - matchName: "orchestrator.{{  $.Values.datadog.site }}"
           {{- else}}
+          - matchName: "app.datadoghq.com"
           - matchPattern: "*-app.agent.datadoghq.com"
           - matchName: "orchestrator.datadoghq.com"
           {{- end}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates CiliumNetworkPolicy to allow sending Agent Flares. 
Resolves post error when attempting to send flare from an agent running on a cluster that uses Cilium network policies. 

#### Which issue this PR fixes
  - fixes #555

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
