### PR TITLE
Cahillsf/simplify ksm core labels as tags

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.1.4
+
+* Improve `datadog.kubeStateMetricsCore.labelsAsTags` to inherit labelAsTags mappings from `datadog.<RESOURCE>LabelsAsTags`.
+
 ## 3.1.3
 
 * Add `datadog.helmCheck.valuesAsTags` option to collect helm values and use them as tags.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.1.3
+version: 3.1.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/ci/ksm-labelstotags-values.yaml
+++ b/charts/datadog/ci/ksm-labelstotags-values.yaml
@@ -1,0 +1,24 @@
+commonLabels:
+  test-label-key: important-val
+  test-label-key-2: important-val-2
+
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  kubeStateMetricsCore:
+    enabled: true
+    labelsAsTags:
+      pod:
+        test-label-key: test-label-key
+      node:
+        kubernetes.io/hostname: k8s-hostname
+      namespace:
+        kubernetes.io/metadata.name: k8s-ns-name
+      deployment:
+        test-label-key: test-label-key
+  nodeLabelsAsTags:
+    node-role: node-role
+  podLabelsAsTags:
+    test-label-key-2:  test-label-key-2
+  namespaceLabelsAsTags:
+    ns-key-2: ns-key-2

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -715,3 +715,25 @@ In 7.36, `--config` was deprecated and `--cfgpath` should be used instead.
 --config
 {{- end -}}
 {{- end -}}
+
+{{/*
+Returns a merged dictionary of datadog.kubeStateMetricsCore.labelsAsTags and datadog.<RESOURCE>LabelsAsTags.
+*/}}
+{{- define "datadog.mergeLabelsAsTags" -}}
+{{- $resourcesList := list -}}
+{{- range $k, $v := .Values.datadog -}}
+{{- $curAtt := $k | toString -}}
+{{- if regexMatch ".*LabelsAsTags" $curAtt }}
+{{- $resourcesList = append $resourcesList $curAtt -}}
+{{- end }}
+{{- end }}
+{{- $resourcesDict := dict -}}
+{{- range $resource := $resourcesList }}
+{{- if (get $.Values.datadog $resource) }}
+{{- $dictKey := trimSuffix "LabelsAsTags" $resource }}
+{{- $_ := set $resourcesDict $dictKey (get $.Values.datadog $resource) }}
+{{- end }}
+{{- end }}
+{{- $labelMappingDict := merge $resourcesDict $.Values.datadog.kubeStateMetricsCore.labelsAsTags }}
+{{ $labelMappingDict | toYaml | indent 10 }}
+{{- end -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -720,19 +720,15 @@ In 7.36, `--config` was deprecated and `--cfgpath` should be used instead.
 Returns a merged dictionary of datadog.kubeStateMetricsCore.labelsAsTags and datadog.<RESOURCE>LabelsAsTags.
 */}}
 {{- define "datadog.mergeLabelsAsTags" -}}
-{{- $resourcesList := list -}}
 {{- $resourcesDict := dict -}}
 {{- $labelMappingDict := dict -}}
 {{- range $k, $v := .Values.datadog -}}
 {{- $curAtt := $k | toString -}}
 {{- if regexMatch ".*LabelsAsTags" $curAtt }}
-{{- $resourcesList = append $resourcesList $curAtt -}}
+{{- if (get $.Values.datadog $curAtt) }}
+{{- $dictKey := trimSuffix "LabelsAsTags" $curAtt }}
+{{- $_ := set $resourcesDict $dictKey (get $.Values.datadog $curAtt) }}
 {{- end }}
-{{- end }}
-{{- range $resource := $resourcesList }}
-{{- if (get $.Values.datadog $resource) }}
-{{- $dictKey := trimSuffix "LabelsAsTags" $resource }}
-{{- $_ := set $resourcesDict $dictKey (get $.Values.datadog $resource) }}
 {{- end }}
 {{- end }}
 {{- if $.Values.datadog.kubeStateMetricsCore.labelsAsTags }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -721,19 +721,24 @@ Returns a merged dictionary of datadog.kubeStateMetricsCore.labelsAsTags and dat
 */}}
 {{- define "datadog.mergeLabelsAsTags" -}}
 {{- $resourcesList := list -}}
+{{- $resourcesDict := dict -}}
+{{- $labelMappingDict := dict -}}
 {{- range $k, $v := .Values.datadog -}}
 {{- $curAtt := $k | toString -}}
 {{- if regexMatch ".*LabelsAsTags" $curAtt }}
 {{- $resourcesList = append $resourcesList $curAtt -}}
 {{- end }}
 {{- end }}
-{{- $resourcesDict := dict -}}
 {{- range $resource := $resourcesList }}
 {{- if (get $.Values.datadog $resource) }}
 {{- $dictKey := trimSuffix "LabelsAsTags" $resource }}
 {{- $_ := set $resourcesDict $dictKey (get $.Values.datadog $resource) }}
 {{- end }}
 {{- end }}
