### PR TITLE
DATADOG-CHART: Use last version of datadog-crds dependency

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 2.30.15
+## 2.30.16
 
 * Default Datadog CRD chart to `0.4.7`.
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.30.15
 
+* Default Datadog CRD chart to `0.4.7`.
+
+## 2.30.15
+
 * Default Datadog Agent image to `7.34.0`.
 * Default Datadog Cluster-Agent image to `1.18.0`.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.30.15
+version: 2.30.16
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.30.15](https://img.shields.io/badge/Version-2.30.15-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.30.16](https://img.shields.io/badge/Version-2.30.16-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -28,7 +28,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://helm.datadoghq.com | datadog-crds | 0.4.5 |
+| https://helm.datadoghq.com | datadog-crds | 0.4.7 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 
 ## Quick start

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
-digest: sha256:e1da3f34d6f6d62fb12c0ba6560d52e0d5621d406f184a308936dafc7b88b481
-generated: "2021-11-24T14:07:41.643706+01:00"
+digest: sha256:6757563c3d9ab1f942022ad081c7957cf8585415557ebe09c0a6a75f4189375d
+generated: "2022-03-09T12:17:49.22812862+01:00"

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
-digest: sha256:6757563c3d9ab1f942022ad081c7957cf8585415557ebe09c0a6a75f4189375d
-generated: "2022-03-09T12:17:49.22812862+01:00"
+digest: sha256:ebed249fa850dd365390e2e43fc82b8d47cedfbc3831d6c81039a7c216474d6b
+generated: "2022-03-09T12:28:39.941176978+01:00"

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 0.4.5
+  version: 0.4.7
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: datadog-crds
-    version: 0.4.5
+    version: 0.4.7
     repository: https://helm.datadoghq.com
     condition: clusterAgent.metricsProvider.useDatadogMetrics
     tags:


### PR DESCRIPTION
#### What this PR does / why we need it:
Use `0.4.7` version of `datadog-crds` chart with fix of `Capabilities.APIVersions` to install CRD into Kubernetes version >=1.22.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)