### PR TITLE
charts/datadog: move datadog.dogstatsd.useHostPID under datadog.

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.3.0
+
+* Add datadog.hostPID option and deprecate datadog.dogstatsd.hostPID.
+
 ## 3.2.2
 
 * Mount `/host/proc` and `/host/sys/fs/cgroup` in trace-agent container for better support of container tagging

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.2.2
+version: 3.3.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.2.2](https://img.shields.io/badge/Version-3.2.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -605,7 +605,7 @@ helm install <RELEASE_NAME> \
 | datadog.dogstatsd.socketPath | string | `"/var/run/datadog/dsd.socket"` | Path to the DogStatsD socket |
 | datadog.dogstatsd.tagCardinality | string | `"low"` | Sets the tag cardinality relative to the origin detection |
 | datadog.dogstatsd.tags | list | `[]` | List of static tags to attach to every custom metric, event and service check collected by Dogstatsd. |
-| datadog.dogstatsd.useHostPID | bool | `false` | Run the agent in the host's PID namespace |
+| datadog.dogstatsd.useHostPID | bool | `false` | Run the agent in the host's PID namespace # DEPRECATED: use datadog.useHostPID instead. |
 | datadog.dogstatsd.useHostPort | bool | `false` | Sets the hostPort to the same value of the container port |
 | datadog.dogstatsd.useSocketVolume | bool | `true` | Enable dogstatsd over Unix Domain Socket with an HostVolume |
 | datadog.env | list | `[]` | Set environment variables for all Agents |
@@ -703,6 +703,7 @@ helm install <RELEASE_NAME> \
 | datadog.systemProbe.seccomp | string | `"localhost/system-probe"` | Apply an ad-hoc seccomp profile to the system-probe agent to restrict its privileges |
 | datadog.systemProbe.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |
 | datadog.tags | list | `[]` | List of static tags to attach to every metric, event and service check collected by this Agent. |
+| datadog.useHostPID | bool | `true` | Run the agent in the host's PID namespace, required for origin detection / unified service tagging |
 | existingClusterAgent.clusterchecksEnabled | bool | `true` | set this to false if you don’t want the agents to run the cluster checks of the joined external cluster agent |
 | existingClusterAgent.join | bool | `false` | set this to true if you want the agents deployed by this chart to connect to a Cluster Agent deployed independently |
 | existingClusterAgent.serviceName | string | `nil` | Existing service name to use for reaching the external Cluster Agent |
@@ -726,6 +727,7 @@ Some options above are not working/not available on Windows, here is the list of
 | Parameter                                | Reason                                           |
 |------------------------------------------|--------------------------------------------------|
 | `datadog.dogstatsd.useHostPID`           | Host PID not supported by Windows Containers     |
+| `datadog.useHostPID`                     | Host PID not supported by Windows Containers     |
 | `datadog.dogstatsd.useSocketVolume`      | Unix sockets not supported on Windows            |
 | `datadog.dogstatsd.socketPath`           | Unix sockets not supported on Windows            |
 | `datadog.processAgent.processCollection` | Unable to access host/other containers processes |

--- a/charts/datadog/README.md.gotmpl
+++ b/charts/datadog/README.md.gotmpl
@@ -398,6 +398,7 @@ Some options above are not working/not available on Windows, here is the list of
 | Parameter                                | Reason                                           |
 |------------------------------------------|--------------------------------------------------|
 | `datadog.dogstatsd.useHostPID`           | Host PID not supported by Windows Containers     |
+| `datadog.useHostPID`                     | Host PID not supported by Windows Containers     |
 | `datadog.dogstatsd.useSocketVolume`      | Unix sockets not supported on Windows            |
 | `datadog.dogstatsd.socketPath`           | Unix sockets not supported on Windows            |
 | `datadog.processAgent.processCollection` | Unable to access host/other containers processes |

--- a/charts/datadog/templates/agent-psp.yaml
+++ b/charts/datadog/templates/agent-psp.yaml
@@ -20,7 +20,7 @@ spec:
   - min: 8125
     max: 8126
   {{- end }}
-  hostPID: {{ or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID }}
+  hostPID: {{ or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID .Values.datadog.useHostPID }}
   allowedCapabilities:
 {{ toYaml .Values.agents.podSecurity.capabilities | indent 4 }}
   allowedUnsafeSysctls:

--- a/charts/datadog/templates/agent-scc.yaml
+++ b/charts/datadog/templates/agent-scc.yaml
@@ -11,7 +11,7 @@ priority: 8
 # Allow host ports for dsd / trace intake
 allowHostPorts: {{ or .Values.datadog.dogstatsd.useHostPort .Values.datadog.apm.enabled .Values.datadog.apm.portEnabled .Values.agents.useHostNetwork }}
 # Allow host PID for dogstatsd origin detection
-allowHostPID: {{ or .Values.datadog.securityAgent.compliance.enabled .Values.datadog.dogstatsd.useHostPID }}
+allowHostPID: {{ or .Values.datadog.securityAgent.compliance.enabled .Values.datadog.dogstatsd.useHostPID .Values.datadog.useHostPID }}
 # Allow host network for the CRIO check to reach Prometheus through localhost
 allowHostNetwork: {{ .Values.agents.useHostNetwork }}
 # Allow hostPath for docker / process metrics

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -97,7 +97,7 @@ spec:
       dnsConfig:
 {{ toYaml .Values.agents.dnsConfig | indent 8 }}
       {{- end }}
-      {{- if or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID }}
+      {{- if or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID .Values.datadog.useHostPID }}
       hostPID: true
       {{- end }}
       {{- if .Values.agents.image.pullSecrets }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -292,6 +292,7 @@ datadog:
     useHostPort: false
 
     # datadog.dogstatsd.useHostPID -- Run the agent in the host's PID namespace
+    ## DEPRECATED: use datadog.useHostPID instead.
 
     ## This is required for Dogstatsd origin detection to work.
     ## See https://docs.datadoghq.com/developers/dogstatsd/unix_socket/
@@ -301,6 +302,13 @@ datadog:
 
     ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
     nonLocalTraffic: true
+
+  # datadog.useHostPID -- Run the agent in the host's PID namespace, required for origin detection
+  # / unified service tagging
+
+  ## This is required for Dogstatsd origin detection to work in dogstatsd and trace agent
+  ## See https://docs.datadoghq.com/developers/dogstatsd/unix_socket/
+  useHostPID: true
 
   # datadog.collectEvents -- Enables this to start event collection from the kubernetes API
 


### PR DESCRIPTION
#### What this PR does / why we need it:
useHostPID is being moved under the datadog namespace from under the datadog.dogstatsd namespace.

This change is happening since the host pid namespace is no longer used just for origin detection in dogstatsd. The Trace Agent also now relies on being in the host's pid namespace for origin detection to work under cgroup v2.

This commit deprecates the old datadog.dogstatsd.useHostPID value and adds a new one named datadog.useHostPID. This variable is then used in the templates everywhere where dogstatsd.useHostPID is.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
