### PR TITLE
Added namespaces to all namespace scoped objects 

### DIFF
--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "datadog-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog-operator.labels" . | indent 4 }}
 spec:

--- a/charts/datadog-operator/templates/pod_disruption_budget.yaml
+++ b/charts/datadog-operator/templates/pod_disruption_budget.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "policy.poddisruptionbudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "datadog-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog-operator.labels" . | indent 4 }}
 spec:

--- a/charts/datadog-operator/templates/secret_api_key.yaml
+++ b/charts/datadog-operator/templates/secret_api_key.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "datadog-operator.apiKeySecretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "datadog-operator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/datadog-operator/templates/secret_application_key.yaml
+++ b/charts/datadog-operator/templates/secret_application_key.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "datadog-operator.appKeySecretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "datadog-operator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/datadog-operator/templates/service_account.yaml
+++ b/charts/datadog-operator/templates/service_account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "datadog-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.serviceAccount.annotations }}
   annotations:
 {{- toYaml .Values.serviceAccount.annotations | nindent 4 | }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Added namespaces to all namespace scoped objects using the HELM standard `Release.namespace`

#### Which issue this PR fixes
When installing this chart via Kustomize and syncing with ArgoCD, the chart does not get installed into the intended target namespace. This change should not affect existing behavior while still allowing for additional tooling to operate with the chart.


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
