### PR TITLE
update default values for failure policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 charts/*/charts
 helm-docs
 kubeval
+.idea

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.34.4
 
-* Add `clusterAgent.admission_controller.failurePolicy` configuration to set the failure policy for dynamic admission control
+* Add `clusterAgent.admissionController.failurePolicy` configuration to set the failure policy for dynamic admission control
 
 ## 2.34.3
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 2.34.2
 
 * Default Cluster Agent image to `1.20.0`.
+* Add `clusterAgent.admission_controller.failurePolicy` configuration to set the failure policy for dynamic admission control
 
 ## 2.34.1
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.34.4
+
+* Add `clusterAgent.admission_controller.failurePolicy` configuration to set the failure policy for dynamic admission control
+
 ## 2.34.3
 
 * Introduce `clusterAgent.admissionController.configMode` (requires Cluster Agent `1.20+`). It allows choosing the kind of configuration to be injected ("hostip", "service", or "socket").
@@ -7,7 +11,6 @@
 ## 2.34.2
 
 * Default Cluster Agent image to `1.20.0`.
-* Add `clusterAgent.admission_controller.failurePolicy` configuration to set the failure policy for dynamic admission control
 
 ## 2.34.1
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.34.3
+version: 2.34.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.34.3](https://img.shields.io/badge/Version-2.34.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.34.4](https://img.shields.io/badge/Version-2.34.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -532,6 +532,7 @@ helm install --name <RELEASE_NAME> \
 | clusterAgent.additionalLabels | object | `{}` | Adds labels to the Cluster Agent deployment and pods |
 | clusterAgent.admissionController.configMode | string | `nil` | The kind of configuration to be injected, it can be "hostip", "service", or "socket". |
 | clusterAgent.admissionController.enabled | bool | `false` | Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods |
+| clusterAgent.admissionController.failurePolicy | string | `"Ignore"` | Set the failure policy for dynamic admission control.' |
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |
 | clusterAgent.advancedConfd | object | `{}` | Provide additional cluster check configurations. Each key is an integration containing several config files. |
 | clusterAgent.affinity | object | `{}` | Allow the Cluster Agent Deployment to schedule using affinity rules |

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
-digest: sha256:6757563c3d9ab1f942022ad081c7957cf8585415557ebe09c0a6a75f4189375d
-generated: "2022-06-03T06:56:59.207364-04:00"
+digest: sha256:ebed249fa850dd365390e2e43fc82b8d47cedfbc3831d6c81039a7c216474d6b
+generated: "2022-03-09T12:28:39.941176978+01:00"

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
-digest: sha256:ebed249fa850dd365390e2e43fc82b8d47cedfbc3831d6c81039a7c216474d6b
-generated: "2022-03-09T12:28:39.941176978+01:00"
+digest: sha256:6757563c3d9ab1f942022ad081c7957cf8585415557ebe09c0a6a75f4189375d
+generated: "2022-06-03T06:56:59.207364-04:00"

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -304,6 +304,9 @@ are enabled:
 {{- if .Values.clusterAgent.metricsProvider.enabled }}
 * External Metrics Provider
 {{- end }}
+{{- if eq .Values.clusterAgent.metricsProvider.failurePolicy "Fail" }}
+* Failure policy is set to "Fail"
+{{- end }}
 
 To run in high availability mode, our recommandation is to update the chart
 configuration with:

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -304,7 +304,7 @@ are enabled:
 {{- if .Values.clusterAgent.metricsProvider.enabled }}
 * External Metrics Provider
 {{- end }}
-{{- if eq .Values.clusterAgent.metricsProvider.failurePolicy "Fail" }}
+{{- if eq .Values.clusterAgent.admissionController.failurePolicy "Fail" }}
 * Failure policy is set to "Fail"
 {{- end }}
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -305,7 +305,7 @@ are enabled:
 * External Metrics Provider
 {{- end }}
 {{- if eq .Values.clusterAgent.admissionController.failurePolicy "Fail" }}
-* Failure policy is set to "Fail"
+* Failure policy of the Admission Controller is set to "Fail"
 {{- end }}
 
 To run in high availability mode, our recommandation is to update the chart

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -184,7 +184,7 @@ spec:
             value: {{ template "localService.name" . }}
           {{- end }}
           - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
-            value: {{ .Values.clusterAgent.admission_controller.failurePolicy | quote }}
+            value: {{ .Values.clusterAgent.admissionController.failurePolicy | quote }}
           {{- end }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -183,6 +183,8 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
             value: {{ template "localService.name" . }}
           {{- end }}
+          - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
+            value: {{ .Values.clusterAgent.admission_controller.failurePolicy | quote }}
           {{- end }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -722,6 +722,11 @@ clusterAgent:
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/#configure-apm-and-dogstatsd-communication-mode
     configMode:  # "hostip", "socket" or "service"
 
+    # clusterAgent.admissionController.failurePolicy -- Set the failure policy for dynamic admission control.'
+    ## The default of Ignore means that pods will still be admitted even if the webhook is unavailable to inject them.
+    ## Setting to Fail will require the admission controller to be present and pods to be injected before they are allowed to run.
+    failurePolicy: Ignore
+
   # clusterAgent.confd -- Provide additional cluster check configurations. Each key will become a file in /conf.d.
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/
   confd: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates default values for admission controller failure policy.
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #
This is related to https://github.com/DataDog/datadog-agent/issues/11426
and depends on https://github.com/DataDog/datadog-agent/pull/11432
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
