### PR TITLE
Add option to toggle Host Ports of OTLP Ingest, add use of Agent Service

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.1.11
+
+* Allow disabling use of the Host Port when enabling OTLP Ingest for Agent
+* Add OTLP Ingest ports to Agent Service, to be used when Host Port is disabled
+
 ## 3.1.10
 
 * Default "Agent" and "Cluster-Agent" image tag to `7.39.2`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.1.10
+version: 3.1.11
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.1.10](https://img.shields.io/badge/Version-3.1.10-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.1.11](https://img.shields.io/badge/Version-3.1.11-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -649,8 +649,10 @@ helm install <RELEASE_NAME> \
 | datadog.osReleasePath | string | `"/etc/os-release"` | Specify the path to your os-release file |
 | datadog.otlp.receiver.protocols.grpc.enabled | bool | `false` | Enable the OTLP/gRPC endpoint |
 | datadog.otlp.receiver.protocols.grpc.endpoint | string | `"0.0.0.0:4317"` |  |
+| datadog.otlp.receiver.protocols.grpc.useHostPort | bool | `true` | Enable the Host Port for the OTLP/gRPC endpoint |
 | datadog.otlp.receiver.protocols.http.enabled | bool | `false` | Enable the OTLP/HTTP endpoint |
 | datadog.otlp.receiver.protocols.http.endpoint | string | `"0.0.0.0:4318"` | OTLP/HTTP endpoint |
+| datadog.otlp.receiver.protocols.http.useHostPort | bool | `true` | Enable the Host Port for the OTLP/HTTP endpoint |
 | datadog.podAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Annotations to Datadog Tags |
 | datadog.podLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Labels to Datadog Tags |
 | datadog.processAgent.enabled | bool | `true` | Set this to true to enable live process monitoring agent |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -409,3 +409,21 @@ More information about this change: https://github.com/DataDog/helm-charts/pull/
 You are using datadog.containerInclude or DD_CONTAINER_INCLUDE but you haven't excluded any containers. The default behavior is to include everything; if the intent is to exclude all other containers, set datadog.containerExclude to 'name:.*' .
 
 {{- end }}
+
+{{- if and .Values.datadog.otlp.receiver.protocols.grpc.enabled (not .Values.datadog.otlp.receiver.protocols.grpc.useHostPort) }}
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+You have enabled OTLP Ingest for the gRPC port without the Host Port enabled. 
+
+To send OTLP data to the Agent use the Service created by specifying "{{ template "localService.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.datadog.otlp.receiver.protocols.grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}" as the endpoint.
+{{- end }}
+
+{{- if and .Values.datadog.otlp.receiver.protocols.http.enabled (not .Values.datadog.otlp.receiver.protocols.http.useHostPort) }}
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+You have enabled OTLP Ingest for the HTTP port without the Host Port enabled. 
+
+To send OTLP data to the Agent use the Service created by specifying "{{ template "localService.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}" as the endpoint.
+{{- end }}

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -414,7 +414,7 @@ You are using datadog.containerInclude or DD_CONTAINER_INCLUDE but you haven't e
 #################################################################
 ####               WARNING: Configuration notice             ####
 #################################################################
-You have enabled OTLP Ingest for the gRPC port without the Host Port enabled. 
+You have enabled OTLP Ingest for the gRPC port without the Host Port enabled.
 
 To send OTLP data to the Agent use the Service created by specifying "http://{{ template "localService.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.datadog.otlp.receiver.protocols.grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}" as the endpoint.
 {{- end }}
@@ -423,7 +423,7 @@ To send OTLP data to the Agent use the Service created by specifying "http://{{ 
 #################################################################
 ####               WARNING: Configuration notice             ####
 #################################################################
-You have enabled OTLP Ingest for the HTTP port without the Host Port enabled. 
+You have enabled OTLP Ingest for the HTTP port without the Host Port enabled.
 
 To send OTLP data to the Agent use the Service created by specifying "http://{{ template "localService.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}" as the endpoint.
 {{- end }}

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -416,7 +416,7 @@ You are using datadog.containerInclude or DD_CONTAINER_INCLUDE but you haven't e
 #################################################################
 You have enabled OTLP Ingest for the gRPC port without the Host Port enabled. 
 
-To send OTLP data to the Agent use the Service created by specifying "{{ template "localService.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.datadog.otlp.receiver.protocols.grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}" as the endpoint.
+To send OTLP data to the Agent use the Service created by specifying "http://{{ template "localService.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.datadog.otlp.receiver.protocols.grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}" as the endpoint.
 {{- end }}
 
 {{- if and .Values.datadog.otlp.receiver.protocols.http.enabled (not .Values.datadog.otlp.receiver.protocols.http.useHostPort) }}
@@ -425,5 +425,5 @@ To send OTLP data to the Agent use the Service created by specifying "{{ templat
 #################################################################
 You have enabled OTLP Ingest for the HTTP port without the Host Port enabled. 
 
