### PR TITLE
charts/datadog: Use downward API to provide K8S CPU Limit to trace-agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.2.0
+
+* Expose any K8S CPU limit set on the trace-agent as `DD_K8S_MAX_CPU`
+
 ## 3.1.11
 
 * Allow disabling use of the Host Port when enabling OTLP Ingest for Agent

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.1.11
+version: 3.2.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.1.11](https://img.shields.io/badge/Version-3.1.11-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -33,6 +33,12 @@
   env:
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
+    - name: DD_K8S_MAX_CPU
+      valueFrom:
+        resourceFieldRef:
+          containerName: trace-agent
+          resource: limits.cpu
+          divisor: 1m
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.traceAgent.logLevel | default .Values.datadog.logLevel | quote }}
     - name: DD_APM_ENABLED

--- a/charts/datadog/templates/datadog-yaml-configmap.yaml
+++ b/charts/datadog/templates/datadog-yaml-configmap.yaml
@@ -30,7 +30,6 @@ data:
       enabled: true
       apm_non_local_traffic: true
       max_memory: 0
-      max_cpu_percent: 0
 
     {{- $version := (.Values.agents.image.tag | toString | trimSuffix "-jmx") }}
     {{- $length := len (split "." $version ) -}} 


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR exposes any configured cpu limit on the trace-agent to the container so it can use it to better inform rate limiting. Currently in K8s environments the trace-agent only relies on the container runtime / k8s for cpu throttling. This means that the trace-agent can become overwhelmed with traffic but not report this to the backend leading to customers being unaware their trace-agents need more resources (or less traffic). Exposing the k8s limit to the trace-agent will allow it to set an internal "CPU Watchdog" based on this value which is then used to rate limit (read: drop) traffic when it starts to be overwhelmed, thereby indicating to the backend (via tags) that the trace-agent has insufficient resources.

The previous default value of `0` is removed so that the auto-lookup can take place. Setting a value of `0` explicitly disables the cpu watchdog entirely.

[Here's the PR ](https://github.com/DataDog/datadog-agent/pull/14014) where the trace-agent will make use of this new variable

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
