### PR TITLE
[datadog-crds] Remove `preserveUnknownFields` from v1beta1 crds

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+* Remove `preserveUnknownFields` to maintain compatibility with Kubernetes versions <1.15.
+
 ## 0.5.0
 
 * Update CRDs from Datadog Operator v0.8.0.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.5.0
+version: 0.5.1
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -20,7 +20,6 @@ spec:
     shortNames:
       - dd
     singular: datadogagent
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
@@ -34,7 +34,6 @@ spec:
     listKind: DatadogMetricList
     plural: datadogmetrics
     singular: datadogmetric
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
@@ -38,7 +38,6 @@ spec:
     listKind: DatadogMonitorList
     plural: datadogmonitors
     singular: datadogmonitor
-  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -30,6 +30,10 @@ download_crd() {
         yq -i eval 'del(.. | select(has("description")).description)' "$path"
     fi
 
+    if [ "$version" = "v1beta1" ]; then
+        yq -i eval 'del(.spec.preserveUnknownFields)' "$path"
+    fi
+
     ifCondition="{{- if and .Values.crds.$installOption (not (.Capabilities.APIVersions.Has \"apiextensions.k8s.io/v1/CustomResourceDefinition\")) }}"
     if [ "$version" = "v1" ]; then
         ifCondition="{{- if and .Values.crds.$installOption (.Capabilities.APIVersions.Has \"apiextensions.k8s.io/v1/CustomResourceDefinition\") }}"


### PR DESCRIPTION
#### What this PR does / why we need it:

The updated `v1beta1` CRDs from https://github.com/DataDog/helm-charts/pull/626 cause issues on clusters using v1.14.x or lower since CRD pruning was not introduced until v1.15.0. Error from the failed build job attempting to install the `datadog-operator` chart on v1.14.10: https://github.com/DataDog/helm-charts/runs/6472542441?check_suite_focus=true

`Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(CustomResourceDefinition.spec): unknown field "preserveUnknownFields" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec`

#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