-{{- $labelMappingDict := merge $resourcesDict $.Values.datadog.kubeStateMetricsCore.labelsAsTags }}
+{{- if $.Values.datadog.kubeStateMetricsCore.labelsAsTags }}
+{{- $labelMappingDict = merge $resourcesDict $.Values.datadog.kubeStateMetricsCore.labelsAsTags }}
+{{- else }}
+{{- $labelMappingDict = $resourcesDict }}
+{{- end }}
 {{ $labelMappingDict | toYaml | indent 10 }}
 {{- end -}}

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -38,4 +38,6 @@ kubernetes_state_core.yaml.default: |-
 {{- end }}
       labels_as_tags:
 {{ .Values.datadog.kubeStateMetricsCore.labelsAsTags | toYaml | indent 10 }}
+         node:
+{{ .Values.datadog.nodeLabelsAsTags | toYaml | indent 12 }}
 {{- end -}}

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -37,13 +37,20 @@ kubernetes_state_core.yaml.default: |-
       skip_leader_election: true
 {{- end }}
       labels_as_tags:
-{{- $resourcesList := list "pod" "node" "namespace" -}}
+{{- $resourcesList := list -}}
+{{- range $k, $v := .Values.datadog -}}
+{{- $curAtt := $k | toString -}}
+{{- if regexMatch ".*LabelsAsTags" $curAtt }}
+{{- $resourcesList = append $resourcesList $curAtt -}}
+{{- end }}
+{{- end }}
 {{- $resourcesDict := dict -}}
 {{- range $resource := $resourcesList }}
-{{- if (get $.Values.datadog (printf "%sLabelsAsTags" $resource)) }}
-{{- $_ := set $resourcesDict $resource (get $.Values.datadog (printf "%sLabelsAsTags" $resource))}}
+{{- if (get $.Values.datadog $resource) }}
+{{- $dictKey := trimSuffix "LabelsAsTags" $resource -}}
+{{- $_ := set $resourcesDict $dictKey (get $.Values.datadog $resource)}}
 {{- end }}
 {{- end }}
 {{- $labelMappingDict := merge $resourcesDict $.Values.datadog.kubeStateMetricsCore.labelsAsTags }}
-{{  $labelMappingDict | toYaml | indent 10 }}
+{{ $labelMappingDict | toYaml | indent 10 }}
 {{- end -}}

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -38,15 +38,12 @@ kubernetes_state_core.yaml.default: |-
 {{- end }}
       labels_as_tags:
 {{- $resourcesList := list "pod" "node" "namespace" -}}
+{{- $resourcesDict := dict -}}
 {{- range $resource := $resourcesList }}
 {{- if (get $.Values.datadog (printf "%sLabelsAsTags" $resource)) }}
-          {{ $resource }}:
-{{ (get $.Values.datadog (printf "%sLabelsAsTags" $resource)) | toYaml | indent 12 }}
-{{ (get $.Values.datadog.kubeStateMetricsCore.labelsAsTags (printf $resource)) | toYaml | indent 12 }}
-{{- $_ := (unset $.Values.datadog.kubeStateMetricsCore.labelsAsTags (printf $resource)) }}
+{{- $_ := set $resourcesDict $resource (get $.Values.datadog (printf "%sLabelsAsTags" $resource))}}
 {{- end }}
 {{- end }}
-{{- if .Values.datadog.kubeStateMetricsCore.labelsAsTags }}
-{{ .Values.datadog.kubeStateMetricsCore.labelsAsTags | toYaml | indent 10 }}
-{{- end }}
+{{- $labelMappingDict := merge $resourcesDict $.Values.datadog.kubeStateMetricsCore.labelsAsTags }}
+{{  $labelMappingDict | toYaml | indent 10 }}
 {{- end -}}

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -36,21 +36,5 @@ kubernetes_state_core.yaml.default: |-
 {{- if .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners }}
       skip_leader_election: true
 {{- end }}
-      labels_as_tags:
-{{- $resourcesList := list -}}
-{{- range $k, $v := .Values.datadog -}}
-{{- $curAtt := $k | toString -}}
-{{- if regexMatch ".*LabelsAsTags" $curAtt }}
-{{- $resourcesList = append $resourcesList $curAtt -}}
-{{- end }}
-{{- end }}
-{{- $resourcesDict := dict -}}
-{{- range $resource := $resourcesList }}
-{{- if (get $.Values.datadog $resource) }}
-{{- $dictKey := trimSuffix "LabelsAsTags" $resource -}}
-{{- $_ := set $resourcesDict $dictKey (get $.Values.datadog $resource)}}
-{{- end }}
-{{- end }}
-{{- $labelMappingDict := merge $resourcesDict $.Values.datadog.kubeStateMetricsCore.labelsAsTags }}
-{{ $labelMappingDict | toYaml | indent 10 }}
+      labels_as_tags: {{ template "datadog.mergeLabelsAsTags" . }}
 {{- end -}}

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -37,13 +37,16 @@ kubernetes_state_core.yaml.default: |-
       skip_leader_election: true
 {{- end }}
       labels_as_tags:
