### PR TITLE
[synthetics-private-location] allow custom configuration of the worker-config volume

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.14.4
 
-* Add `configVolume` to pass in a custom volume mount for the configuration directory
+* Do not default to `configFile` value for configuration to allow using `extraVolumes` to mount configuration files
 
 ### 0.14.3
 

--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+### 0.14.4
+
+* Add `configVolume` to pass in a custom volume mount for the configuration directory
+
 ### 0.14.3
 
 * Update private location image version to `1.25.0`.

--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-### 0.14.4
+### 0.15.0
 
 * Do not default to `configFile` value for configuration to allow using `extraVolumes` to mount configuration files
 

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.14.3
+version: 0.14.4
 appVersion: 1.25.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.14.4
+version: 0.15.0
 appVersion: 1.25.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -29,7 +29,6 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | configConfigMap | string | `""` | Config Map that stores the configuration of the private location worker for the deployment |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
 | configSecret | string | `""` | Secret that stores the configuration of the private location worker for the deployment |
-| configVolume | string | `{}` | Custom volume mount block for the configuration of the private location worker |
 | enableStatusProbes | bool | `false` | Enable both liveness and readiness probes (minimal private location image version required: 1.12.0) |
 | env | list | `[]` | Set environment variables |
 | envFrom | list | `[]` | Set environment variables from configMaps and/or secrets |

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.14.4](https://img.shields.io/badge/Version-0.14.4-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![AppVersion: 1.26.0](https://img.shields.io/badge/AppVersion-1.26.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.14.3](https://img.shields.io/badge/Version-0.14.3-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
+![Version: 0.14.4](https://img.shields.io/badge/Version-0.14.4-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -29,6 +29,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | configConfigMap | string | `""` | Config Map that stores the configuration of the private location worker for the deployment |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
 | configSecret | string | `""` | Secret that stores the configuration of the private location worker for the deployment |
+| configVolume | string | `{}` | Custom volume mount block for the configuration of the private location worker |
 | enableStatusProbes | bool | `false` | Enable both liveness and readiness probes (minimal private location image version required: 1.12.0) |
 | env | list | `[]` | Set environment variables |
 | envFrom | list | `[]` | Set environment variables from configMaps and/or secrets |

--- a/charts/synthetics-private-location/templates/NOTES.txt
+++ b/charts/synthetics-private-location/templates/NOTES.txt
@@ -24,5 +24,3 @@ You provided configSecret and configFile. The secret provided by configSecret ta
 
 You provided configConfigMap and configSecret. The config map provided by configConfigMap takes precedence over configSecret, so configSecret was ignored.
 {{- end }}
-
-{{- if and .Values.configConfigMap .Values.configVolume }}

--- a/charts/synthetics-private-location/templates/NOTES.txt
+++ b/charts/synthetics-private-location/templates/NOTES.txt
@@ -26,19 +26,3 @@ You provided configConfigMap and configSecret. The config map provided by config
 {{- end }}
 
 {{- if and .Values.configConfigMap .Values.configVolume }}
-
-#################################################################
-####               WARNING: Configuration notice             ####
-#################################################################
-
-You provided configConfigMap and configVolume. The config map provided by configConfigMap takes precedence over configVolume, so configVolume was ignored.
-{{- end }}
-
-{{- if and .Values.configVolume .Values.configSecret }}
-
-#################################################################
-####               WARNING: Configuration notice             ####
-#################################################################
-
-You provided configVolume and configSecret. The config map provided by configVolume takes precedence over configSecret, so configSecret was ignored.
-{{- end }}

--- a/charts/synthetics-private-location/templates/NOTES.txt
+++ b/charts/synthetics-private-location/templates/NOTES.txt
@@ -24,3 +24,21 @@ You provided configSecret and configFile. The secret provided by configSecret ta
 
 You provided configConfigMap and configSecret. The config map provided by configConfigMap takes precedence over configSecret, so configSecret was ignored.
 {{- end }}
+
+{{- if and .Values.configConfigMap .Values.configVolume }}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+You provided configConfigMap and configVolume. The config map provided by configConfigMap takes precedence over configVolume, so configVolume was ignored.
+{{- end }}
+
+{{- if and .Values.configVolume .Values.configSecret }}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+You provided configVolume and configSecret. The config map provided by configVolume takes precedence over configSecret, so configSecret was ignored.
+{{- end }}

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -50,8 +50,10 @@ spec:
               port: 8080
           {{- end }}
           volumeMounts:
+          {{- if or (.Values.configFile) (.Values.configConfigMap) (.Values.configSecret) }}
           - mountPath: /etc/datadog
             name: worker-config
+          {{- end }}
           {{- if .Values.extraVolumeMounts }}
           {{- toYaml .Values.extraVolumeMounts | nindent 10 }}
           {{- end }}
@@ -78,13 +80,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if or (.Values.configFile) (.Values.configConfigMap) (.Values.configSecret) }}
       - name: worker-config
         {{- if .Values.configConfigMap }}
         configMap:
           name: {{ tpl .Values.configConfigMap . | quote }}
