### PR TITLE
[charts/datadog] Allow granular read secret roles

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 2.33.8
 
-* Added new value `datadog.secretBackend.enableGlobalPermissions` which when set to `false` will not allow Datadog agents to read all secrets in all clusters - defaults to `true` (current behaviour)
-* Added new value `datadog.secretBackend.roles` which will create `Role` and `RoleBinding` for each namespace defined - allowing for opt-in read permissions for secrets in those namespaces
+* Add the `datadog.secretBackend.enableGlobalPermissions` value, which when set to `false`, does not allow Datadog agents to read all secrets in all clusters. Defaults to `true`.
+* Add the `datadog.secretBackend.roles` value,  which creates `Role` and `RoleBinding` for each namespace defined. Allows for opt-in read permissions for secrets in those namespaces.
 
 ## 2.33.7
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.33.8
+
+* Added new value `datadog.secretBackend.enableGlobalPermissions` which when set to `false` will not allow Datadog agents to read all secrets in all clusters - defaults to `true` (current behaviour)
+* Added new value `datadog.secretBackend.roles` which will create `Role` and `RoleBinding` for each namespace defined - allowing for opt-in read permissions for secrets in those namespaces
+
 ## 2.33.7
 
 * Fix inaccurate documentation example for `datadog.kubeStateMetricsCore.labelsAsTags`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.33.7
+version: 2.33.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -702,8 +702,8 @@ helm install --name <RELEASE_NAME> \
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. See https://datadoghq.dev/integrations-core/legacy/prometheus/#config-changes-between-versions for the differences between the two versions. (Version 2 requires Agent version 7.34+) |
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |
 | datadog.secretBackend.command | string | `nil` | Configure the secret backend command, path to the secret backend binary. |
-| datadog.secretBackend.enableGlobalPermissions | bool | `true` | Whether to create a global permission allowing Datadog agents to read all secrets when datadog.secretBackend.command is set to "/readsecret_multiple_providers.sh" |
-| datadog.secretBackend.roles | list | `[]` | Creates roles for Datadog to read the specified secrets - replaces datadog.secretBackend.enableGlobalPermissions |
+| datadog.secretBackend.enableGlobalPermissions | bool | `true` | Whether to create a global permission allowing Datadog agents to read all secrets when `datadog.secretBackend.command` is set to `"/readsecret_multiple_providers.sh"`. |
+| datadog.secretBackend.roles | list | `[]` | Creates roles for Datadog to read the specified secrets - replacing `datadog.secretBackend.enableGlobalPermissions`. |
 | datadog.secretBackend.timeout | string | `nil` | Configure the secret backend command timeout in seconds. |
 | datadog.securityAgent.compliance.checkInterval | string | `"20m"` | Compliance check run interval |
 | datadog.securityAgent.compliance.configMap | string | `nil` | Contains CSPM compliance benchmarks that will be used |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.33.7](https://img.shields.io/badge/Version-2.33.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.33.8](https://img.shields.io/badge/Version-2.33.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -702,6 +702,8 @@ helm install --name <RELEASE_NAME> \
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. See https://datadoghq.dev/integrations-core/legacy/prometheus/#config-changes-between-versions for the differences between the two versions. (Version 2 requires Agent version 7.34+) |
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |
 | datadog.secretBackend.command | string | `nil` | Configure the secret backend command, path to the secret backend binary. |
+| datadog.secretBackend.enableGlobalPermissions | bool | `true` | Whether to create a global permission allowing Datadog agents to read all secrets |
+| datadog.secretBackend.roles | list | `[]` | Creates roles for Datadog to read the specified secrets |
 | datadog.secretBackend.timeout | string | `nil` | Configure the secret backend command timeout in seconds. |
 | datadog.securityAgent.compliance.checkInterval | string | `"20m"` | Compliance check run interval |
 | datadog.securityAgent.compliance.configMap | string | `nil` | Contains CSPM compliance benchmarks that will be used |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -702,8 +702,8 @@ helm install --name <RELEASE_NAME> \
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. See https://datadoghq.dev/integrations-core/legacy/prometheus/#config-changes-between-versions for the differences between the two versions. (Version 2 requires Agent version 7.34+) |
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |
 | datadog.secretBackend.command | string | `nil` | Configure the secret backend command, path to the secret backend binary. |
-| datadog.secretBackend.enableGlobalPermissions | bool | `true` | Whether to create a global permission allowing Datadog agents to read all secrets |
-| datadog.secretBackend.roles | list | `[]` | Creates roles for Datadog to read the specified secrets |
+| datadog.secretBackend.enableGlobalPermissions | bool | `true` | Whether to create a global permission allowing Datadog agents to read all secrets when datadog.secretBackend.command is set to "/readsecret_multiple_providers.sh" |
+| datadog.secretBackend.roles | list | `[]` | Creates roles for Datadog to read the specified secrets - replaces datadog.secretBackend.enableGlobalPermissions |
 | datadog.secretBackend.timeout | string | `nil` | Configure the secret backend command timeout in seconds. |
 | datadog.securityAgent.compliance.checkInterval | string | `"20m"` | Compliance check run interval |
 | datadog.securityAgent.compliance.configMap | string | `nil` | Contains CSPM compliance benchmarks that will be used |

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -586,7 +586,7 @@ Return true if secret RBACs are needed for secret backend.
 */}}
 {{- define "need-secret-permissions" -}}
 {{- if .Values.datadog.secretBackend.command -}}
