### PR TITLE
Add option to enable verticalpodautoscalers collection for KSM Core

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.32.6
+
+* Add `verticalpodautoscalers` in `kubernetes_state_core.yaml.default` to enable collection in KSM Core by default
+
 ## 2.32.5
 
 * Fix process detection, by adding `kill` syscall with signal `0` to system-probe seccomp profile.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.32.5
+version: 2.32.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.32.5](https://img.shields.io/badge/Version-2.32.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.32.6](https://img.shields.io/badge/Version-2.32.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -660,6 +660,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.ignoreAutoConfig | list | `[]` | List of integration to ignore auto_conf.yaml. |
 | datadog.kubeStateMetricsCore.collectSecretMetrics | bool | `true` | Enable watching secret objects and collecting their corresponding metrics kubernetes_state.secret.* |
+| datadog.kubeStateMetricsCore.collectVpaMetrics | bool | `false` | Enable watching VPA objects and collecting their corresponding metrics kubernetes_state.vpa.* |
 | datadog.kubeStateMetricsCore.enabled | bool | `false` | Enable the kubernetes_state_core check in the Cluster Agent (Requires Cluster Agent 1.12.0+) |
 | datadog.kubeStateMetricsCore.ignoreLegacyKSMCheck | bool | `true` | Disable the auto-configuration of legacy kubernetes_state check (taken into account only when datadog.kubeStateMetricsCore.enabled is true) |
 | datadog.kubeStateMetricsCore.labelsAsTags | object | `{}` | Extra labels to collect from resources and to turn into datadog tag. |

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -9,6 +9,9 @@ kubernetes_state_core.yaml.default: |-
 {{- if .Values.datadog.kubeStateMetricsCore.collectSecretMetrics }}
       - secrets
 {{- end }}
+{{- if .Values.datadog.kubeStateMetricsCore.collectVpaMetrics }}
+      - verticalpodautoscalers
+{{- end }}
       - nodes
       - pods
       - services
@@ -29,7 +32,6 @@ kubernetes_state_core.yaml.default: |-
       - poddisruptionbudgets
       - storageclasses
       - volumeattachments
-      - verticalpodautoscalers
 {{- if .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners }}
       skip_leader_election: true
 {{- end }}

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -29,6 +29,7 @@ kubernetes_state_core.yaml.default: |-
       - poddisruptionbudgets
       - storageclasses
       - volumeattachments
+      - verticalpodautoscalers
 {{- if .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners }}
       skip_leader_election: true
 {{- end }}

--- a/charts/datadog/templates/kube-state-metrics-core-rbac.yaml
+++ b/charts/datadog/templates/kube-state-metrics-core-rbac.yaml
@@ -75,6 +75,7 @@ rules:
   verbs:
   - list
   - watch
+{{- if .Values.datadog.kubeStateMetricsCore.collectVpaMetrics }}
 - apiGroups:
   - autoscaling.k8s.io
   resources:
@@ -82,6 +83,7 @@ rules:
   verbs:
   - list
   - watch
+{{- end }}    
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -109,6 +109,10 @@ datadog:
     ## Configuring this field will change the default kubernetes_state_core check configuration and the RBACs granted to Datadog Cluster Agent to run the kubernetes_state_core check.
     collectSecretMetrics: true
 
+    # datadog.kubeStateMetricsCore.collectVpaMetrics -- Enable watching VPA objects and collecting their corresponding metrics kubernetes_state.vpa.*
+    ## Configuring this field will change the default kubernetes_state_core check configuration and the RBACs granted to Datadog Cluster Agent to run the kubernetes_state_core check.
+    collectVpaMetrics: false
+
     # datadog.kubeStateMetricsCore.useClusterCheckRunners -- For large clusters where the Kubernetes State Metrics Check Core needs to be distributed on dedicated workers.
     ## Configuring this field will create a separate deployment which will run Cluster Checks, including Kubernetes State Metrics Core.
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/clusterchecksrunner?tab=helm


### PR DESCRIPTION
#### What this PR does / why we need it:
Add configuration `datadog.kubeStateMetricsCore.collectVpaMetrics` to add the `verticalpodautoscalers` to the list of collectors in the `kubernetes_state_core.yaml.default`  to enable collection. Updated the RBAC to only provision the `ClusterRole` portion for this when enabled. 

VPAs are not enabled by default in most Kubernetes Clusters, and the `verticalpodautoscalers` KSM collector will throw errors when it is active and VPAs are not enabled. So this option is set to `false` by default.

#### Which issue this PR fixes
  - fixes https://github.com/DataDog/helm-charts/issues/603

#### Special notes for your reviewer:
Can validate that when enabled the `/etc/datadog-agent/conf.d/kubernetes_state_core.yaml.default` file gets this collector added and the `ClusterRole: datadog-ksm-core` has that corresponding permission.

For full validation can deploy a VPA like the following (with respect to existing Deployment/Container) and verify `kubernetes_state.vpa.*` metrics are coming in.

```yaml
apiVersion: autoscaling.k8s.io/v1
kind: VerticalPodAutoscaler
metadata:
  name: nginx-deployment-vpa
spec:
  targetRef:
    apiVersion: "apps/v1"
    kind:       Deployment
    name:       nginx
  updatePolicy:
    updateMode: "Off"
  recommendation:
    containerRecommendations:
      - containerName: nginx
        lowerBound:
          cpu: 40m
          memory: 16Mi
        target:
          cpu: 60m
          memory: 32Mi
        upperBound:
          cpu: 100m
          memory: 64Mi
```


#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
