### PR TITLE
Mount host release files for proper host OS detection

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 2.37.5
+
+* Mount host release files for proper host OS detection
+
 ## 2.37.4
 
 * Add `digest` as a configurable value for all datadog images used

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.37.4
+version: 2.37.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -697,7 +697,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
 | datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
-| datadog.osReleasePath | string | `nil` | Specify the path to your os-release file if you don't want to attempt mounting all `/etc/*-release` file by default |
+| datadog.osReleasePath | string | `nil` | Specify the path to your os-release file if you don't want to attempt mounting all `/etc/*-release` files by default |
 | datadog.otlp.receiver.protocols.grpc.enabled | bool | `false` | Enable the OTLP/gRPC endpoint |
 | datadog.otlp.receiver.protocols.grpc.endpoint | string | `"0.0.0.0:4317"` |  |
 | datadog.otlp.receiver.protocols.http.enabled | bool | `false` | Enable the OTLP/HTTP endpoint |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.37.4](https://img.shields.io/badge/Version-2.37.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.37.5](https://img.shields.io/badge/Version-2.37.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -697,6 +697,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
 | datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
+| datadog.osReleasePath | string | `nil` | Specify the path to your os-release file if you don't want to attempt mounting all `/etc/*-release` file by default |
 | datadog.otlp.receiver.protocols.grpc.enabled | bool | `false` | Enable the OTLP/gRPC endpoint |
 | datadog.otlp.receiver.protocols.grpc.endpoint | string | `"0.0.0.0:4317"` |  |
 | datadog.otlp.receiver.protocols.http.enabled | bool | `false` | Enable the OTLP/HTTP endpoint |
@@ -740,7 +741,6 @@ helm install --name <RELEASE_NAME> \
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
 | datadog.systemProbe.maxTrackedConnections | int | `131072` | the maximum number of tracked connections |
 | datadog.systemProbe.mountPackageManagementDirs | list | `[]` | Enables mounting of specific package management directories when runtime compilation is enabled |
-| datadog.systemProbe.osReleasePath | string | `nil` | Specify the path to your os-release file if you don't want to attempt mounting all `/etc/*-release` file by default |
 | datadog.systemProbe.runtimeCompilationAssetDir | string | `"/var/tmp/datadog-agent/system-probe"` | Specify a directory for runtime compilation assets to live in |
 | datadog.systemProbe.seccomp | string | `"localhost/system-probe"` | Apply an ad-hoc seccomp profile to the system-probe agent to restrict its privileges |
 | datadog.systemProbe.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -697,7 +697,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
 | datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
-| datadog.osReleasePath | string | `/etc/os-release` | Specify the path to your os-release file |
+| datadog.osReleasePath | string | `"/etc/os-release"` | Specify the path to your os-release file |
 | datadog.otlp.receiver.protocols.grpc.enabled | bool | `false` | Enable the OTLP/gRPC endpoint |
 | datadog.otlp.receiver.protocols.grpc.endpoint | string | `"0.0.0.0:4317"` |  |
 | datadog.otlp.receiver.protocols.http.enabled | bool | `false` | Enable the OTLP/HTTP endpoint |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -697,7 +697,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
 | datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
-| datadog.osReleasePath | string | `nil` | Specify the path to your os-release file if you don't want to attempt mounting all `/etc/*-release` files by default |
+| datadog.osReleasePath | string | `/etc/os-release` | Specify the path to your os-release file |
 | datadog.otlp.receiver.protocols.grpc.enabled | bool | `false` | Enable the OTLP/gRPC endpoint |
 | datadog.otlp.receiver.protocols.grpc.endpoint | string | `"0.0.0.0:4317"` |  |
 | datadog.otlp.receiver.protocols.http.enabled | bool | `false` | Enable the OTLP/HTTP endpoint |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -353,6 +353,17 @@ To enable it please set clusterAgent.enabled to 'true'.
 You are using the datadog.acInclude or datadog.acExclude parameters, which have been deprecated since Datadog Agent 7.20. Please use datadog.containerInclude and datadog.containerExclude instead.
 {{- end }}
 
+{{- if and .Values.datadog.systemProbe.osReleasePath (eq (include "system-probe-feature" .) "true") }}
+
+#################################################################
+####               WARNING: Deprecation notice               ####
+#################################################################
+
+You are using the datadog.systemProbe.osReleasePath parameter, which has been renamed datadog.osReleasePath.
+This version still supports datadog.systemProbe.osReleasePath parameter, but it will be removed in the next major version of our Helm chart.
+More information about this change: https://github.com/DataDog/helm-charts/pull/717
+{{- end }}
+
 
 {{- $hasContainerIncludeEnv := false }}
 {{- range $key := .Values.datadog.env }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -160,6 +160,7 @@
       mountPath: {{ template "datadog.confPath" . }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
+    {{- include "container-host-release-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-host-release-volumemounts.yaml
+++ b/charts/datadog/templates/_container-host-release-volumemounts.yaml
@@ -1,12 +1,12 @@
 {{- define "container-host-release-volumemounts" -}}
 {{- if eq (include "should-enable-system-probe" .) "true" }}
 - name: os-release-file
-  mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath | default "/etc/os-release" }}
+  mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
   readOnly: true
 {{- else }}
 - name: os-release-file
-  mountPath: /host{{ .Values.datadog.osReleasePath | default "/etc/os-release" }}
+  mountPath: /host{{ .Values.datadog.osReleasePath }}
   mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
   readOnly: true
 {{- end }}

--- a/charts/datadog/templates/_container-host-release-volumemounts.yaml
+++ b/charts/datadog/templates/_container-host-release-volumemounts.yaml
@@ -1,8 +1,14 @@
 {{- define "container-host-release-volumemounts" -}}
 {{- if or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath }}
+{{- if eq (include "should-enable-system-probe" .) "true" }}
 - name: os-release-file
   mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   readOnly: true
+{{- else }}
+- name: os-release-file
+  mountPath: /host{{ .Values.datadog.osReleasePath }}
+  readOnly: true
+{{- end }}
 {{- else }}
 - name: etc-os-release
   mountPath: /host/etc/os-release

--- a/charts/datadog/templates/_container-host-release-volumemounts.yaml
+++ b/charts/datadog/templates/_container-host-release-volumemounts.yaml
@@ -1,0 +1,24 @@
+{{- define "container-host-release-volumemounts" -}}
+{{- if or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath }}
+- name: os-release-file
+  mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
+  readOnly: true
+{{- else }}
+- name: etc-os-release
+  mountPath: /host/etc/os-release
+  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+  readOnly: true
+- name: etc-redhat-release
+  mountPath: /host/etc/redhat-release
+  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+  readOnly: true
+- name: etc-fedora-release
+  mountPath: /host/etc/fedora-release
+  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+  readOnly: true
+- name: etc-lsb-release
+  mountPath: /host/etc/lsb-release
+  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+  readOnly: true
+{{- end }}
+{{- end }}

--- a/charts/datadog/templates/_container-host-release-volumemounts.yaml
+++ b/charts/datadog/templates/_container-host-release-volumemounts.yaml
@@ -1,29 +1,12 @@
 {{- define "container-host-release-volumemounts" -}}
-{{- if or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath }}
 {{- if eq (include "should-enable-system-probe" .) "true" }}
 - name: os-release-file
-  mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
+  mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath | default "/etc/os-release" }}
+  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
   readOnly: true
 {{- else }}
 - name: os-release-file
-  mountPath: /host{{ .Values.datadog.osReleasePath }}
-  readOnly: true
-{{- end }}
-{{- else }}
-- name: etc-os-release
-  mountPath: /host/etc/os-release
-  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-  readOnly: true
-- name: etc-redhat-release
-  mountPath: /host/etc/redhat-release
-  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-  readOnly: true
-- name: etc-fedora-release
-  mountPath: /host/etc/fedora-release
-  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-  readOnly: true
-- name: etc-lsb-release
-  mountPath: /host/etc/lsb-release
+  mountPath: /host{{ .Values.datadog.osReleasePath | default "/etc/os-release" }}
   mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
   readOnly: true
 {{- end }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -64,6 +64,7 @@
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
+    {{- include "container-host-release-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -64,6 +64,7 @@
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
+    {{- include "container-host-release-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -54,27 +54,12 @@
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-{{- if .Values.datadog.systemProbe.osReleasePath }}
+{{- if or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath }}
     - name: os-release-file
-      mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath }}
+      mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
       readOnly: true
 {{- else }}
-    - name: etc-os-release
-      mountPath: /host/etc/os-release
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
-    - name: etc-redhat-release
-      mountPath: /host/etc/redhat-release
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
-    - name: etc-fedora-release
-      mountPath: /host/etc/fedora-release
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
-    - name: etc-lsb-release
-      mountPath: /host/etc/lsb-release
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
+    {{- include "container-host-release-volumemounts" . | nindent 4 }}
 {{- end }}
 {{- if .Values.datadog.serviceMonitoring.enabled }}
     - name: hostroot

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -70,7 +70,8 @@
     - name: etc-lsb-release
       mountPath: /host/etc/lsb-release
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true{{- if .Values.datadog.serviceMonitoring.enabled }}
+      readOnly: true
+{{- if .Values.datadog.serviceMonitoring.enabled }}
     - name: hostroot
       mountPath: /host/root
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -54,14 +54,23 @@
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-{{- if or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath }}
-    - name: os-release-file
-      mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
-      readOnly: true
-{{- else }}
     {{- include "container-host-release-volumemounts" . | nindent 4 }}
-{{- end }}
-{{- if .Values.datadog.serviceMonitoring.enabled }}
+    - name: etc-os-release
+      mountPath: /host/etc/os-release
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
+    - name: etc-redhat-release
+      mountPath: /host/etc/redhat-release
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
+    - name: etc-fedora-release
+      mountPath: /host/etc/fedora-release
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
+    - name: etc-lsb-release
+      mountPath: /host/etc/lsb-release
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true{{- if .Values.datadog.serviceMonitoring.enabled }}
     - name: hostroot
       mountPath: /host/root
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -55,10 +55,6 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
     {{- include "container-host-release-volumemounts" . | nindent 4 }}
-    - name: etc-os-release
-      mountPath: /host/etc/os-release
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     - name: etc-redhat-release
       mountPath: /host/etc/redhat-release
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -9,14 +9,10 @@
 - hostPath:
     path: /sys/fs/cgroup
   name: cgroups
-{{- if or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath }}
 - hostPath:
-    path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
+    path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath | default "/etc/os-release" }}
   name: os-release-file
-{{- else }}
-- hostPath:
-    path: /etc/os-release
-  name: etc-os-release
+{{- if eq (include "should-enable-system-probe" .) "true" }}
 - hostPath:
     path: /etc/redhat-release
   name: etc-redhat-release

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -10,7 +10,7 @@
     path: /sys/fs/cgroup
   name: cgroups
 - hostPath:
-    path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath | default "/etc/os-release" }}
+    path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   name: os-release-file
 {{- if eq (include "should-enable-system-probe" .) "true" }}
 - hostPath:

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -9,10 +9,9 @@
 - hostPath:
     path: /sys/fs/cgroup
   name: cgroups
