### PR TITLE
Introduce agents.containers.agent.command

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.34.3
+Introduce `agents.containers.agent.command`, which allows overriding the agent
+entrypoint with a custom command. Defaults to `agent run`.
+
 ## 2.34.2
 
 * Default Cluster Agent image to `1.20.0`.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Datadog changelog
 
 ## 2.34.3
-Introduce `agents.containers.agent.command`, which allows overriding the agent
+Introduce `agents.containers.agent.command`, which allows overriding the Agent
 entrypoint with a custom command. Defaults to `agent run`.
 
 ## 2.34.2

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.34.2
+version: 2.34.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.34.2](https://img.shields.io/badge/Version-2.34.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.34.3](https://img.shields.io/badge/Version-2.34.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -453,6 +453,7 @@ helm install --name <RELEASE_NAME> \
 |-----|------|---------|-------------|
 | agents.additionalLabels | object | `{}` | Adds labels to the Agent daemonset and pods |
 | agents.affinity | object | `{}` | Allow the DaemonSet to schedule using affinity rules |
+| agents.containers.agent.command | list | `["agent","run"]` | Command to run in the Datadog Agent container as entrypoint |
 | agents.containers.agent.env | list | `[]` | Additional environment variables for the agent container |
 | agents.containers.agent.envFrom | list | `[]` | Set environment variables specific to agent container from configMaps and/or secrets |
 | agents.containers.agent.healthPort | int | `5555` | Port number to use in the node agent for the healthz endpoint |

--- a/charts/datadog/ci/datadog-agent-override-command-values.yaml
+++ b/charts/datadog/ci/datadog-agent-override-command-values.yaml
@@ -1,0 +1,7 @@
+agents:
+  containers:
+    agent:
+      command: 
+        - "time"
+        - "agent"
+        - "run"

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
-digest: sha256:ebed249fa850dd365390e2e43fc82b8d47cedfbc3831d6c81039a7c216474d6b
-generated: "2022-03-09T12:28:39.941176978+01:00"
+digest: sha256:6757563c3d9ab1f942022ad081c7957cf8585415557ebe09c0a6a75f4189375d
+generated: "2022-06-02T22:00:30.199031-07:00"

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -2,7 +2,11 @@
 - name: agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command: ["agent", "run"]
+  {{- with .Values.agents.containers.agent.command }}
+  command: {{ range . }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
 {{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.agent.securityContext "targetSystem" .Values.targetSystem) | indent 2 }}
   resources:
 {{ toYaml .Values.agents.containers.agent.resources | indent 4 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -998,6 +998,11 @@ agents:
 
   containers:
     agent:
+      # agents.containers.agent.command -- Command to run in the Datadog Agent container as entrypoint
+      command:
+        - "agent"
+        - "run"
+
       # agents.containers.agent.env -- Additional environment variables for the agent container
       env: []
 


### PR DESCRIPTION
#### What this PR does / why we need it:
The datadog agent runs `["agent", "run"]` by default, which works well. This
change allows overriding the entrypoint, instead of having to patch helm
templates, while defaulting to `agent run`.

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:

#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
