### PR TITLE
Add "tolerations" to kube-state-metrics

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.36.2
+
+* Add `tolerations` field to kube-state-metrics in values.yaml.
+
 ## 2.36.1
 
 * Add `datadog.otlp` section to configure OTLP ingest.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.36.1
+version: 2.36.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.36.1](https://img.shields.io/badge/Version-2.36.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.36.2](https://img.shields.io/badge/Version-2.36.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -750,6 +750,7 @@ helm install --name <RELEASE_NAME> \
 | kube-state-metrics.resources | object | `{}` | Resource requests and limits for the kube-state-metrics container. |
 | kube-state-metrics.serviceAccount.create | bool | `true` | If true, create ServiceAccount, require rbac kube-state-metrics.rbac.create true |
 | kube-state-metrics.serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. |
+| kube-state-metrics.tolerations | list | `[]` | Tolerations for pod assignment |
 | nameOverride | string | `nil` | Override name of app |
 | providers.eks.ec2.useHostnameFromFile | bool | `false` | Use hostname from EC2 filesystem instead of fetching from metadata endpoint. |
 | providers.gke.autopilot | bool | `false` | Enables Datadog Agent deployment on GKE Autopilot |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1646,6 +1646,11 @@ kube-state-metrics:
   nodeSelector:
     kubernetes.io/os: linux
 
+  # kube-state-metrics.tolerations -- Tolerations for pod assignment
+
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
   # # kube-state-metrics.image -- Override default image information for the kube-state-metrics container.
   # image:
   #  # kube-state-metrics.repository -- Override default image registry for the kube-state-metrics container.


### PR DESCRIPTION
#### What this PR does / why we need it:
I have added `tolerations` field to kube-state-metrics in values.yaml because it's missing.
In our env, all nodes has taints, so we need to specify some tolerations to all pods.

`tolerations` was already supported in "kube-state-metrics" of v.2.13.2. -> https://github.com/prometheus-community/helm-charts/blob/kube-state-metrics-2.13.2/charts/kube-state-metrics/values.yaml#L101

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
