### PR TITLE
chore: update helm-docs version and support M1

### DIFF
--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-HELM_DOCS_VERSION="1.5.0"
+HELM_DOCS_VERSION="1.10.0"
 OS=$(uname)
+ARCH=$(uname -m)
 
 # install helm-docs
-curl --silent --show-error --fail --location --output /tmp/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v"${HELM_DOCS_VERSION}"/helm-docs_"${HELM_DOCS_VERSION}"_${OS}_x86_64.tar.gz
+curl --silent --show-error --fail --location --output /tmp/helm-docs.tar.gz "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_${OS}_${ARCH}.tar.gz"
 tar -xf /tmp/helm-docs.tar.gz helm-docs
 
 # validate docs


### PR DESCRIPTION
#### What this PR does / why we need it:
The existing script doesn't function properly for Apple M1 Macs.
Use `uname -m` to get the arch, rather than hard-coding to x86_64.

This also requires updating to a later version of helm-docs, so update from 1.5.0 to 1.10.0

Use double quotes around the entire string with interpolated variables, vs. individual variables themselves.

**Note** This does generate some changes to the generated docs. I did not update the docs in this PR, though I can if preferred.

Most of the changes are things like this
```
 | providers.gke.autopilot | bool | `false` | Enables Datadog Agent deployment on GKE Autopilot |
-| registry | string | `"gcr.io/datadoghq"` | Registry to use for all Agent images (default gcr.io) |
+| registry | string | `"gcr.io/datadoghq"` | Registry to use for all Agent images (default gcr.io) # Currently we offer Datadog Agent images on: # GCR - use gcr.io/datadoghq (default) # DockerHub - use docker.io/datadog # AWS - use public.ecr.aws/datadog |
```

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
