### PR TITLE
Add faccessat2 syscall to system-probe-configmap

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.0.3
+
+* Add `faccessat2` to allowed actions in system-probe seccomp profile
+
 ## 3.0.1
 
 * Add `datadog.systemProbe.enableDefaultKernelHeadersPaths` option that allows

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.0.2
+version: 3.0.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -106,6 +106,7 @@ data:
             "execveat",
             "exit",
             "exit_group",
+            "faccessat2",
             "fchmod",
             "fchmodat",
             "fchown",


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

New versions of runc may call the faccessat2 syscall. If this syscall is not allowed the system-probe container will fail to start with the following error:

"start container process: exec /opt/datadog-agent/embedded/bin/system-probe: operation not permitted: unknown"

Additional context:

https://github.com/opencontainers/runc/commit/d83a861d950b42b53406424468f8644551fa8980
https://github.com/bottlerocket-os/bottlerocket/issues/2394

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated

