### PR TITLE
Remove duplicate resource names from RBAC policy when default Release name is used

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.33.8
+
+* Fix duplicate resources in RBAC policy (`datadogtoken`, `datadog-leader-election`) when default Helm release name is used.
+
 ## 2.33.7
 
 * Fix inaccurate documentation example for `datadog.kubeStateMetricsCore.labelsAsTags`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.33.7
+version: 2.33.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.33.7](https://img.shields.io/badge/Version-2.33.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.33.8](https://img.shields.io/badge/Version-2.33.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -48,7 +48,9 @@ rules:
   - configmaps
   resourceNames:
   - {{ template "datadog.fullname" . }}token  # Kubernetes event collection state
+  {{- if not (eq (include "datadog.fullname" .) "datadog") }}
   - datadogtoken  # Kept for backward compatibility with agent <7.37.0
+  {{- end }}
   verbs:
   - get
   - update
@@ -59,7 +61,9 @@ rules:
   - configmaps
   resourceNames:
   - {{ template "datadog.fullname" . }}-leader-election  # Leader election token
+  {{- if not (eq (include "datadog.fullname" .) "datadog") }}
   - datadog-leader-election  # Kept for backward compatibility with agent <7.37.0
+  {{- end }}
 {{- if .Values.clusterAgent.metricsProvider.enabled }}
   - datadog-custom-metrics
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This behavior was discovered when upgrading the DataDog helm chart from version `2.30.17` to `2.33.5`.

When default release name is used (`datadog`), the chart adds duplicate resource names to the RBAC ClusterRole `datadog-cluster-agent`.

Here are some screenshots of diffs from my internal PR to bump the DataDog Helm Chart version. You can see the lines changed:

![Screen Shot 2022-05-23 at 12 25 50 PM](https://user-images.githubusercontent.com/17263955/169865161-76b2eb77-3320-48a8-8c13-e1b181fc230d.png)
![Screen Shot 2022-05-23 at 12 25 32 PM](https://user-images.githubusercontent.com/17263955/169865163-5afd849d-94fe-4450-84bf-f82ffc6ef6e1.png)
![Screen Shot 2022-05-23 at 12 25 22 PM](https://user-images.githubusercontent.com/17263955/169865165-3085a86f-1b74-40fc-8677-4bf42c797091.png)

Example:
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
    app.kubernetes.io/instance: datadog
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: datadog
    app.kubernetes.io/version: "7"
    helm.sh/chart: datadog-2.30.17
    helm.sh/chart: datadog-2.33.5
  name: datadog-cluster-agent
rules:
...
- apiGroups:
  - ""
  resourceNames:
  - datadogtoken
  - datadogtoken # duplicate line
  resources:
  - configmaps
  verbs:
  - get
  - update
- apiGroups:
  - ""
  resourceNames:
  - datadog-leader-election
  - datadog-leader-election # duplicate line
  - datadog-custom-metrics
  resources:
  - configmaps
  verbs:
  - get
  - update
...
```

The approach taken by this PR is to only add the fallback backwards compatibility values for agent <7.37.0 if the default release name is not being used. If the default value is being used, then the logic from #618 will work. It just needs to not be added twice.

#### Which issue this PR fixes

Fixes behavior added as a result of #618

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
