### PR TITLE
Update datadog operator chart v2alpha1

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.0
+
+* Add option to deactivate the conversion webhook for usecases where v2alpha1 is solely used.
+* Conversion webhook option is not used if the operator version does not support it.
+* V2alpha1 is now always served.
+
 ## 0.8.8
 
 * Update chart to Datadog Operator tag `0.8.2`.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-  - name: datadog-crds
-    repository: https://helm.datadoghq.com
-    version: 0.5.4
-digest: sha256:b88c0b1039699026d655b06960066db33bb291d1ca400d94c2224653bdb54bd6
-generated: "2022-08-09T11:11:02.328648-05:00"
+- name: datadog-crds
+  repository: https://helm.datadoghq.com
+  version: 0.5.6
+digest: sha256:ea0a6ac02d15be41292f4914b259d53700e7a13a3840927d69cde17665d08393
+generated: "2022-11-04T16:28:33.274701-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.8.8
-appVersion: 0.8.2
+version: 0.9.0
+appVersion: 0.8.3
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "=0.5.4"
+  version: "=0.5.6"
   repository: https://helm.datadoghq.com
   condition: installCRDs
   tags:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.8.8](https://img.shields.io/badge/Version-0.8.8-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: 0.8.3](https://img.shields.io/badge/AppVersion-0.8.3-informational?style=flat-square)
 
 ## Values
 
@@ -16,6 +16,7 @@
 | datadog-crds.crds.datadogAgents | bool | `true` | Set to true to deploy the DatadogAgents CRD |
 | datadog-crds.crds.datadogMetrics | bool | `true` | Set to true to deploy the DatadogMetrics CRD |
 | datadog-crds.crds.datadogMonitors | bool | `true` | Set to true to deploy the DatadogMonitors CRD |
+| datadog-crds.migration.datadogAgents.version | string | `"v1alpha1"` |  |
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |
@@ -27,6 +28,7 @@
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | logLevel | string | `"info"` | Set Datadog Operator log level (debug, info, error, panic, fatal) |
 | metricsPort | int | `8383` | Port used for OpenMetrics endpoint |
+| migration.webhook.enabled | bool | `false` |  |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Operator on specific nodes |
 | podAnnotations | object | `{}` | Allows setting additional annotations for Datadog Operator PODs |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -28,7 +28,6 @@
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | logLevel | string | `"info"` | Set Datadog Operator log level (debug, info, error, panic, fatal) |
 | metricsPort | int | `8383` | Port used for OpenMetrics endpoint |
-| migration.webhook.enabled | bool | `false` |  |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Operator on specific nodes |
 | podAnnotations | object | `{}` | Allows setting additional annotations for Datadog Operator PODs |
@@ -45,6 +44,7 @@
 | supportExtendedDaemonset | string | `"false"` | If true, supports using ExtendedDeamonSet CRD |
 | tolerations | list | `[]` | Allows to schedule Datadog Operator on tainted nodes |
 | watchNamespaces | list | `[]` | Restrics the Operator to watch its managed resources on specific namespaces |
+| webhook | object | `{"conversion":{"enabled":false}}` | configure webhook servers |
 
 ## How to configure which namespaces are watched by the Operator.
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             - "-logEncoder=json"
             - "-metrics-addr=:{{ .Values.metricsPort }}"
             - "-loglevel={{ .Values.logLevel }}"
-          {{- if and (not .Values.migration.webhook.enabled) (semverCompare ">=1.0.0-0" .Values.image.tag ) }}
+          {{- if and (not .Values.webhook.conversion.enabled) (semverCompare ">=1.0.0-0" .Values.image.tag ) }}
             - "-webhookEnabled=false"
           {{- end }}
           {{- if .Values.secretBackend.command }}

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -93,6 +93,9 @@ spec:
             - "-logEncoder=json"
             - "-metrics-addr=:{{ .Values.metricsPort }}"
             - "-loglevel={{ .Values.logLevel }}"
+          {{- if and (not .Values.migration.webhook.enabled) (semverCompare ">=1.0.0-0" .Values.image.tag ) }}
+            - "-webhookEnabled=false"
+          {{- end }}
           {{- if .Values.secretBackend.command }}
             - "-secretBackendCommand={{ .Values.secretBackend.command }}"
           {{- end }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -110,8 +110,10 @@ datadog-crds:
     datadogAgents:
       version: "v1alpha1"
 
-migration:
-  webhook:
+# webhook -- configure webhook servers
+webhook:
+  ## Use the conversion webhook server when multiple versions of objects managed by the Datadog Operator are served.
+  conversion:
     enabled: false
 
 # podAnnotations -- Allows setting additional annotations for Datadog Operator PODs

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -106,6 +106,13 @@ datadog-crds:
     datadogMetrics: true
     # datadog-crds.crds.datadogMonitors -- Set to true to deploy the DatadogMonitors CRD
     datadogMonitors: true
+  migration:
+    datadogAgents:
+      version: "v1alpha1"
+
+migration:
+  webhook:
+    enabled: false
 
 # podAnnotations -- Allows setting additional annotations for Datadog Operator PODs
 podAnnotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

- Following up on https://github.com/DataDog/helm-charts/pull/798
- Add reference to updated CRD that allows storing/serving v2alpha1
- Add ability to deactivate Conversion Webhook and add safeguard not to use for versions of the Operator that don't support it.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