-{{- if eq .Values.datadog.secretBackend.command "/readsecret_multiple_providers.sh" -}}
+{{- if and .Values.datadog.secretBackend.enableGlobalPermissions (eq .Values.datadog.secretBackend.command "/readsecret_multiple_providers.sh") -}}
 true
 {{- end -}}
 {{- else -}}

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -173,5 +173,5 @@ roleRef:
   kind: Role
   name: {{ template "datadog.fullname" $ }}-secret-reader-{{ $role.namespace }}
   apiGroup: ""
-{{- end }} # end {{ range $role := .Values.datadog.secretBackend.roles }}
+{{- end }} # end range $role := .Values.datadog.secretBackend.roles
 {{- end -}}

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -137,4 +137,41 @@ metadata:
   {{- end }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}
+{{- range $role := .Values.datadog.secretBackend.roles }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "datadog.fullname" $ }}-secret-reader-{{ $role.namespace }}
+  namespace: {{ $role.namespace }}
+  labels:
+{{ include "datadog.labels" $ | indent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames: {{ toYaml $role.secrets | nindent 6 }}
+    verbs:
+      - get
+      - watch
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "datadog.fullname" $ }}-read-secrets-{{ $role.namespace }}
+  namespace: {{ $role.namespace }}
+  labels:
+{{ include "datadog.labels" $ | indent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "datadog.fullname" $ }}
+    apiGroup: ""
+    namespace: {{ $.Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ template "datadog.fullname" $ }}-secret-reader-{{ $role.namespace }}
+  apiGroup: ""
+{{- end }} # end {{ range $role := .Values.datadog.secretBackend.roles }}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -53,6 +53,16 @@ datadog:
     # datadog.secretBackend.timeout -- Configure the secret backend command timeout in seconds.
     timeout:  # 30
 
+    # datadog.secretBackend.enableGlobalPermissions -- Whether to create a global permission allowing Datadog agents to read all secrets
+    enableGlobalPermissions: true
+
+    # datadog.secretBackend.roles -- Creates roles for Datadog to read the specified secrets
+    roles: []
+    # - namespace: secret-location-namespace
+    #   secrets:
+    #     - secret-1
+    #     - secret-2
+
   # datadog.securityContext -- Allows you to overwrite the default PodSecurityContext on the Daemonset or Deployment
   securityContext:
     runAsUser: 0

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -43,7 +43,7 @@ datadog:
   ## Examples: https://docs.datadoghq.com/agent/guide/secrets-management/#setup-examples-1
   secretBackend:
     # datadog.secretBackend.command -- Configure the secret backend command, path to the secret backend binary.
