### PR TITLE
Fix os-release mount in GKE autopilot

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.0.2
+
+* Fix preventing mounting os-release in GKE autopilot for all containers.
+
 ## 3.0.1
 
 * Add `datadog.systemProbe.enableDefaultKernelHeadersPaths` option that allows

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## 3.0.2
 
-* aAllow disabling kubeStateMetricsCore rbac creation.
+* Allow disabling kubeStateMetricsCore rbac creation.
 
 ## 3.0.1
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.0.1
+version: 3.0.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-host-release-volumemounts.yaml
+++ b/charts/datadog/templates/_container-host-release-volumemounts.yaml
@@ -4,7 +4,7 @@
   mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
   readOnly: true
-{{- else }}
+{{- else if not .Values.providers.gke.autopilot}}
 - name: os-release-file
   mountPath: /host{{ .Values.datadog.osReleasePath }}
   mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -9,7 +9,7 @@
 - hostPath:
     path: /sys/fs/cgroup
   name: cgroups
-{{- if or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath }}
+{{- if and (not .Values.providers.gke.autopilot) (or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath) }}
 - hostPath:
     path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   name: os-release-file


### PR DESCRIPTION
#### What this PR does / why we need it:

This is blocking a few customers - I believe it might be tied to https://github.com/DataDog/helm-charts/issues/549
We can revisit the logic around mounting the os-release file soon.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated

