### PR TITLE
feat(datadog): hardcode serviceAccount&ConfigMap name on GKE Autopilot

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.33.0
 
-***Warning:*** From this version onwards, on GKE Autopilot, only one "datadog" Helm chart release is allowed by the Kubernetes namespace due to the following new constraints:
+***Warning:*** From this version onwards, on GKE Autopilot, only one "datadog" Helm chart release is allowed by Kubernetes namespace due to the following new constraints:
 * On GKE Autopilot, hardcode the "Agent" DaemonSet serviceAccountName.
 * On GKE Autopilot, hardcode the "Install Info" ConfigMap name.
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 2.33.0
 
 ***Warning:*** From this version onwards, on GKE Autopilot, only one "datadog" Helm chart release is allowed by the Kubernetes namespace due to the following new constraints:
-* On GKE Autopilot, make the "Agent" DaemonSet serviceAccountName immutable.
-* On GKE Autopilot, make the "Install Info" ConfigMap name immutable.
+* On GKE Autopilot, hardcode the "Agent" DaemonSet serviceAccountName.
+* On GKE Autopilot, hardcode the "Install Info" ConfigMap name.
 
 ## 2.32.5
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 2.33.0
 
-***Warning:*** From this version, on GKE Autopilot, only one "datadog" helm chart release is allow by Kubernetes namespace due to the following new constraints:
-* On GKE autopilot, make the "Agent" Daemonset serviceaccountName immutable.
-* On GKE autopilot, make the "Install Info" ConfigMap name immutable.
+***Warning:*** From this version onwards, on GKE Autopilot, only one "datadog" Helm chart release is allowed by the Kubernetes namespace due to the following new constraints:
+* On GKE Autopilot, make the "Agent" DaemonSet serviceAccountName immutable.
+* On GKE Autopilot, make the "Install Info" ConfigMap name immutable.
 
 ## 2.32.5
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 2.33.0
+
+***Warning:*** From this version, on GKE Autopilot, only one "datadog" helm chart release is allow by Kubernetes namespace due to the following new constraints:
+* On GKE autopilot, make the "Agent" Daemonset serviceaccountName immutable.
+* On GKE autopilot, make the "Install Info" ConfigMap name immutable.
+
 ## 2.32.5
 
 * Fix process detection, by adding `kill` syscall with signal `0` to system-probe seccomp profile.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.32.5
