### PR TITLE
fix(datadog): gke-autopilot process-agent compatibility

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 2.36.6
+
+* Fix GKE Autopilot installation. The `process-agent` command must
+  use the `-config` argument to be compliant with the Datadog Agent's
+  GKE Autopilot security profile.
+
 ## 2.36.5
 
 * Use `regexFind` in favor of `mustRegexFind` to support helm2.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.36.5
+version: 2.36.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.36.5](https://img.shields.io/badge/Version-2.36.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.36.6](https://img.shields.io/badge/Version-2.36.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -681,7 +681,9 @@ Returns the flag used to specify the config file for the process-agent.
 In 7.36, `--config` was deprecated and `--cfgpath` should be used instead.
 */}}
 {{- define "process-agent-config-file-flag" -}}
-{{- if not .Values.agents.image.doNotCheckTag -}}
+{{- if  .Values.providers.gke.autopilot -}}
+-config
+{{- else if not .Values.agents.image.doNotCheckTag -}}
 {{- $version := .Values.agents.image.tag | toString | trimSuffix "-jmx" -}}
 {{- $length := len (split "." $version ) -}}
 {{- if and (gt $length 1) (not (semverCompare "^6.36.0 || ^7.36.0" $version)) -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix GKE Autopilot installation. The `process-agent` command must
use the `-config` argument to be compliant with the Datadog Agent's
GKE Autopilot security profile.

#### Which issue this PR fixes
  - fixes #549

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
