### PR TITLE
Fixing corner case for semver

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,8 +83,8 @@ jobs:
           - v1.14.10
           - v1.16.15
           - v1.18.20
-          - v1.22.12
-          - v1.24.3
+          - v1.22.9
+          - v1.24.2
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -112,8 +112,8 @@ jobs:
           - v1.14.10
           - v1.16.15
           - v1.18.20
-          - v1.22.12
-          - v1.24.3
+          - v1.22.9
+          - v1.24.2
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.4
+
+* Fix semver comparison for minor version corner case.
+* Upadte charts.
+
 ## 0.5.3
 
 * Fix the semver comparison so v1beta1 is used on 1.21.

--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.5.4
 
 * Fix semver comparison for minor version corner case.
-* Upadte charts.
+* Update charts.
 
 ## 0.5.3
 

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.5.3
+version: 0.5.4
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogAgents (semverCompare ">21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogAgents (semverCompare ">1.21.x" .Capabilities.KubeVersion.Version ) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -6158,38 +6158,10 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        ddUrl:
+                          type: string
                         enabled:
                           type: boolean
-                        endpoint:
-                          properties:
-                            credentials:
-                              properties:
-                                apiKey:
-                                  type: string
-                                apiSecret:
-                                  properties:
-                                    keyName:
-                                      type: string
-                                    secretName:
-                                      type: string
-                                  required:
-                                    - secretName
-                                  type: object
-                                appKey:
-                                  type: string
-                                appSecret:
-                                  properties:
-                                    keyName:
-                                      type: string
-                                    secretName:
-                                      type: string
-                                  required:
-                                    - secretName
-                                  type: object
-                              type: object
-                            url:
-                              type: string
-                          type: object
                         extraTags:
                           items:
                             type: string

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogAgents (semverCompare ">1.21.x" .Capabilities.KubeVersion.Version ) }}
+{{- if and .Values.crds.datadogAgents (semverCompare ">1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogAgents (semverCompare "<=21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogAgents (semverCompare "<=1.21.x" .Capabilities.KubeVersion.Version ) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -6143,38 +6143,10 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        ddUrl:
+                          type: string
                         enabled:
                           type: boolean
-                        endpoint:
-                          properties:
-                            credentials:
-                              properties:
-                                apiKey:
-                                  type: string
-                                apiSecret:
-                                  properties:
-                                    keyName:
-                                      type: string
-                                    secretName:
-                                      type: string
-                                  required:
-                                    - secretName
-                                  type: object
-                                appKey:
-                                  type: string
-                                appSecret:
-                                  properties:
-                                    keyName:
-                                      type: string
-                                    secretName:
-                                      type: string
-                                  required:
-                                    - secretName
-                                  type: object
-                              type: object
-                            url:
-                              type: string
-                          type: object
                         extraTags:
                           items:
                             type: string

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogAgents (semverCompare "<=1.21.x" .Capabilities.KubeVersion.Version ) }}
+{{- if and .Values.crds.datadogAgents (semverCompare "<=1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare ">21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare ">1.21.x" .Capabilities.KubeVersion.Version ) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare ">1.21.x" .Capabilities.KubeVersion.Version ) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare ">1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare "<=21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare "<=1.21.x" .Capabilities.KubeVersion.Version ) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare "<=1.21.x" .Capabilities.KubeVersion.Version ) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare "<=1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMonitors (semverCompare ">21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogMonitors (semverCompare ">1.21.x" .Capabilities.KubeVersion.Version ) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMonitors (semverCompare ">1.21.x" .Capabilities.KubeVersion.Version ) }}
+{{- if and .Values.crds.datadogMonitors (semverCompare ">1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMonitors (semverCompare "<=1.21.x" .Capabilities.KubeVersion.Version ) }}
+{{- if and .Values.crds.datadogMonitors (semverCompare "<=1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMonitors (semverCompare "<=21" .Capabilities.KubeVersion.Minor) }}
+{{- if and .Values.crds.datadogMonitors (semverCompare "<=1.21.x" .Capabilities.KubeVersion.Version ) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -34,9 +34,9 @@ download_crd() {
         yq -i eval 'del(.spec.preserveUnknownFields)' "$path"
     fi
 
-    ifCondition="{{- if and .Values.crds.$installOption (semverCompare \"<=21\" .Capabilities.KubeVersion.Minor) }}"
+    ifCondition="{{- if and .Values.crds.$installOption (semverCompare \"<=1.21.x\" .Capabilities.KubeVersion.Version ) }}"
     if [ "$version" = "v1" ]; then
-        ifCondition="{{- if and .Values.crds.$installOption (semverCompare \">21\" .Capabilities.KubeVersion.Minor) }}"
+        ifCondition="{{- if and .Values.crds.$installOption (semverCompare \">1.21.x\" .Capabilities.KubeVersion.Version ) }}"
         cp "$path" "$ROOT/crds/datadoghq.com_$name.yaml"
     fi
 

--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -34,9 +34,9 @@ download_crd() {
         yq -i eval 'del(.spec.preserveUnknownFields)' "$path"
     fi
 
-    ifCondition="{{- if and .Values.crds.$installOption (semverCompare \"<=1.21.x\" .Capabilities.KubeVersion.Version ) }}"
+    ifCondition="{{- if and .Values.crds.$installOption (semverCompare \"<=1.21-0\" .Capabilities.KubeVersion.GitVersion ) }}"
     if [ "$version" = "v1" ]; then
-        ifCondition="{{- if and .Values.crds.$installOption (semverCompare \">1.21.x\" .Capabilities.KubeVersion.Version ) }}"
+        ifCondition="{{- if and .Values.crds.$installOption (semverCompare \">1.21-0\" .Capabilities.KubeVersion.GitVersion ) }}"
         cp "$path" "$ROOT/crds/datadoghq.com_$name.yaml"
     fi
 

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -6152,38 +6152,10 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        ddUrl:
+                          type: string
                         enabled:
                           type: boolean
-                        endpoint:
-                          properties:
-                            credentials:
-                              properties:
-                                apiKey:
-                                  type: string
-                                apiSecret:
-                                  properties:
-                                    keyName:
-                                      type: string
-                                    secretName:
-                                      type: string
-                                  required:
-                                    - secretName
-                                  type: object
-                                appKey:
-                                  type: string
-                                appSecret:
-                                  properties:
-                                    keyName:
-                                      type: string
-                                    secretName:
-                                      type: string
-                                  required:
-                                    - secretName
-                                  type: object
-                              type: object
-                            url:
-                              type: string
-                          type: object
                         extraTags:
                           items:
                             type: string


### PR DESCRIPTION
#### What this PR does / why we need it:

By comparing the minor version with the semverCompare the function would fail in certain cases (e.g. 1.22+).
This should fix it.
We can't rely on `.Capabilities.KubeVersion.Version` because it's not supported with helm2, so I went with `GitVersion`.

```
    testGitVersion: '{{ semverCompare ">1.21-0" .Capabilities.KubeVersion.GitVersion }}'
    gitversion: '{{ .Capabilities.KubeVersion.GitVersion }}'
```
yields:
```
    testGitVersion: "true"
    gitversion: v1.23.8-gke.400
```
with helm2 and helm3.

Which should cover the `+` case in the versionning:
```
Server Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.8-gke.400", GitCommit:"efbcd8d250c89b4290356c0fc27843d583c80a35", GitTreeState:"clean", BuildDate:"2022-06-24T09:25:13Z", GoVersion:"go1.17.10b7", Compiler:"gc", Platform:"linux/amd64"}
```

#### Which issue this PR fixes
  - fixes https://github.com/DataDog/datadog-operator/issues/565

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [x] Check compatibility with helm 2