### PR TITLE
fix(datadog): clusterchecks.enable without ksm core

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.30.17
+
+* Fix the function `should-enable-cluster-check-workers` to not require `datadog.kubeStateMetricsCore.useClusterCheckRunners:true` to enable the `ClusterCheckRunners`.
+
 ## 2.30.16
 
 * Default Datadog CRD chart to `0.4.7`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.30.16
+version: 2.30.17
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.30.16](https://img.shields.io/badge/Version-2.30.16-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.30.17](https://img.shields.io/badge/Version-2.30.17-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -419,7 +419,7 @@ false
 Return true if the Cluster Check Workers have to be deployed
 */}}
 {{- define "should-enable-cluster-check-workers" -}}
-{{- if or .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners (and .Values.datadog.clusterChecks.enabled .Values.clusterChecksRunner.enabled) -}}
+{{- if or .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners .Values.datadog.clusterChecks.enabled .Values.clusterChecksRunner.enabled -}}
 true
 {{- else -}}
 false


### PR DESCRIPTION
#### What this PR does / why we need it:

* Fix the function `should-enable-cluster-check-workers` to not require `datadog.kubeStateMetricsCore.useClusterCheckRunners:true` to enable the `ClusterCheckRunners`.

#### Which issue this PR fixes

Discover this issue when doing some QA.

#### Special notes for your reviewer:

values file to test

```yaml
datadog:
  clusterName: <clustername>
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret

  clusterChecks:
    enabled: true
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
