### PR TITLE
Update README with updated NPM instructions

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.30.19
+
+* Update documentation for enabling NPM.
+
 ## 2.30.18
 
 * Enforce use of `root` user for the node agent.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.30.18
+version: 2.30.19
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.30.18](https://img.shields.io/badge/Version-2.30.18-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.30.19](https://img.shields.io/badge/Version-2.30.19-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -310,14 +310,14 @@ then upgrade your Datadog Helm chart:
 helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
-### Enabling System Probe Collection
+### Enabling NPM Collection
 
-The system-probe agent only runs in dedicated container environment. Update your `datadog-values.yaml` file with the system-probe collection configuration:
+The system-probe agent only runs in dedicated container environment. Update your `datadog-values.yaml` file with the NPM collection configuration:
 
 ```yaml
 datadog:
   # (...)
-  systemProbe:
+  networkMonitoring:
     # (...)
     enabled: true
 

--- a/charts/datadog/README.md.gotmpl
+++ b/charts/datadog/README.md.gotmpl
@@ -305,14 +305,14 @@ then upgrade your Datadog Helm chart:
 helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
-### Enabling System Probe Collection
+### Enabling NPM Collection
 
-The system-probe agent only runs in dedicated container environment. Update your `datadog-values.yaml` file with the system-probe collection configuration:
+The system-probe agent only runs in dedicated container environment. Update your `datadog-values.yaml` file with the NPM collection configuration:
 
 ```yaml
 datadog:
   # (...)
-  systemProbe:
+  networkMonitoring:
     # (...)
     enabled: true
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes the docs for enabling NPM to use the newer `datadog.networkMonitoring.enabled` value.

#### Special notes for your reviewer:

#### Checklist

