### PR TITLE
(hold) feat: support admissionController.configInjectionMode

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.YY.XX (TODO: update this)
+
+* Add `clusterAgent.admissionController.configInjectionMode` to configure the admission controller injection mode (requires Cluster Agent 1.20.0+)
+
 ## 2.30.17
 
 * Add `datadog.helmCheck.collectEvents` to enable event collection in the Helm check.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.30.17
+version: 2.30.17 # (TODO: update this)
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -576,3 +576,14 @@ Return the appropriate apiVersion for PodDisruptionBudget policy APIs.
 "policy/v1beta1"
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the Agent's local service name.
+*/}}
+{{- define "agent-local-service-name" -}}
+{{- if ne .Values.agents.localService.overrideName "" }}
+{{- .Values.agents.localService.overrideName -}}
+{{- else -}}
+{{ template "datadog.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/datadog/templates/agent-services.yaml
+++ b/charts/datadog/templates/agent-services.yaml
@@ -66,11 +66,7 @@ apiVersion: v1
 kind: Service
 
 metadata:
-  {{- if ne .Values.agents.localService.overrideName "" }}
-  name: {{ .Values.agents.localService.overrideName }}
-  {{- else }}
-  name: {{ template "datadog.fullname" . }}
-  {{- end }}
+  name: {{ template "agent-local-service-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "datadog.fullname" . }}"

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -169,6 +169,12 @@ spec:
             value: {{ .Values.clusterAgent.admissionController.mutateUnlabelled | quote }}
           - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
             value: {{ template "datadog.fullname" . }}-cluster-agent-admission-controller
+          {{- if .Values.clusterAgent.admissionController.configInjectionMode }}
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE
+            value: {{ .Values.clusterAgent.admissionController.configInjectionMode | quote }}
+          {{- end }}
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
+            value: {{ template "agent-local-service-name" . }}
           {{- end }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -681,6 +681,9 @@ clusterAgent:
     # clusterAgent.admissionController.mutateUnlabelled -- Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"'
     mutateUnlabelled: false
 
+    # clusterAgent.admissionController.configInjectionMode -- The kind of configuration to be injected, it can be "hostip", "service" or "socket".
+    configInjectionMode: # hostip, service or socket
+
   # clusterAgent.confd -- Provide additional cluster check configurations. Each key will become a file in /conf.d.
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/
   confd: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add `clusterAgent.admissionController.configInjectionMode` to configure the admission controller injection mode
* Auto-configure `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

- Requires Cluster Agent 1.20.0+
- Related to https://github.com/DataDog/datadog-agent/pull/11373

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
