### PR TITLE
feat: add installInfoExistingConfigMap

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.1.10
+
+* Add `datadog.installInfoExistingConfigMap` option.
+
 ## 3.1.9
 
 * Add `faccessat` to system-probe seccomp profile.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.1.9
+version: 3.1.10
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -617,6 +617,7 @@ helm install <RELEASE_NAME> \
 | datadog.helmCheck.valuesAsTags | object | `{}` | Collects Helm values from a release and uses them as tags (Requires Agent and Cluster Agent 7.40.0+). This requires datadog.HelmCheck.enabled to be set to true |
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.ignoreAutoConfig | list | `[]` | List of integration to ignore auto_conf.yaml. |
+| datadog.installInfoExistingConfigMap | string | `nil` | Use existing ConfigMap which stores installInfo instead of creating a new one. The value should be set to the name of the existing ConfigMap |
 | datadog.kubeStateMetricsCore.collectSecretMetrics | bool | `true` | Enable watching secret objects and collecting their corresponding metrics kubernetes_state.secret.* |
 | datadog.kubeStateMetricsCore.collectVpaMetrics | bool | `false` | Enable watching VPA objects and collecting their corresponding metrics kubernetes_state.vpa.* |
 | datadog.kubeStateMetricsCore.enabled | bool | `true` | Enable the kubernetes_state_core check in the Cluster Agent (Requires Cluster Agent 1.12.0+) |

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -479,6 +479,8 @@ datadog-agent-datadog-yaml
 {{- define "agents-install-info-configmap-name" -}}
 {{- if .Values.providers.gke.autopilot -}}
 datadog-agent-installinfo
+{{- else if .Values.datadog.installInfoExistingConfigMap -}}
+{{ .Values.datadog.installInfoExistingConfigMap }}
 {{- else -}}
 {{ template "datadog.fullname" . }}-installinfo
 {{- end -}}

--- a/charts/datadog/templates/install_info-configmap.yaml
+++ b/charts/datadog/templates/install_info-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.datadog.installInfoExistingConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
       tool: helm
       tool_version: {{ .Release.Service }}
       installer_version: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -677,6 +677,9 @@ datadog:
   #  - redisdb
   #  - kubernetes_state
 
+  # datadog.installInfoExistingConfigMap -- Use an existing ConfigMap for InstallInfo
+  installInfoExistingConfigMap:
+
   # datadog.containerExclude -- Exclude containers from the Agent
   # Autodiscovery, as a space-sepatered list
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Enable the ability to use a pre-existing Install Info ConfigMap.

This is something, admittedly very niche, that I ran into when trying to have separate Linux and Windows deployments on a cluster, it will not install as it creates duplicate ConfigMaps.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