-{{- if eq (include "should-enable-system-probe" .) "true" }}
-{{- if .Values.datadog.systemProbe.osReleasePath }}
+{{- if or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath }}
 - hostPath:
-    path: {{ .Values.datadog.systemProbe.osReleasePath }}
+    path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   name: os-release-file
 {{- else }}
 - hostPath:
@@ -27,7 +26,6 @@
 - hostPath:
     path: /etc/lsb-release
   name: etc-lsb-release
-{{- end -}}
 {{- end -}}
 {{- if eq (include "should-mount-hostPath-for-dsd-socket" .) "true" }}
 - hostPath:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -459,6 +459,9 @@ datadog:
     # datadog.processAgent.processDiscovery -- Enables or disables autodiscovery of integrations
     processDiscovery: false
 
+  # datadog.osReleasePath -- Specify the path to your os-release file if you don't want to attempt mounting all `/etc/*-release` file by default
+  osReleasePath:
+
   ## Enable systemProbe agent and provide custom configs
   systemProbe:
 
@@ -504,9 +507,6 @@ datadog:
     #   hostPath: /etc/apt
     #   mountPath: /host/etc/apt
     ## If this list is empty, then all necessary package management directories (for all supported OSs) will be mounted.
-
-    # datadog.systemProbe.osReleasePath -- Specify the path to your os-release file if you don't want to attempt mounting all `/etc/*-release` file by default
-    osReleasePath:
 
     # datadog.systemProbe.runtimeCompilationAssetDir -- Specify a directory for runtime compilation assets to live in
     runtimeCompilationAssetDir: /var/tmp/datadog-agent/system-probe

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -459,8 +459,8 @@ datadog:
     # datadog.processAgent.processDiscovery -- Enables or disables autodiscovery of integrations
     processDiscovery: false
 
-  # datadog.osReleasePath -- Specify the path to your os-release file if you don't want to attempt mounting all `/etc/*-release` files by default
-  osReleasePath:
+  # datadog.osReleasePath -- Specify the path to your os-release file
+  osReleasePath: /etc/os-release
 
   ## Enable systemProbe agent and provide custom configs
   systemProbe:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -459,7 +459,7 @@ datadog:
     # datadog.processAgent.processDiscovery -- Enables or disables autodiscovery of integrations
     processDiscovery: false
 
-  # datadog.osReleasePath -- Specify the path to your os-release file if you don't want to attempt mounting all `/etc/*-release` file by default
+  # datadog.osReleasePath -- Specify the path to your os-release file if you don't want to attempt mounting all `/etc/*-release` files by default
   osReleasePath:
 
   ## Enable systemProbe agent and provide custom configs


### PR DESCRIPTION
#### What this PR does / why we need it:

Change the osReleasePath parameter to datadog.osReleasePath to mount proper files into every container.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
