### PR TITLE
ci: update schema location for chart validation

### DIFF
--- a/.github/kubeval.sh
+++ b/.github/kubeval.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 KUBEVAL_VERSION="v0.16.1"
-SCHEMA_LOCATION="https://kubernetesjsonschema.dev/"
+SCHEMA_LOCATION="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master"
 OS=$(uname)
 
 CHANGED_CHARTS=${CHANGED_CHARTS:-${1:-}}
@@ -14,7 +14,7 @@ else
 fi
 
 # install kubeval
-curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz https://github.com/instrumenta/kubeval/releases/download/"${KUBEVAL_VERSION}"/kubeval-${OS}-amd64.tar.gz
+curl --silent --show-error --fail --location --output /tmp/kubeval.tar.gz "https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-${OS}-amd64.tar.gz"
 tar -xf /tmp/kubeval.tar.gz kubeval
 
 # validate charts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,12 +74,17 @@ jobs:
       - changed
     strategy:
       matrix:
-        # When changing versions here, check that the version exists at: https://github.com/instrumenta/kubernetes-json-schema
+        # When changing versions here, check that the version exists at:
+        # https://github.com/yannh/kubernetes-json-schema
+        # The original source at:
+        # https://github.com/instrumenta/kubernetes-json-schema is no
+        # longer updated
         k8s:
           - v1.14.10
-          - v1.16.9
-          - v1.18.4
-          - v1.22.4
+          - v1.16.15
+          - v1.18.20
+          - v1.22.12
+          - v1.24.3
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -107,7 +112,8 @@ jobs:
           - v1.14.10
           - v1.16.15
           - v1.18.20
-          - v1.22.9
+          - v1.22.12
+          - v1.24.3
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
#### What this PR does / why we need it:
Despite the note about checking for available schemas, many of the schemas being tested about do not exist at
https://kubernetesjsonschema.dev/, which is no longer updated; this could result in a false sense of confidence (because of `--ignore-missing-schemas`, I believe this will fail soft)

Update to later 1.18.x and 1.22.x variants in the matrix, add 1.24.x, and switch to the schemas at https://github.com/yannh/kubernetes-json-schema (used by `kubeconform`).

While this may seem a little strange, I haven't found a more updated / stable source to use thus far.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