-    ## Note: If the command value is "/readsecret_multiple_providers.sh" the agents will have permissions to get secret objects.
+    ## Note: If the command value is "/readsecret_multiple_providers.sh", and datadog.secretBackend.enableGlobalPermissions is enabled below, the agents will have permissions to get secret objects across the cluster.
     ## Read more about "/readsecret_multiple_providers.sh": https://docs.datadoghq.com/agent/guide/secrets-management/#script-for-reading-from-multiple-secret-providers-readsecret_multiple_providerssh
     command:  # "/readsecret.sh" or "/readsecret_multiple_providers.sh" or any custom binary path
 
@@ -53,10 +53,10 @@ datadog:
     # datadog.secretBackend.timeout -- Configure the secret backend command timeout in seconds.
     timeout:  # 30
 
-    # datadog.secretBackend.enableGlobalPermissions -- Whether to create a global permission allowing Datadog agents to read all secrets
+    # datadog.secretBackend.enableGlobalPermissions -- Whether to create a global permission allowing Datadog agents to read all secrets when datadog.secretBackend.command is set to "/readsecret_multiple_providers.sh"
     enableGlobalPermissions: true
 
-    # datadog.secretBackend.roles -- Creates roles for Datadog to read the specified secrets
+    # datadog.secretBackend.roles -- Creates roles for Datadog to read the specified secrets - replaces datadog.secretBackend.enableGlobalPermissions
     roles: []
     # - namespace: secret-location-namespace
     #   secrets:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -53,10 +53,10 @@ datadog:
     # datadog.secretBackend.timeout -- Configure the secret backend command timeout in seconds.
     timeout:  # 30
 
-    # datadog.secretBackend.enableGlobalPermissions -- Whether to create a global permission allowing Datadog agents to read all secrets when datadog.secretBackend.command is set to "/readsecret_multiple_providers.sh"
+    # datadog.secretBackend.enableGlobalPermissions -- Whether to create a global permission allowing Datadog agents to read all secrets when `datadog.secretBackend.command` is set to `"/readsecret_multiple_providers.sh"`.
     enableGlobalPermissions: true
 
-    # datadog.secretBackend.roles -- Creates roles for Datadog to read the specified secrets - replaces datadog.secretBackend.enableGlobalPermissions
+    # datadog.secretBackend.roles -- Creates roles for Datadog to read the specified secrets - replacing `datadog.secretBackend.enableGlobalPermissions`.
     roles: []
     # - namespace: secret-location-namespace
     #   secrets:


### PR DESCRIPTION
#### What this PR does / why we need it:

When we set `datadog.secretBackend.command` to `/readsecret_multiple_providers.sh`, it will add a cluster wide permission to read any secret. This is an anti-pattern that does not follow the principle of least privilege.

This PR will add a new value `datadog.secretBackend.enableGlobalPermissions` with the default set to `true` (non-breaking behaviour), when it is set to `false` it will prevent this cluster wide permission being created.

In its place is a new value `datadog.secretBackend.roles` which have the following structure:

```yaml
datadog:
  secretBackend:
    enableGlobalPermissions: false
    roles:
      - namespace: some-namespace
        secrets:
          - secret-1
          - secret-2
      - namespace: another-namespace
        secrets:
          - another-secret-1
```

The chart will then create a `Role` and then a `RoleBinding` for each namespace in this list of roles, allowing each secret defined in that namespace to be read by the Datadog `ServiceAccount`.

From the configuration above, these additional roles are created:

This follows the guidance on the [Datadog docs](https://docs.datadoghq.com/agent/guide/secrets-management/?tab=linux#read-from-kubernetes-secret-example).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #634 

#### Special notes for your reviewer:

- Feel free to suggest alternative names for the new values. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
