### PR TITLE
Make the DCA leader election ConfigMap name depend on the Helm release name

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.33.5
+
+* Make the DCA leader election ConfigMap name depend on the Helm release name.
+
 ## 2.33.4
 
 * Improves help message when only `.datadog.containerInclude` is defined but no `.datadog.containerExclude`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.33.4
+version: 2.33.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.33.4](https://img.shields.io/badge/Version-2.33.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.33.5](https://img.shields.io/badge/Version-2.33.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -210,6 +210,10 @@ spec:
           - name: DD_LEADER_LEASE_DURATION
             value: "15"
           {{- end }}
+          - name: DD_LEASE_NAME
+            value: {{ template "datadog.fullname" . }}-leader-election
+          - name: DD_CLUSTER_AGENT_TOKEN_NAME
+            value: {{ template "datadog.fullname" . }}token
           {{- if .Values.datadog.collectEvents }}
           - name: DD_COLLECT_KUBERNETES_EVENTS
             value: {{ .Values.datadog.collectEvents | quote}}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -47,7 +47,8 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - datadogtoken  # Kubernetes event collection state
+  - {{ template "datadog.fullname" . }}token  # Kubernetes event collection state
+  - datadogtoken  # Kept for backward compatibility with agent <7.37.0
   verbs:
   - get
   - update
@@ -57,7 +58,8 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - datadog-leader-election  # Leader election token
+  - {{ template "datadog.fullname" . }}-leader-election  # Leader election token
+  - datadog-leader-election  # Kept for backward compatibility with agent <7.37.0
 {{- if .Values.clusterAgent.metricsProvider.enabled }}
   - datadog-custom-metrics
 {{- end }}

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -33,7 +33,8 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - datadogtoken  # Kubernetes event collection state
+  - {{ template "datadog.fullname" . }}token  # Kubernetes event collection state
+  - datadogtoken  # Kept for backward compatibility with agent <7.37.0
   verbs:
   - get
   - update
@@ -44,7 +45,8 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - datadog-leader-election  # Leader election token
+  - {{ template "datadog.fullname" . }}-leader-election  # Leader election token
+  - datadog-leader-election  # Kept for backward compatibility with agent <7.37.0
   verbs:
   - get
   - update


### PR DESCRIPTION
#### What this PR does / why we need it:

In order to elect a leader among all the cluster-agent replicas, a ConfigMap is used as a synchronisation point.
The name of this ConfigMap used to be hardcoded to `datadog-leader-election`.
This change makes this name depend on the Helm release name.
Thanks to this change, two distinct Helm releases can cohabit in the same namespace.

#### Which issue this PR fixes

#### Special notes for your reviewer:

In order to be functional, this PR requires a version of the agent that includes DataDog/datadog-agent#11949.
It’s safe to use this version of the chart with a previous version of the agent docker image. But it will just have no effect.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