-        {{- else }}
-        {{- if .Values.configVolume }}
-          {{- toYaml .Values.configVolume | nindent 10 }}
         {{- else }}
         secret:
         {{- if .Values.configSecret }}
@@ -93,7 +93,7 @@ spec:
           secretName: {{ include "synthetics-private-location.fullname" . }}-config
         {{- end }}
         {{- end }}
-        {{- end }}
+      {{- end }}
       {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               port: 8080
           {{- end }}
           volumeMounts:
-          {{- if or (.Values.configFile) (.Values.configConfigMap) (.Values.configSecret) }}
+          {{- if or (ne .Values.configFile "{}") (.Values.configConfigMap) (.Values.configSecret) }}
           - mountPath: /etc/datadog
             name: worker-config
           {{- end }}
@@ -80,7 +80,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-      {{- if or (.Values.configFile) (.Values.configConfigMap) (.Values.configSecret) }}
+      {{- if or (ne .Values.configFile "{}") (.Values.configConfigMap) (.Values.configSecret) }}
       - name: worker-config
         {{- if .Values.configConfigMap }}
         configMap:

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -83,11 +83,15 @@ spec:
         configMap:
           name: {{ tpl .Values.configConfigMap . | quote }}
         {{- else }}
+        {{- if .Values.configVolume }}
+          {{- toYaml .Values.configVolume | nindent 10 }}
+        {{- else }}
         secret:
         {{- if .Values.configSecret }}
           secretName: {{ tpl .Values.configSecret . | quote }}
         {{- else }}
           secretName: {{ include "synthetics-private-location.fullname" . }}-config
+        {{- end }}
         {{- end }}
         {{- end }}
       {{- if .Values.extraVolumes }}

--- a/charts/synthetics-private-location/templates/secret.yaml
+++ b/charts/synthetics-private-location/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.configConfigMap) (not .Values.configSecret) (not .Values.configVolume) }}
+{{- if .Values.configFile }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/synthetics-private-location/templates/secret.yaml
+++ b/charts/synthetics-private-location/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configFile }}
+{{- if ne .Values.configFile "{}" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/synthetics-private-location/templates/secret.yaml
+++ b/charts/synthetics-private-location/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.configConfigMap) (not .Values.configSecret) }}
+{{- if and (not .Values.configConfigMap) (not .Values.configSecret) (not .Values.configVolume) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +9,3 @@ data:
   synthetics-check-runner.json: {{ .Values.configFile | b64enc | quote }}
 ---
 {{- end }}
-

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -87,9 +87,6 @@ configConfigMap: ""
 # configSecret -- Secret that stores the configuration of the private location worker for the deployment
 configSecret: ""
 
-# configVolume -- Custom volume mount block for the configuration of the private location worker
-configVolume: {}
-
 # envFrom -- Set environment variables from configMaps and/or secrets
 envFrom: []
 #   - configMapRef:

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -87,6 +87,9 @@ configConfigMap: ""
 # configSecret -- Secret that stores the configuration of the private location worker for the deployment
 configSecret: ""
 
+# configVolume -- Custom volume mount block for the configuration of the private location worker
+configVolume: {}
+
 # envFrom -- Set environment variables from configMaps and/or secrets
 envFrom: []
 #   - configMapRef:


### PR DESCRIPTION
#### What this PR does / why we need it:

This allows providing a custom configuration for the config volume mount via `extraVolumes` if neither `configFile`, `configConfigMap` or `configSecret` are supplied. This is useful if for example you are using the [CSI secrets driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/usage.html).

#### Special notes for your reviewer:

Example usage:

```yaml
extraVolumes:
  - name: worker-config
    csi:
      driver: secrets-store.csi.k8s.io
      readOnly: true
      volumeAttributes:
        secretProviderClass: my-secret-provider
extraVolumeMounts:
  - name: worker-config
    mountPath: /etc/datadog
    readOnly: true
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