+version: 2.33.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.32.5](https://img.shields.io/badge/Version-2.32.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.33.0](https://img.shields.io/badge/Version-2.33.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/ci/gke-autopilot-values.yaml
+++ b/charts/datadog/ci/gke-autopilot-values.yaml
@@ -1,4 +1,7 @@
-# Empty values file for testing default parameters.
+providers:
+  gke:
+    autopilot: true
+
 datadog:
   apiKey: "00000000000000000000000000000000"
   appKey: "0000000000000000000000000000000000000000"
@@ -12,9 +15,18 @@ datadog:
   kubeStateMetricsCore:
     enabled: true
 
-providers:
-  gke:
-    autopilot: true
+  confd:
+    redisdb.yaml: |-
+      init_config:
+      instances:
+        - host: "name"
+          port: "6379"
+
+  checksd:
+    service.py: |-
+
+agents:
+  useConfigMap: true
 
 clusterAgent:
   metricsProvider:

--- a/charts/datadog/ci/gke-autopilot-values.yaml
+++ b/charts/datadog/ci/gke-autopilot-values.yaml
@@ -6,7 +6,7 @@ datadog:
   logs:
     enabled: true
   apm:
-    enabled: true
+    portEnabled: true
 
   kubeStateMetricsEnabled: false
   kubeStateMetricsCore:

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -211,6 +211,21 @@ To enable it please set clusterAgent.enabled to 'true'.
 {{- end }}
 
 {{- if .Values.providers.gke.autopilot}}
+
+#######################################################################################################
+####               WARNING: only one datadog chart release allows by namespace on GKE autopilot    ####
+#######################################################################################################
+
+{{- if not .Values.agents.rbac.create }}
+
+####################################################################################
+####               WARNING: agents.rbac.create must be true on GKE autopilot    ####
+####################################################################################
+
+{{- fail "On GKE autopilot environment, the option 'agents.rbac.create' must be set to 'true'" }}
+
+{{- end }}
+
 {{- if eq (include "system-probe-feature" .) "true" }}
 
 ##################################################################################
@@ -219,11 +234,24 @@ To enable it please set clusterAgent.enabled to 'true'.
 
 {{- end }}
 
-{{- if or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.securityAgent.compliance.enabled }}
 
-###################################################################################
-####               WARNING: Security Agent is not supported on GKE Autopilot   ####
-###################################################################################
+{{- if .Values.datadog.securityAgent.runtime.enabled }}
+
+##################################################################################################
+####               WARNING: Cloud Workload Security (CWS) is not supported on GKE Autopilot   ####
+##################################################################################################
+
+{{- fail "On GKE autopilot environment, Cloud Workload Security (CWS) is not supported. The option 'datadog.securityAgent.runtime.enabled' must be set 'false'" }}
+
+{{- end }}
+
+{{- if .Values.datadog.securityAgent.compliance.enabled }}
+
+#############################################################################################################
+####               WARNING: Cloud Security Posture Management (CSPM) is not supported on GKE Autopilot   ####
+#############################################################################################################
+
+{{- fail "On GKE autopilot environment, Cloud Security Posture Management (CSPM) is not supported. The option 'datadog.securityAgent.compliance.enabled' must be set to 'false'" }}
 
 {{- end }}
 
@@ -240,6 +268,16 @@ To enable it please set clusterAgent.enabled to 'true'.
 ##############################################################################
 ####   WARNING: APM with Unix socket is not supported on GKE Autopilot   ####
 ##############################################################################
+
+{{- end }}
+
+{{- if .Values.datadog.networkMonitoring.enabled }}
+
+#######################################################################################
+####   WARNING: Network Performance Monitoring is not supported on GKE Autopilot   ####
+#######################################################################################
+
+{{- fail "On GKE autopilot environment, Network Performance Monitoring is not supported. The option 'datadog.networkMonitoring.enabled' must be set to 'false'" }}
 
 {{- end }}
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -213,16 +213,16 @@ To enable it please set clusterAgent.enabled to 'true'.
 {{- if .Values.providers.gke.autopilot}}
 
 #######################################################################################################
-####               WARNING: only one datadog chart release allows by namespace on GKE autopilot    ####
+####               WARNING: Only one Datadog chart release allowed by namespace on GKE Autopilot    ####
 #######################################################################################################
 
 {{- if not .Values.agents.rbac.create }}
 
 ####################################################################################
-####               WARNING: agents.rbac.create must be true on GKE autopilot    ####
+####               WARNING: agents.rbac.create must be true on GKE Autopilot    ####
 ####################################################################################
 
-{{- fail "On GKE autopilot environment, the option 'agents.rbac.create' must be set to 'true'" }}
+{{- fail "On GKE Autopilot environments, the option 'agents.rbac.create' must be set to 'true'" }}
 
 {{- end }}
 
@@ -241,7 +241,7 @@ To enable it please set clusterAgent.enabled to 'true'.
 ####               WARNING: Cloud Workload Security (CWS) is not supported on GKE Autopilot   ####
 ##################################################################################################
 
-{{- fail "On GKE autopilot environment, Cloud Workload Security (CWS) is not supported. The option 'datadog.securityAgent.runtime.enabled' must be set 'false'" }}
+{{- fail "On GKE Autopilot environments, Cloud Workload Security (CWS) is not supported. The option 'datadog.securityAgent.runtime.enabled' must be set 'false'" }}
 
 {{- end }}
 
@@ -251,7 +251,7 @@ To enable it please set clusterAgent.enabled to 'true'.
 ####               WARNING: Cloud Security Posture Management (CSPM) is not supported on GKE Autopilot   ####
 #############################################################################################################
 
-{{- fail "On GKE autopilot environment, Cloud Security Posture Management (CSPM) is not supported. The option 'datadog.securityAgent.compliance.enabled' must be set to 'false'" }}
+{{- fail "On GKE autopilot environments, Cloud Security Posture Management (CSPM) is not supported. The option 'datadog.securityAgent.compliance.enabled' must be set to 'false'" }}
 
 {{- end }}
 
@@ -277,7 +277,7 @@ To enable it please set clusterAgent.enabled to 'true'.
 ####   WARNING: Network Performance Monitoring is not supported on GKE Autopilot   ####
 #######################################################################################
 
-{{- fail "On GKE autopilot environment, Network Performance Monitoring is not supported. The option 'datadog.networkMonitoring.enabled' must be set to 'false'" }}
+{{- fail "On GKE Autopilot environments, Network Performance Monitoring is not supported. The option 'datadog.networkMonitoring.enabled' must be set to 'false'" }}
 
 {{- end }}
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -216,19 +216,16 @@ To enable it please set clusterAgent.enabled to 'true'.
 ####   WARNING: Only one Datadog chart release allowed by namespace on GKE Autopilot   ####
 ###########################################################################################
 
-{{- if not .Values.agents.rbac.create }}
-
-########################################################################
-####   WARNING: agents.rbac.create must be true on GKE Autopilot   ####
-########################################################################
-
-{{- fail "On GKE Autopilot environments, the option 'agents.rbac.create' must be set to 'true'" }}
+On GKE Autopilot, only one "datadog" Helm chart release is allowed by Kubernetes namespace due to the following new constraints on the Agent DaemonSet:
+* The serviceAccountName must be "datadog-agent".
+* All ConfigMap names mounted must be hardcode.
 
 {{- if eq (include "system-probe-feature" .) "true" }}
 
 #####################################################################
 ####   WARNING: System Probe is not supported on GKE Autopilot   ####
 #####################################################################
+{{- fail "On GKE Autopilot environments, System Probe is not supported. The option 'datadog.securityAgent.runtime.enabled' must be set 'false'" }}
 
 {{- end }}
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -224,8 +224,6 @@ To enable it please set clusterAgent.enabled to 'true'.
 
 {{- fail "On GKE Autopilot environments, the option 'agents.rbac.create' must be set to 'true'" }}
 
-{{- end }}
-
 {{- if eq (include "system-probe-feature" .) "true" }}
 
 #####################################################################

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -212,15 +212,15 @@ To enable it please set clusterAgent.enabled to 'true'.
 
 {{- if .Values.providers.gke.autopilot}}
 
-#######################################################################################################
-####               WARNING: Only one Datadog chart release allowed by namespace on GKE Autopilot    ####
-#######################################################################################################
+###########################################################################################
+####   WARNING: Only one Datadog chart release allowed by namespace on GKE Autopilot   ####
+###########################################################################################
 
 {{- if not .Values.agents.rbac.create }}
 
-####################################################################################
-####               WARNING: agents.rbac.create must be true on GKE Autopilot    ####
-####################################################################################
+########################################################################
+####   WARNING: agents.rbac.create must be true on GKE Autopilot   ####
+########################################################################
 
 {{- fail "On GKE Autopilot environments, the option 'agents.rbac.create' must be set to 'true'" }}
 
@@ -228,18 +228,18 @@ To enable it please set clusterAgent.enabled to 'true'.
 
 {{- if eq (include "system-probe-feature" .) "true" }}
 
-##################################################################################
-####               WARNING: System Probe is not supported on GKE Autopilot    ####
-##################################################################################
+#####################################################################
+####   WARNING: System Probe is not supported on GKE Autopilot   ####
+#####################################################################
 
 {{- end }}
 
 
 {{- if .Values.datadog.securityAgent.runtime.enabled }}
 
-##################################################################################################
-####               WARNING: Cloud Workload Security (CWS) is not supported on GKE Autopilot   ####
-##################################################################################################
+######################################################################################
+####   WARNING: Cloud Workload Security (CWS) is not supported on GKE Autopilot   ####
+######################################################################################
 
 {{- fail "On GKE Autopilot environments, Cloud Workload Security (CWS) is not supported. The option 'datadog.securityAgent.runtime.enabled' must be set 'false'" }}
 
@@ -247,9 +247,9 @@ To enable it please set clusterAgent.enabled to 'true'.
 
 {{- if .Values.datadog.securityAgent.compliance.enabled }}
 
-#############################################################################################################
-####               WARNING: Cloud Security Posture Management (CSPM) is not supported on GKE Autopilot   ####
-#############################################################################################################
+#################################################################################################
+####   WARNING: Cloud Security Posture Management (CSPM) is not supported on GKE Autopilot   ####
+#################################################################################################
 
 {{- fail "On GKE autopilot environments, Cloud Security Posture Management (CSPM) is not supported. The option 'datadog.securityAgent.compliance.enabled' must be set to 'false'" }}
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -135,7 +135,7 @@
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
-    - name: {{ template "datadog.fullname" . }}-datadog-yaml
+    - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
     {{- end }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -65,7 +65,7 @@
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
-    - name: {{ template "datadog.fullname" . }}-datadog-yaml
+    - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
     {{- end }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -67,7 +67,7 @@
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
-    - name: {{ template "datadog.fullname" . }}-datadog-yaml
+    - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
     {{- end }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -41,7 +41,7 @@
       mountPath: {{ template "datadog.confPath" . }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
-    - name: {{ template "datadog.fullname" . }}-datadog-yaml
+    - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
     {{- end }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -54,7 +54,7 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
     {{- if .Values.agents.useConfigMap }}
-    - name: {{ template "datadog.fullname" . }}-datadog-yaml
+    - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
     {{- end }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -61,7 +61,7 @@
 {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
 - name: confd
   configMap:
-    name: {{ template "datadog.fullname" . }}-confd
+    name: {{ include "agents.confd-configmap-name" . }}
 {{- end }}
 {{- if eq (include "should-enable-system-probe" .) "true" }}
 - name: sysprobe-config

--- a/charts/datadog/templates/_daemonset-volumes-windows.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-windows.yaml
@@ -8,7 +8,7 @@
 {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
 - name: confd
   configMap:
-    name: {{ template "datadog.fullname" . }}-confd
+    name: {{ include "agents.confd-configmap-name" . }}
 {{- end }}
 {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
 - hostPath:

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -435,6 +435,26 @@ gke-autopilot
 {{- end -}}
 {{- end -}}
 
+Return the container runtime socket
+*/}}
+{{- define "agents.serviceAccountName" -}}
+{{- if .Values.providers.gke.autopilot -}}
+datadog-agent
+{{- else if .Values.agents.rbac.create -}}
+{{ template "datadog.fullname" . }}
+{{- else -}}
+{{ .Values.agents.rbac.serviceAccountName }}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "agents.installInfo-configmap-name" -}}
+{{- if .Values.providers.gke.autopilot -}}
+datadog-agent-installinfo
+{{- else -}}
+{{ template "datadog.fullname" . }}-installinfo
+{{- end -}}
+{{- end -}}
 
 {{/*
 Common template labels

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -435,7 +435,7 @@ gke-autopilot
 {{- end -}}
 {{- end -}}
 
-Return the container runtime socket
+Return the service account name
 */}}
 {{- define "agents.serviceAccountName" -}}
 {{- if .Values.providers.gke.autopilot -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -435,6 +435,7 @@ gke-autopilot
 {{- end -}}
 {{- end -}}
 
+{{/*
 Return the service account name
 */}}
 {{- define "agents.serviceAccountName" -}}
@@ -447,12 +448,35 @@ datadog-agent
 {{- end -}}
 {{- end -}}
 
+{{- define "agents-useConfigMap-configmap-name" -}}
+{{- if .Values.providers.gke.autopilot -}}
+datadog-agent-datadog-yaml
+{{- else -}}
+{{ template "datadog.fullname" . }}-datadog-yaml
+{{- end -}}
+{{- end -}}
 
-{{- define "agents.installInfo-configmap-name" -}}
+{{- define "agents-install-info-configmap-name" -}}
 {{- if .Values.providers.gke.autopilot -}}
 datadog-agent-installinfo
 {{- else -}}
 {{ template "datadog.fullname" . }}-installinfo
+{{- end -}}
+{{- end -}}
+
+{{- define "agents.confd-configmap-name" -}}
+{{- if .Values.providers.gke.autopilot -}}
+datadog-agent-confd
+{{- else -}}
+{{ template "datadog.fullname" . }}-confd
+{{- end -}}
+{{- end -}}
+
+{{- define "datadog-checksd-configmap-name" -}}
+{{- if .Values.providers.gke.autopilot -}}
+datadog-agent-checksd
+{{- else -}}
+{{ template "datadog.fullname" . }}-checksd
 {{- end -}}
 {{- end -}}
 

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -206,7 +206,7 @@ spec:
       volumes:
         - name: installinfo
           configMap:
-            name: {{ template "datadog.fullname" . }}-installinfo
+            name: {{ include "agents.installInfo-configmap-name" . }}
 {{- if .Values.clusterChecksRunner.volumes }}
 {{ toYaml .Values.clusterChecksRunner.volumes | indent 8 }}
 {{- end }}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -206,7 +206,7 @@ spec:
       volumes:
         - name: installinfo
           configMap:
-            name: {{ include "agents.installInfo-configmap-name" . }}
+            name: {{ include "agents-install-info-configmap-name" . }}
 {{- if .Values.clusterChecksRunner.volumes }}
 {{ toYaml .Values.clusterChecksRunner.volumes | indent 8 }}
 {{- end }}
@@ -215,7 +215,7 @@ spec:
 {{- if .Values.datadog.checksd }}
         - name: checksd
           configMap:
-            name: {{ template "datadog.fullname" . }}-checksd
+            name: {{ include "agents.checksd-configmap-name" . }}
 {{- end }}
       affinity:
 {{- if .Values.clusterChecksRunner.affinity }}

--- a/charts/datadog/templates/agent-scc.yaml
+++ b/charts/datadog/templates/agent-scc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
 users:
-- system:serviceaccount:{{ .Release.Namespace }}:{{ template "datadog.fullname" . }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ include "agents.serviceAccountName" . }}
 priority: 8
 # Allow host ports for dsd / trace intake
 allowHostPorts: {{ or .Values.datadog.dogstatsd.useHostPort .Values.datadog.apm.enabled .Values.datadog.apm.portEnabled .Values.agents.useHostNetwork }}

--- a/charts/datadog/templates/checksd-configmap.yaml
+++ b/charts/datadog/templates/checksd-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "datadog.fullname" . }}-checksd
+  name: {{ include "datadog-checksd-configmap-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -290,7 +290,7 @@ spec:
       volumes:
         - name: installinfo
           configMap:
-            name: {{ include "agents.installInfo-configmap-name" . }}
+            name: {{ include "agents-install-info-configmap-name" . }}
 {{- if eq (include "need-cluster-agent-confd" .) "true" }}
         - name: confd
           configMap:

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -290,7 +290,7 @@ spec:
       volumes:
         - name: installinfo
           configMap:
-            name: {{ template "datadog.fullname" . }}-installinfo
+            name: {{ include "agents.installInfo-configmap-name" . }}
 {{- if eq (include "need-cluster-agent-confd" .) "true" }}
         - name: confd
           configMap:

--- a/charts/datadog/templates/confd-configmap.yaml
+++ b/charts/datadog/templates/confd-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "datadog.fullname" . }}-confd
+  name: {{ include "agents.confd-configmap-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -131,7 +131,7 @@ spec:
       volumes:
       - name: installinfo
         configMap:
-          name: {{ template "datadog.fullname" . }}-installinfo
+          name: {{ include "agents.installInfo-configmap-name" . }}
       - name: config
         emptyDir: {}
       {{- if .Values.datadog.checksd }}
@@ -165,7 +165,7 @@ spec:
       {{- end }}
       affinity:
 {{ toYaml .Values.agents.affinity | indent 8 }}
-      serviceAccountName: {{ if .Values.agents.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.agents.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ include "agents.serviceAccountName" . | quote }}
       nodeSelector:
         {{ template "label.os" . }}: {{ .Values.targetSystem }}
       {{- if .Values.agents.nodeSelector }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -131,18 +131,18 @@ spec:
       volumes:
       - name: installinfo
         configMap:
-          name: {{ include "agents.installInfo-configmap-name" . }}
+          name: {{ include "agents-install-info-configmap-name" . }}
       - name: config
         emptyDir: {}
       {{- if .Values.datadog.checksd }}
       - name: checksd
         configMap:
-          name: {{ template "datadog.fullname" . }}-checksd
+          name: {{ include "datadog-checksd-configmap-name" . }}
       {{- end }}
       {{- if .Values.agents.useConfigMap }}
-      - name: {{ template "datadog.fullname" . }}-datadog-yaml
+      - name: datadog-yaml
         configMap:
-          name: {{ template "datadog.fullname" . }}-datadog-yaml
+          name: {{ include "agents-useConfigMap-configmap-name" . }}
       {{- end }}
       {{- if eq .Values.targetSystem "windows" }}
         {{ include "daemonset-volumes-windows" . | nindent 6 }}

--- a/charts/datadog/templates/datadog-yaml-configmap.yaml
+++ b/charts/datadog/templates/datadog-yaml-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "datadog.fullname" . }}-datadog-yaml
+  name: {{ include "agents-useConfigMap-configmap-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}

--- a/charts/datadog/templates/helm-check-rbac.yaml
+++ b/charts/datadog/templates/helm-check-rbac.yaml
@@ -31,7 +31,7 @@ subjects:
     {{- if and .Values.datadog.clusterChecks.enabled .Values.clusterChecksRunner.enabled }}
     name: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}-cluster-checks{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}
     {{- else }}
-    name: {{ if .Values.clusterAgent.rbac.create }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.rbac.serviceAccountName }}"{{ end }}
+    name: {{ include "agents.serviceAccountName" . }}
     {{- end }}
     namespace: {{ .Release.Namespace }}
 ---

--- a/charts/datadog/templates/helm-check-rbac.yaml
+++ b/charts/datadog/templates/helm-check-rbac.yaml
@@ -31,7 +31,7 @@ subjects:
     {{- if and .Values.datadog.clusterChecks.enabled .Values.clusterChecksRunner.enabled }}
     name: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}-cluster-checks{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}
     {{- else }}
-    name: {{ include "agents.serviceAccountName" . }}
+    name: {{ if .Values.clusterAgent.rbac.create }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.rbac.serviceAccountName }}"{{ end }}
     {{- end }}
     namespace: {{ .Release.Namespace }}
 ---

--- a/charts/datadog/templates/install_info-configmap.yaml
+++ b/charts/datadog/templates/install_info-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "datadog.fullname" . }}-installinfo
+  name: {{ include "agents.installInfo-configmap-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}

--- a/charts/datadog/templates/install_info-configmap.yaml
+++ b/charts/datadog/templates/install_info-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "agents.installInfo-configmap-name" . }}
+  name: {{ include "agents-install-info-configmap-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -122,13 +122,13 @@ roleRef:
   name: {{ template "datadog.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "datadog.fullname" . }}
+    name: {{ include "agents.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "datadog.fullname" . }}
+  name: {{ include "agents.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.agents.rbac.serviceAccountAnnotations }}
   annotations: {{ tpl (toYaml .Values.agents.rbac.serviceAccountAnnotations) . | nindent 4}}


### PR DESCRIPTION
#### What this PR does / why we need it:

From this version, on GKE Autopilot, only one "datadog" helm chart release is allow by Kubernetes namespace due to the following new constraints:
* On GKE autopilot, make the "Agent" Daemonset serviceaccountName immutable.
* On GKE autopilot, make the "Install Info" ConfigMap name immutable.
* Improve `Notes.txt` to better document GKE Autopilot limitation, fail the
  installation when an unsupported option has been used in the configuration.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
