### PR TITLE
Remove `container-integrations` from the code owners of `synthetics-private-location`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 charts/datadog/templates/container-system-probe.yaml @DataDog/agent-network @DataDog/container-integrations
 charts/datadog/templates/system-probe-configmap.yaml @DataDog/agent-network @DataDog/container-integrations
 charts/datadog/templates/system-probe-init.yaml      @DataDog/agent-network @DataDog/container-integrations
-charts/synthetics-private-location/*                 @Datadog/synthetics @DataDog/container-integrations
+charts/synthetics-private-location/                  @Datadog/synthetics


### PR DESCRIPTION
#### What this PR does / why we need it:

Removes `container-integrations` from the code owners of `synthetics-private-location`.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
