### PR TITLE
Updating condition to deploy v1 or v1beta1 of CRD to work with Google marketplace

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.2
+
+* Rely on the Kubernetes version to deploy the CRD v1 or v1beta1.
+
 ## 0.5.1
 
 * Remove `preserveUnknownFields` to maintain compatibility with Kubernetes versions <1.15.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.5.1
+version: 0.5.2
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogAgents (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition") }}
+{{- if and .Values.crds.datadogAgents (semverCompare ">=21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -506,6 +506,16 @@ spec:
                             failureThreshold:
                               format: int32
                               type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
                             httpGet:
                               properties:
                                 host:
@@ -847,6 +857,16 @@ spec:
                             failureThreshold:
                               format: int32
                               type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
                             httpGet:
                               properties:
                                 host:
@@ -933,6 +953,16 @@ spec:
                             failureThreshold:
                               format: int32
                               type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
                             httpGet:
                               properties:
                                 host:
@@ -1066,6 +1096,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                hostProcess:
+                                  type: boolean
                                 runAsUserName:
                                   type: string
                               type: object
@@ -1312,6 +1344,18 @@ spec:
                                               type: string
                                             type: array
                                           dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          dataSourceRef:
                                             properties:
                                               apiGroup:
                                                 type: string
@@ -1808,6 +1852,8 @@ spec:
                           properties:
                             autoFail:
                               properties:
+                                canaryTimeout:
+                                  type: string
                                 enabled:
                                   type: boolean
                                 maxRestarts:
@@ -1863,6 +1909,11 @@ spec:
                                 - type: integer
                                 - type: string
                               x-kubernetes-int-or-string: true
+                            validationMode:
+                              enum:
+                                - auto
+                                - manual
+                              type: string
                           type: object
                         reconcileFrequency:
                           type: string
@@ -2563,6 +2614,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                hostProcess:
+                                  type: boolean
                                 runAsUserName:
                                   type: string
                               type: object
@@ -3197,6 +3250,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                hostProcess:
+                                  type: boolean
                                 runAsUserName:
                                   type: string
                               type: object
@@ -3421,6 +3476,18 @@ spec:
                                               type: string
                                             type: array
                                           dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          dataSourceRef:
                                             properties:
                                               apiGroup:
                                                 type: string
@@ -4456,6 +4523,16 @@ spec:
                             failureThreshold:
                               format: int32
                               type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
                             httpGet:
                               properties:
                                 host:
@@ -4526,6 +4603,16 @@ spec:
                             failureThreshold:
                               format: int32
                               type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
                             httpGet:
                               properties:
                                 host:
@@ -4659,6 +4746,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                hostProcess:
+                                  type: boolean
                                 runAsUserName:
                                   type: string
                               type: object
@@ -4883,6 +4972,18 @@ spec:
                                               type: string
                                             type: array
                                           dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          dataSourceRef:
                                             properties:
                                               apiGroup:
                                                 type: string
@@ -5775,7 +5876,7 @@ spec:
                               format: int32
                               type: integer
                           type: object
-                        unixDomainSocket:
+                        unixDomainSocketConfig:
                           properties:
                             enabled:
                               type: boolean
@@ -5783,21 +5884,18 @@ spec:
                               type: string
                           type: object
                       type: object
-                    clusterChecksRunner:
+                    clusterChecks:
                       properties:
                         enabled:
                           type: boolean
-                      type: object
-                    containerCollection:
-                      properties:
-                        enabled:
+                        useClusterChecksRunners:
                           type: boolean
                       type: object
                     cspm:
                       properties:
                         checkInterval:
                           type: string
-                        configDir:
+                        customBenchmarks:
                           properties:
                             items:
                               items:
@@ -5825,7 +5923,7 @@ spec:
                       type: object
                     cws:
                       properties:
-                        configDir:
+                        customPolicies:
                           properties:
                             items:
                               items:
@@ -5848,14 +5946,67 @@ spec:
                             name:
                               type: string
                           type: object
-                        enableSyscallMonitor:
-                          type: boolean
                         enabled:
+                          type: boolean
+                        syscallMonitorEnabled:
                           type: boolean
                       type: object
                     datadogMonitor:
                       properties:
                         enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        originDetectionEnabled:
+                          type: boolean
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
                           type: boolean
                       type: object
                     externalMetricsServer:
@@ -5933,6 +6084,16 @@ spec:
                         enabled:
                           type: boolean
                       type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     logCollection:
                       properties:
                         containerCollectAll:
@@ -5954,6 +6115,15 @@ spec:
                           type: string
                       type: object
                     npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
                       properties:
                         enabled:
                           type: boolean
@@ -6028,17 +6198,17 @@ spec:
                         scrubContainers:
                           type: boolean
                       type: object
-                    processCollection:
-                      properties:
-                        enabled:
-                          type: boolean
-                      type: object
                     prometheusScrape:
                       properties:
                         additionalConfigs:
                           type: string
                         enableServiceEndpoints:
                           type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    tcpQueueLength:
+                      properties:
                         enabled:
                           type: boolean
                       type: object
@@ -6050,6 +6220,8 @@ spec:
                   type: object
                 global:
                   properties:
+                    clusterAgentToken:
+                      type: string
                     clusterName:
                       type: string
                     credentials:
@@ -6076,6 +6248,98 @@ spec:
                           required:
                             - secretName
                           type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                          type: object
+                        hostCAPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
                       type: object
                     localService:
                       properties:
@@ -6119,6 +6383,14 @@ spec:
                         flavor:
                           type: string
                       type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
                     registry:
                       type: string
                     site:
@@ -6132,1470 +6404,1840 @@ spec:
                 override:
                   additionalProperties:
                     properties:
-                      name:
-                        type: string
-                      podOverride:
+                      affinity:
                         properties:
-                          affinity:
+                          nodeAffinity:
                             properties:
-                              nodeAffinity:
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        preference:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchFields:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                          type: object
-                                        weight:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                        - preference
-                                        - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    properties:
-                                      nodeSelectorTerms:
-                                        items:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchFields:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                          type: object
-                                        type: array
-                                    required:
-                                      - nodeSelectorTerms
-                                    type: object
-                                type: object
-                              podAffinity:
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        podAffinityTerm:
-                                          properties:
-                                            labelSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                      - key
-                                                      - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            namespaceSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                      - key
-                                                      - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            namespaces:
-                                              items:
-                                                type: string
-                                              type: array
-                                            topologyKey:
-                                              type: string
-                                          required:
-                                            - topologyKey
-                                          type: object
-                                        weight:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                        - podAffinityTerm
-                                        - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaceSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                        - topologyKey
-                                      type: object
-                                    type: array
-                                type: object
-                              podAntiAffinity:
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        podAffinityTerm:
-                                          properties:
-                                            labelSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                      - key
-                                                      - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            namespaceSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                      - key
-                                                      - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            namespaces:
-                                              items:
-                                                type: string
-                                              type: array
-                                            topologyKey:
-                                              type: string
-                                          required:
-                                            - topologyKey
-                                          type: object
-                                        weight:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                        - podAffinityTerm
-                                        - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaceSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                        - topologyKey
-                                      type: object
-                                    type: array
-                                type: object
-                            type: object
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          containers:
-                            items:
-                              properties:
-                                args:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                command:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                env:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                      valueFrom:
-                                        properties:
-                                          configMapKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                              - key
-                                            type: object
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                              - fieldPath
-                                            type: object
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                type: string
-                                            required:
-                                              - resource
-                                            type: object
-                                          secretKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                              - key
-                                            type: object
-                                        type: object
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                healthPort:
-                                  format: int32
-                                  type: integer
-                                livenessProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                              - name
-                                              - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                        - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                        - port
-                                      type: object
-                                    terminationGracePeriodSeconds:
-                                      format: int64
-                                      type: integer
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                name:
-                                  type: string
-                                readinessProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                              - name
-                                              - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                        - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                        - port
-                                      type: object
-                                    terminationGracePeriodSeconds:
-                                      format: int64
-                                      type: integer
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                resources:
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                  type: object
-                                volumeMounts:
-                                  items:
-                                    properties:
-                                      mountPath:
-                                        type: string
-                                      mountPropagation:
-                                        type: string
-                                      name:
-                                        type: string
-                                      readOnly:
-                                        type: boolean
-                                      subPath:
-                                        type: string
-                                      subPathExpr:
-                                        type: string
-                                    required:
-                                      - mountPath
-                                      - name
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                    - mountPath
-                                  x-kubernetes-list-type: map
-                              type: object
-                            type: array
-                          image:
-                            properties:
-                              jmxEnabled:
-                                type: boolean
-                              name:
-                                type: string
-                              pullPolicy:
-                                type: string
-                              pullSecrets:
+                              preferredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
-                                    name:
-                                      type: string
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
                                   type: object
                                 type: array
-                              tag:
-                                type: string
-                            type: object
-                          kubelet:
-                            properties:
-                              agentCAPath:
-                                type: string
-                              host:
+                              requiredDuringSchedulingIgnoredDuringExecution:
                                 properties:
-                                  configMapKeyRef:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                              hostCAPath:
-                                type: string
-                              tlsVerify:
-                                type: boolean
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          priorityClassName:
-                            type: string
-                          securityContext:
-                            properties:
-                              fsGroup:
-                                format: int64
-                                type: integer
-                              fsGroupChangePolicy:
-                                type: string
-                              runAsGroup:
-                                format: int64
-                                type: integer
-                              runAsNonRoot:
-                                type: boolean
-                              runAsUser:
-                                format: int64
-                                type: integer
-                              seLinuxOptions:
-                                properties:
-                                  level:
-                                    type: string
-                                  role:
-                                    type: string
-                                  type:
-                                    type: string
-                                  user:
-                                    type: string
-                                type: object
-                              seccompProfile:
-                                properties:
-                                  localhostProfile:
-                                    type: string
-                                  type:
-                                    type: string
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
                                 required:
-                                  - type
-                                type: object
-                              supplementalGroups:
-                                items:
-                                  format: int64
-                                  type: integer
-                                type: array
-                              sysctls:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              windowsOptions:
-                                properties:
-                                  gmsaCredentialSpec:
-                                    type: string
-                                  gmsaCredentialSpecName:
-                                    type: string
-                                  runAsUserName:
-                                    type: string
+                                  - nodeSelectorTerms
                                 type: object
                             type: object
-                          tolerations:
-                            items:
-                              properties:
-                                effect:
-                                  type: string
-                                key:
-                                  type: string
-                                operator:
-                                  type: string
-                                tolerationSeconds:
-                                  format: int64
-                                  type: integer
-                                value:
-                                  type: string
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          volumes:
-                            items:
-                              properties:
-                                awsElasticBlockStore:
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
                                   properties:
-                                    fsType:
-                                      type: string
-                                    partition:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
                                       format: int32
                                       type: integer
-                                    readOnly:
-                                      type: boolean
-                                    volumeID:
-                                      type: string
                                   required:
-                                    - volumeID
+                                    - podAffinityTerm
+                                    - weight
                                   type: object
-                                azureDisk:
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
                                   properties:
-                                    cachingMode:
-                                      type: string
-                                    diskName:
-                                      type: string
-                                    diskURI:
-                                      type: string
-                                    fsType:
-                                      type: string
-                                    kind:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                  required:
-                                    - diskName
-                                    - diskURI
-                                  type: object
-                                azureFile:
-                                  properties:
-                                    readOnly:
-                                      type: boolean
-                                    secretName:
-                                      type: string
-                                    shareName:
-                                      type: string
-                                  required:
-                                    - secretName
-                                    - shareName
-                                  type: object
-                                cephfs:
-                                  properties:
-                                    monitors:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
                                       items:
                                         type: string
                                       type: array
-                                    path:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretFile:
-                                      type: string
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    user:
+                                    topologyKey:
                                       type: string
                                   required:
-                                    - monitors
+                                    - topologyKey
                                   type: object
-                                cinder:
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
                                   properties:
-                                    fsType:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
+                                    podAffinityTerm:
                                       properties:
-                                        name:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
                                           type: string
+                                      required:
+                                        - topologyKey
                                       type: object
-                                    volumeID:
-                                      type: string
-                                  required:
-                                    - volumeID
-                                  type: object
-                                configMap:
-                                  properties:
-                                    defaultMode:
+                                    weight:
                                       format: int32
                                       type: integer
-                                    items:
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
                                       items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
                                         properties:
                                           key:
                                             type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
+                                          name:
                                             type: string
+                                          optional:
+                                            type: boolean
                                         required:
                                           - key
-                                          - path
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
                                         type: object
                                       type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
                                     name:
                                       type: string
                                     optional:
                                       type: boolean
-                                  type: object
-                                csi:
-                                  properties:
-                                    driver:
-                                      type: string
-                                    fsType:
-                                      type: string
-                                    nodePublishSecretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    readOnly:
-                                      type: boolean
-                                    volumeAttributes:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
                                   required:
-                                    - driver
+                                    - key
                                   type: object
-                                downwardAPI:
+                                fieldRef:
                                   properties:
-                                    defaultMode:
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      items:
-                                        properties:
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                              - fieldPath
-                                            type: object
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                type: string
-                                            required:
-                                              - resource
-                                            type: object
-                                        required:
-                                          - path
-                                        type: object
-                                      type: array
-                                  type: object
-                                emptyDir:
-                                  properties:
-                                    medium:
+                                    apiVersion:
                                       type: string
-                                    sizeLimit:
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
                                       anyOf:
                                         - type: integer
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                  type: object
-                                ephemeral:
-                                  properties:
-                                    volumeClaimTemplate:
-                                      properties:
-                                        metadata:
-                                          type: object
-                                        spec:
-                                          properties:
-                                            accessModes:
-                                              items:
-                                                type: string
-                                              type: array
-                                            dataSource:
-                                              properties:
-                                                apiGroup:
-                                                  type: string
-                                                kind:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                              required:
-                                                - kind
-                                                - name
-                                              type: object
-                                            resources:
-                                              properties:
-                                                limits:
-                                                  additionalProperties:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
-                                                  type: object
-                                                requests:
-                                                  additionalProperties:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
-                                                  type: object
-                                              type: object
-                                            selector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                      - key
-                                                      - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            storageClassName:
-                                              type: string
-                                            volumeMode:
-                                              type: string
-                                            volumeName:
-                                              type: string
-                                          type: object
-                                      required:
-                                        - spec
-                                      type: object
-                                  type: object
-                                fc:
-                                  properties:
-                                    fsType:
+                                    resource:
                                       type: string
-                                    lun:
+                                  required:
+                                    - resource
+                                  type: object
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      extraChecksd:
+                        properties:
+                          configData:
+                            type: string
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
                                       format: int32
                                       type: integer
-                                    readOnly:
-                                      type: boolean
-                                    targetWWNs:
-                                      items:
-                                        type: string
-                                      type: array
-                                    wwids:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                flexVolume:
-                                  properties:
-                                    driver:
-                                      type: string
-                                    fsType:
-                                      type: string
-                                    options:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                  required:
-                                    - driver
-                                  type: object
-                                flocker:
-                                  properties:
-                                    datasetName:
-                                      type: string
-                                    datasetUUID:
-                                      type: string
-                                  type: object
-                                gcePersistentDisk:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    partition:
-                                      format: int32
-                                      type: integer
-                                    pdName:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                  required:
-                                    - pdName
-                                  type: object
-                                gitRepo:
-                                  properties:
-                                    directory:
-                                      type: string
-                                    repository:
-                                      type: string
-                                    revision:
-                                      type: string
-                                  required:
-                                    - repository
-                                  type: object
-                                glusterfs:
-                                  properties:
-                                    endpoints:
-                                      type: string
                                     path:
                                       type: string
-                                    readOnly:
-                                      type: boolean
                                   required:
-                                    - endpoints
+                                    - key
                                     - path
                                   type: object
-                                hostPath:
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configData:
+                            type: string
+                          configMap:
+                            properties:
+                              items:
+                                items:
                                   properties:
-                                    path:
+                                    key:
                                       type: string
-                                    type:
-                                      type: string
-                                  required:
-                                    - path
-                                  type: object
-                                iscsi:
-                                  properties:
-                                    chapAuthDiscovery:
-                                      type: boolean
-                                    chapAuthSession:
-                                      type: boolean
-                                    fsType:
-                                      type: string
-                                    initiatorName:
-                                      type: string
-                                    iqn:
-                                      type: string
-                                    iscsiInterface:
-                                      type: string
-                                    lun:
+                                    mode:
                                       format: int32
                                       type: integer
-                                    portals:
-                                      items:
-                                        type: string
-                                      type: array
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    targetPortal:
+                                    path:
                                       type: string
                                   required:
-                                    - iqn
-                                    - lun
-                                    - targetPortal
+                                    - key
+                                    - path
                                   type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
                                 name:
                                   type: string
-                                nfs:
+                              type: object
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      secCompCustomProfile:
+                        properties:
+                          configData:
+                            type: string
+                          configMap:
+                            properties:
+                              items:
+                                items:
                                   properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
                                     path:
                                       type: string
-                                    readOnly:
-                                      type: boolean
-                                    server:
-                                      type: string
                                   required:
+                                    - key
                                     - path
-                                    - server
                                   type: object
-                                persistentVolumeClaim:
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      secCompProfileName:
+                        type: string
+                      secCompRootPath:
+                        type: string
+                      securityContext:
+                        properties:
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
                                   properties:
-                                    claimName:
+                                    name:
                                       type: string
-                                    readOnly:
-                                      type: boolean
-                                  required:
-                                    - claimName
                                   type: object
-                                photonPersistentDisk:
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
                                   properties:
-                                    fsType:
+                                    name:
                                       type: string
-                                    pdID:
-                                      type: string
-                                  required:
-                                    - pdID
                                   type: object
-                                portworxVolume:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    volumeID:
-                                      type: string
-                                  required:
-                                    - volumeID
-                                  type: object
-                                projected:
-                                  properties:
-                                    defaultMode:
-                                      format: int32
-                                      type: integer
-                                    sources:
-                                      items:
-                                        properties:
-                                          configMap:
-                                            properties:
-                                              items:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    mode:
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      type: string
-                                                  required:
-                                                    - key
-                                                    - path
-                                                  type: object
-                                                type: array
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            type: object
-                                          downwardAPI:
-                                            properties:
-                                              items:
-                                                items:
-                                                  properties:
-                                                    fieldRef:
-                                                      properties:
-                                                        apiVersion:
-                                                          type: string
-                                                        fieldPath:
-                                                          type: string
-                                                      required:
-                                                        - fieldPath
-                                                      type: object
-                                                    mode:
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      type: string
-                                                    resourceFieldRef:
-                                                      properties:
-                                                        containerName:
-                                                          type: string
-                                                        divisor:
-                                                          anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                          x-kubernetes-int-or-string: true
-                                                        resource:
-                                                          type: string
-                                                      required:
-                                                        - resource
-                                                      type: object
-                                                  required:
-                                                    - path
-                                                  type: object
-                                                type: array
-                                            type: object
-                                          secret:
-                                            properties:
-                                              items:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    mode:
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      type: string
-                                                  required:
-                                                    - key
-                                                    - path
-                                                  type: object
-                                                type: array
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            type: object
-                                          serviceAccountToken:
-                                            properties:
-                                              audience:
-                                                type: string
-                                              expirationSeconds:
-                                                format: int64
-                                                type: integer
-                                              path:
-                                                type: string
-                                            required:
-                                              - path
-                                            type: object
-                                        type: object
-                                      type: array
-                                  type: object
-                                quobyte:
-                                  properties:
-                                    group:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    registry:
-                                      type: string
-                                    tenant:
-                                      type: string
-                                    user:
-                                      type: string
-                                    volume:
-                                      type: string
-                                  required:
-                                    - registry
-                                    - volume
-                                  type: object
-                                rbd:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    image:
-                                      type: string
-                                    keyring:
-                                      type: string
-                                    monitors:
-                                      items:
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
                                         type: string
-                                      type: array
-                                    pool:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    user:
-                                      type: string
-                                  required:
-                                    - image
-                                    - monitors
-                                  type: object
-                                scaleIO:
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
                                   properties:
-                                    fsType:
+                                    name:
                                       type: string
-                                    gateway:
-                                      type: string
-                                    protectionDomain:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    sslEnabled:
-                                      type: boolean
-                                    storageMode:
-                                      type: string
-                                    storagePool:
-                                      type: string
-                                    system:
-                                      type: string
-                                    volumeName:
-                                      type: string
-                                  required:
-                                    - gateway
-                                    - secretRef
-                                    - system
                                   type: object
-                                secret:
-                                  properties:
-                                    defaultMode:
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      items:
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
                                         properties:
-                                          key:
+                                          apiVersion:
                                             type: string
-                                          mode:
-                                            format: int32
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
                                             type: integer
                                           path:
                                             type: string
                                         required:
-                                          - key
                                           - path
                                         type: object
-                                      type: array
-                                    optional:
-                                      type: boolean
-                                    secretName:
-                                      type: string
-                                  type: object
-                                storageos:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    volumeName:
-                                      type: string
-                                    volumeNamespace:
-                                      type: string
-                                  type: object
-                                vsphereVolume:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    storagePolicyID:
-                                      type: string
-                                    storagePolicyName:
-                                      type: string
-                                    volumePath:
-                                      type: string
-                                  required:
-                                    - volumePath
-                                  type: object
-                              required:
-                                - name
+                                    type: object
+                                  type: array
                               type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                              - name
-                            x-kubernetes-list-type: map
-                        type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                user:
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                     type: object
                   type: object
               type: object
             status:
               properties:
-                defaultOverride:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
                   type: object
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
               type: object
           type: object
       served: false

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogAgents (not (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition")) }}
+{{- if and .Values.crds.datadogAgents (semverCompare "<21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -12,6 +12,22 @@ metadata:
     app.kubernetes.io/name: '{{ include "datadog-crds.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'
 spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[?(@.type=='Active')].status
+      name: active
+      type: string
+    - JSONPath: .status.agent.status
+      name: agent
+      type: string
+    - JSONPath: .status.clusterAgent.status
+      name: cluster-agent
+      type: string
+    - JSONPath: .status.clusterChecksRunner.status
+      name: cluster-checks-runner
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
   group: datadoghq.com
   names:
     kind: DatadogAgent
@@ -21,391 +37,1937 @@ spec:
       - dd
     singular: datadogagent
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
           properties:
-            agent:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
               properties:
-                additionalAnnotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                additionalLabels:
-                  additionalProperties:
-                    type: string
-                  type: object
-                affinity:
+                agent:
                   properties:
-                    nodeAffinity:
+                    additionalAnnotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    additionalLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    affinity:
                       properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              preference:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
+                        nodeAffinity:
                           properties:
-                            nodeSelectorTerms:
+                            preferredDuringSchedulingIgnoredDuringExecution:
                               items:
                                 properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
                                 type: object
                               type: array
-                          required:
-                            - nodeSelectorTerms
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
                           type: object
                       type: object
-                    podAffinity:
+                    apm:
                       properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        command:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        enabled:
+                          type: boolean
+                        env:
                           items:
                             properties:
-                              podAffinityTerm:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
                                 properties:
-                                  labelSelector:
+                                  configMapKeyRef:
                                     properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
                                     type: object
-                                  namespaceSelector:
+                                  fieldRef:
                                     properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
                                     type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                  - topologyKey
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
                                 type: object
-                              weight:
-                                format: int32
-                                type: integer
                             required:
-                              - podAffinityTerm
-                              - weight
+                              - name
                             type: object
                           type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        hostPort:
+                          format: int32
+                          type: integer
+                        livenessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        unixDomainSocket:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostFilepath:
+                              type: string
+                          type: object
+                        volumeMounts:
                           items:
                             properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaceSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
                                 type: string
                             required:
-                              - topologyKey
+                              - mountPath
+                              - name
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                            - mountPath
+                          x-kubernetes-list-type: map
                       type: object
-                    podAntiAffinity:
+                    config:
                       properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
+                        args:
                           items:
-                            properties:
-                              podAffinityTerm:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        checksd:
+                          properties:
+                            configMapName:
+                              type: string
+                            items:
+                              items:
                                 properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
+                                  key:
+                                    type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
                                     type: string
                                 required:
-                                  - topologyKey
+                                  - key
+                                  - path
                                 type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - key
+                              x-kubernetes-list-type: map
+                          type: object
+                        collectEvents:
+                          type: boolean
+                        command:
+                          items:
+                            type: string
                           type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
+                          x-kubernetes-list-type: atomic
+                        confd:
+                          properties:
+                            configMapName:
+                              type: string
+                            items:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - key
+                              x-kubernetes-list-type: map
+                          type: object
+                        criSocket:
+                          properties:
+                            criSocketPath:
+                              type: string
+                            dockerSocketPath:
+                              type: string
+                          type: object
+                        ddUrl:
+                          type: string
+                        dogstatsd:
+                          properties:
+                            dogstatsdOriginDetection:
+                              type: boolean
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    fileKey:
+                                      type: string
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            unixDomainSocket:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostFilepath:
+                                  type: string
+                              type: object
+                          type: object
+                        env:
                           items:
                             properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaceSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
+                              name:
                                 type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
                             required:
-                              - topologyKey
+                              - name
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        healthPort:
+                          format: int32
+                          type: integer
+                        hostPort:
+                          format: int32
+                          type: integer
+                        kubelet:
+                          properties:
+                            agentCAPath:
+                              type: string
+                            host:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                              type: object
+                            hostCAPath:
+                              type: string
+                            tlsVerify:
+                              type: boolean
+                          type: object
+                        leaderElection:
+                          type: boolean
+                        livenessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        logLevel:
+                          type: string
+                        namespaceLabelsAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        nodeLabelsAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        podAnnotationsAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        podLabelsAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        readinessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        securityContext:
+                          properties:
+                            fsGroup:
+                              format: int64
+                              type: integer
+                            fsGroupChangePolicy:
+                              type: string
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - type
+                              type: object
+                            supplementalGroups:
+                              items:
+                                format: int64
+                                type: integer
+                              type: array
+                            sysctls:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                hostProcess:
+                                  type: boolean
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        tags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                            - mountPath
+                          x-kubernetes-list-type: map
+                        volumes:
+                          items:
+                            properties:
+                              awsElasticBlockStore:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              azureDisk:
+                                properties:
+                                  cachingMode:
+                                    type: string
+                                  diskName:
+                                    type: string
+                                  diskURI:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - diskName
+                                  - diskURI
+                                type: object
+                              azureFile:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                  shareName:
+                                    type: string
+                                required:
+                                  - secretName
+                                  - shareName
+                                type: object
+                              cephfs:
+                                properties:
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretFile:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                  - monitors
+                                type: object
+                              cinder:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeID:
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              configMap:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              csi:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  nodePublishSecretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                required:
+                                  - driver
+                                type: object
+                              downwardAPI:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                      required:
+                                        - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                properties:
+                                  medium:
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                properties:
+                                  volumeClaimTemplate:
+                                    properties:
+                                      metadata:
+                                        type: object
+                                      spec:
+                                        properties:
+                                          accessModes:
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          dataSourceRef:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          resources:
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          selector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          storageClassName:
+                                            type: string
+                                          volumeMode:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        type: object
+                                    required:
+                                      - spec
+                                    type: object
+                                type: object
+                              fc:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  targetWWNs:
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                required:
+                                  - driver
+                                type: object
+                              flocker:
+                                properties:
+                                  datasetName:
+                                    type: string
+                                  datasetUUID:
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - pdName
+                                type: object
+                              gitRepo:
+                                properties:
+                                  directory:
+                                    type: string
+                                  repository:
+                                    type: string
+                                  revision:
+                                    type: string
+                                required:
+                                  - repository
+                                type: object
+                              glusterfs:
+                                properties:
+                                  endpoints:
+                                    type: string
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - endpoints
+                                  - path
+                                type: object
+                              hostPath:
+                                properties:
+                                  path:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                  - path
+                                type: object
+                              iscsi:
+                                properties:
+                                  chapAuthDiscovery:
+                                    type: boolean
+                                  chapAuthSession:
+                                    type: boolean
+                                  fsType:
+                                    type: string
+                                  initiatorName:
+                                    type: string
+                                  iqn:
+                                    type: string
+                                  iscsiInterface:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  targetPortal:
+                                    type: string
+                                required:
+                                  - iqn
+                                  - lun
+                                  - targetPortal
+                                type: object
+                              name:
+                                type: string
+                              nfs:
+                                properties:
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  server:
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
+                              persistentVolumeClaim:
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - claimName
+                                type: object
+                              photonPersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  pdID:
+                                    type: string
+                                required:
+                                  - pdID
+                                type: object
+                              portworxVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              projected:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    items:
+                                      properties:
+                                        configMap:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                  - key
+                                                  - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                      - fieldPath
+                                                    type: object
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                      - resource
+                                                    type: object
+                                                required:
+                                                  - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                  - key
+                                                  - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        serviceAccountToken:
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                            - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                type: object
+                              quobyte:
+                                properties:
+                                  group:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  registry:
+                                    type: string
+                                  tenant:
+                                    type: string
+                                  user:
+                                    type: string
+                                  volume:
+                                    type: string
+                                required:
+                                  - registry
+                                  - volume
+                                type: object
+                              rbd:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  image:
+                                    type: string
+                                  keyring:
+                                    type: string
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                  - image
+                                  - monitors
+                                type: object
+                              scaleIO:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  gateway:
+                                    type: string
+                                  protectionDomain:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  sslEnabled:
+                                    type: boolean
+                                  storageMode:
+                                    type: string
+                                  storagePool:
+                                    type: string
+                                  system:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - gateway
+                                  - secretRef
+                                  - system
+                                type: object
+                              secret:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                type: object
+                              storageos:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeName:
+                                    type: string
+                                  volumeNamespace:
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  storagePolicyID:
+                                    type: string
+                                  storagePolicyName:
+                                    type: string
+                                  volumePath:
+                                    type: string
+                                required:
+                                  - volumePath
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
                       type: object
-                  type: object
-                apm:
-                  properties:
-                    args:
-                      items:
-                        type: string
-                      type: array
-                    command:
-                      items:
-                        type: string
-                      type: array
+                    customConfig:
+                      properties:
+                        configData:
+                          type: string
+                        configMap:
+                          properties:
+                            fileKey:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                      type: object
+                    daemonsetName:
+                      type: string
+                    deploymentStrategy:
+                      properties:
+                        canary:
+                          properties:
+                            autoFail:
+                              properties:
+                                canaryTimeout:
+                                  type: string
+                                enabled:
+                                  type: boolean
+                                maxRestarts:
+                                  format: int32
+                                  type: integer
+                                maxRestartsDuration:
+                                  type: string
+                              type: object
+                            autoPause:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                maxRestarts:
+                                  format: int32
+                                  type: integer
+                                maxSlowStartDuration:
+                                  type: string
+                              type: object
+                            duration:
+                              type: string
+                            noRestartsDuration:
+                              type: string
+                            nodeAntiAffinityKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            nodeSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            replicas:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            validationMode:
+                              enum:
+                                - auto
+                                - manual
+                              type: string
+                          type: object
+                        reconcileFrequency:
+                          type: string
+                        rollingUpdate:
+                          properties:
+                            maxParallelPodCreation:
+                              format: int32
+                              type: integer
+                            maxPodSchedulerFailure:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            slowStartAdditiveIncrease:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            slowStartIntervalDuration:
+                              type: string
+                          type: object
+                        updateStrategyType:
+                          type: string
+                      type: object
+                    dnsConfig:
+                      properties:
+                        nameservers:
+                          items:
+                            type: string
+                          type: array
+                        options:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        searches:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    dnsPolicy:
+                      type: string
                     enabled:
                       type: boolean
                     env:
@@ -446,6 +2008,7 @@ spec:
                                       - type: integer
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                   resource:
                                     type: string
                                 required:
@@ -467,186 +2030,430 @@ spec:
                           - name
                         type: object
                       type: array
-                    hostPort:
-                      format: int32
-                      type: integer
-                    livenessProbe:
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    hostNetwork:
+                      type: boolean
+                    hostPID:
+                      type: boolean
+                    image:
                       properties:
-                        exec:
-                          properties:
-                            command:
-                              items:
+                        jmxEnabled:
+                          type: boolean
+                        name:
+                          type: string
+                        pullPolicy:
+                          type: string
+                        pullSecrets:
+                          items:
+                            properties:
+                              name:
                                 type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          format: int32
-                          type: integer
-                        httpGet:
-                          properties:
-                            host:
-                              type: string
-                            httpHeaders:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                            scheme:
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          properties:
-                            host:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          format: int32
-                          type: integer
+                            type: object
+                          type: array
+                        tag:
+                          type: string
                       type: object
-                    resources:
+                    keepAnnotations:
+                      type: string
+                    keepLabels:
+                      type: string
+                    localService:
                       properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
+                        forceLocalServiceEnable:
+                          type: boolean
+                        overrideName:
+                          type: string
                       type: object
-                    unixDomainSocket:
+                    log:
                       properties:
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
                         enabled:
                           type: boolean
-                        hostFilepath:
-                          type: string
-                      type: object
-                    volumeMounts:
-                      items:
-                        properties:
-                          mountPath:
-                            type: string
-                          mountPropagation:
-                            type: string
-                          name:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          subPath:
-                            type: string
-                          subPathExpr:
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                config:
-                  properties:
-                    args:
-                      items:
-                        type: string
-                      type: array
-                    checksd:
-                      properties:
-                        configMapName:
-                          type: string
-                        items:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                            required:
-                              - key
-                              - path
-                            type: object
-                          type: array
-                      type: object
-                    collectEvents:
-                      type: boolean
-                    command:
-                      items:
-                        type: string
-                      type: array
-                    confd:
-                      properties:
-                        configMapName:
-                          type: string
-                        items:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                            required:
-                              - key
-                              - path
-                            type: object
-                          type: array
-                      type: object
-                    criSocket:
-                      properties:
-                        criSocketPath:
-                          type: string
-                        dockerSocketPath:
-                          type: string
-                      type: object
-                    ddUrl:
-                      type: string
-                    dogstatsd:
-                      properties:
-                        dogstatsdOriginDetection:
+                        logsConfigContainerCollectAll:
                           type: boolean
-                        mapperProfiles:
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    priorityClassName:
+                      type: string
+                    process:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        command:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        enabled:
+                          type: boolean
+                        env:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        processCollectionEnabled:
+                          type: boolean
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                            - mountPath
+                          x-kubernetes-list-type: map
+                      type: object
+                    rbac:
+                      properties:
+                        create:
+                          type: boolean
+                        serviceAccountName:
+                          type: string
+                      type: object
+                    security:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        command:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        compliance:
+                          properties:
+                            checkInterval:
+                              type: string
+                            configDir:
+                              properties:
+                                configMapName:
+                                  type: string
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        env:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        runtime:
+                          properties:
+                            enabled:
+                              type: boolean
+                            policiesDir:
+                              properties:
+                                configMapName:
+                                  type: string
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                              type: object
+                            syscallMonitor:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                            - mountPath
+                          x-kubernetes-list-type: map
+                      type: object
+                    systemProbe:
+                      properties:
+                        appArmorProfileName:
+                          type: string
+                        args:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        bpfDebugEnabled:
+                          type: boolean
+                        collectDNSStats:
+                          type: boolean
+                        command:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        conntrackEnabled:
+                          type: boolean
+                        customConfig:
                           properties:
                             configData:
                               type: string
@@ -658,79 +2465,3809 @@ spec:
                                   type: string
                               type: object
                           type: object
-                        unixDomainSocket:
+                        debugPort:
+                          format: int32
+                          type: integer
+                        enableOOMKill:
+                          type: boolean
+                        enableTCPQueueLength:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        env:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        resources:
                           properties:
-                            enabled:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        secCompCustomProfileConfigMap:
+                          type: string
+                        secCompProfileName:
+                          type: string
+                        secCompRootPath:
+                          type: string
+                        securityContext:
+                          properties:
+                            allowPrivilegeEscalation:
                               type: boolean
-                            hostFilepath:
+                            capabilities:
+                              properties:
+                                add:
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              type: boolean
+                            procMount:
                               type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - type
+                              type: object
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                hostProcess:
+                                  type: boolean
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                            - mountPath
+                          x-kubernetes-list-type: map
+                      type: object
+                    useExtendedDaemonset:
+                      type: boolean
+                  type: object
+                clusterAgent:
+                  properties:
+                    additionalAnnotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    additionalLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    affinity:
+                      properties:
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
                           type: object
                       type: object
-                    env:
-                      items:
-                        properties:
-                          name:
+                    config:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            enabled:
+                              type: boolean
+                            mutateUnlabelled:
+                              type: boolean
+                            serviceName:
+                              type: string
+                          type: object
+                        args:
+                          items:
                             type: string
-                          value:
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        clusterChecksEnabled:
+                          type: boolean
+                        collectEvents:
+                          type: boolean
+                        command:
+                          items:
                             type: string
-                          valueFrom:
-                            properties:
-                              configMapKeyRef:
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        confd:
+                          properties:
+                            configMapName:
+                              type: string
+                            items:
+                              items:
                                 properties:
                                   key:
                                     type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - key
+                              x-kubernetes-list-type: map
+                          type: object
+                        env:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        externalMetrics:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiKeyExistingSecret:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appKeyExistingSecret:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              type: string
+                            port:
+                              format: int32
+                              type: integer
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        healthPort:
+                          format: int32
+                          type: integer
+                        logLevel:
+                          type: string
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        securityContext:
+                          properties:
+                            fsGroup:
+                              format: int64
+                              type: integer
+                            fsGroupChangePolicy:
+                              type: string
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - type
+                              type: object
+                            supplementalGroups:
+                              items:
+                                format: int64
+                                type: integer
+                              type: array
+                            sysctls:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                hostProcess:
+                                  type: boolean
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                            - mountPath
+                          x-kubernetes-list-type: map
+                        volumes:
+                          items:
+                            properties:
+                              awsElasticBlockStore:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              azureDisk:
+                                properties:
+                                  cachingMode:
+                                    type: string
+                                  diskName:
+                                    type: string
+                                  diskURI:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - diskName
+                                  - diskURI
+                                type: object
+                              azureFile:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                  shareName:
+                                    type: string
+                                required:
+                                  - secretName
+                                  - shareName
+                                type: object
+                              cephfs:
+                                properties:
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretFile:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                  - monitors
+                                type: object
+                              cinder:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeID:
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              configMap:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                      type: object
+                                    type: array
                                   name:
                                     type: string
                                   optional:
                                     type: boolean
-                                required:
-                                  - key
                                 type: object
-                              fieldRef:
+                              csi:
                                 properties:
-                                  apiVersion:
+                                  driver:
                                     type: string
-                                  fieldPath:
+                                  fsType:
                                     type: string
+                                  nodePublishSecretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 required:
-                                  - fieldPath
+                                  - driver
                                 type: object
-                              resourceFieldRef:
+                              downwardAPI:
                                 properties:
-                                  containerName:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                      required:
+                                        - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                properties:
+                                  medium:
                                     type: string
-                                  divisor:
+                                  sizeLimit:
                                     anyOf:
                                       - type: integer
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  resource:
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                properties:
+                                  volumeClaimTemplate:
+                                    properties:
+                                      metadata:
+                                        type: object
+                                      spec:
+                                        properties:
+                                          accessModes:
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          dataSourceRef:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          resources:
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          selector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          storageClassName:
+                                            type: string
+                                          volumeMode:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        type: object
+                                    required:
+                                      - spec
+                                    type: object
+                                type: object
+                              fc:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  targetWWNs:
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                required:
+                                  - driver
+                                type: object
+                              flocker:
+                                properties:
+                                  datasetName:
+                                    type: string
+                                  datasetUUID:
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - pdName
+                                type: object
+                              gitRepo:
+                                properties:
+                                  directory:
+                                    type: string
+                                  repository:
+                                    type: string
+                                  revision:
                                     type: string
                                 required:
-                                  - resource
+                                  - repository
                                 type: object
-                              secretKeyRef:
+                              glusterfs:
                                 properties:
-                                  key:
+                                  endpoints:
                                     type: string
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - endpoints
+                                  - path
+                                type: object
+                              hostPath:
+                                properties:
+                                  path:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                  - path
+                                type: object
+                              iscsi:
+                                properties:
+                                  chapAuthDiscovery:
+                                    type: boolean
+                                  chapAuthSession:
+                                    type: boolean
+                                  fsType:
+                                    type: string
+                                  initiatorName:
+                                    type: string
+                                  iqn:
+                                    type: string
+                                  iscsiInterface:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  targetPortal:
+                                    type: string
+                                required:
+                                  - iqn
+                                  - lun
+                                  - targetPortal
+                                type: object
+                              name:
+                                type: string
+                              nfs:
+                                properties:
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  server:
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
+                              persistentVolumeClaim:
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - claimName
+                                type: object
+                              photonPersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  pdID:
+                                    type: string
+                                required:
+                                  - pdID
+                                type: object
+                              portworxVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              projected:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    items:
+                                      properties:
+                                        configMap:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                  - key
+                                                  - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                      - fieldPath
+                                                    type: object
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                      - resource
+                                                    type: object
+                                                required:
+                                                  - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                  - key
+                                                  - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        serviceAccountToken:
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                            - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                type: object
+                              quobyte:
+                                properties:
+                                  group:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  registry:
+                                    type: string
+                                  tenant:
+                                    type: string
+                                  user:
+                                    type: string
+                                  volume:
+                                    type: string
+                                required:
+                                  - registry
+                                  - volume
+                                type: object
+                              rbd:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  image:
+                                    type: string
+                                  keyring:
+                                    type: string
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                  - image
+                                  - monitors
+                                type: object
+                              scaleIO:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  gateway:
+                                    type: string
+                                  protectionDomain:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  sslEnabled:
+                                    type: boolean
+                                  storageMode:
+                                    type: string
+                                  storagePool:
+                                    type: string
+                                  system:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - gateway
+                                  - secretRef
+                                  - system
+                                type: object
+                              secret:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                type: object
+                              storageos:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeName:
+                                    type: string
+                                  volumeNamespace:
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  storagePolicyID:
+                                    type: string
+                                  storagePolicyName:
+                                    type: string
+                                  volumePath:
+                                    type: string
+                                required:
+                                  - volumePath
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    customConfig:
+                      properties:
+                        configData:
+                          type: string
+                        configMap:
+                          properties:
+                            fileKey:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                      type: object
+                    deploymentName:
+                      type: string
+                    enabled:
+                      type: boolean
+                    image:
+                      properties:
+                        jmxEnabled:
+                          type: boolean
+                        name:
+                          type: string
+                        pullPolicy:
+                          type: string
+                        pullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        tag:
+                          type: string
+                      type: object
+                    keepAnnotations:
+                      type: string
+                    keepLabels:
+                      type: string
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    priorityClassName:
+                      type: string
+                    rbac:
+                      properties:
+                        create:
+                          type: boolean
+                        serviceAccountName:
+                          type: string
+                      type: object
+                    replicas:
+                      format: int32
+                      type: integer
+                    tolerations:
+                      items:
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            format: int64
+                            type: integer
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    additionalAnnotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    additionalLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    affinity:
+                      properties:
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    config:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        command:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        env:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        healthPort:
+                          format: int32
+                          type: integer
+                        livenessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        logLevel:
+                          type: string
+                        readinessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        securityContext:
+                          properties:
+                            fsGroup:
+                              format: int64
+                              type: integer
+                            fsGroupChangePolicy:
+                              type: string
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - type
+                              type: object
+                            supplementalGroups:
+                              items:
+                                format: int64
+                                type: integer
+                              type: array
+                            sysctls:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                hostProcess:
+                                  type: boolean
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                            - mountPath
+                          x-kubernetes-list-type: map
+                        volumes:
+                          items:
+                            properties:
+                              awsElasticBlockStore:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              azureDisk:
+                                properties:
+                                  cachingMode:
+                                    type: string
+                                  diskName:
+                                    type: string
+                                  diskURI:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - diskName
+                                  - diskURI
+                                type: object
+                              azureFile:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                  shareName:
+                                    type: string
+                                required:
+                                  - secretName
+                                  - shareName
+                                type: object
+                              cephfs:
+                                properties:
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretFile:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                  - monitors
+                                type: object
+                              cinder:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeID:
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              configMap:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                      type: object
+                                    type: array
                                   name:
                                     type: string
                                   optional:
                                     type: boolean
+                                type: object
+                              csi:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  nodePublishSecretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
                                 required:
-                                  - key
+                                  - driver
+                                type: object
+                              downwardAPI:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                      required:
+                                        - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                properties:
+                                  medium:
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                properties:
+                                  volumeClaimTemplate:
+                                    properties:
+                                      metadata:
+                                        type: object
+                                      spec:
+                                        properties:
+                                          accessModes:
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          dataSourceRef:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          resources:
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          selector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          storageClassName:
+                                            type: string
+                                          volumeMode:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        type: object
+                                    required:
+                                      - spec
+                                    type: object
+                                type: object
+                              fc:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  targetWWNs:
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                required:
+                                  - driver
+                                type: object
+                              flocker:
+                                properties:
+                                  datasetName:
+                                    type: string
+                                  datasetUUID:
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - pdName
+                                type: object
+                              gitRepo:
+                                properties:
+                                  directory:
+                                    type: string
+                                  repository:
+                                    type: string
+                                  revision:
+                                    type: string
+                                required:
+                                  - repository
+                                type: object
+                              glusterfs:
+                                properties:
+                                  endpoints:
+                                    type: string
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - endpoints
+                                  - path
+                                type: object
+                              hostPath:
+                                properties:
+                                  path:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                  - path
+                                type: object
+                              iscsi:
+                                properties:
+                                  chapAuthDiscovery:
+                                    type: boolean
+                                  chapAuthSession:
+                                    type: boolean
+                                  fsType:
+                                    type: string
+                                  initiatorName:
+                                    type: string
+                                  iqn:
+                                    type: string
+                                  iscsiInterface:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  targetPortal:
+                                    type: string
+                                required:
+                                  - iqn
+                                  - lun
+                                  - targetPortal
+                                type: object
+                              name:
+                                type: string
+                              nfs:
+                                properties:
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  server:
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
+                              persistentVolumeClaim:
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                  - claimName
+                                type: object
+                              photonPersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  pdID:
+                                    type: string
+                                required:
+                                  - pdID
+                                type: object
+                              portworxVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              projected:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    items:
+                                      properties:
+                                        configMap:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                  - key
+                                                  - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                      - fieldPath
+                                                    type: object
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                      - resource
+                                                    type: object
+                                                required:
+                                                  - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                  - key
+                                                  - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        serviceAccountToken:
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                            - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                type: object
+                              quobyte:
+                                properties:
+                                  group:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  registry:
+                                    type: string
+                                  tenant:
+                                    type: string
+                                  user:
+                                    type: string
+                                  volume:
+                                    type: string
+                                required:
+                                  - registry
+                                  - volume
+                                type: object
+                              rbd:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  image:
+                                    type: string
+                                  keyring:
+                                    type: string
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                  - image
+                                  - monitors
+                                type: object
+                              scaleIO:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  gateway:
+                                    type: string
+                                  protectionDomain:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  sslEnabled:
+                                    type: boolean
+                                  storageMode:
+                                    type: string
+                                  storagePool:
+                                    type: string
+                                  system:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - gateway
+                                  - secretRef
+                                  - system
+                                type: object
+                              secret:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                type: object
+                              storageos:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeName:
+                                    type: string
+                                  volumeNamespace:
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  storagePolicyID:
+                                    type: string
+                                  storagePolicyName:
+                                    type: string
+                                  volumePath:
+                                    type: string
+                                required:
+                                  - volumePath
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    customConfig:
+                      properties:
+                        configData:
+                          type: string
+                        configMap:
+                          properties:
+                            fileKey:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                      type: object
+                    deploymentName:
+                      type: string
+                    enabled:
+                      type: boolean
+                    image:
+                      properties:
+                        jmxEnabled:
+                          type: boolean
+                        name:
+                          type: string
+                        pullPolicy:
+                          type: string
+                        pullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        tag:
+                          type: string
+                      type: object
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
                                 type: object
                             type: object
-                        required:
-                          - name
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    priorityClassName:
+                      type: string
+                    rbac:
+                      properties:
+                        create:
+                          type: boolean
+                        serviceAccountName:
+                          type: string
+                      type: object
+                    replicas:
+                      format: int32
+                      type: integer
+                    tolerations:
+                      items:
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            format: int64
+                            type: integer
+                          value:
+                            type: string
                         type: object
                       type: array
-                    healthPort:
+                      x-kubernetes-list-type: atomic
+                  type: object
+                clusterName:
+                  type: string
+                credentials:
+                  properties:
+                    apiKey:
+                      type: string
+                    apiKeyExistingSecret:
+                      type: string
+                    apiSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    appKey:
+                      type: string
+                    appKeyExistingSecret:
+                      type: string
+                    appSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
+                    token:
+                      type: string
+                    useSecretBackend:
+                      type: boolean
+                  type: object
+                features:
+                  properties:
+                    kubeStateMetricsCore:
+                      properties:
+                        clusterCheck:
+                          type: boolean
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                fileKey:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        logsConfigContainerCollectAll:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    networkMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        additionalEndpoints:
+                          type: string
+                        clusterCheck:
+                          type: boolean
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                fileKey:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        ddUrl:
+                          type: string
+                        enabled:
+                          type: boolean
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubbing:
+                          properties:
+                            containers:
+                              type: boolean
+                          type: object
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enabled:
+                          type: boolean
+                        serviceEndpoints:
+                          type: boolean
+                      type: object
+                  type: object
+                registry:
+                  type: string
+                site:
+                  type: string
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    available:
                       format: int32
                       type: integer
-                    hostPort:
+                    current:
                       format: int32
                       type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                defaultOverride:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          type: object
+      served: true
+      storage: true
+    - name: v2alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                features:
+                  properties:
+                    admissionController:
+                      properties:
+                        agentCommunicationMode:
+                          type: string
+                        enabled:
+                          type: boolean
+                        mutateUnlabelled:
+                          type: boolean
+                        serviceName:
+                          type: string
+                      type: object
+                    apm:
+                      properties:
+                        enabled:
+                          type: boolean
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    clusterChecks:
+                      properties:
+                        enabled:
+                          type: boolean
+                        useClusterChecksRunners:
+                          type: boolean
+                      type: object
+                    cspm:
+                      properties:
+                        checkInterval:
+                          type: string
+                        customBenchmarks:
+                          properties:
+                            items:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - key
+                              x-kubernetes-list-type: map
+                            name:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    cws:
+                      properties:
+                        customPolicies:
+                          properties:
+                            items:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - key
+                              x-kubernetes-list-type: map
+                            name:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        syscallMonitorEnabled:
+                          type: boolean
+                      type: object
+                    datadogMonitor:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        originDetectionEnabled:
+                          type: boolean
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
+                          type: boolean
+                      type: object
+                    externalMetricsServer:
+                      properties:
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        port:
+                          format: int32
+                          type: integer
+                        useDatadogMetrics:
+                          type: boolean
+                        wpaController:
+                          type: boolean
+                      type: object
+                    kubeStateMetricsCore:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    logCollection:
+                      properties:
+                        containerCollectAll:
+                          type: boolean
+                        containerCollectUsingFiles:
+                          type: boolean
+                        containerLogsPath:
+                          type: string
+                        containerSymlinksPath:
+                          type: string
+                        enabled:
+                          type: boolean
+                        openFilesLimit:
+                          format: int32
+                          type: integer
+                        podLogsPath:
+                          type: string
+                        tempStoragePath:
+                          type: string
+                      type: object
+                    npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    orchestratorExplorer:
+                      properties:
+                        conf:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        endpoint:
+                          properties:
+                            credentials:
+                              properties:
+                                apiKey:
+                                  type: string
+                                apiSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                                appKey:
+                                  type: string
+                                appSecret:
+                                  properties:
+                                    keyName:
+                                      type: string
+                                    secretName:
+                                      type: string
+                                  required:
+                                    - secretName
+                                  type: object
+                              type: object
+                            url:
+                              type: string
+                          type: object
+                        extraTags:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        scrubContainers:
+                          type: boolean
+                      type: object
+                    prometheusScrape:
+                      properties:
+                        additionalConfigs:
+                          type: string
+                        enableServiceEndpoints:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    tcpQueueLength:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    usm:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                global:
+                  properties:
+                    clusterAgentToken:
+                      type: string
+                    clusterName:
+                      type: string
+                    credentials:
+                      properties:
+                        apiKey:
+                          type: string
+                        apiSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                        appKey:
+                          type: string
+                        appSecret:
+                          properties:
+                            keyName:
+                              type: string
+                            secretName:
+                              type: string
+                          required:
+                            - secretName
+                          type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
                     kubelet:
                       properties:
                         agentCAPath:
@@ -766,6 +6303,7 @@ spec:
                                     - type: integer
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                                 resource:
                                   type: string
                               required:
@@ -788,83 +6326,47 @@ spec:
                         tlsVerify:
                           type: boolean
                       type: object
-                    leaderElection:
-                      type: boolean
-                    livenessProbe:
+                    localService:
                       properties:
-                        exec:
-                          properties:
-                            command:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          format: int32
-                          type: integer
-                        httpGet:
-                          properties:
-                            host:
-                              type: string
-                            httpHeaders:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                            scheme:
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          properties:
-                            host:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          format: int32
-                          type: integer
+                        forceEnableLocalService:
+                          type: boolean
+                        nameOverride:
+                          type: string
                       type: object
                     logLevel:
                       type: string
-                    namespaceLabelsAsTags:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    nodeLabelsAsTags:
-                      additionalProperties:
-                        type: string
+                    networkPolicy:
+                      properties:
+                        create:
+                          type: boolean
+                        dnsSelectorEndpoints:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        flavor:
+                          type: string
                       type: object
                     podAnnotationsAsTags:
                       additionalProperties:
@@ -874,801 +6376,827 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
-                    readinessProbe:
-                      properties:
-                        exec:
-                          properties:
-                            command:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          format: int32
-                          type: integer
-                        httpGet:
-                          properties:
-                            host:
-                              type: string
-                            httpHeaders:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                            scheme:
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          properties:
-                            host:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          format: int32
-                          type: integer
-                      type: object
-                    resources:
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                      type: object
-                    securityContext:
-                      properties:
-                        fsGroup:
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          type: string
-                        runAsGroup:
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          type: boolean
-                        runAsUser:
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          properties:
-                            level:
-                              type: string
-                            role:
-                              type: string
-                            type:
-                              type: string
-                            user:
-                              type: string
-                          type: object
-                        seccompProfile:
-                          properties:
-                            localhostProfile:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          properties:
-                            gmsaCredentialSpec:
-                              type: string
-                            gmsaCredentialSpecName:
-                              type: string
-                            runAsUserName:
-                              type: string
-                          type: object
-                      type: object
+                    registry:
+                      type: string
+                    site:
+                      type: string
                     tags:
                       items:
                         type: string
                       type: array
-                    tolerations:
-                      items:
+                      x-kubernetes-list-type: set
+                  type: object
+                override:
+                  additionalProperties:
+                    properties:
+                      affinity:
                         properties:
-                          effect:
-                            type: string
-                          key:
-                            type: string
-                          operator:
-                            type: string
-                          tolerationSeconds:
-                            format: int64
-                            type: integer
-                          value:
-                            type: string
-                        type: object
-                      type: array
-                    volumeMounts:
-                      items:
-                        properties:
-                          mountPath:
-                            type: string
-                          mountPropagation:
-                            type: string
-                          name:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          subPath:
-                            type: string
-                          subPathExpr:
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                    volumes:
-                      items:
-                        properties:
-                          awsElasticBlockStore:
+                          nodeAffinity:
                             properties:
-                              fsType:
-                                type: string
-                              partition:
-                                format: int32
-                                type: integer
-                              readOnly:
-                                type: boolean
-                              volumeID:
-                                type: string
-                            required:
-                              - volumeID
-                            type: object
-                          azureDisk:
-                            properties:
-                              cachingMode:
-                                type: string
-                              diskName:
-                                type: string
-                              diskURI:
-                                type: string
-                              fsType:
-                                type: string
-                              kind:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - diskName
-                              - diskURI
-                            type: object
-                          azureFile:
-                            properties:
-                              readOnly:
-                                type: boolean
-                              secretName:
-                                type: string
-                              shareName:
-                                type: string
-                            required:
-                              - secretName
-                              - shareName
-                            type: object
-                          cephfs:
-                            properties:
-                              monitors:
-                                items:
-                                  type: string
-                                type: array
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretFile:
-                                type: string
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              user:
-                                type: string
-                            required:
-                              - monitors
-                            type: object
-                          cinder:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              volumeID:
-                                type: string
-                            required:
-                              - volumeID
-                            type: object
-                          configMap:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              items:
+                              preferredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
-                                    key:
-                                      type: string
-                                    mode:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
                                       format: int32
                                       type: integer
-                                    path:
-                                      type: string
                                   required:
-                                    - key
-                                    - path
+                                    - preference
+                                    - weight
                                   type: object
                                 type: array
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          csi:
-                            properties:
-                              driver:
-                                type: string
-                              fsType:
-                                type: string
-                              nodePublishSecretRef:
+                              requiredDuringSchedulingIgnoredDuringExecution:
                                 properties:
-                                  name:
-                                    type: string
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                  - nodeSelectorTerms
                                 type: object
-                              readOnly:
-                                type: boolean
-                              volumeAttributes:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            required:
-                              - driver
                             type: object
-                          downwardAPI:
+                          podAffinity:
                             properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              items:
+                              preferredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
-                                    fieldRef:
+                                    podAffinityTerm:
                                       properties:
-                                        apiVersion:
-                                          type: string
-                                        fieldPath:
-                                          type: string
-                                      required:
-                                        - fieldPath
-                                      type: object
-                                    mode:
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      type: string
-                                    resourceFieldRef:
-                                      properties:
-                                        containerName:
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        resource:
-                                          type: string
-                                      required:
-                                        - resource
-                                      type: object
-                                  required:
-                                    - path
-                                  type: object
-                                type: array
-                            type: object
-                          emptyDir:
-                            properties:
-                              medium:
-                                type: string
-                              sizeLimit:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            type: object
-                          ephemeral:
-                            properties:
-                              volumeClaimTemplate:
-                                properties:
-                                  metadata:
-                                    type: object
-                                  spec:
-                                    properties:
-                                      accessModes:
-                                        items:
-                                          type: string
-                                        type: array
-                                      dataSource:
-                                        properties:
-                                          apiGroup:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
                                             type: string
-                                          kind:
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
                                             type: string
                                           name:
                                             type: string
+                                          optional:
+                                            type: boolean
                                         required:
-                                          - kind
-                                          - name
+                                          - key
                                         type: object
-                                      resources:
+                                      fieldRef:
                                         properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            type: object
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
                                         type: object
-                                      selector:
+                                      resourceFieldRef:
                                         properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
                                         type: object
-                                      storageClassName:
-                                        type: string
-                                      volumeMode:
-                                        type: string
-                                      volumeName:
-                                        type: string
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
                                     type: object
                                 required:
-                                  - spec
+                                  - name
                                 type: object
-                            type: object
-                          fc:
-                            properties:
-                              fsType:
-                                type: string
-                              lun:
-                                format: int32
-                                type: integer
-                              readOnly:
-                                type: boolean
-                              targetWWNs:
-                                items:
-                                  type: string
-                                type: array
-                              wwids:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          flexVolume:
-                            properties:
-                              driver:
-                                type: string
-                              fsType:
-                                type: string
-                              options:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                            required:
-                              - driver
-                            type: object
-                          flocker:
-                            properties:
-                              datasetName:
-                                type: string
-                              datasetUUID:
-                                type: string
-                            type: object
-                          gcePersistentDisk:
-                            properties:
-                              fsType:
-                                type: string
-                              partition:
-                                format: int32
-                                type: integer
-                              pdName:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - pdName
-                            type: object
-                          gitRepo:
-                            properties:
-                              directory:
-                                type: string
-                              repository:
-                                type: string
-                              revision:
-                                type: string
-                            required:
-                              - repository
-                            type: object
-                          glusterfs:
-                            properties:
-                              endpoints:
-                                type: string
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - endpoints
-                              - path
-                            type: object
-                          hostPath:
-                            properties:
-                              path:
-                                type: string
-                              type:
-                                type: string
-                            required:
-                              - path
-                            type: object
-                          iscsi:
-                            properties:
-                              chapAuthDiscovery:
-                                type: boolean
-                              chapAuthSession:
-                                type: boolean
-                              fsType:
-                                type: string
-                              initiatorName:
-                                type: string
-                              iqn:
-                                type: string
-                              iscsiInterface:
-                                type: string
-                              lun:
-                                format: int32
-                                type: integer
-                              portals:
-                                items:
-                                  type: string
-                                type: array
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              targetPortal:
-                                type: string
-                            required:
-                              - iqn
-                              - lun
-                              - targetPortal
-                            type: object
-                          name:
-                            type: string
-                          nfs:
-                            properties:
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              server:
-                                type: string
-                            required:
-                              - path
-                              - server
-                            type: object
-                          persistentVolumeClaim:
-                            properties:
-                              claimName:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - claimName
-                            type: object
-                          photonPersistentDisk:
-                            properties:
-                              fsType:
-                                type: string
-                              pdID:
-                                type: string
-                            required:
-                              - pdID
-                            type: object
-                          portworxVolume:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              volumeID:
-                                type: string
-                            required:
-                              - volumeID
-                            type: object
-                          projected:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              sources:
-                                items:
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
                                   properties:
-                                    configMap:
-                                      properties:
-                                        items:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              mode:
-                                                format: int32
-                                                type: integer
-                                              path:
-                                                type: string
-                                            required:
-                                              - key
-                                              - path
-                                            type: object
-                                          type: array
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                    downwardAPI:
-                                      properties:
-                                        items:
-                                          items:
-                                            properties:
-                                              fieldRef:
-                                                properties:
-                                                  apiVersion:
-                                                    type: string
-                                                  fieldPath:
-                                                    type: string
-                                                required:
-                                                  - fieldPath
-                                                type: object
-                                              mode:
-                                                format: int32
-                                                type: integer
-                                              path:
-                                                type: string
-                                              resourceFieldRef:
-                                                properties:
-                                                  containerName:
-                                                    type: string
-                                                  divisor:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  resource:
-                                                    type: string
-                                                required:
-                                                  - resource
-                                                type: object
-                                            required:
-                                              - path
-                                            type: object
-                                          type: array
-                                      type: object
-                                    secret:
-                                      properties:
-                                        items:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              mode:
-                                                format: int32
-                                                type: integer
-                                              path:
-                                                type: string
-                                            required:
-                                              - key
-                                              - path
-                                            type: object
-                                          type: array
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                    serviceAccountToken:
-                                      properties:
-                                        audience:
-                                          type: string
-                                        expirationSeconds:
-                                          format: int64
-                                          type: integer
-                                        path:
-                                          type: string
-                                      required:
-                                        - path
-                                      type: object
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
                                   type: object
-                                type: array
-                            type: object
-                          quobyte:
-                            properties:
-                              group:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              registry:
-                                type: string
-                              tenant:
-                                type: string
-                              user:
-                                type: string
-                              volume:
-                                type: string
-                            required:
-                              - registry
-                              - volume
-                            type: object
-                          rbd:
-                            properties:
-                              fsType:
-                                type: string
-                              image:
-                                type: string
-                              keyring:
-                                type: string
-                              monitors:
-                                items:
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
                                   type: string
-                                type: array
-                              pool:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            volumeMounts:
+                              items:
                                 properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
                                   name:
                                     type: string
-                                type: object
-                              user:
-                                type: string
-                            required:
-                              - image
-                              - monitors
-                            type: object
-                          scaleIO:
-                            properties:
-                              fsType:
-                                type: string
-                              gateway:
-                                type: string
-                              protectionDomain:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
                                     type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
                                 type: object
-                              sslEnabled:
-                                type: boolean
-                              storageMode:
-                                type: string
-                              storagePool:
-                                type: string
-                              system:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - gateway
-                              - secretRef
-                              - system
-                            type: object
-                          secret:
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      extraChecksd:
+                        properties:
+                          configData:
+                            type: string
+                          configMap:
                             properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
                               items:
                                 items:
                                   properties:
@@ -1684,3871 +7212,1019 @@ spec:
                                     - path
                                   type: object
                                 type: array
-                              optional:
-                                type: boolean
-                              secretName:
-                                type: string
-                            type: object
-                          storageos:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              volumeName:
-                                type: string
-                              volumeNamespace:
-                                type: string
-                            type: object
-                          vsphereVolume:
-                            properties:
-                              fsType:
-                                type: string
-                              storagePolicyID:
-                                type: string
-                              storagePolicyName:
-                                type: string
-                              volumePath:
-                                type: string
-                            required:
-                              - volumePath
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                customConfig:
-                  properties:
-                    configData:
-                      type: string
-                    configMap:
-                      properties:
-                        fileKey:
-                          type: string
-                        name:
-                          type: string
-                      type: object
-                  type: object
-                daemonsetName:
-                  type: string
-                deploymentStrategy:
-                  properties:
-                    canary:
-                      properties:
-                        autoFail:
-                          properties:
-                            enabled:
-                              type: boolean
-                            maxRestarts:
-                              format: int32
-                              type: integer
-                            maxRestartsDuration:
-                              type: string
-                          type: object
-                        autoPause:
-                          properties:
-                            enabled:
-                              type: boolean
-                            maxRestarts:
-                              format: int32
-                              type: integer
-                            maxSlowStartDuration:
-                              type: string
-                          type: object
-                        duration:
-                          type: string
-                        noRestartsDuration:
-                          type: string
-                        nodeAntiAffinityKeys:
-                          items:
-                            type: string
-                          type: array
-                        nodeSelector:
-                          properties:
-                            matchExpressions:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
+                                x-kubernetes-list-map-keys:
                                   - key
-                                  - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
+                                x-kubernetes-list-type: map
+                              name:
                                 type: string
-                              type: object
-                          type: object
-                        replicas:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                      type: object
-                    reconcileFrequency:
-                      type: string
-                    rollingUpdate:
-                      properties:
-                        maxParallelPodCreation:
-                          format: int32
-                          type: integer
-                        maxPodSchedulerFailure:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                        maxUnavailable:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                        slowStartAdditiveIncrease:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                        slowStartIntervalDuration:
-                          type: string
-                      type: object
-                    updateStrategyType:
-                      type: string
-                  type: object
-                dnsConfig:
-                  properties:
-                    nameservers:
-                      items:
-                        type: string
-                      type: array
-                    options:
-                      items:
+                            type: object
+                        type: object
+                      extraConfd:
                         properties:
+                          configData:
+                            type: string
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
                           name:
                             type: string
-                          value:
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            type: array
+                          tag:
                             type: string
                         type: object
-                      type: array
-                    searches:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                dnsPolicy:
-                  type: string
-                enabled:
-                  type: boolean
-                env:
-                  items:
-                    properties:
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       name:
                         type: string
-                      value:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
                         type: string
-                      valueFrom:
+                      replicas:
+                        format: int32
+                        type: integer
+                      secCompCustomProfile:
                         properties:
-                          configMapKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                          fieldRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              fieldPath:
-                                type: string
-                            required:
-                              - fieldPath
-                            type: object
-                          resourceFieldRef:
-                            properties:
-                              containerName:
-                                type: string
-                              divisor:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              resource:
-                                type: string
-                            required:
-                              - resource
-                            type: object
-                          secretKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-                hostNetwork:
-                  type: boolean
-                hostPID:
-                  type: boolean
-                image:
-                  properties:
-                    jmxEnabled:
-                      type: boolean
-                    name:
-                      type: string
-                    pullPolicy:
-                      type: string
-                    pullSecrets:
-                      items:
-                        properties:
-                          name:
+                          configData:
                             type: string
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
                         type: object
-                      type: array
-                    tag:
-                      type: string
-                  type: object
-                keepAnnotations:
-                  type: string
-                keepLabels:
-                  type: string
-                localService:
-                  properties:
-                    forceLocalServiceEnable:
-                      type: boolean
-                    overrideName:
-                      type: string
-                  type: object
-                log:
-                  properties:
-                    containerCollectUsingFiles:
-                      type: boolean
-                    containerLogsPath:
-                      type: string
-                    containerSymlinksPath:
-                      type: string
-                    enabled:
-                      type: boolean
-                    logsConfigContainerCollectAll:
-                      type: boolean
-                    openFilesLimit:
-                      format: int32
-                      type: integer
-                    podLogsPath:
-                      type: string
-                    tempStoragePath:
-                      type: string
-                  type: object
-                networkPolicy:
-                  properties:
-                    create:
-                      type: boolean
-                    dnsSelectorEndpoints:
-                      items:
+                      secCompProfileName:
+                        type: string
+                      secCompRootPath:
+                        type: string
+                      securityContext:
                         properties:
-                          matchExpressions:
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
                             items:
                               properties:
-                                key:
+                                name:
                                   type: string
-                                operator:
+                                value:
                                   type: string
-                                values:
-                                  items:
-                                    type: string
-                                  type: array
                               required:
-                                - key
-                                - operator
+                                - name
+                                - value
                               type: object
                             type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      type: array
-                    flavor:
-                      type: string
-                  type: object
-                priorityClassName:
-                  type: string
-                process:
-                  properties:
-                    args:
-                      items:
-                        type: string
-                      type: array
-                    command:
-                      items:
-                        type: string
-                      type: array
-                    enabled:
-                      type: boolean
-                    env:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                          valueFrom:
+                          windowsOptions:
                             properties:
-                              configMapKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldPath:
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  resource:
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    processCollectionEnabled:
-                      type: boolean
-                    resources:
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                      type: object
-                    volumeMounts:
-                      items:
-                        properties:
-                          mountPath:
-                            type: string
-                          mountPropagation:
-                            type: string
-                          name:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          subPath:
-                            type: string
-                          subPathExpr:
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                rbac:
-                  properties:
-                    create:
-                      type: boolean
-                    serviceAccountName:
-                      type: string
-                  type: object
-                security:
-                  properties:
-                    args:
-                      items:
-                        type: string
-                      type: array
-                    command:
-                      items:
-                        type: string
-                      type: array
-                    compliance:
-                      properties:
-                        checkInterval:
-                          type: string
-                        configDir:
-                          properties:
-                            configMapName:
-                              type: string
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                  - key
-                                  - path
-                                type: object
-                              type: array
-                          type: object
-                        enabled:
-                          type: boolean
-                      type: object
-                    env:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                          valueFrom:
-                            properties:
-                              configMapKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldPath:
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  resource:
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    resources:
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                      type: object
-                    runtime:
-                      properties:
-                        enabled:
-                          type: boolean
-                        policiesDir:
-                          properties:
-                            configMapName:
-                              type: string
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                  - key
-                                  - path
-                                type: object
-                              type: array
-                          type: object
-                        syscallMonitor:
-                          properties:
-                            enabled:
-                              type: boolean
-                          type: object
-                      type: object
-                    volumeMounts:
-                      items:
-                        properties:
-                          mountPath:
-                            type: string
-                          mountPropagation:
-                            type: string
-                          name:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          subPath:
-                            type: string
-                          subPathExpr:
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                systemProbe:
-                  properties:
-                    appArmorProfileName:
-                      type: string
-                    args:
-                      items:
-                        type: string
-                      type: array
-                    bpfDebugEnabled:
-                      type: boolean
-                    collectDNSStats:
-                      type: boolean
-                    command:
-                      items:
-                        type: string
-                      type: array
-                    conntrackEnabled:
-                      type: boolean
-                    customConfig:
-                      properties:
-                        configData:
-                          type: string
-                        configMap:
-                          properties:
-                            fileKey:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                      type: object
-                    debugPort:
-                      format: int32
-                      type: integer
-                    enableOOMKill:
-                      type: boolean
-                    enableTCPQueueLength:
-                      type: boolean
-                    enabled:
-                      type: boolean
-                    env:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                          valueFrom:
-                            properties:
-                              configMapKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldPath:
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  resource:
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    resources:
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                      type: object
-                    secCompCustomProfileConfigMap:
-                      type: string
-                    secCompProfileName:
-                      type: string
-                    secCompRootPath:
-                      type: string
-                    securityContext:
-                      properties:
-                        allowPrivilegeEscalation:
-                          type: boolean
-                        capabilities:
-                          properties:
-                            add:
-                              items:
+                              gmsaCredentialSpec:
                                 type: string
-                              type: array
-                            drop:
-                              items:
+                              gmsaCredentialSpecName:
                                 type: string
-                              type: array
-                          type: object
-                        privileged:
-                          type: boolean
-                        procMount:
-                          type: string
-                        readOnlyRootFilesystem:
-                          type: boolean
-                        runAsGroup:
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          type: boolean
-                        runAsUser:
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          properties:
-                            level:
-                              type: string
-                            role:
-                              type: string
-                            type:
-                              type: string
-                            user:
-                              type: string
-                          type: object
-                        seccompProfile:
-                          properties:
-                            localhostProfile:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          properties:
-                            gmsaCredentialSpec:
-                              type: string
-                            gmsaCredentialSpecName:
-                              type: string
-                            runAsUserName:
-                              type: string
-                          type: object
-                      type: object
-                    volumeMounts:
-                      items:
-                        properties:
-                          mountPath:
-                            type: string
-                          mountPropagation:
-                            type: string
-                          name:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          subPath:
-                            type: string
-                          subPathExpr:
-                            type: string
-                        required:
-                          - mountPath
-                          - name
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
                         type: object
-                      type: array
-                  type: object
-                useExtendedDaemonset:
-                  type: boolean
-              type: object
-            clusterAgent:
-              properties:
-                additionalAnnotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                additionalLabels:
-                  additionalProperties:
-                    type: string
-                  type: object
-                affinity:
-                  properties:
-                    nodeAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              preference:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          properties:
-                            nodeSelectorTerms:
-                              items:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                            - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaceSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaceSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                config:
-                  properties:
-                    admissionController:
-                      properties:
-                        agentCommunicationMode:
-                          type: string
-                        enabled:
-                          type: boolean
-                        mutateUnlabelled:
-                          type: boolean
-                        serviceName:
-                          type: string
-                      type: object
-                    args:
-                      items:
+                      serviceAccountName:
                         type: string
-                      type: array
-                    clusterChecksEnabled:
-                      type: boolean
-                    collectEvents:
-                      type: boolean
-                    command:
-                      items:
-                        type: string
-                      type: array
-                    confd:
-                      properties:
-                        configMapName:
-                          type: string
+                      tolerations:
                         items:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                            required:
-                              - key
-                              - path
-                            type: object
-                          type: array
-                      type: object
-                    env:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                          valueFrom:
-                            properties:
-                              configMapKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldPath:
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  resource:
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    externalMetrics:
-                      properties:
-                        credentials:
                           properties:
-                            apiKey:
+                            effect:
                               type: string
-                            apiKeyExistingSecret:
+                            key:
                               type: string
-                            apiSecret:
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
                               properties:
-                                keyName:
+                                fsType:
                                   type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
                                 secretName:
+                                  type: string
+                                shareName:
                                   type: string
                               required:
                                 - secretName
+                                - shareName
                               type: object
-                            appKey:
-                              type: string
-                            appKeyExistingSecret:
-                              type: string
-                            appSecret:
+                            cephfs:
                               properties:
-                                keyName:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
                                   type: string
-                                secretName:
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                user:
                                   type: string
                               required:
-                                - secretName
+                                - monitors
                               type: object
-                          type: object
-                        enabled:
-                          type: boolean
-                        endpoint:
-                          type: string
-                        port:
-                          format: int32
-                          type: integer
-                        useDatadogMetrics:
-                          type: boolean
-                        wpaController:
-                          type: boolean
-                      type: object
-                    healthPort:
-                      format: int32
-                      type: integer
-                    logLevel:
-                      type: string
-                    resources:
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                      type: object
-                    securityContext:
-                      properties:
-                        fsGroup:
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          type: string
-                        runAsGroup:
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          type: boolean
-                        runAsUser:
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          properties:
-                            level:
-                              type: string
-                            role:
-                              type: string
-                            type:
-                              type: string
-                            user:
-                              type: string
-                          type: object
-                        seccompProfile:
-                          properties:
-                            localhostProfile:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          properties:
-                            gmsaCredentialSpec:
-                              type: string
-                            gmsaCredentialSpecName:
-                              type: string
-                            runAsUserName:
-                              type: string
-                          type: object
-                      type: object
-                    volumeMounts:
-                      items:
-                        properties:
-                          mountPath:
-                            type: string
-                          mountPropagation:
-                            type: string
-                          name:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          subPath:
-                            type: string
-                          subPathExpr:
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                    volumes:
-                      items:
-                        properties:
-                          awsElasticBlockStore:
-                            properties:
-                              fsType:
-                                type: string
-                              partition:
-                                format: int32
-                                type: integer
-                              readOnly:
-                                type: boolean
-                              volumeID:
-                                type: string
-                            required:
-                              - volumeID
-                            type: object
-                          azureDisk:
-                            properties:
-                              cachingMode:
-                                type: string
-                              diskName:
-                                type: string
-                              diskURI:
-                                type: string
-                              fsType:
-                                type: string
-                              kind:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - diskName
-                              - diskURI
-                            type: object
-                          azureFile:
-                            properties:
-                              readOnly:
-                                type: boolean
-                              secretName:
-                                type: string
-                              shareName:
-                                type: string
-                            required:
-                              - secretName
-                              - shareName
-                            type: object
-                          cephfs:
-                            properties:
-                              monitors:
-                                items:
+                            cinder:
+                              properties:
+                                fsType:
                                   type: string
-                                type: array
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretFile:
-                                type: string
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              user:
-                                type: string
-                            required:
-                              - monitors
-                            type: object
-                          cinder:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              volumeID:
-                                type: string
-                            required:
-                              - volumeID
-                            type: object
-                          configMap:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              items:
-                                items:
+                                readOnly:
+                                  type: boolean
+                                secretRef:
                                   properties:
-                                    key:
+                                    name:
                                       type: string
-                                    mode:
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      type: string
-                                  required:
-                                    - key
-                                    - path
                                   type: object
-                                type: array
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          csi:
-                            properties:
-                              driver:
-                                type: string
-                              fsType:
-                                type: string
-                              nodePublishSecretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              readOnly:
-                                type: boolean
-                              volumeAttributes:
-                                additionalProperties:
+                                volumeID:
                                   type: string
-                                type: object
-                            required:
-                              - driver
-                            type: object
-                          downwardAPI:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              items:
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
                                 items:
-                                  properties:
-                                    fieldRef:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        fieldPath:
-                                          type: string
-                                      required:
-                                        - fieldPath
-                                      type: object
-                                    mode:
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      type: string
-                                    resourceFieldRef:
-                                      properties:
-                                        containerName:
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        resource:
-                                          type: string
-                                      required:
-                                        - resource
-                                      type: object
-                                  required:
-                                    - path
-                                  type: object
-                                type: array
-                            type: object
-                          emptyDir:
-                            properties:
-                              medium:
-                                type: string
-                              sizeLimit:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            type: object
-                          ephemeral:
-                            properties:
-                              volumeClaimTemplate:
-                                properties:
-                                  metadata:
-                                    type: object
-                                  spec:
+                                  items:
                                     properties:
-                                      accessModes:
-                                        items:
-                                          type: string
-                                        type: array
-                                      dataSource:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
                                         properties:
-                                          apiGroup:
+                                          apiVersion:
                                             type: string
-                                          kind:
-                                            type: string
-                                          name:
+                                          fieldPath:
                                             type: string
                                         required:
-                                          - kind
-                                          - name
+                                          - fieldPath
                                         type: object
-                                      resources:
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
                                         properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            type: object
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
                                         type: object
-                                      selector:
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      configMap:
                                         properties:
-                                          matchExpressions:
+                                          items:
                                             items:
                                               properties:
                                                 key:
                                                   type: string
-                                                operator:
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
                                                   type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
                                               required:
                                                 - key
-                                                - operator
+                                                - path
                                               type: object
                                             type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                      storageClassName:
-                                        type: string
-                                      volumeMode:
-                                        type: string
-                                      volumeName:
-                                        type: string
-                                    type: object
-                                required:
-                                  - spec
-                                type: object
-                            type: object
-                          fc:
-                            properties:
-                              fsType:
-                                type: string
-                              lun:
-                                format: int32
-                                type: integer
-                              readOnly:
-                                type: boolean
-                              targetWWNs:
-                                items:
-                                  type: string
-                                type: array
-                              wwids:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          flexVolume:
-                            properties:
-                              driver:
-                                type: string
-                              fsType:
-                                type: string
-                              options:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                            required:
-                              - driver
-                            type: object
-                          flocker:
-                            properties:
-                              datasetName:
-                                type: string
-                              datasetUUID:
-                                type: string
-                            type: object
-                          gcePersistentDisk:
-                            properties:
-                              fsType:
-                                type: string
-                              partition:
-                                format: int32
-                                type: integer
-                              pdName:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - pdName
-                            type: object
-                          gitRepo:
-                            properties:
-                              directory:
-                                type: string
-                              repository:
-                                type: string
-                              revision:
-                                type: string
-                            required:
-                              - repository
-                            type: object
-                          glusterfs:
-                            properties:
-                              endpoints:
-                                type: string
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - endpoints
-                              - path
-                            type: object
-                          hostPath:
-                            properties:
-                              path:
-                                type: string
-                              type:
-                                type: string
-                            required:
-                              - path
-                            type: object
-                          iscsi:
-                            properties:
-                              chapAuthDiscovery:
-                                type: boolean
-                              chapAuthSession:
-                                type: boolean
-                              fsType:
-                                type: string
-                              initiatorName:
-                                type: string
-                              iqn:
-                                type: string
-                              iscsiInterface:
-                                type: string
-                              lun:
-                                format: int32
-                                type: integer
-                              portals:
-                                items:
-                                  type: string
-                                type: array
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              targetPortal:
-                                type: string
-                            required:
-                              - iqn
-                              - lun
-                              - targetPortal
-                            type: object
-                          name:
-                            type: string
-                          nfs:
-                            properties:
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              server:
-                                type: string
-                            required:
-                              - path
-                              - server
-                            type: object
-                          persistentVolumeClaim:
-                            properties:
-                              claimName:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - claimName
-                            type: object
-                          photonPersistentDisk:
-                            properties:
-                              fsType:
-                                type: string
-                              pdID:
-                                type: string
-                            required:
-                              - pdID
-                            type: object
-                          portworxVolume:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              volumeID:
-                                type: string
-                            required:
-                              - volumeID
-                            type: object
-                          projected:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              sources:
-                                items:
-                                  properties:
-                                    configMap:
-                                      properties:
-                                        items:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              mode:
-                                                format: int32
-                                                type: integer
-                                              path:
-                                                type: string
-                                            required:
-                                              - key
-                                              - path
-                                            type: object
-                                          type: array
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                    downwardAPI:
-                                      properties:
-                                        items:
-                                          items:
-                                            properties:
-                                              fieldRef:
-                                                properties:
-                                                  apiVersion:
-                                                    type: string
-                                                  fieldPath:
-                                                    type: string
-                                                required:
-                                                  - fieldPath
-                                                type: object
-                                              mode:
-                                                format: int32
-                                                type: integer
-                                              path:
-                                                type: string
-                                              resourceFieldRef:
-                                                properties:
-                                                  containerName:
-                                                    type: string
-                                                  divisor:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  resource:
-                                                    type: string
-                                                required:
-                                                  - resource
-                                                type: object
-                                            required:
-                                              - path
-                                            type: object
-                                          type: array
-                                      type: object
-                                    secret:
-                                      properties:
-                                        items:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              mode:
-                                                format: int32
-                                                type: integer
-                                              path:
-                                                type: string
-                                            required:
-                                              - key
-                                              - path
-                                            type: object
-                                          type: array
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                    serviceAccountToken:
-                                      properties:
-                                        audience:
-                                          type: string
-                                        expirationSeconds:
-                                          format: int64
-                                          type: integer
-                                        path:
-                                          type: string
-                                      required:
-                                        - path
-                                      type: object
-                                  type: object
-                                type: array
-                            type: object
-                          quobyte:
-                            properties:
-                              group:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              registry:
-                                type: string
-                              tenant:
-                                type: string
-                              user:
-                                type: string
-                              volume:
-                                type: string
-                            required:
-                              - registry
-                              - volume
-                            type: object
-                          rbd:
-                            properties:
-                              fsType:
-                                type: string
-                              image:
-                                type: string
-                              keyring:
-                                type: string
-                              monitors:
-                                items:
-                                  type: string
-                                type: array
-                              pool:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              user:
-                                type: string
-                            required:
-                              - image
-                              - monitors
-                            type: object
-                          scaleIO:
-                            properties:
-                              fsType:
-                                type: string
-                              gateway:
-                                type: string
-                              protectionDomain:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              sslEnabled:
-                                type: boolean
-                              storageMode:
-                                type: string
-                              storagePool:
-                                type: string
-                              system:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - gateway
-                              - secretRef
-                              - system
-                            type: object
-                          secret:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              items:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    mode:
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      type: string
-                                  required:
-                                    - key
-                                    - path
-                                  type: object
-                                type: array
-                              optional:
-                                type: boolean
-                              secretName:
-                                type: string
-                            type: object
-                          storageos:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              volumeName:
-                                type: string
-                              volumeNamespace:
-                                type: string
-                            type: object
-                          vsphereVolume:
-                            properties:
-                              fsType:
-                                type: string
-                              storagePolicyID:
-                                type: string
-                              storagePolicyName:
-                                type: string
-                              volumePath:
-                                type: string
-                            required:
-                              - volumePath
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                customConfig:
-                  properties:
-                    configData:
-                      type: string
-                    configMap:
-                      properties:
-                        fileKey:
-                          type: string
-                        name:
-                          type: string
-                      type: object
-                  type: object
-                deploymentName:
-                  type: string
-                enabled:
-                  type: boolean
-                image:
-                  properties:
-                    jmxEnabled:
-                      type: boolean
-                    name:
-                      type: string
-                    pullPolicy:
-                      type: string
-                    pullSecrets:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                        type: object
-                      type: array
-                    tag:
-                      type: string
-                  type: object
-                keepAnnotations:
-                  type: string
-                keepLabels:
-                  type: string
-                networkPolicy:
-                  properties:
-                    create:
-                      type: boolean
-                    dnsSelectorEndpoints:
-                      items:
-                        properties:
-                          matchExpressions:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                operator:
-                                  type: string
-                                values:
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      type: array
-                    flavor:
-                      type: string
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  type: object
-                priorityClassName:
-                  type: string
-                rbac:
-                  properties:
-                    create:
-                      type: boolean
-                    serviceAccountName:
-                      type: string
-                  type: object
-                replicas:
-                  format: int32
-                  type: integer
-                tolerations:
-                  items:
-                    properties:
-                      effect:
-                        type: string
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      tolerationSeconds:
-                        format: int64
-                        type: integer
-                      value:
-                        type: string
-                    type: object
-                  type: array
-              type: object
-            clusterChecksRunner:
-              properties:
-                additionalAnnotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                additionalLabels:
-                  additionalProperties:
-                    type: string
-                  type: object
-                affinity:
-                  properties:
-                    nodeAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              preference:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          properties:
-                            nodeSelectorTerms:
-                              items:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                            - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaceSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaceSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                config:
-                  properties:
-                    args:
-                      items:
-                        type: string
-                      type: array
-                    command:
-                      items:
-                        type: string
-                      type: array
-                    env:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                          valueFrom:
-                            properties:
-                              configMapKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldPath:
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  resource:
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    healthPort:
-                      format: int32
-                      type: integer
-                    livenessProbe:
-                      properties:
-                        exec:
-                          properties:
-                            command:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          format: int32
-                          type: integer
-                        httpGet:
-                          properties:
-                            host:
-                              type: string
-                            httpHeaders:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                            scheme:
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          properties:
-                            host:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          format: int32
-                          type: integer
-                      type: object
-                    logLevel:
-                      type: string
-                    readinessProbe:
-                      properties:
-                        exec:
-                          properties:
-                            command:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          format: int32
-                          type: integer
-                        httpGet:
-                          properties:
-                            host:
-                              type: string
-                            httpHeaders:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                            scheme:
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          properties:
-                            host:
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          format: int32
-                          type: integer
-                      type: object
-                    resources:
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          type: object
-                      type: object
-                    securityContext:
-                      properties:
-                        fsGroup:
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          type: string
-                        runAsGroup:
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          type: boolean
-                        runAsUser:
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          properties:
-                            level:
-                              type: string
-                            role:
-                              type: string
-                            type:
-                              type: string
-                            user:
-                              type: string
-                          type: object
-                        seccompProfile:
-                          properties:
-                            localhostProfile:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          properties:
-                            gmsaCredentialSpec:
-                              type: string
-                            gmsaCredentialSpecName:
-                              type: string
-                            runAsUserName:
-                              type: string
-                          type: object
-                      type: object
-                    volumeMounts:
-                      items:
-                        properties:
-                          mountPath:
-                            type: string
-                          mountPropagation:
-                            type: string
-                          name:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          subPath:
-                            type: string
-                          subPathExpr:
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                    volumes:
-                      items:
-                        properties:
-                          awsElasticBlockStore:
-                            properties:
-                              fsType:
-                                type: string
-                              partition:
-                                format: int32
-                                type: integer
-                              readOnly:
-                                type: boolean
-                              volumeID:
-                                type: string
-                            required:
-                              - volumeID
-                            type: object
-                          azureDisk:
-                            properties:
-                              cachingMode:
-                                type: string
-                              diskName:
-                                type: string
-                              diskURI:
-                                type: string
-                              fsType:
-                                type: string
-                              kind:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - diskName
-                              - diskURI
-                            type: object
-                          azureFile:
-                            properties:
-                              readOnly:
-                                type: boolean
-                              secretName:
-                                type: string
-                              shareName:
-                                type: string
-                            required:
-                              - secretName
-                              - shareName
-                            type: object
-                          cephfs:
-                            properties:
-                              monitors:
-                                items:
-                                  type: string
-                                type: array
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretFile:
-                                type: string
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              user:
-                                type: string
-                            required:
-                              - monitors
-                            type: object
-                          cinder:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              volumeID:
-                                type: string
-                            required:
-                              - volumeID
-                            type: object
-                          configMap:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              items:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    mode:
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      type: string
-                                  required:
-                                    - key
-                                    - path
-                                  type: object
-                                type: array
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            type: object
-                          csi:
-                            properties:
-                              driver:
-                                type: string
-                              fsType:
-                                type: string
-                              nodePublishSecretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              readOnly:
-                                type: boolean
-                              volumeAttributes:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            required:
-                              - driver
-                            type: object
-                          downwardAPI:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              items:
-                                items:
-                                  properties:
-                                    fieldRef:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        fieldPath:
-                                          type: string
-                                      required:
-                                        - fieldPath
-                                      type: object
-                                    mode:
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      type: string
-                                    resourceFieldRef:
-                                      properties:
-                                        containerName:
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        resource:
-                                          type: string
-                                      required:
-                                        - resource
-                                      type: object
-                                  required:
-                                    - path
-                                  type: object
-                                type: array
-                            type: object
-                          emptyDir:
-                            properties:
-                              medium:
-                                type: string
-                              sizeLimit:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            type: object
-                          ephemeral:
-                            properties:
-                              volumeClaimTemplate:
-                                properties:
-                                  metadata:
-                                    type: object
-                                  spec:
-                                    properties:
-                                      accessModes:
-                                        items:
-                                          type: string
-                                        type: array
-                                      dataSource:
-                                        properties:
-                                          apiGroup:
-                                            type: string
-                                          kind:
-                                            type: string
                                           name:
                                             type: string
-                                        required:
-                                          - kind
-                                          - name
+                                          optional:
+                                            type: boolean
                                         type: object
-                                      resources:
+                                      downwardAPI:
                                         properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            type: object
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
                                         type: object
-                                      selector:
+                                      secret:
                                         properties:
-                                          matchExpressions:
+                                          items:
                                             items:
                                               properties:
                                                 key:
                                                   type: string
-                                                operator:
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
                                                   type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
                                               required:
                                                 - key
-                                                - operator
+                                                - path
                                               type: object
                                             type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
                                         type: object
-                                      storageClassName:
-                                        type: string
-                                      volumeMode:
-                                        type: string
-                                      volumeName:
-                                        type: string
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
                                     type: object
-                                required:
-                                  - spec
-                                type: object
-                            type: object
-                          fc:
-                            properties:
-                              fsType:
-                                type: string
-                              lun:
-                                format: int32
-                                type: integer
-                              readOnly:
-                                type: boolean
-                              targetWWNs:
-                                items:
-                                  type: string
-                                type: array
-                              wwids:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          flexVolume:
-                            properties:
-                              driver:
-                                type: string
-                              fsType:
-                                type: string
-                              options:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                            required:
-                              - driver
-                            type: object
-                          flocker:
-                            properties:
-                              datasetName:
-                                type: string
-                              datasetUUID:
-                                type: string
-                            type: object
-                          gcePersistentDisk:
-                            properties:
-                              fsType:
-                                type: string
-                              partition:
-                                format: int32
-                                type: integer
-                              pdName:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - pdName
-                            type: object
-                          gitRepo:
-                            properties:
-                              directory:
-                                type: string
-                              repository:
-                                type: string
-                              revision:
-                                type: string
-                            required:
-                              - repository
-                            type: object
-                          glusterfs:
-                            properties:
-                              endpoints:
-                                type: string
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - endpoints
-                              - path
-                            type: object
-                          hostPath:
-                            properties:
-                              path:
-                                type: string
-                              type:
-                                type: string
-                            required:
-                              - path
-                            type: object
-                          iscsi:
-                            properties:
-                              chapAuthDiscovery:
-                                type: boolean
-                              chapAuthSession:
-                                type: boolean
-                              fsType:
-                                type: string
-                              initiatorName:
-                                type: string
-                              iqn:
-                                type: string
-                              iscsiInterface:
-                                type: string
-                              lun:
-                                format: int32
-                                type: integer
-                              portals:
-                                items:
-                                  type: string
-                                type: array
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              targetPortal:
-                                type: string
-                            required:
-                              - iqn
-                              - lun
-                              - targetPortal
-                            type: object
-                          name:
-                            type: string
-                          nfs:
-                            properties:
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              server:
-                                type: string
-                            required:
-                              - path
-                              - server
-                            type: object
-                          persistentVolumeClaim:
-                            properties:
-                              claimName:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                              - claimName
-                            type: object
-                          photonPersistentDisk:
-                            properties:
-                              fsType:
-                                type: string
-                              pdID:
-                                type: string
-                            required:
-                              - pdID
-                            type: object
-                          portworxVolume:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              volumeID:
-                                type: string
-                            required:
-                              - volumeID
-                            type: object
-                          projected:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              sources:
-                                items:
-                                  properties:
-                                    configMap:
-                                      properties:
-                                        items:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              mode:
-                                                format: int32
-                                                type: integer
-                                              path:
-                                                type: string
-                                            required:
-                                              - key
-                                              - path
-                                            type: object
-                                          type: array
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                    downwardAPI:
-                                      properties:
-                                        items:
-                                          items:
-                                            properties:
-                                              fieldRef:
-                                                properties:
-                                                  apiVersion:
-                                                    type: string
-                                                  fieldPath:
-                                                    type: string
-                                                required:
-                                                  - fieldPath
-                                                type: object
-                                              mode:
-                                                format: int32
-                                                type: integer
-                                              path:
-                                                type: string
-                                              resourceFieldRef:
-                                                properties:
-                                                  containerName:
-                                                    type: string
-                                                  divisor:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  resource:
-                                                    type: string
-                                                required:
-                                                  - resource
-                                                type: object
-                                            required:
-                                              - path
-                                            type: object
-                                          type: array
-                                      type: object
-                                    secret:
-                                      properties:
-                                        items:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              mode:
-                                                format: int32
-                                                type: integer
-                                              path:
-                                                type: string
-                                            required:
-                                              - key
-                                              - path
-                                            type: object
-                                          type: array
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      type: object
-                                    serviceAccountToken:
-                                      properties:
-                                        audience:
-                                          type: string
-                                        expirationSeconds:
-                                          format: int64
-                                          type: integer
-                                        path:
-                                          type: string
-                                      required:
-                                        - path
-                                      type: object
-                                  type: object
-                                type: array
-                            type: object
-                          quobyte:
-                            properties:
-                              group:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              registry:
-                                type: string
-                              tenant:
-                                type: string
-                              user:
-                                type: string
-                              volume:
-                                type: string
-                            required:
-                              - registry
-                              - volume
-                            type: object
-                          rbd:
-                            properties:
-                              fsType:
-                                type: string
-                              image:
-                                type: string
-                              keyring:
-                                type: string
-                              monitors:
-                                items:
-                                  type: string
-                                type: array
-                              pool:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              user:
-                                type: string
-                            required:
-                              - image
-                              - monitors
-                            type: object
-                          scaleIO:
-                            properties:
-                              fsType:
-                                type: string
-                              gateway:
-                                type: string
-                              protectionDomain:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              sslEnabled:
-                                type: boolean
-                              storageMode:
-                                type: string
-                              storagePool:
-                                type: string
-                              system:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - gateway
-                              - secretRef
-                              - system
-                            type: object
-                          secret:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              items:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    mode:
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      type: string
-                                  required:
-                                    - key
-                                    - path
-                                  type: object
-                                type: array
-                              optional:
-                                type: boolean
-                              secretName:
-                                type: string
-                            type: object
-                          storageos:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              volumeName:
-                                type: string
-                              volumeNamespace:
-                                type: string
-                            type: object
-                          vsphereVolume:
-                            properties:
-                              fsType:
-                                type: string
-                              storagePolicyID:
-                                type: string
-                              storagePolicyName:
-                                type: string
-                              volumePath:
-                                type: string
-                            required:
-                              - volumePath
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                customConfig:
-                  properties:
-                    configData:
-                      type: string
-                    configMap:
-                      properties:
-                        fileKey:
-                          type: string
-                        name:
-                          type: string
-                      type: object
-                  type: object
-                deploymentName:
-                  type: string
-                enabled:
-                  type: boolean
-                image:
-                  properties:
-                    jmxEnabled:
-                      type: boolean
-                    name:
-                      type: string
-                    pullPolicy:
-                      type: string
-                    pullSecrets:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                        type: object
-                      type: array
-                    tag:
-                      type: string
-                  type: object
-                networkPolicy:
-                  properties:
-                    create:
-                      type: boolean
-                    dnsSelectorEndpoints:
-                      items:
-                        properties:
-                          matchExpressions:
-                            items:
+                                  type: array
+                              type: object
+                            quobyte:
                               properties:
-                                key:
+                                group:
                                   type: string
-                                operator:
+                                readOnly:
+                                  type: boolean
+                                registry:
                                   type: string
-                                values:
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  type: string
+                                monitors:
                                   items:
                                     type: string
                                   type: array
+                                pool:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                user:
+                                  type: string
                               required:
-                                - key
-                                - operator
+                                - image
+                                - monitors
                               type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      type: array
-                    flavor:
-                      type: string
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  type: object
-                priorityClassName:
-                  type: string
-                rbac:
-                  properties:
-                    create:
-                      type: boolean
-                    serviceAccountName:
-                      type: string
-                  type: object
-                replicas:
-                  format: int32
-                  type: integer
-                tolerations:
-                  items:
-                    properties:
-                      effect:
-                        type: string
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      tolerationSeconds:
-                        format: int64
-                        type: integer
-                      value:
-                        type: string
-                    type: object
-                  type: array
-              type: object
-            clusterName:
-              type: string
-            credentials:
-              properties:
-                apiKey:
-                  type: string
-                apiKeyExistingSecret:
-                  type: string
-                apiSecret:
-                  properties:
-                    keyName:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                    - secretName
-                  type: object
-                appKey:
-                  type: string
-                appKeyExistingSecret:
-                  type: string
-                appSecret:
-                  properties:
-                    keyName:
-                      type: string
-                    secretName:
-                      type: string
-                  required:
-                    - secretName
-                  type: object
-                token:
-                  type: string
-                useSecretBackend:
-                  type: boolean
-              type: object
-            features:
-              properties:
-                kubeStateMetricsCore:
-                  properties:
-                    clusterCheck:
-                      type: boolean
-                    conf:
-                      properties:
-                        configData:
-                          type: string
-                        configMap:
-                          properties:
-                            fileKey:
-                              type: string
-                            name:
-                              type: string
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
                           type: object
-                      type: object
-                    enabled:
-                      type: boolean
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    type: object
                   type: object
-                logCollection:
+              type: object
+            status:
+              properties:
+                agent:
                   properties:
-                    containerCollectUsingFiles:
-                      type: boolean
-                    containerLogsPath:
-                      type: string
-                    containerSymlinksPath:
-                      type: string
-                    enabled:
-                      type: boolean
-                    logsConfigContainerCollectAll:
-                      type: boolean
-                    openFilesLimit:
+                    available:
                       format: int32
                       type: integer
-                    podLogsPath:
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
                       type: string
-                    tempStoragePath:
+                    daemonsetName:
                       type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
                   type: object
-                networkMonitoring:
+                clusterAgent:
                   properties:
-                    enabled:
-                      type: boolean
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
                   type: object
-                orchestratorExplorer:
+                clusterChecksRunner:
                   properties:
-                    additionalEndpoints:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
                       type: string
-                    clusterCheck:
-                      type: boolean
-                    conf:
-                      properties:
-                        configData:
-                          type: string
-                        configMap:
-                          properties:
-                            fileKey:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                      type: object
-                    ddUrl:
+                    deploymentName:
                       type: string
-                    enabled:
-                      type: boolean
-                    extraTags:
-                      items:
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
                         type: string
-                      type: array
-                    scrubbing:
-                      properties:
-                        containers:
-                          type: boolean
-                      type: object
-                  type: object
-                prometheusScrape:
-                  properties:
-                    additionalConfigs:
-                      type: string
-                    enabled:
-                      type: boolean
-                    serviceEndpoints:
-                      type: boolean
-                  type: object
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
               type: object
-            registry:
-              type: string
-            site:
-              type: string
           type: object
-        status:
-          properties:
-            agent:
-              properties:
-                available:
-                  format: int32
-                  type: integer
-                current:
-                  format: int32
-                  type: integer
-                currentHash:
-                  type: string
-                daemonsetName:
-                  type: string
-                desired:
-                  format: int32
-                  type: integer
-                lastUpdate:
-                  format: date-time
-                  type: string
-                ready:
-                  format: int32
-                  type: integer
-                state:
-                  type: string
-                status:
-                  type: string
-                upToDate:
-                  format: int32
-                  type: integer
-              required:
-                - available
-                - current
-                - desired
-                - ready
-                - upToDate
-              type: object
-            clusterAgent:
-              properties:
-                availableReplicas:
-                  format: int32
-                  type: integer
-                currentHash:
-                  type: string
-                deploymentName:
-                  type: string
-                generatedToken:
-                  type: string
-                lastUpdate:
-                  format: date-time
-                  type: string
-                readyReplicas:
-                  format: int32
-                  type: integer
-                replicas:
-                  format: int32
-                  type: integer
-                state:
-                  type: string
-                status:
-                  type: string
-                unavailableReplicas:
-                  format: int32
-                  type: integer
-                updatedReplicas:
-                  format: int32
-                  type: integer
-              type: object
-            clusterChecksRunner:
-              properties:
-                availableReplicas:
-                  format: int32
-                  type: integer
-                currentHash:
-                  type: string
-                deploymentName:
-                  type: string
-                generatedToken:
-                  type: string
-                lastUpdate:
-                  format: date-time
-                  type: string
-                readyReplicas:
-                  format: int32
-                  type: integer
-                replicas:
-                  format: int32
-                  type: integer
-                state:
-                  type: string
-                status:
-                  type: string
-                unavailableReplicas:
-                  format: int32
-                  type: integer
-                updatedReplicas:
-                  format: int32
-                  type: integer
-              type: object
-            conditions:
-              items:
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                  - status
-                  - type
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-    - name: v2alpha1
       served: false
       storage: false
 status:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition") }}
+{{- if and .Values.crds.datadogMetrics (semverCompare ">=21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (not (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition")) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare "<21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMonitors (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition") }}
+{{- if and .Values.crds.datadogMonitors (semverCompare ">=21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMonitors (not (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition")) }}
+{{- if and .Values.crds.datadogMonitors (semverCompare "<21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -34,9 +34,9 @@ download_crd() {
         yq -i eval 'del(.spec.preserveUnknownFields)' "$path"
     fi
 
-    ifCondition="{{- if and .Values.crds.$installOption (not (.Capabilities.APIVersions.Has \"apiextensions.k8s.io/v1/CustomResourceDefinition\")) }}"
+    ifCondition="{{- if and .Values.crds.$installOption (semverCompare \"<21\" .Capabilities.KubeVersion.Minor) }}"
     if [ "$version" = "v1" ]; then
-        ifCondition="{{- if and .Values.crds.$installOption (.Capabilities.APIVersions.Has \"apiextensions.k8s.io/v1/CustomResourceDefinition\") }}"
+        ifCondition="{{- if and .Values.crds.$installOption (semverCompare \">=21\" .Capabilities.KubeVersion.Minor) }}"
         cp "$path" "$ROOT/crds/datadoghq.com_$name.yaml"
     fi
 

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -500,6 +500,16 @@ spec:
                             failureThreshold:
                               format: int32
                               type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
                             httpGet:
                               properties:
                                 host:
@@ -841,6 +851,16 @@ spec:
                             failureThreshold:
                               format: int32
                               type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
                             httpGet:
                               properties:
                                 host:
@@ -927,6 +947,16 @@ spec:
                             failureThreshold:
                               format: int32
                               type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
                             httpGet:
                               properties:
                                 host:
@@ -1060,6 +1090,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                hostProcess:
+                                  type: boolean
                                 runAsUserName:
                                   type: string
                               type: object
@@ -1306,6 +1338,18 @@ spec:
                                               type: string
                                             type: array
                                           dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          dataSourceRef:
                                             properties:
                                               apiGroup:
                                                 type: string
@@ -1802,6 +1846,8 @@ spec:
                           properties:
                             autoFail:
                               properties:
+                                canaryTimeout:
+                                  type: string
                                 enabled:
                                   type: boolean
                                 maxRestarts:
@@ -1857,6 +1903,11 @@ spec:
                                 - type: integer
                                 - type: string
                               x-kubernetes-int-or-string: true
+                            validationMode:
+                              enum:
+                                - auto
+                                - manual
+                              type: string
                           type: object
                         reconcileFrequency:
                           type: string
@@ -2557,6 +2608,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                hostProcess:
+                                  type: boolean
                                 runAsUserName:
                                   type: string
                               type: object
@@ -3191,6 +3244,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                hostProcess:
+                                  type: boolean
                                 runAsUserName:
                                   type: string
                               type: object
@@ -3415,6 +3470,18 @@ spec:
                                               type: string
                                             type: array
                                           dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          dataSourceRef:
                                             properties:
                                               apiGroup:
                                                 type: string
@@ -4450,6 +4517,16 @@ spec:
                             failureThreshold:
                               format: int32
                               type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
                             httpGet:
                               properties:
                                 host:
@@ -4520,6 +4597,16 @@ spec:
                             failureThreshold:
                               format: int32
                               type: integer
+                            grpc:
+                              properties:
+                                port:
+                                  format: int32
+                                  type: integer
+                                service:
+                                  type: string
+                              required:
+                                - port
+                              type: object
                             httpGet:
                               properties:
                                 host:
@@ -4653,6 +4740,8 @@ spec:
                                   type: string
                                 gmsaCredentialSpecName:
                                   type: string
+                                hostProcess:
+                                  type: boolean
                                 runAsUserName:
                                   type: string
                               type: object
@@ -4877,6 +4966,18 @@ spec:
                                               type: string
                                             type: array
                                           dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          dataSourceRef:
                                             properties:
                                               apiGroup:
                                                 type: string
@@ -5769,7 +5870,7 @@ spec:
                               format: int32
                               type: integer
                           type: object
-                        unixDomainSocket:
+                        unixDomainSocketConfig:
                           properties:
                             enabled:
                               type: boolean
@@ -5777,21 +5878,18 @@ spec:
                               type: string
                           type: object
                       type: object
-                    clusterChecksRunner:
+                    clusterChecks:
                       properties:
                         enabled:
                           type: boolean
-                      type: object
-                    containerCollection:
-                      properties:
-                        enabled:
+                        useClusterChecksRunners:
                           type: boolean
                       type: object
                     cspm:
                       properties:
                         checkInterval:
                           type: string
-                        configDir:
+                        customBenchmarks:
                           properties:
                             items:
                               items:
@@ -5819,7 +5917,7 @@ spec:
                       type: object
                     cws:
                       properties:
-                        configDir:
+                        customPolicies:
                           properties:
                             items:
                               items:
@@ -5842,14 +5940,67 @@ spec:
                             name:
                               type: string
                           type: object
-                        enableSyscallMonitor:
-                          type: boolean
                         enabled:
+                          type: boolean
+                        syscallMonitorEnabled:
                           type: boolean
                       type: object
                     datadogMonitor:
                       properties:
                         enabled:
+                          type: boolean
+                      type: object
+                    dogstatsd:
+                      properties:
+                        hostPortConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPort:
+                              format: int32
+                              type: integer
+                          type: object
+                        mapperProfiles:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        originDetectionEnabled:
+                          type: boolean
+                        unixDomainSocketConfig:
+                          properties:
+                            enabled:
+                              type: boolean
+                            path:
+                              type: string
+                          type: object
+                      type: object
+                    eventCollection:
+                      properties:
+                        collectKubernetesEvents:
                           type: boolean
                       type: object
                     externalMetricsServer:
@@ -5927,6 +6078,16 @@ spec:
                         enabled:
                           type: boolean
                       type: object
+                    liveContainerCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    liveProcessCollection:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     logCollection:
                       properties:
                         containerCollectAll:
@@ -5948,6 +6109,15 @@ spec:
                           type: string
                       type: object
                     npm:
+                      properties:
+                        collectDNSStats:
+                          type: boolean
+                        enableConntrack:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    oomKill:
                       properties:
                         enabled:
                           type: boolean
@@ -6022,17 +6192,17 @@ spec:
                         scrubContainers:
                           type: boolean
                       type: object
-                    processCollection:
-                      properties:
-                        enabled:
-                          type: boolean
-                      type: object
                     prometheusScrape:
                       properties:
                         additionalConfigs:
                           type: string
                         enableServiceEndpoints:
                           type: boolean
+                        enabled:
+                          type: boolean
+                      type: object
+                    tcpQueueLength:
+                      properties:
                         enabled:
                           type: boolean
                       type: object
@@ -6044,6 +6214,8 @@ spec:
                   type: object
                 global:
                   properties:
+                    clusterAgentToken:
+                      type: string
                     clusterName:
                       type: string
                     credentials:
@@ -6070,6 +6242,98 @@ spec:
                           required:
                             - secretName
                           type: object
+                      type: object
+                    criSocketPath:
+                      type: string
+                    dockerSocketPath:
+                      type: string
+                    endpoint:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              type: string
+                            apiSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                            appKey:
+                              type: string
+                            appSecret:
+                              properties:
+                                keyName:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                                - secretName
+                              type: object
+                          type: object
+                        url:
+                          type: string
+                      type: object
+                    kubelet:
+                      properties:
+                        agentCAPath:
+                          type: string
+                        host:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                          type: object
+                        hostCAPath:
+                          type: string
+                        tlsVerify:
+                          type: boolean
                       type: object
                     localService:
                       properties:
@@ -6113,6 +6377,14 @@ spec:
                         flavor:
                           type: string
                       type: object
+                    podAnnotationsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    podLabelsAsTags:
+                      additionalProperties:
+                        type: string
+                      type: object
                     registry:
                       type: string
                     site:
@@ -6126,1470 +6398,1840 @@ spec:
                 override:
                   additionalProperties:
                     properties:
-                      name:
-                        type: string
-                      podOverride:
+                      affinity:
                         properties:
-                          affinity:
+                          nodeAffinity:
                             properties:
-                              nodeAffinity:
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        preference:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchFields:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                          type: object
-                                        weight:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                        - preference
-                                        - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    properties:
-                                      nodeSelectorTerms:
-                                        items:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchFields:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                          type: object
-                                        type: array
-                                    required:
-                                      - nodeSelectorTerms
-                                    type: object
-                                type: object
-                              podAffinity:
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        podAffinityTerm:
-                                          properties:
-                                            labelSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                      - key
-                                                      - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            namespaceSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                      - key
-                                                      - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            namespaces:
-                                              items:
-                                                type: string
-                                              type: array
-                                            topologyKey:
-                                              type: string
-                                          required:
-                                            - topologyKey
-                                          type: object
-                                        weight:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                        - podAffinityTerm
-                                        - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaceSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                        - topologyKey
-                                      type: object
-                                    type: array
-                                type: object
-                              podAntiAffinity:
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        podAffinityTerm:
-                                          properties:
-                                            labelSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                      - key
-                                                      - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            namespaceSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                      - key
-                                                      - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            namespaces:
-                                              items:
-                                                type: string
-                                              type: array
-                                            topologyKey:
-                                              type: string
-                                          required:
-                                            - topologyKey
-                                          type: object
-                                        weight:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                        - podAffinityTerm
-                                        - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaceSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                  - key
-                                                  - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                        - topologyKey
-                                      type: object
-                                    type: array
-                                type: object
-                            type: object
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          containers:
-                            items:
-                              properties:
-                                args:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                command:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                env:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                      valueFrom:
-                                        properties:
-                                          configMapKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                              - key
-                                            type: object
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                              - fieldPath
-                                            type: object
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                type: string
-                                            required:
-                                              - resource
-                                            type: object
-                                          secretKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                              - key
-                                            type: object
-                                        type: object
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                healthPort:
-                                  format: int32
-                                  type: integer
-                                livenessProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                              - name
-                                              - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                        - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                        - port
-                                      type: object
-                                    terminationGracePeriodSeconds:
-                                      format: int64
-                                      type: integer
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                name:
-                                  type: string
-                                readinessProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                              - name
-                                              - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                        - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                        - port
-                                      type: object
-                                    terminationGracePeriodSeconds:
-                                      format: int64
-                                      type: integer
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                resources:
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                  type: object
-                                volumeMounts:
-                                  items:
-                                    properties:
-                                      mountPath:
-                                        type: string
-                                      mountPropagation:
-                                        type: string
-                                      name:
-                                        type: string
-                                      readOnly:
-                                        type: boolean
-                                      subPath:
-                                        type: string
-                                      subPathExpr:
-                                        type: string
-                                    required:
-                                      - mountPath
-                                      - name
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                    - mountPath
-                                  x-kubernetes-list-type: map
-                              type: object
-                            type: array
-                          image:
-                            properties:
-                              jmxEnabled:
-                                type: boolean
-                              name:
-                                type: string
-                              pullPolicy:
-                                type: string
-                              pullSecrets:
+                              preferredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
-                                    name:
-                                      type: string
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
                                   type: object
                                 type: array
-                              tag:
-                                type: string
-                            type: object
-                          kubelet:
-                            properties:
-                              agentCAPath:
-                                type: string
-                              host:
+                              requiredDuringSchedulingIgnoredDuringExecution:
                                 properties:
-                                  configMapKeyRef:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                              hostCAPath:
-                                type: string
-                              tlsVerify:
-                                type: boolean
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          priorityClassName:
-                            type: string
-                          securityContext:
-                            properties:
-                              fsGroup:
-                                format: int64
-                                type: integer
-                              fsGroupChangePolicy:
-                                type: string
-                              runAsGroup:
-                                format: int64
-                                type: integer
-                              runAsNonRoot:
-                                type: boolean
-                              runAsUser:
-                                format: int64
-                                type: integer
-                              seLinuxOptions:
-                                properties:
-                                  level:
-                                    type: string
-                                  role:
-                                    type: string
-                                  type:
-                                    type: string
-                                  user:
-                                    type: string
-                                type: object
-                              seccompProfile:
-                                properties:
-                                  localhostProfile:
-                                    type: string
-                                  type:
-                                    type: string
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
                                 required:
-                                  - type
-                                type: object
-                              supplementalGroups:
-                                items:
-                                  format: int64
-                                  type: integer
-                                type: array
-                              sysctls:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              windowsOptions:
-                                properties:
-                                  gmsaCredentialSpec:
-                                    type: string
-                                  gmsaCredentialSpecName:
-                                    type: string
-                                  runAsUserName:
-                                    type: string
+                                  - nodeSelectorTerms
                                 type: object
                             type: object
-                          tolerations:
-                            items:
-                              properties:
-                                effect:
-                                  type: string
-                                key:
-                                  type: string
-                                operator:
-                                  type: string
-                                tolerationSeconds:
-                                  format: int64
-                                  type: integer
-                                value:
-                                  type: string
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          volumes:
-                            items:
-                              properties:
-                                awsElasticBlockStore:
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
                                   properties:
-                                    fsType:
-                                      type: string
-                                    partition:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
                                       format: int32
                                       type: integer
-                                    readOnly:
-                                      type: boolean
-                                    volumeID:
-                                      type: string
                                   required:
-                                    - volumeID
+                                    - podAffinityTerm
+                                    - weight
                                   type: object
-                                azureDisk:
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
                                   properties:
-                                    cachingMode:
-                                      type: string
-                                    diskName:
-                                      type: string
-                                    diskURI:
-                                      type: string
-                                    fsType:
-                                      type: string
-                                    kind:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                  required:
-                                    - diskName
-                                    - diskURI
-                                  type: object
-                                azureFile:
-                                  properties:
-                                    readOnly:
-                                      type: boolean
-                                    secretName:
-                                      type: string
-                                    shareName:
-                                      type: string
-                                  required:
-                                    - secretName
-                                    - shareName
-                                  type: object
-                                cephfs:
-                                  properties:
-                                    monitors:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
                                       items:
                                         type: string
                                       type: array
-                                    path:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretFile:
-                                      type: string
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    user:
+                                    topologyKey:
                                       type: string
                                   required:
-                                    - monitors
+                                    - topologyKey
                                   type: object
-                                cinder:
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
                                   properties:
-                                    fsType:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
+                                    podAffinityTerm:
                                       properties:
-                                        name:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
                                           type: string
+                                      required:
+                                        - topologyKey
                                       type: object
-                                    volumeID:
-                                      type: string
-                                  required:
-                                    - volumeID
-                                  type: object
-                                configMap:
-                                  properties:
-                                    defaultMode:
+                                    weight:
                                       format: int32
                                       type: integer
-                                    items:
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
                                       items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      containers:
+                        additionalProperties:
+                          properties:
+                            appArmorProfileName:
+                              type: string
+                            args:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
                                         properties:
                                           key:
                                             type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
+                                          name:
                                             type: string
+                                          optional:
+                                            type: boolean
                                         required:
                                           - key
-                                          - path
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            healthPort:
+                              format: int32
+                              type: integer
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
                                         type: object
                                       type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            logLevel:
+                              type: string
+                            name:
+                              type: string
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  properties:
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                              x-kubernetes-list-type: map
+                          type: object
+                        type: object
+                      createRbac:
+                        type: boolean
+                      customConfigurations:
+                        additionalProperties:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: object
+                      disabled:
+                        type: boolean
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
                                     name:
                                       type: string
                                     optional:
                                       type: boolean
-                                  type: object
-                                csi:
-                                  properties:
-                                    driver:
-                                      type: string
-                                    fsType:
-                                      type: string
-                                    nodePublishSecretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    readOnly:
-                                      type: boolean
-                                    volumeAttributes:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
                                   required:
-                                    - driver
+                                    - key
                                   type: object
-                                downwardAPI:
+                                fieldRef:
                                   properties:
-                                    defaultMode:
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      items:
-                                        properties:
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                              - fieldPath
-                                            type: object
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                type: string
-                                            required:
-                                              - resource
-                                            type: object
-                                        required:
-                                          - path
-                                        type: object
-                                      type: array
-                                  type: object
-                                emptyDir:
-                                  properties:
-                                    medium:
+                                    apiVersion:
                                       type: string
-                                    sizeLimit:
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
                                       anyOf:
                                         - type: integer
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                  type: object
-                                ephemeral:
-                                  properties:
-                                    volumeClaimTemplate:
-                                      properties:
-                                        metadata:
-                                          type: object
-                                        spec:
-                                          properties:
-                                            accessModes:
-                                              items:
-                                                type: string
-                                              type: array
-                                            dataSource:
-                                              properties:
-                                                apiGroup:
-                                                  type: string
-                                                kind:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                              required:
-                                                - kind
-                                                - name
-                                              type: object
-                                            resources:
-                                              properties:
-                                                limits:
-                                                  additionalProperties:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
-                                                  type: object
-                                                requests:
-                                                  additionalProperties:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                    x-kubernetes-int-or-string: true
-                                                  type: object
-                                              type: object
-                                            selector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                      - key
-                                                      - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            storageClassName:
-                                              type: string
-                                            volumeMode:
-                                              type: string
-                                            volumeName:
-                                              type: string
-                                          type: object
-                                      required:
-                                        - spec
-                                      type: object
-                                  type: object
-                                fc:
-                                  properties:
-                                    fsType:
+                                    resource:
                                       type: string
-                                    lun:
+                                  required:
+                                    - resource
+                                  type: object
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      extraChecksd:
+                        properties:
+                          configData:
+                            type: string
+                          configMap:
+                            properties:
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
                                       format: int32
                                       type: integer
-                                    readOnly:
-                                      type: boolean
-                                    targetWWNs:
-                                      items:
-                                        type: string
-                                      type: array
-                                    wwids:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                flexVolume:
-                                  properties:
-                                    driver:
-                                      type: string
-                                    fsType:
-                                      type: string
-                                    options:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                  required:
-                                    - driver
-                                  type: object
-                                flocker:
-                                  properties:
-                                    datasetName:
-                                      type: string
-                                    datasetUUID:
-                                      type: string
-                                  type: object
-                                gcePersistentDisk:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    partition:
-                                      format: int32
-                                      type: integer
-                                    pdName:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                  required:
-                                    - pdName
-                                  type: object
-                                gitRepo:
-                                  properties:
-                                    directory:
-                                      type: string
-                                    repository:
-                                      type: string
-                                    revision:
-                                      type: string
-                                  required:
-                                    - repository
-                                  type: object
-                                glusterfs:
-                                  properties:
-                                    endpoints:
-                                      type: string
                                     path:
                                       type: string
-                                    readOnly:
-                                      type: boolean
                                   required:
-                                    - endpoints
+                                    - key
                                     - path
                                   type: object
-                                hostPath:
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      extraConfd:
+                        properties:
+                          configData:
+                            type: string
+                          configMap:
+                            properties:
+                              items:
+                                items:
                                   properties:
-                                    path:
+                                    key:
                                       type: string
-                                    type:
-                                      type: string
-                                  required:
-                                    - path
-                                  type: object
-                                iscsi:
-                                  properties:
-                                    chapAuthDiscovery:
-                                      type: boolean
-                                    chapAuthSession:
-                                      type: boolean
-                                    fsType:
-                                      type: string
-                                    initiatorName:
-                                      type: string
-                                    iqn:
-                                      type: string
-                                    iscsiInterface:
-                                      type: string
-                                    lun:
+                                    mode:
                                       format: int32
                                       type: integer
-                                    portals:
-                                      items:
-                                        type: string
-                                      type: array
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    targetPortal:
+                                    path:
                                       type: string
                                   required:
-                                    - iqn
-                                    - lun
-                                    - targetPortal
+                                    - key
+                                    - path
                                   type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      image:
+                        properties:
+                          jmxEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                          pullPolicy:
+                            type: string
+                          pullSecrets:
+                            items:
+                              properties:
                                 name:
                                   type: string
-                                nfs:
+                              type: object
+                            type: array
+                          tag:
+                            type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      priorityClassName:
+                        type: string
+                      replicas:
+                        format: int32
+                        type: integer
+                      secCompCustomProfile:
+                        properties:
+                          configData:
+                            type: string
+                          configMap:
+                            properties:
+                              items:
+                                items:
                                   properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
                                     path:
                                       type: string
-                                    readOnly:
-                                      type: boolean
-                                    server:
-                                      type: string
                                   required:
+                                    - key
                                     - path
-                                    - server
                                   type: object
-                                persistentVolumeClaim:
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - key
+                                x-kubernetes-list-type: map
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      secCompProfileName:
+                        type: string
+                      secCompRootPath:
+                        type: string
+                      securityContext:
+                        properties:
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountName:
+                        type: string
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - diskName
+                                - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                                - secretName
+                                - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
                                   properties:
-                                    claimName:
+                                    name:
                                       type: string
-                                    readOnly:
-                                      type: boolean
-                                  required:
-                                    - claimName
                                   type: object
-                                photonPersistentDisk:
+                                user:
+                                  type: string
+                              required:
+                                - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
                                   properties:
-                                    fsType:
+                                    name:
                                       type: string
-                                    pdID:
-                                      type: string
-                                  required:
-                                    - pdID
                                   type: object
-                                portworxVolume:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    volumeID:
-                                      type: string
-                                  required:
-                                    - volumeID
-                                  type: object
-                                projected:
-                                  properties:
-                                    defaultMode:
-                                      format: int32
-                                      type: integer
-                                    sources:
-                                      items:
-                                        properties:
-                                          configMap:
-                                            properties:
-                                              items:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    mode:
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      type: string
-                                                  required:
-                                                    - key
-                                                    - path
-                                                  type: object
-                                                type: array
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            type: object
-                                          downwardAPI:
-                                            properties:
-                                              items:
-                                                items:
-                                                  properties:
-                                                    fieldRef:
-                                                      properties:
-                                                        apiVersion:
-                                                          type: string
-                                                        fieldPath:
-                                                          type: string
-                                                      required:
-                                                        - fieldPath
-                                                      type: object
-                                                    mode:
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      type: string
-                                                    resourceFieldRef:
-                                                      properties:
-                                                        containerName:
-                                                          type: string
-                                                        divisor:
-                                                          anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                          x-kubernetes-int-or-string: true
-                                                        resource:
-                                                          type: string
-                                                      required:
-                                                        - resource
-                                                      type: object
-                                                  required:
-                                                    - path
-                                                  type: object
-                                                type: array
-                                            type: object
-                                          secret:
-                                            properties:
-                                              items:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    mode:
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      type: string
-                                                  required:
-                                                    - key
-                                                    - path
-                                                  type: object
-                                                type: array
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            type: object
-                                          serviceAccountToken:
-                                            properties:
-                                              audience:
-                                                type: string
-                                              expirationSeconds:
-                                                format: int64
-                                                type: integer
-                                              path:
-                                                type: string
-                                            required:
-                                              - path
-                                            type: object
-                                        type: object
-                                      type: array
-                                  type: object
-                                quobyte:
-                                  properties:
-                                    group:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    registry:
-                                      type: string
-                                    tenant:
-                                      type: string
-                                    user:
-                                      type: string
-                                    volume:
-                                      type: string
-                                  required:
-                                    - registry
-                                    - volume
-                                  type: object
-                                rbd:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    image:
-                                      type: string
-                                    keyring:
-                                      type: string
-                                    monitors:
-                                      items:
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
                                         type: string
-                                      type: array
-                                    pool:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    user:
-                                      type: string
-                                  required:
-                                    - image
-                                    - monitors
-                                  type: object
-                                scaleIO:
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
                                   properties:
-                                    fsType:
+                                    name:
                                       type: string
-                                    gateway:
-                                      type: string
-                                    protectionDomain:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    sslEnabled:
-                                      type: boolean
-                                    storageMode:
-                                      type: string
-                                    storagePool:
-                                      type: string
-                                    system:
-                                      type: string
-                                    volumeName:
-                                      type: string
-                                  required:
-                                    - gateway
-                                    - secretRef
-                                    - system
                                   type: object
-                                secret:
-                                  properties:
-                                    defaultMode:
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      items:
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
                                         properties:
-                                          key:
+                                          apiVersion:
                                             type: string
-                                          mode:
-                                            format: int32
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                    required:
+                                      - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                    - spec
+                                  type: object
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              required:
+                                - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                                - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - endpoints
+                                - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                                - path
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  type: string
+                              required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                                - path
+                                - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                                - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                                - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                                - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
                                             type: integer
                                           path:
                                             type: string
                                         required:
-                                          - key
                                           - path
                                         type: object
-                                      type: array
-                                    optional:
-                                      type: boolean
-                                    secretName:
-                                      type: string
-                                  type: object
-                                storageos:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    volumeName:
-                                      type: string
-                                    volumeNamespace:
-                                      type: string
-                                  type: object
-                                vsphereVolume:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    storagePolicyID:
-                                      type: string
-                                    storagePolicyName:
-                                      type: string
-                                    volumePath:
-                                      type: string
-                                  required:
-                                    - volumePath
-                                  type: object
-                              required:
-                                - name
+                                    type: object
+                                  type: array
                               type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                              - name
-                            x-kubernetes-list-type: map
-                        type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                                - registry
+                                - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                user:
+                                  type: string
+                              required:
+                                - image
+                                - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - gateway
+                                - secretRef
+                                - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                                - volumePath
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                     type: object
                   type: object
               type: object
             status:
               properties:
-                defaultOverride:
+                agent:
+                  properties:
+                    available:
+                      format: int32
+                      type: integer
+                    current:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    daemonsetName:
+                      type: string
+                    desired:
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    ready:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    upToDate:
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
                   type: object
+                clusterAgent:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                clusterChecksRunner:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    currentHash:
+                      type: string
+                    deploymentName:
+                      type: string
+                    generatedToken:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    state:
+                      type: string
+                    status:
+                      type: string
+                    unavailableReplicas:
+                      format: int32
+                      type: integer
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
               type: object
           type: object
       served: false


### PR DESCRIPTION
The `.Capabilities.APIVersions` does not expose `CustomResourceDefinition` in GKE so the process of publishing the operator is not working.

#### What this PR does / why we need it:

Make sure we publish the operator to the Google Marketplace.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
