### PR TITLE
[datadog] Fix include in agent-clusterchecks-deployment tmpl

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.35.6
+
+* Fix `include` in clusterchecks deployment template.
+
 ## 2.35.5
 
 * Allow cross-DCA communication in DCA `NetworkPolicy` and `CiliumNetworkPolicy`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.35.5
+version: 2.35.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.35.5](https://img.shields.io/badge/Version-2.35.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.35.6](https://img.shields.io/badge/Version-2.35.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -216,7 +216,7 @@ spec:
 {{- if .Values.datadog.checksd }}
         - name: checksd
           configMap:
-            name: {{ include "agents.checksd-configmap-name" . }}
+            name: {{ include "datadog-checksd-configmap-name" . }}
 {{- end }}
       affinity:
 {{- if .Values.clusterChecksRunner.affinity }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes an `include` in the agent-clusterchecks-deployment template of the datadog chart.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
