### PR TITLE
Add support for overriding the detected Kubernetes version

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.5
+
+* Added support for overriding detected Kubernetes version.
+
 ## 0.5.4
 
 * Fix semver comparison for minor version corner case.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.5.4
+version: 0.5.5
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -26,6 +26,7 @@ But the recommended Kubernetes versions are `1.16+`.
 | crds.datadogMetrics | bool | `false` | Set to true to deploy the DatadogMetrics CRD |
 | crds.datadogMonitors | bool | `false` | Set to true to deploy the DatadogMonitors CRD |
 | fullnameOverride | string | `""` | Override the fully qualified app name |
+| kubeVersionOverride | string | `""` | Override the detected Kubernetes version |
 | nameOverride | string | `""` | Override name of app |
 
 ## Developers

--- a/charts/datadog-crds/templates/_helpers.tpl
+++ b/charts/datadog-crds/templates/_helpers.tpl
@@ -29,3 +29,14 @@ Create chart name and version as used by the chart label.
 {{- define "datadog-crds.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+Set value for comparison of Kubernetes Version
+*/}}
+{{- define "datadog-crds.kubeVersion" -}}
+{{- if .Values.kubeVersionOverride }}
+{{- semver .Values.kubeVersionOverride }}
+{{- else }}
+{{- .Capabilities.KubeVersion.GitVersion }}
+{{- end }}
+{{- end }}

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare ">1.21-0" (include "datadog-crds.kubeVersion" .)) }}
+{{- if and .Values.crds.datadogAgents (semverCompare ">1.21-0" (include "datadog-crds.kubeVersion" .)) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogAgents (semverCompare ">1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare ">1.21-0" (include "datadog-crds.kubeVersion" .)) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogAgents (semverCompare "<=1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare "<=1.21-0" (include "datadog-crds.kubeVersion" .)) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare "<=1.21-0" (include "datadog-crds.kubeVersion" .)) }}
+{{- if and .Values.crds.datadogAgents (semverCompare "<=1.21-0" (include "datadog-crds.kubeVersion" .)) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare ">1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare ">1.21-0" (include "datadog-crds.kubeVersion" .)) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmetrics_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare "<=1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare "<=1.21-0" (include "datadog-crds.kubeVersion" .)) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare ">1.21-0" (include "datadog-crds.kubeVersion" .)) }}
+{{- if and .Values.crds.datadogMonitors (semverCompare ">1.21-0" (include "datadog-crds.kubeVersion" .)) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMonitors (semverCompare ">1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare ">1.21-0" (include "datadog-crds.kubeVersion" .)) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMetrics (semverCompare "<=1.21-0" (include "datadog-crds.kubeVersion" .)) }}
+{{- if and .Values.crds.datadogMonitors (semverCompare "<=1.21-0" (include "datadog-crds.kubeVersion" .)) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.crds.datadogMonitors (semverCompare "<=1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
+{{- if and .Values.crds.datadogMetrics (semverCompare "<=1.21-0" (include "datadog-crds.kubeVersion" .)) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/datadog-crds/values.yaml
+++ b/charts/datadog-crds/values.yaml
@@ -15,3 +15,6 @@ nameOverride: ""
 
 # fullnameOverride -- Override the fully qualified app name
 fullnameOverride: ""
+
+# kubeVersionOverride -- Override the detected Kubernetes version
+kubeVersionOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds the capability to override `.Capabilities.KubeVersion.GitVersion` which makes sure support for Anthos Config Management and Kustomize is maintained.

Not bumping chart version as I don't know if this warrants a new release alone.

#### Which issue this PR fixes
fixes #733 

#### Special notes for your reviewer:

#### Checklist
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