-{{ .Values.datadog.kubeStateMetricsCore.labelsAsTags | toYaml | indent 10 }}
 {{- $resourcesList := list "pod" "node" "namespace" -}}
 {{- range $resource := $resourcesList }}
 {{- if (get $.Values.datadog (printf "%sLabelsAsTags" $resource)) }}
           {{ $resource }}:
 {{ (get $.Values.datadog (printf "%sLabelsAsTags" $resource)) | toYaml | indent 12 }}
 {{ (get $.Values.datadog.kubeStateMetricsCore.labelsAsTags (printf $resource)) | toYaml | indent 12 }}
+{{- $_ := (unset $.Values.datadog.kubeStateMetricsCore.labelsAsTags (printf $resource)) }}
 {{- end }}
+{{- end }}
+{{- if .Values.datadog.kubeStateMetricsCore.labelsAsTags }}
+{{ .Values.datadog.kubeStateMetricsCore.labelsAsTags | toYaml | indent 10 }}
 {{- end }}
 {{- end -}}

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -38,6 +38,12 @@ kubernetes_state_core.yaml.default: |-
 {{- end }}
       labels_as_tags:
 {{ .Values.datadog.kubeStateMetricsCore.labelsAsTags | toYaml | indent 10 }}
-         node:
-{{ .Values.datadog.nodeLabelsAsTags | toYaml | indent 12 }}
+{{- $resourcesList := list "pod" "node" "namespace" -}}
+{{- range $resource := $resourcesList }}
+{{- if (get $.Values.datadog (printf "%sLabelsAsTags" $resource)) }}
+          {{ $resource }}:
+{{ (get $.Values.datadog (printf "%sLabelsAsTags" $resource)) | toYaml | indent 12 }}
+{{ (get $.Values.datadog.kubeStateMetricsCore.labelsAsTags (printf $resource)) | toYaml | indent 12 }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -168,8 +168,6 @@ datadog:
     ##   <resource2>:
     ##     <label3>: <tag3>
     ##
-    ## Warning: the label must match the transformation done by kube-state-metrics,
-    ## for example tags.datadoghq.com/version becomes tags_datadoghq_com_version.
     labelsAsTags: {}
     #  pod:
     #    app: app
@@ -188,12 +186,16 @@ datadog:
     shareProcessNamespace: false
 
   # datadog.nodeLabelsAsTags -- Provide a mapping of Kubernetes Node Labels to Datadog Tags
+  # Mappings configured here will propogate to the corresponding resource's 
+  # LabelsAsTags mapping in datadog.kubeStateMetricsCore.labelsAsTags
   nodeLabelsAsTags: {}
   #   beta.kubernetes.io/instance-type: aws-instance-type
   #   kubernetes.io/role: kube_role
   #   <KUBERNETES_NODE_LABEL>: <DATADOG_TAG_KEY>
 
   # datadog.podLabelsAsTags -- Provide a mapping of Kubernetes Labels to Datadog Tags
+  # Mappings configured here will propogate to the corresponding resource's 
+  # LabelsAsTags mapping in datadog.kubeStateMetricsCore.labelsAsTags
   podLabelsAsTags: {}
   #   app: kube_app
   #   release: helm_release
@@ -205,6 +207,8 @@ datadog:
   #   <KUBERNETES_ANNOTATIONS>: <DATADOG_TAG_KEY>
 
   # datadog.namespaceLabelsAsTags -- Provide a mapping of Kubernetes Namespace Labels to Datadog Tags
+  # Mappings configured here will propogate to the corresponding resource's 
+  # LabelsAsTags mapping in datadog.kubeStateMetricsCore.labelsAsTags
   namespaceLabelsAsTags: {}
   #   env: environment
   #   <KUBERNETES_NAMESPACE_LABEL>: <DATADOG_TAG_KEY>


### PR DESCRIPTION
#### What this PR does / why we need it:
Improves the behavior of `datadog.kubeStateMetricsCore.labelsAsTags` by inheriting the label mappings provided  in `datadog.<RESOURCE>LabelsAsTags`. 

In the [ci testing file](https://github.com/DataDog/helm-charts/blob/cahillsf/simplify-ksm-core-labels-as-tags/charts/datadog/ci/ksm-labelstotags-values.yaml) you will see that there are two separate sets of label mappings provided.  The improved behavior merges these two label mappings, with the resulting configuration for the KSM core check reflected by the cluster agent:

```
=== kubernetes_state_core check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/kubernetes_state_core.yaml.default
Instance ID: kubernetes_state_core:1d53d28973a0abd2
collectors:
- secrets
...
- volumeattachments
- ingresses
labels_as_tags:
  deployment:
    test-label-key: test-label-key
  namespace:
    kubernetes.io/metadata.name: k8s-ns-name
    ns-key-2: ns-key-2
  node:
    kubernetes.io/hostname: k8s-hostname
    node-role: node-role
  pod:
    test-label-key: test-label-key
    test-label-key-2: test-label-key-2
~
===
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
