### PR TITLE
Update Chart.yaml to fix Semver in Operator

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.6
+
+* Updating dependency to CRD chart.
+
 ## 0.8.5
 
 * Updating dependency to CRD chart.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: datadog-crds
-  repository: https://helm.datadoghq.com
-  version: 0.5.3
-digest: sha256:11f223124e11ef914dbcab05cc1a0e79a7d1dc68bd34f05f115a59c5b4de26e2
-generated: "2022-07-15T17:40:54.432218-04:00"
+  - name: datadog-crds
+    repository: https://helm.datadoghq.com
+    version: 0.5.4
+digest: sha256:b88c0b1039699026d655b06960066db33bb291d1ca400d94c2224653bdb54bd6
+generated: "2022-08-09T11:11:02.328648-05:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.8.5
+version: 0.8.6
 appVersion: 0.8.1
 description: Datadog Operator
 keywords:
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "=0.5.3"
+  version: "=0.5.4"
   repository: https://helm.datadoghq.com
   condition: installCRDs
   tags:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.8.5](https://img.shields.io/badge/Version-0.8.5-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
+![Version: 0.8.6](https://img.shields.io/badge/Version-0.8.6-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
 ## Values
 


### PR DESCRIPTION
It looks like the fix for the following wasn't added to the operator helm chart:
* https://github.com/DataDog/datadog-operator/issues/565
* https://github.com/DataDog/helm-charts/issues/689

This changes the `datadog-crds` dependency version and the version of the chart itself.

#### What this PR does / why we need it:

The noted fixes are not reflected in the datadog-operator chart yet because its version hasn't been updated.

#### Which issue this PR fixes

* https://github.com/DataDog/datadog-operator/issues/565
* https://github.com/DataDog/helm-charts/issues/689

#### Special notes for your reviewer:

#### Checklist
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
