### PR TITLE
[datadog] Fix windows nodes deployment

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 2.37.7
+
+* Fix Windows nodes deployment: do not mount `container-host-release-volumemounts` if
+  the `targetSystem` is "Windows".
+
 ## 2.37.6
 
 * Add `chmod` to allowed actions in system-probe seccomp profile

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.37.6
+version: 2.37.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.37.6](https://img.shields.io/badge/Version-2.37.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.37.7](https://img.shields.io/badge/Version-2.37.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -155,12 +155,12 @@
     - name: tmpdir
       mountPath: /tmp
       readOnly: false
+    {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
     {{- end }}
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
-    {{- include "container-host-release-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-host-release-volumemounts.yaml
+++ b/charts/datadog/templates/_container-host-release-volumemounts.yaml
@@ -1,4 +1,4 @@
-{{- define "container-host-release-volumemounts" -}}
+{{- define "linux-container-host-release-volumemounts" -}}
 {{- if eq (include "should-enable-system-probe" .) "true" }}
 - name: os-release-file
   mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -61,10 +61,10 @@
     - name: tmpdir
       mountPath: /tmp
       readOnly: false
+    {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
-    {{- include "container-host-release-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -61,10 +61,10 @@
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: true
+    {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
-    {{- include "container-host-release-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -54,7 +54,7 @@
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    {{- include "container-host-release-volumemounts" . | nindent 4 }}
+    {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
     - name: etc-redhat-release
       mountPath: /host/etc/redhat-release
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix Windows nodes deployment: do not mount `container-host-release-volumemounts`
if the `targetSystem` is "Windows".

changes:
* move the `include container-host-release-volumemounts` to the `if linux` section.
* rename `container-host-release-volumemounts` to `linux-container-host-release-volumemounts` to be sure that people understand it can only be use on a linux system

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #729

#### Special notes for your reviewer:

this PR doesn't fix the issue reported in this comment: https://github.com/DataDog/helm-charts/pull/717#issuecomment-1228231227. A second PR will come later

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
