### PR TITLE
Mount yum & dnf vars to /host/etc

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.36.8
+
+* Add `/etc/dnf/vars` and `/etc/yum/vars` to the default package management directories mounted for kernel header downloading.
+
 ## 2.36.7
 * Add `priorityPreemptionPolicyValue` as a configurable value on the Agent charts
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.36.7
+version: 2.36.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.36.9](https://img.shields.io/badge/Version-2.36.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.36.9](https://img.shields.io/badge/Version-2.36.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.36.7](https://img.shields.io/badge/Version-2.36.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.36.8](https://img.shields.io/badge/Version-2.36.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -117,6 +117,12 @@
     - name: public-key-dir
       mountPath: /host/etc/pki
       readOnly: true
+    - name: yum-vars-dir
+      mountPath: /host/etc/yum/vars
+      readOnly: true
+    - name: dnf-vars-dir
+      mountPath: /host/etc/dnf/vars
+      readOnly: true
     - name: rhel-subscription-dir
       mountPath: /host/etc/rhsm
       readOnly: true

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -111,6 +111,12 @@
     path: /etc/pki
   name: public-key-dir
 - hostPath:
+    path: /etc/yum/vars
+  name: yum-vars-dir
+- hostPath:
+    path: /etc/dnf/vars
+  name: dnf-vars-dir
+- hostPath:
     path: /etc/rhsm
   name: rhel-subscription-dir
 {{- else }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `/etc/dnf/vars` and `/etc/yum/vars` to the default package management directories mounted to `/host/etc` for kernel header downloading. 

This is necessary for kernel header downloading to be able to resolve variables in `yum` and `dnf` repo files.

Users can prevent these folders from being mounted unnecessarily by setting `systemProbe.mountPackageManagementDirs` to only the directories required for their system.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
