### PR TITLE
[operator] update tag to 0.8.1

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.3
+
+* Update chart to Datadog Operator tag `0.8.1`.
+
 ## 0.8.2
 
 * Fix comments in `values.yaml` to allow a seamless `helm-docs` update.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.8.2
-appVersion: 0.8.0
+version: 0.8.3
+appVersion: 0.8.1
 description: Datadog Operator
 keywords:
 - monitoring

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
 ## Values
 
@@ -22,7 +22,7 @@
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"0.8.0"` | Define the Datadog Operator version to use |
+| image.tag | string | `"0.8.1"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | logLevel | string | `"info"` | Set Datadog Operator log level (debug, info, error, panic, fatal) |

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -42,7 +42,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 0.8.0
+  tag: 0.8.1
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
 # imagePullSecrets -- Datadog Operator repository pullSecret (ex: specify docker registry credentials)


### PR DESCRIPTION
#### What this PR does / why we need it:

Update datadog operator tag to 0.8.1

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
