### PR TITLE
Add: support common labels for all resources

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.35.4
+
+* Support `commonlabels` configuration to be able to add common labels on all resources created by the chart.
+
 ## 2.35.3
 
 * Add `openat2` to system-probe seccomp profile to fix issues with opening files.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.35.3
+version: 2.35.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.35.3](https://img.shields.io/badge/Version-2.35.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.35.4](https://img.shields.io/badge/Version-2.35.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -617,6 +617,7 @@ helm install --name <RELEASE_NAME> \
 | clusterChecksRunner.tolerations | list | `[]` | Tolerations for pod assignment |
 | clusterChecksRunner.volumeMounts | list | `[]` | Specify additional volumes to mount in the cluster checks container |
 | clusterChecksRunner.volumes | list | `[]` | Specify additional volumes to mount in the cluster checks container |
+| commonLabels | object | `{}` | Labels to apply to all resources |
 | datadog-crds.crds.datadogMetrics | bool | `true` | Set to true to deploy the DatadogMetrics CRD |
 | datadog.apiKey | string | `"<DATADOG_API_KEY>"` | Your Datadog API key ref: https://app.datadoghq.com/account/settings#agent/kubernetes |
 | datadog.apiKeyExistingSecret | string | `nil` | Use existing Secret which stores API key instead of creating a new one. The value should be set with the `api-key` key inside the secret. |

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -498,6 +498,9 @@ helm.sh/chart: '{{ include "datadog.chart" . }}'
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -14,6 +14,10 @@ fullnameOverride:  # ""
 # targetSystem -- Target OS for this deployment (possible values: linux, windows)
 targetSystem: "linux"
 
+# commonLabels -- Labels to apply to all resources
+commonLabels: {}
+# team_name: dev
+
 # registry -- Registry to use for all Agent images (default gcr.io)
 ## Currently we offer Datadog Agent images on:
 ## GCR - use gcr.io/datadoghq (default)


### PR DESCRIPTION
Usefull when we have a policies manager as Kyverno.

Signed-off-by: Flaagada <mary.thibault2@gmail.com>

#### What this PR does / why we need it:

When we used a policies manager as Kyverno, it's usefull to be able to add a common labels on all resources created by the chart in order to respect the policy.

#### Special notes for your reviewer:

#### Checklist
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
