### PR TITLE
Update Kube-State-Metrics Dependency to more recent version

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.33.6
+
+* Update kube-state-metrics dependency to version 4.7.0
+
 ## 2.33.5
 
 * Make the DCA leader election ConfigMap name depend on the Helm release name. (Requires DCA 1.21+)

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.33.5
+version: 2.33.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -6,6 +6,6 @@ dependencies:
     tags:
     - install-crds
   - name: kube-state-metrics
-    version: 2.13.2
+    version:  4.7.0
     repository: https://prometheus-community.github.io/helm-charts
     condition: datadog.kubeStateMetricsEnabled


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates the dependency on Kube-State-Metrics in the DataDog helm chart to a more recent version to avoid issues with security vulnerabilities and errors in more recent versions of Kubernetes

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #620

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
