### PR TITLE
Remove DD_HOSTNAME from agent-clusterchecks

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 3.1.10
+* Removed `DD_HOSTNAME` so that it won't supersede hostname from other sources.
+
 ## 3.1.9
 
 * Add `faccessat` to system-probe seccomp profile.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.1.9
+version: 3.1.10
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.1.9](https://img.shields.io/badge/Version-3.1.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.1.10](https://img.shields.io/badge/Version-3.1.10-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -177,10 +177,6 @@ spec:
             value: "false"
           - name: DD_APM_ENABLED
             value: "false"
-          - name: DD_HOSTNAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
           {{- if .Values.datadog.clusterName }}
           {{- template "check-cluster-name" . }}
           - name: DD_CLUSTER_NAME


### PR DESCRIPTION
#### What this PR does / why we need it:
Removed `DD_HOSTNAME` so that it won't supersede hostname from other sources.  More specifically, the presence of this environment variable supersedes other sources where the hostname can come from, such as imds (in case of aws).  This is a problem because the incorrect value provided by `spec.nodeName` can cause the wrong hostname to be sent to the backend, causing confusion.

#### Special notes for your reviewer:
These removed lines came from [this first commit](https://github.com/DataDog/helm-charts/commit/c88ada62#diff-a8ae734b61ca9075fd28fabe0f8a2af3d7ae18f99e3b0f765296e89d7aadab69R96) which added the datadog chart.  The commit is over two years old and these 4 lines are probably now obsolete given how datadog has evolved over the years.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
