### PR TITLE
Add: support common labels for resources from Kuberntes deployment

### DIFF
--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.3
+version: 0.15.4
 appVersion: 1.28.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.3](https://img.shields.io/badge/Version-0.15.3-informational?style=flat-square) ![AppVersion: 1.28.0](https://img.shields.io/badge/AppVersion-1.28.0-informational?style=flat-square)
+![Version: 0.15.4](https://img.shields.io/badge/Version-0.15.4-informational?style=flat-square) ![AppVersion: 1.28.0](https://img.shields.io/badge/AppVersion-1.28.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 

--- a/charts/synthetics-private-location/templates/_helpers.tpl
+++ b/charts/synthetics-private-location/templates/_helpers.tpl
@@ -51,6 +51,9 @@ Selector labels
 {{- define "synthetics-private-location.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "synthetics-private-location.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Usefull when we have a policies manager as Kyverno.

Signed-off-by: Flaagada <mary.thibault2@gmail.com>

#### What this PR does / why we need it:

When we used a policies manager as Kyverno, it's usefull to be able to add a common labels in all resources created by the chart in order to respect the policy. In this [PR](https://github.com/DataDog/helm-charts/pull/785), it missing commonLabels on ressources (RS + Pods) from deployment.

#### Special notes for your reviewer:

#### Checklist
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
