### PR TITLE
Allow cross cluster-agent communication in DCA `NetworkPolicy` and `CiliumNetworkPolicy`

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.35.5
+
+* Allow cross-DCA communication in DCA `NetworkPolicy` and `CiliumNetworkPolicy`
+
 ## 2.35.4
 
 * Fix comments in `values.yaml` to allow a seamless `helm-docs` update.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.35.4
+version: 2.35.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.35.4](https://img.shields.io/badge/Version-2.35.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.35.5](https://img.shields.io/badge/Version-2.35.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-cilium-network-policy.yaml
+++ b/charts/datadog/templates/cluster-agent-cilium-network-policy.yaml
@@ -86,8 +86,46 @@ specs:
           - ports:
               - port: "443"
                 protocol: TCP
+  - description: Ingress from cluster agent
+    endpointSelector:
+      matchLabels:
+        app: {{ template "datadog.fullname" . }}-cluster-agent
+        {{- if .Values.clusterAgent.podLabels }}
+        {{ toYaml .Values.clusterAgent.podLabels | indent 8 }}
+        {{- end }}
+    ingress:
+    -
+      fromEndpoints:
+        - matchLabels:
+            app: {{ template "datadog.fullname" . }}
+            {{- if .Values.clusterAgent.podLabels }}
+            {{ toYaml .Values.clusterAgent.podLabels | indent 10 }}
+            {{- end }}
+      toPorts:
+      - ports:
+        - port: "5005"
+          protocol: TCP
+  - description: Egress to cluster agent
+    endpointSelector:
+      matchLabels:
+        app: {{ template "datadog.fullname" . }}-cluster-agent
+        {{- if .Values.clusterAgent.podLabels }}
+        {{ toYaml .Values.clusterAgent.podLabels | indent 8 }}
+        {{- end }}
+    egress:
+    -
+      toEndpoints:
+        - matchLabels:
+            app: {{ template "datadog.fullname" . }}
+            {{- if .Values.clusterAgent.podLabels }}
+            {{ toYaml .Values.clusterAgent.podLabels | indent 10 }}
+            {{- end }}
+      toPorts:
+      - ports:
+        - port: "5005"
+          protocol: TCP
 {{- if $.Values.agents.enabled }}
-  - description: Ingress from agent
+  - description: "Ingress from agent"
     endpointSelector:
       matchLabels:
         app: {{ template "datadog.fullname" . }}-cluster-agent

--- a/charts/datadog/templates/cluster-agent-network-policy.yaml
+++ b/charts/datadog/templates/cluster-agent-network-policy.yaml
@@ -14,33 +14,45 @@ spec:
     - Ingress
     - Egress
   ingress:
-  - # Ingress from the node agents (for the metadata provider and prometheus check)
-    ports:
-      - port: 5005
-      - port: 5000
-    from:
-      - podSelector:
-          matchLabels:
-            app: {{ template "datadog.fullname" . }}
+    - # Ingress from the node agents (for the prometheus check)
+      ports:
+        - port: 5000
+      from:
+        - podSelector:
+            matchLabels:
+              app: {{ template "datadog.fullname" . }}
+    - # Ingress from node agents (for the metadata provider), other cluster agents and from cluster checks runner
+      ports:
+        - port: 5005
+      from:
+        - podSelector:
+            matchLabels:
+              app: {{ template "datadog.fullname" . }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "datadog.fullname" . }}-cluster-agent
 {{- if $.Values.clusterChecksRunner.enabled }}
-  - # Ingress from cluster checks runner
-    ports:
-      - port: 5005
-    from:
-      - podSelector:
-          matchLabels:
-            app: {{ template "datadog.fullname" . }}-clusterchecks
+        - podSelector:
+            matchLabels:
+              app: {{ template "datadog.fullname" . }}-clusterchecks
 {{- end }}
 {{- if .Values.clusterAgent.admissionController.enabled }}
-  - ports:
-      - port: 8000
+    - ports:
+        - port: 8000
 {{- end }}
 {{- if .Values.clusterAgent.metricsProvider.enabled }}
-  - # Ingress from API server for external metrics
-    ports:
-      - port: {{ template "clusterAgent.metricsProvider.port" . }}
+    - # Ingress from API server for external metrics
+      ports:
+        - port: {{ template "clusterAgent.metricsProvider.port" . }}
 {{- end }}
   egress:
+    - # Egress to other cluster agents
+      ports:
+        - port: 5005
+      to:
+        - podSelector:
+            matchLabels:
+              app: {{ template "datadog.fullname" . }}-cluster-agent
     - # Egress to
       # * Datadog intake
       # * Kube API server


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow cross cluster-agent communication in DCA `NetworkPolicy` and `CiliumNetworkPolicy`.
This is needed to allow “follower” cluster agents to forward queries to the “leader” one.
This new behaviour was introduced in cluster-agent `1.21` by DataDog/datadog-agent#11864.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
