### PR TITLE
Adding option to store v2alpha1 version of the DatadogAgent

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.6
+
+* Introduce option to store DatadogAgent v2alpha1 or v1alpha1.
+
 ## 0.5.5
 
 * Fix CI, by renaming `kubeval.yaml` to `kubeval-values.yaml`

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.5.5
+version: 0.5.6
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.5.6](https://img.shields.io/badge/Version-0.5.6-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 
@@ -26,6 +26,7 @@ But the recommended Kubernetes versions are `1.16+`.
 | crds.datadogMetrics | bool | `false` | Set to true to deploy the DatadogMetrics CRD |
 | crds.datadogMonitors | bool | `false` | Set to true to deploy the DatadogMonitors CRD |
 | fullnameOverride | string | `""` | Override the fully qualified app name |
+| migration.datadogAgents.version | string | `"v1alpha1"` |  |
 | nameOverride | string | `""` | Override name of app |
 
 ## Developers

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -5819,8 +5819,13 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
               type: object
           type: object
+      {{- if not (eq .Values.migration.datadogAgents.version "v2alpha1") }}
       served: true
       storage: true
+      {{- else }}
+      served: true
+      storage: false
+      {{- end }}
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -8212,8 +8217,13 @@ spec:
                   x-kubernetes-list-type: map
               type: object
           type: object
-      served: false
+      {{- if eq .Values.migration.datadogAgents.version "v2alpha1" }}
+      served: true
+      storage: true
+      {{- else }}
+      served: true
       storage: false
+      {{- end }}
       subresources:
         status: {}
 status:

--- a/charts/datadog-crds/values.yaml
+++ b/charts/datadog-crds/values.yaml
@@ -10,6 +10,11 @@ crds:
   # crds.datadogMonitors -- Set to true to deploy the DatadogMonitors CRD
   datadogMonitors: false
 
+migration:
+  datadogAgents:
+    # enabled: false # Will be used when we add the option to add the webhookConversion field in the CRD.
+    version: "v1alpha1"
+
 # nameOverride -- Override name of app
 nameOverride: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it:

PR in the CRDs before PR in the operator to support using DDA in v2alpha1 directly.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
