### PR TITLE
Fix commonLabels template

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.15.6
+
+* Fix `commonLabels` template
+
 ## 0.15.5
 
 * Update private location image version to `1.29.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.5
+version: 0.15.6
 appVersion: 1.29.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.5](https://img.shields.io/badge/Version-0.15.5-informational?style=flat-square) ![AppVersion: 1.29.0](https://img.shields.io/badge/AppVersion-1.29.0-informational?style=flat-square)
+![Version: 0.15.6](https://img.shields.io/badge/Version-0.15.6-informational?style=flat-square) ![AppVersion: 1.29.0](https://img.shields.io/badge/AppVersion-1.29.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 

--- a/charts/synthetics-private-location/templates/_helpers.tpl
+++ b/charts/synthetics-private-location/templates/_helpers.tpl
@@ -35,7 +35,6 @@ Common labels
 */}}
 {{- define "synthetics-private-location.labels" -}}
 helm.sh/chart: {{ include "synthetics-private-location.chart" . }}
-{{ include "synthetics-private-location.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR removes the label duplication in `deploy.metadata.labels`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

```
values.yaml
commonLabels:
  app_name: 'test'
  team_name: 'two'
  label_test: 'three'
replicaCount: 3
```

Before the PR Change
```
# Source: synthetics-private-location/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: datadog-private-synthetics-private-location
  labels:
    helm.sh/chart: synthetics-private-location-0.15.6
    app.kubernetes.io/name: synthetics-private-location
    app.kubernetes.io/instance: datadog-private
    app_name: test
    label_test: three
    team_name: two
    app.kubernetes.io/version: "1.29.0"
    app.kubernetes.io/managed-by: Helm
    app_name: test
    label_test: three
    team_name: two
```

After the PR Change
```
# Source: synthetics-private-location/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: datadog-private-synthetics-private-location
  labels:
    helm.sh/chart: synthetics-private-location-0.15.6
    app.kubernetes.io/version: "1.29.0"
    app.kubernetes.io/managed-by: Helm
    app_name: test
    label_test: three
    team_name: two
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
