### PR TITLE
Fix the configuration of the default seccomp profile for system-probe

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.1.7
+
+* Fix the configuration of the default seccomp profile for system-probe
+
 ## 3.1.6
 
 * Fix usage of `generate-security-context` helper.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.1.6
+version: 3.1.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.1.6](https://img.shields.io/badge/Version-3.1.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.1.7](https://img.shields.io/badge/Version-3.1.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -679,7 +679,7 @@ securityContext:
     type: Unconfined
     {{- end -}}
     {{- if hasPrefix "localhost/" .seccomp }}
-    localhostProfile: {{ .seccomp }}
+    localhostProfile: {{ trimPrefix "localhost/" .seccomp }}
     {{- end }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the new way of specifying the `system-probe` seccomp profile on Kube 1.19+ introduced in #768.

#### Which issue this PR fixes

Fix the `system-probe` container remaining in `CreateContainerError` state forever because of the following error:

```
Warning  Failed     11m                 kubelet            Error: failed to create containerd container: cannot load seccomp profile "/var/lib/kubelet/seccomp/localhost/system-probe": open /var/lib/kubelet/seccomp/localhost/system-probe: no such file or directory
```

This is because the profile was copied in `/var/lib/kubelet/seccomp/system-probe`, without the `/localhost/` subdirectory.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
