### PR TITLE
[datadog] avoid volumemount conflict in system probe

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 2.37.8
 
-* Fix: avoid volumeMount duplication in `system-probe` container if `datadog.osReleasePath` value
-  correspond to one of the default os-release-paths mounted automatically.
-* Feat: add the possibility to disable the default os-release path mount linked to `system-probe` container.
+* Fix the volumeMount duplication in `system-probe` container if `datadog.osReleasePath` value
+  corresponds to one of the default os-release-paths automatically mounted.
+* Add the option to disable the default os-release path mount linked to `system-probe` container.
 
 ## 2.37.7
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 2.37.8
+
+* Fix: avoid volumeMount duplication in `system-probe` container if `datadog.osReleasePath` value
+  correspond to one of the default os-release-paths mounted automatically.
+* Feat: add the possibility to disable the default os-release path mount linked to `system-probe` container.
+
 ## 2.37.7
 
 * Fix Windows nodes deployment: do not mount `container-host-release-volumemounts` if

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.37.7
+version: 2.37.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 2.37.7](https://img.shields.io/badge/Version-2.37.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 2.37.8](https://img.shields.io/badge/Version-2.37.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -735,6 +735,7 @@ helm install --name <RELEASE_NAME> \
 | datadog.systemProbe.conntrackMaxStateSize | int | `131072` | the maximum size of the userspace conntrack cache |
 | datadog.systemProbe.debugPort | int | `0` | Specify the port to expose pprof and expvar for system-probe agent |
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
+| datadog.systemProbe.enableDefaultOsReleasePaths | bool | `true` | enable default os-release files mount |
 | datadog.systemProbe.enableKernelHeaderDownload | bool | `false` | Enable the downloading of kernel headers for runtime compilation of eBPF probes |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
 | datadog.systemProbe.enableRuntimeCompiler | bool | `false` | Enable the runtime compiler for eBPF probes |

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -55,18 +55,26 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
     {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
+  {{- if .Values.datadog.systemProbe.enableDefaultOsReleasePaths }}
+    {{- if ne .Values.datadog.osReleasePath "/etc/redhat-release" }}
     - name: etc-redhat-release
       mountPath: /host/etc/redhat-release
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+    {{- end }}
+    {{- if ne .Values.datadog.osReleasePath "/etc/fedora-release" }}
     - name: etc-fedora-release
       mountPath: /host/etc/fedora-release
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+    {{- end }}
+    {{- if ne .Values.datadog.osReleasePath "/etc/lsb-release" }}
     - name: etc-lsb-release
       mountPath: /host/etc/lsb-release
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+    {{- end }}
+  {{- end }}
 {{- if .Values.datadog.serviceMonitoring.enabled }}
     - name: hostroot
       mountPath: /host/root

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -9,10 +9,13 @@
 - hostPath:
     path: /sys/fs/cgroup
   name: cgroups
+{{- if or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath }}
 - hostPath:
     path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   name: os-release-file
+{{- end }}
 {{- if eq (include "should-enable-system-probe" .) "true" }}
+{{- if .Values.datadog.systemProbe.enableDefaultOsReleasePaths }}
 - hostPath:
     path: /etc/redhat-release
   name: etc-redhat-release
@@ -22,6 +25,7 @@
 - hostPath:
     path: /etc/lsb-release
   name: etc-lsb-release
+{{- end }}
 {{- end -}}
 {{- if eq (include "should-mount-hostPath-for-dsd-socket" .) "true" }}
 - hostPath:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -523,6 +523,9 @@ datadog:
     # datadog.systemProbe.conntrackInitTimeout -- the time to wait for conntrack to initialize before failing
     conntrackInitTimeout: 10s
 
+    # datadog.systemProbe.enableDefaultOsReleasePaths -- enable default os-release files mount
+    enableDefaultOsReleasePaths: true
+
   orchestratorExplorer:
     # datadog.orchestratorExplorer.enabled -- Set this to false to disable the orchestrator explorer
 


### PR DESCRIPTION
#### What this PR does / why we need it:

* Fix: avoid volumeMount duplication in `system-probe`
  container if `datadog.osReleasePath` value correspond
  to one of the default os-release-paths mounted
  automatically.
* Feat: add the possibility to disable the default
  os-release path mount linked to `system-probe`
  container with the option: `datadog.systemProbe.enableDefaultOsReleasePaths:false`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes https://github.com/DataDog/helm-charts/pull/717#issuecomment-1228231227

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
