### PR TITLE
Revert "Encore use of `root` user for the node agent (#577)"

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.30.20
+
+* Revert: Enforce use of `root` user for the node agent.
+
 ## 2.30.19
 
 * Update documentation for enabling NPM.
@@ -512,7 +516,7 @@ Change OpenShift SCC priorities from 10 to 8 to avoid conflicts with OpenShift A
 
 ## 2.15.1
 
-* Add parameter `clusterAgent.rbac.serviceAccountAnnotations` for specifying annotations for dedicated ServiceAccount for Cluster Agent.
+* Add parameter `clustersAgent.rbac.serviceAccountAnnotations` for specifying annotations for dedicated ServiceAccount for Cluster Agent.
 * Add parameter `agents.rbac.serviceAccountAnnotations` for specifying annotations for dedicated ServiceAccount for Agents.
 * Support template expansion for `agents.podAnnotations`
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.30.19
+version: 2.30.20
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.30.19](https://img.shields.io/badge/Version-2.30.19-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.30.20](https://img.shields.io/badge/Version-2.30.20-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -51,8 +51,7 @@ datadog:
     timeout:  # 30
 
   # datadog.securityContext -- Allows you to overwrite the default PodSecurityContext on the Daemonset or Deployment
-  securityContext:
-    runAsUser: 0
+  securityContext: {}
   #  seLinuxOptions:
   #    user: "system_u"
   #    role: "system_r"


### PR DESCRIPTION
This reverts commit d4a807dfaef4582f097d10847e0fd213259175e3.
@L3n41c and @clamoriniere
This causes an error on our agent when we deploy this chart:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x28418f7]

goroutine 63 [running]:
github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).handleEvents(0xc00089a280, 0xc000827000, 0x8c, 0x8c)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:397 +0xb7
github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).Start.func1(0xc00089a280, 0x550bbe0, 0xc000128010)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:121 +0x185
created by github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).Start
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:114 +0x57
```
What's harder is that if you unset the securityContext: `datadog.securityContext: {}` helm3 does a three-way merge and doesn't remove the change. What gets more interesting is that even setting the version in helm `--version 2.30.5` doesn't roll back the change... Basically, you have to either edit the daemonset and remove it or delete `--cascade=orphan` and redeploy.

Criminy this was difficult to track down. The way I found this update was doing a diff on the yaml output of a new and old pod after pinning the chart version...

> [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
> 
> * [x]  Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
> * [x]  Chart Version bumped
> * [x]  `CHANGELOG.md` has been updated
> * [x]  Variables are documented in the `README.md`

