### PR TITLE
Add `datadog.command` to replace `agent run` with arbitrary commands

### DIFF
--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.1.3
+version: 3.2.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -587,6 +587,7 @@ helm install <RELEASE_NAME> \
 | datadog.clusterChecks.shareProcessNamespace | bool | `false` | Set the process namespace sharing on the cluster checks agent |
 | datadog.clusterName | string | `nil` | Set a unique cluster name to allow scoping hosts and Cluster Checks easily |
 | datadog.collectEvents | bool | `true` | Enables this to start event collection from the kubernetes API |
+| datadog.command | list | `["agent","run"]` | Command to run in the Agent container as entrypoint |
 | datadog.confd | object | `{}` | Provide additional check configurations (static and Autodiscovery) |
 | datadog.containerExclude | string | `nil` | Exclude containers from the Agent Autodiscovery, as a space-sepatered list |
 | datadog.containerExcludeLogs | string | `nil` | Exclude logs from the Agent Autodiscovery, as a space-separated list |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.1.3](https://img.shields.io/badge/Version-3.1.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -2,7 +2,11 @@
 - name: agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command: ["agent", "run"]
+  {{- with .Values.datadog.command }}
+  command: {{ range . }}
+   - {{ . | quote }}
+  {{- end }}
+  {{- end }}
 {{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.agent.securityContext "targetSystem" .Values.targetSystem) | indent 2 }}
   resources:
 {{ toYaml .Values.agents.containers.agent.resources | indent 4 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -43,6 +43,9 @@ datadog:
   ## a Datadog application key for read access to your metrics.
   appKey:  # <DATADOG_APP_KEY>
 
+  # datadog.command -- Command to run in the Agent container as entrypoint
+  command: ["agent", "run"]
+
   # datadog.appKeyExistingSecret -- Use existing Secret which stores APP key instead of creating a new one. The value should be set with the `app-key` key inside the secret.
 
   ## If set, this parameter takes precedence over "appKey".


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `datadog.command` to replace `agent run` with arbitrary commands like [clusterAgent.command](https://github.com/DataDog/helm-charts/blob/afe0da6d31957f0fe54ee7f73858f464cc38a126/charts/datadog/values.yaml#L766).

When we want to use Agent integrations in [integrations-extra](https://github.com/DataDog/integrations-extras), we have to build the agent image.

```Dockerfile
FROM [datadog/agent:7](https://hub.docker.com/r/datadog/agent)
RUN agent integration install -r -t datadog-grpc-check==1.0.1 \
  && /opt/datadog-agent/embedded/bin/pip3 install grpcio grpcio-health-checking
```

With `datadog.command` we don't need build agent image, just replace commands with `agent run`. For example,

values.yaml

```yaml
datadog:
  command: ["bash", "-c", "agent integration install -r -t datadog-grpc-check==1.0.1; /opt/datadog-agent/embedded/bin/pip3 install grpcio grpcio-health-checking; agent run"]
```

result

```yaml
  containers:
  - command:
    - bash
    - -c
    - agent integration install -r -t datadog-grpc-check==1.0.1; /opt/datadog-agent/embedded/bin/pip3
      install grpcio grpcio-health-checking; agent run
```

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
