### PR TITLE
Fix semver comparison to use v1beta1 in 1.21

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3
+
+* Fix the semver comparison so v1beta1 is used on 1.21.
+
 ## 0.5.2
 
 * Rely on the Kubernetes version to deploy the CRD v1 or v1beta1.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.5.2
+version: 0.5.3
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogAgents (semverCompare ">=21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogAgents (semverCompare ">21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogAgents (semverCompare "<21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogAgents (semverCompare "<=21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare ">=21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare ">21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare "<21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare "<=21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMonitors (semverCompare ">=21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogMonitors (semverCompare ">21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMonitors (semverCompare "<21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogMonitors (semverCompare "<=21" .Capabilities.KubeVersion.Minor) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -34,9 +34,9 @@ download_crd() {
         yq -i eval 'del(.spec.preserveUnknownFields)' "$path"
     fi
 
-    ifCondition="{{- if and .Values.crds.$installOption (semverCompare \"<21\" .Capabilities.KubeVersion.Minor) }}"
+    ifCondition="{{- if and .Values.crds.$installOption (semverCompare \"<=21\" .Capabilities.KubeVersion.Minor) }}"
     if [ "$version" = "v1" ]; then
-        ifCondition="{{- if and .Values.crds.$installOption (semverCompare \">=21\" .Capabilities.KubeVersion.Minor) }}"
+        ifCondition="{{- if and .Values.crds.$installOption (semverCompare \">21\" .Capabilities.KubeVersion.Minor) }}"
         cp "$path" "$ROOT/crds/datadoghq.com_$name.yaml"
     fi
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

  - fixes https://github.com/DataDog/helm-charts/issues/689

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
