### PR TITLE
Add: support common labels for all resources

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.15.3
+
+* Support `commonlabels` configuration to be able to add common labels on all resources created by the chart.
+
 ### 0.15.2
 
 * Update private location image version to `1.28.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.2
+version: 0.15.3
 appVersion: 1.28.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.2](https://img.shields.io/badge/Version-0.15.2-informational?style=flat-square) ![AppVersion: 1.28.0](https://img.shields.io/badge/AppVersion-1.28.0-informational?style=flat-square)
+![Version: 0.15.3](https://img.shields.io/badge/Version-0.15.3-informational?style=flat-square) ![AppVersion: 1.28.0](https://img.shields.io/badge/AppVersion-1.28.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -26,6 +26,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Allows to specify affinity for Datadog Synthetics Private Location PODs |
+| commonLabels | object | `{}` | Labels to apply to all resources |
 | configConfigMap | string | `""` | Config Map that stores the configuration of the private location worker for the deployment |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
 | configSecret | string | `""` | Secret that stores the configuration of the private location worker for the deployment |

--- a/charts/synthetics-private-location/templates/_helpers.tpl
+++ b/charts/synthetics-private-location/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "synthetics-private-location.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -5,6 +5,10 @@
 # replicaCount -- Number of instances of Datadog Synthetics Private Location
 replicaCount: 1
 
+# commonLabels -- Labels to apply to all resources
+commonLabels: {}
+# team_name: dev
+
 image:
   # image.repository -- Repository to use for Datadog Synthetics Private Location image
   repository: gcr.io/datadoghq/synthetics-private-location-worker


### PR DESCRIPTION
Usefull when we have a policies manager as Kyverno.

Signed-off-by: Flaagada <mary.thibault2@gmail.com>

#### What this PR does / why we need it:

When we used a policies manager as Kyverno, it's usefull to be able to add a common labels on all resources created by the chart in order to respect the policy.

#### Special notes for your reviewer:

#### Checklist
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
