### PR TITLE
fix: adds missing containerEnvAsTags configuration

### DIFF
--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -929,6 +929,10 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
+                        containerEnvAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
                         nodeLabelsAsTags:
                           additionalProperties:
                             type: string

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -932,6 +932,10 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
+                        containerEnvAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
                         nodeLabelsAsTags:
                           additionalProperties:
                             type: string

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.1.2
+
+* Adds configuration `datadog.containerEnvAsTags` to be able to map specific containers environment variables with datadog tags (https://docs.datadoghq.com/containers/kubernetes/tag/?tab=containerizedagent#container-environment-variables-as-tags).
+
 ## 3.1.1
 
 * Set default value for `datadog.systemProbe.enableKernelHeaderDownload` to `true`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.1.1
+version: 3.1.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -638,6 +638,7 @@ helm install <RELEASE_NAME> \
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
 | datadog.namespaceLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Namespace Labels to Datadog Tags |
+| datadog.containerEnvAsTags | object | `{}` | Provide a mapping of Kubernetes Containers Environment Variables to Datadog Tags |
 | datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
 | datadog.networkPolicy.cilium.dnsSelector | object | kube-dns in namespace kube-system | Cilium selector of the DNS server entity |
 | datadog.networkPolicy.create | bool | `false` | If true, create NetworkPolicy for all the components |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.1.1](https://img.shields.io/badge/Version-3.1.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.1.2](https://img.shields.io/badge/Version-3.1.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -588,6 +588,7 @@ helm install <RELEASE_NAME> \
 | datadog.clusterName | string | `nil` | Set a unique cluster name to allow scoping hosts and Cluster Checks easily |
 | datadog.collectEvents | bool | `true` | Enables this to start event collection from the kubernetes API |
 | datadog.confd | object | `{}` | Provide additional check configurations (static and Autodiscovery) |
+| datadog.containerEnvAsTags | object | `{}` | Provide a mapping of Kubernetes Container Environment Variables to Datadog Tags |
 | datadog.containerExclude | string | `nil` | Exclude containers from the Agent Autodiscovery, as a space-sepatered list |
 | datadog.containerExcludeLogs | string | `nil` | Exclude logs from the Agent Autodiscovery, as a space-separated list |
 | datadog.containerExcludeMetrics | string | `nil` | Exclude metrics from the Agent Autodiscovery, as a space-separated list |
@@ -638,7 +639,6 @@ helm install <RELEASE_NAME> \
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
 | datadog.namespaceLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Namespace Labels to Datadog Tags |
-| datadog.containerEnvAsTags | object | `{}` | Provide a mapping of Kubernetes Containers Environment Variables to Datadog Tags |
 | datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
 | datadog.networkPolicy.cilium.dnsSelector | object | kube-dns in namespace kube-system | Cilium selector of the DNS server entity |
 | datadog.networkPolicy.create | bool | `false` | If true, create NetworkPolicy for all the components |

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -68,6 +68,10 @@
 - name: DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS
   value: '{{ toJson .Values.datadog.namespaceLabelsAsTags }}'
 {{- end }}
+{{- if .Values.datadog.containerEnvAsTags }}
+- name: DD_CONTAINER_ENV_AS_TAGS
+  value: '{{ toJson .Values.datadog.containerEnvAsTags }}'
+{{- end }}
 - name: KUBERNETES
   value: "yes"
 {{- if .Values.datadog.site }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -209,6 +209,11 @@ datadog:
   #   env: environment
   #   <KUBERNETES_NAMESPACE_LABEL>: <DATADOG_TAG_KEY>
 
+  # datadog.containerEnvAsTags -- Provide a mapping of Kubernetes Container Environment Variables to Datadog Tags
+  containerEnvAsTags: {}
+  #   POD_NAME: pod_name
+  #   <ENV_VAR>: <TAG_KEY>
+
   # datadog.tags -- List of static tags to attach to every metric, event and service check collected by this Agent.
 
   ## Learn more about tagging: https://docs.datadoghq.com/tagging/

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -923,6 +923,10 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
+                        containerEnvAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
                         nodeLabelsAsTags:
                           additionalProperties:
                             type: string


### PR DESCRIPTION
#### What this PR does / why we need it:

The helm chart was missing the confiuration to map container env vars to datadog tags, as explained here: https://docs.datadoghq.com/containers/kubernetes/tag/?tab=containerizedagent


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
