### PR TITLE
reduce the name of the admission controller

### DIFF
--- a/charts/datadog/templates/agent-services.yaml
+++ b/charts/datadog/templates/agent-services.yaml
@@ -44,7 +44,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "datadog.fullname" . }}-cluster-agent-admission-controller
+  name: {{ template "datadog.fullname" . }}-cluster-agent-adctrl
   namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "datadog.fullname" . }}"

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -175,7 +175,7 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
             value: {{ .Values.clusterAgent.admissionController.mutateUnlabelled | quote }}
           - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
-            value: {{ template "datadog.fullname" . }}-cluster-agent-admission-controller
+            value: {{ template "datadog.fullname" . }}-cluster-agent-adctrl
           {{- if .Values.clusterAgent.admissionController.configMode }}
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE
             value: {{ .Values.clusterAgent.admissionController.configMode | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Reduce the name of the admission controller as it's break easily the 63 chars limit (need to comply with DNS name length <63 chars apparently.

#### Which issue this PR fixes

"npm-load-testing" environment and customers with long name

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