-To send OTLP data to the Agent use the Service created by specifying "{{ template "localService.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}" as the endpoint.
+To send OTLP data to the Agent use the Service created by specifying "http://{{ template "localService.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}" as the endpoint.
 {{- end }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -22,7 +22,9 @@
   {{- include "verify-otlp-grpc-endpoint-prefix" .grpc.endpoint }}
   {{- include "verify-otlp-endpoint-port" .grpc.endpoint }}
   - containerPort: {{ .grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+    {{- if .grpc.useHostPort }}
     hostPort: {{ .grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+    {{- end }}
     name: otlpgrpcport
     protocol: TCP
   {{- end }}
@@ -30,7 +32,9 @@
   {{- if (and .http .http.enabled) }}
   {{- include "verify-otlp-endpoint-port" .http.endpoint }}
   - containerPort: {{ .http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+    {{- if .http.useHostPort }}
     hostPort: {{ .http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+    {{- end }}
     name: otlphttpport
     protocol: TCP
   {{- end }}

--- a/charts/datadog/templates/agent-services.yaml
+++ b/charts/datadog/templates/agent-services.yaml
@@ -88,5 +88,17 @@ spec:
       targetPort: {{ .Values.datadog.apm.port }}
       name: traceport
 {{- end }}
+{{- if .Values.datadog.otlp.receiver.protocols.grpc.enabled }}
+    - protocol: TCP
+      port: {{ .Values.datadog.otlp.receiver.protocols.grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+      targetPort: {{ .Values.datadog.otlp.receiver.protocols.grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+      name: otlpgrpcport
+{{- end }}
+{{- if .Values.datadog.otlp.receiver.protocols.http.enabled }}
+    - protocol: TCP
+      port: {{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+      targetPort: {{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+      name: otlphttpport
+ {{- end }}
   internalTrafficPolicy: Local
 {{ end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -381,6 +381,8 @@ datadog:
           enabled: false
           # datadog.otlp.receiver.procotols.grpc.endpoint -- OTLP/gRPC endpoint
           endpoint: "0.0.0.0:4317"
+          # datadog.otlp.receiver.protocols.grpc.useHostPort -- Enable the Host Port for the OTLP/gRPC endpoint
+          useHostPort: true
 
         # datadog.otlp.receiver.protocols.http - OTLP/HTTP configuration
         http:
@@ -388,6 +390,8 @@ datadog:
           enabled: false
           # datadog.otlp.receiver.protocols.http.endpoint -- OTLP/HTTP endpoint
           endpoint: "0.0.0.0:4318"
+          # datadog.otlp.receiver.protocols.http.useHostPort -- Enable the Host Port for the OTLP/HTTP endpoint
+          useHostPort: true
 
   # datadog.envFrom -- Set environment variables for all Agents directly from configMaps and/or secrets
 


### PR DESCRIPTION
#### What this PR does / why we need it:
In certain environments users can't enable the use of the Host Ports for the Agent container's OTLP Ingest feature. The Host Port syntax is the original and default strategy for sending data to the Agent as this allows application pods to send data from a given pod to the Host IP, which routes to the Host Port, which routes to the Agent pod on the **same node**. Which we want for tagging purposes.

However, with Kubernetes 1.22+ we can use the Agent `Service` to route traffic to the Agent pod on the same node with `internalTrafficPolicy: Local`. 

This PR adds the ability to allow you to keep the gRPC or HTTP endpoints enabled, but without the host port. For compatibility the host port is on by default. This uses the similar syntax as dogstatsd, `...grpc.useHostPort` and `...http.useHostPort`. 

```yaml
datadog:
  #(...)
  otlp:
    receiver:
      protocols:
        grpc:
          enabled: true
          useHostPort: true
        http:
          enabled: true
          useHostPort: false
```

Likewise added these ports to the `Service` created to allow that data to flow correctly when sent through the Service. The Notes have been updated to inform the users when this should be used and what endpoint to use, relative to the service name and namespace. For example:

```
#################################################################
####               WARNING: Configuration notice             ####
#################################################################
You have enabled OTLP Ingest for the gRPC port without the Host Port enabled.

To send OTLP data to the Agent use the Service created by specifying "http://datadog.default.svc.cluster.local:4317" as the endpoint.
```

```
#################################################################
####               WARNING: Configuration notice             ####
#################################################################
You have enabled OTLP Ingest for the HTTP port without the Host Port enabled.

To send OTLP data to the Agent use the Service created by specifying "http://datadog.default.svc.cluster.local:4318" as the endpoint.
``` 

#### Which issue this PR fixes
- CONS-5013
- CONS-4996

#### Special notes for your reviewer:
This uses the existing syntax of stripping the `port` number off the end of the respective `endpoint` configurations. In the future may want to create an explicit `grpc.port` and `http.port` config option. 

From the perspective of the Agent process, this shouldn't change too much. It's still receiving the data and responding to it the same. It's just receiving it through the `Service` instead of the `HostIP:HostPort`. Validated with sample otel deployment:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
    name: python-otlp
    labels:
        app: python-otlp
spec:
    replicas: 1
    selector:
        matchLabels:
            app: python-otlp  
    template:
        metadata:
            labels:
                app: python-otlp
            annotations:
                ad.datadoghq.com/sample-python-app.check_names: '["http_check"]'
                ad.datadoghq.com/sample-python-app.init_configs: '[{}]'
                ad.datadoghq.com/sample-python-app.instances: '[{"url": "http://%%host%%:5000","name": "sample-python-otel"}]'
        spec:
            containers:
                - name: sample-python-app
                  image: docker.io/jacksondavenport/sample-otel-app:latest
                  env:
                    - name: OTEL_EXPORTER_OTLP_ENDPOINT
                      value: "http://datadog.default.svc.cluster.local:4318"
                    - name: OTLP_EXPORTER_PROTOCOL
                      value: "http"
```
Can set `OTEL_EXPORTER_OTLP_ENDPOINT` accordingly to expected address, and `OTLP_EXPORTER_PROTOCOL` to `grpc` (the default) or `http`.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
