### PR TITLE
[datadog-operator] bump latest image version to 0.8.2

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.8
+
+* Update chart to Datadog Operator tag `0.8.2`.
+
 ## 0.8.7
 
 * Add namespaces to all namespace-scoped objects using the HELM standard `Release.namespace`.
@@ -14,7 +18,7 @@
 
 ## 0.8.4
 
-* Update dependency on CRD chards to `0.5.2` to allow deployment on Google marketplace.
+* Update dependency on CRD charts to `0.5.2` to allow deployment on Google marketplace.
 
 ## 0.8.3
 

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.8.7
-appVersion: 0.8.1
+version: 0.8.8
+appVersion: 0.8.2
 description: Datadog Operator
 keywords:
 - monitoring

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.8.7](https://img.shields.io/badge/Version-0.8.7-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
+![Version: 0.8.8](https://img.shields.io/badge/Version-0.8.8-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 ## Values
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Default to use the latest Datadog Operator image, 0.8.2

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
