### PR TITLE
Fix system-probe integration

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.30.20
+
+* Ensure system-probe communication functions properly by enabling two-way communication between containers through a writable socket (not readOnly).
+* Ensure system-probe communication functions properly by instructing the proccess agent to use its external system probe configuration.
+
 ## 2.30.19
 
 * Update documentation for enabling NPM.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.30.19
+version: 2.30.20
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.30.19](https://img.shields.io/badge/Version-2.30.19-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.30.20](https://img.shields.io/badge/Version-2.30.20-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -139,7 +139,7 @@
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
-      readOnly: true
+      readOnly: false
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -39,6 +39,10 @@
       value: {{ .Values.agents.containers.processAgent.logLevel | default .Values.datadog.logLevel | quote }}
     - name: DD_SYSTEM_PROBE_ENABLED
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}
+    {{- if eq (include "should-enable-system-probe" .) "true" }}
+    - name: DD_SYSTEM_PROBE_EXTERNAL
+      value: "true"
+    {{- end }}
     {{- if .Values.datadog.networkMonitoring.enabled }}
     - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -85,7 +85,7 @@
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
-      readOnly: true
+      readOnly: false
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -46,6 +46,7 @@
       subPath: system-probe.yaml
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
+      readOnly: false
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}


### PR DESCRIPTION
#### What this PR does / why we need it:
~The problem we were having: The datadog agent, process-agent, and system-probe containers were unable to communicate due to the readOnly value set to true in each for the sys-probe-dir directory. We noticed the issue by this message in our process-agent logs:~

```datadog-lvkft process-agent 2022-01-11 18:36:20 UTC | PROCESS | WARN | (pkg/process/checks/net.go:107 in 	 getConnections) | could not initialize system-probe connection: error setting up remote system probe util, socket path does not exist: stat /var/run/sysprobe/sysprobe.sock: no such file or directory (will only log every 10 minutes)```

~We opened up a ticket with datadog support and they recommended that we update the readOnly value to true for the sys-probe-dir in the agent, process-agent, and system-probe containers and set the DD_SYSTEM_PROBE_EXTERNAL variable such that the process-agent container has access to the external system-probe.~

~After implementing these changes the error message went away and we started getting data out of the system-probe for the universal service monitoring beta, so we believe that the error was contributing to issues with that particular feature before we made this change.~

### Edit
Upon further investigation, we discovered that the issue with the system-probe was due to an accidental setting of `DD_SYSPROBE_SOCKET=/var/run/s6/sysprobe.sock` in the `system-probe` container. Once removing that environment variable override and allowing the default value to replace it (`DD_SYSPROBE_SOCKET=/var/run/sysprobe/sysprobe.sock`), our problem was solved.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
