### PR TITLE
Use backward compatible method to support helm2

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.36.5
+
+* Use `regexFind` in favor of `mustRegexFind` to support helm2.
+
 ## 2.36.4
 
 * Support `commonlabels` configuration to be able to add common labels on all resources created by the chart.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.36.4
+version: 2.36.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.36.4](https://img.shields.io/badge/Version-2.36.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.36.5](https://img.shields.io/badge/Version-2.36.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -21,16 +21,16 @@
   {{- if (and .grpc .grpc.enabled) }}
   {{- include "verify-otlp-grpc-endpoint-prefix" .grpc.endpoint }}
   {{- include "verify-otlp-endpoint-port" .grpc.endpoint }}
-  - containerPort: {{ .grpc.endpoint | mustRegexFind ":[0-9]+$" | trimPrefix ":" }}
-    hostPort: {{ .grpc.endpoint | mustRegexFind ":[0-9]+$" | trimPrefix ":" }}
+  - containerPort: {{ .grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+    hostPort: {{ .grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
     name: otlpgrpcport
     protocol: TCP
   {{- end }}
 
   {{- if (and .http .http.enabled) }}
   {{- include "verify-otlp-endpoint-port" .http.endpoint }}
-  - containerPort: {{ .http.endpoint | mustRegexFind ":[0-9]+$" | trimPrefix ":" }}
-    hostPort: {{ .http.endpoint | mustRegexFind ":[0-9]+$" | trimPrefix ":" }}
+  - containerPort: {{ .http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+    hostPort: {{ .http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
     name: otlphttpport
     protocol: TCP
   {{- end }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -671,7 +671,7 @@ The Datadog Agent Helm Chart currently only supports 'host:port' (usually '0.0.0
 Verifies that an OTLP endpoint has a port explicitly set.
 */}}
 {{- define "verify-otlp-endpoint-port" -}}
-{{- if not ( mustRegexMatch ":[0-9]+$" . ) }}
+{{- if not ( regexMatch ":[0-9]+$" . ) }}
 {{ fail "port must be set explicitly on OTLP endpoints" }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Using the regexMatch with works with helm2 instead of the mustRegexMatch.
doc: https://helm.sh/docs/chart_template_guide/function_list/#regexmatch-mustregexmatch

Making sure this still works:
```
➜  datadog git:(charly/fix-helm2-breaking-option) ✗ helm3 template --set datadog.otlp.receiver.protocols.grpc.enabled=true  --set datadog.otlp.receiver.protocols.grpc.endpoint="0.0.0.0:a"  .
Error: execution error at (datadog/templates/daemonset.yaml:109:12): port must be set explicitly on OTLP endpoints

Use --debug flag to render out invalid YAML
➜  datadog git:(charly/fix-helm2-breaking-option) ✗ helm2 template --set datadog.otlp.receiver.protocols.grpc.enabled=true  --set datadog.otlp.receiver.protocols.grpc.endpoint="0.0.0.0:a"  .
Error: render error in "datadog/templates/daemonset.yaml": template: datadog/templates/daemonset.yaml:109:12: executing "datadog/templates/daemonset.yaml" at <include "container-agent" .>: error calling include: template: datadog/templates/_container-agent.yaml:23:6: executing "container-agent" at <include "verify-otlp-endpoint-port" .grpc.endpoint>: error calling include: template: datadog/templates/_helpers.tpl:675:3: executing "verify-otlp-endpoint-port" at <fail "port must be set explicitly on OTLP endpoints">: error calling fail: port must be set explicitly on OTLP endpoints
```

and
```
➜  datadog git:(charly/fix-helm2-breaking-option) ✗ helm3 template --set datadog.otlp.receiver.protocols.grpc.enabled=true  --set datadog.otlp.receiver.protocols.grpc.endpoint="0.0.0.0:1234"  .
[...]
➜  datadog git:(charly/fix-helm2-breaking-option) ✗ helm2 template --set datadog.otlp.receiver.protocols.grpc.enabled=true  --set datadog.otlp.receiver.protocols.grpc.endpoint="0.0.0.0:1234"  .
[...]
// yields
        ports:
        - containerPort: 8125
          name: dogstatsdport
          protocol: UDP
        - containerPort: 1234
          hostPort: 1234
          name: otlpgrpcport
          protocol: TCP
[...]
            value: "yes"
          - name: DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT
            value: "0.0.0.0:1234"
[...]
```

#### Which issue this PR fixes
  - fixes https://github.com/DataDog/helm-charts/issues/692

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
