### PR TITLE
[synthetics] Update liveness and readiness probes in PL chart

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Replace deprecated liveness probe mechanism with the HTTP-based one.
 * Add readiness probe using the HTTP-based mechanism.
-* Add `enableStatusProbes` value to enable/disable both liveness and readiness probes.
+* Add `enableStatusProbes` value to enable/disable both liveness and readiness probes. Minimal private location image version required: `1.12.0`.
 
 ### 0.13.4
 

--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+### 0.14.0
+
+* Replace deprecated liveness probe mechanism with the HTTP-based one.
+* Add readiness probe using the HTTP-based mechanism.
+* Add `enableStatusProbes` value to enable/disable both liveness and readiness probes.
+
 ### 0.13.4
 
 * Update private location image version to `1.23.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.13.4
+version: 0.14.0
 appVersion: 1.23.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -29,7 +29,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | configConfigMap | string | `""` | Config Map that stores the configuration of the private location worker for the deployment |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
 | configSecret | string | `""` | Secret that stores the configuration of the private location worker for the deployment |
-| enableStatusProbes | bool | `false` | Enable both liveness and readiness probes |
+| enableStatusProbes | bool | `false` | Enable both liveness and readiness probes (minimal private location image version required: 1.12.0) |
 | env | list | `[]` | Set environment variables |
 | envFrom | list | `[]` | Set environment variables from configMaps and/or secrets |
 | extraVolumeMounts | list | `[]` | Optionally specify extra list of additional volumeMounts for container |

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.13.4](https://img.shields.io/badge/Version-0.13.4-informational?style=flat-square) ![AppVersion: 1.23.0](https://img.shields.io/badge/AppVersion-1.23.0-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![AppVersion: 1.23.0](https://img.shields.io/badge/AppVersion-1.23.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -26,9 +26,10 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Allows to specify affinity for Datadog Synthetics Private Location PODs |
-| configConfigMap | string | `""` | Config Map that stores the configuration of the private location worked for the deployment |
+| configConfigMap | string | `""` | Config Map that stores the configuration of the private location worker for the deployment |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
 | configSecret | string | `""` | Secret that stores the configuration of the private location worker for the deployment |
+| enableStatusProbes | bool | `false` | Enable both liveness and readiness probes |
 | env | list | `[]` | Set environment variables |
 | envFrom | list | `[]` | Set environment variables from configMaps and/or secrets |
 | extraVolumeMounts | list | `[]` | Optionally specify extra list of additional volumeMounts for container |

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -33,16 +33,22 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.enableStatusProbes }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - '[ $(expr $(cat /tmp/liveness.date) + 300000) -gt $(date +%s%3N) ]'
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            timeoutSeconds: 10
+            httpGet:
+              path: /liveness
+              port: 8080
+          readinessProbe:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 2
-            failureThreshold: 3
+            httpGet:
+              path: /readiness
+              port: 8080
+          {{- end }}
           volumeMounts:
           - mountPath: /etc/datadog
             name: worker-config

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -81,7 +81,7 @@ affinity: {}
 # configFile -- JSON string containing the configuration of the private location worker
 configFile: "{}"
 
-# configConfigMap -- Config Map that stores the configuration of the private location worked for the deployment
+# configConfigMap -- Config Map that stores the configuration of the private location worker for the deployment
 configConfigMap: ""
 
 # configSecret -- Secret that stores the configuration of the private location worker for the deployment
@@ -104,3 +104,7 @@ hostAliases: []
 #  - ip: "10.0.0.1"
 #    hostnames:
 #    - "host.domain.com"
+
+# enableStatusProbes -- Enable both liveness and readiness probes
+enableStatusProbes: false
+  # Requires to be in sync with `enableStatusProbes` in the configuration of the private location worker

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -105,6 +105,6 @@ hostAliases: []
 #    hostnames:
 #    - "host.domain.com"
 
-# enableStatusProbes -- Enable both liveness and readiness probes
+# enableStatusProbes -- Enable both liveness and readiness probes (minimal private location image version required: 1.12.0)
 enableStatusProbes: false
   # Requires to be in sync with `enableStatusProbes` in the configuration of the private location worker


### PR DESCRIPTION
#### What this PR does / why we need it:

The liveness probe mechanism used by the Synthetics Private Location chart is deprecated. We want to use the HTTP liveness probe instead.

Also, we are adding the HTTP readiness probe, with the possibility to enable/disable both probes using a new value: `enableStatusProbes`.

#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
