### PR TITLE
Adding missing fields in the CRD of the DatadogAgent

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.7
+
+* Update CRD of DatadogAgent to have new fields for the cws feature.
+
 ## 0.5.6
 
 * Introduce option to store DatadogAgent v2alpha1 or v1alpha1.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.5.6
+version: 0.5.7
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.5.6](https://img.shields.io/badge/Version-0.5.6-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.5.7](https://img.shields.io/badge/Version-0.5.7-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -5829,9 +5829,6 @@ spec:
       subresources:
         status: {}
     - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=='Active')].status
-          name: active
-          type: string
         - jsonPath: .status.agent.status
           name: agent
           type: string
@@ -5902,26 +5899,31 @@ spec:
                           type: string
                         customBenchmarks:
                           properties:
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                  - key
-                                  - path
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                                - key
-                              x-kubernetes-list-type: map
-                            name:
+                            configData:
                               type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
                           type: object
                         enabled:
                           type: boolean
@@ -5930,35 +5932,35 @@ spec:
                       properties:
                         customPolicies:
                           properties:
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                  - key
-                                  - path
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                                - key
-                              x-kubernetes-list-type: map
-                            name:
+                            configData:
                               type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
                           type: object
                         enabled:
                           type: boolean
                         syscallMonitorEnabled:
-                          type: boolean
-                      type: object
-                    datadogMonitor:
-                      properties:
-                        enabled:
                           type: boolean
                       type: object
                     dogstatsd:
@@ -6098,6 +6100,10 @@ spec:
                       properties:
                         enabled:
                           type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
                       type: object
                     logCollection:
                       properties:
@@ -6175,6 +6181,29 @@ spec:
                         scrubContainers:
                           type: boolean
                       type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
                     prometheusScrape:
                       properties:
                         additionalConfigs:
@@ -6199,6 +6228,15 @@ spec:
                   properties:
                     clusterAgentToken:
                       type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
                     clusterName:
                       type: string
                     credentials:
@@ -6999,6 +7037,39 @@ spec:
                                     x-kubernetes-int-or-string: true
                                   type: object
                               type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -7185,8 +7256,10 @@ spec:
                         x-kubernetes-list-type: map
                       extraChecksd:
                         properties:
-                          configData:
-                            type: string
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
                           configMap:
                             properties:
                               items:
@@ -7213,8 +7286,10 @@ spec:
                         type: object
                       extraConfd:
                         properties:
-                          configData:
-                            type: string
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
                           configMap:
                             properties:
                               items:
@@ -7276,38 +7351,6 @@ spec:
                       replicas:
                         format: int32
                         type: integer
-                      secCompCustomProfile:
-                        properties:
-                          configData:
-                            type: string
-                          configMap:
-                            properties:
-                              items:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    mode:
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      type: string
-                                  required:
-                                    - key
-                                    - path
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                  - key
-                                x-kubernetes-list-type: map
-                              name:
-                                type: string
-                            type: object
-                        type: object
-                      secCompProfileName:
-                        type: string
-                      secCompRootPath:
-                        type: string
                       securityContext:
                         properties:
                           fsGroup:
@@ -7370,6 +7413,148 @@ spec:
                                 type: boolean
                               runAsUserName:
                                 type: string
+                            type: object
+                        type: object
+                      securityContextConstraints:
+                        properties:
+                          create:
+                            type: boolean
+                          customConfiguration:
+                            properties:
+                              allowHostDirVolumePlugin:
+                                type: boolean
+                              allowHostIPC:
+                                type: boolean
+                              allowHostNetwork:
+                                type: boolean
+                              allowHostPID:
+                                type: boolean
+                              allowHostPorts:
+                                type: boolean
+                              allowPrivilegedContainer:
+                                type: boolean
+                              allowedCapabilities:
+                                items:
+                                  type: string
+                                type: array
+                              allowedFlexVolumes:
+                                items:
+                                  properties:
+                                    driver:
+                                      type: string
+                                  type: object
+                                type: array
+                              apiVersion:
+                                type: string
+                              defaultAddCapabilities:
+                                items:
+                                  type: string
+                                type: array
+                              fsGroup:
+                                properties:
+                                  ranges:
+                                    items:
+                                      properties:
+                                        max:
+                                          format: int64
+                                          type: integer
+                                        min:
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                                type: object
+                              groups:
+                                items:
+                                  type: string
+                                type: array
+                              kind:
+                                type: string
+                              metadata:
+                                type: object
+                              priority:
+                                format: int32
+                                type: integer
+                              readOnlyRootFilesystem:
+                                type: boolean
+                              requiredDropCapabilities:
+                                items:
+                                  type: string
+                                type: array
+                              runAsUser:
+                                properties:
+                                  type:
+                                    type: string
+                                  uid:
+                                    format: int64
+                                    type: integer
+                                  uidRangeMax:
+                                    format: int64
+                                    type: integer
+                                  uidRangeMin:
+                                    format: int64
+                                    type: integer
+                                type: object
+                              seLinuxContext:
+                                properties:
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  type:
+                                    type: string
+                                type: object
+                              seccompProfiles:
+                                items:
+                                  type: string
+                                type: array
+                              supplementalGroups:
+                                properties:
+                                  ranges:
+                                    items:
+                                      properties:
+                                        max:
+                                          format: int64
+                                          type: integer
+                                        min:
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                                type: object
+                              users:
+                                items:
+                                  type: string
+                                type: array
+                              volumes:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - allowHostDirVolumePlugin
+                              - allowHostIPC
+                              - allowHostNetwork
+                              - allowHostPID
+                              - allowHostPorts
+                              - allowPrivilegedContainer
+                              - allowedCapabilities
+                              - allowedFlexVolumes
+                              - defaultAddCapabilities
+                              - priority
+                              - readOnlyRootFilesystem
+                              - requiredDropCapabilities
+                              - volumes
                             type: object
                         type: object
                       serviceAccountName:


### PR DESCRIPTION
#### What this PR does / why we need it:

- Some features did not have the most up to date config (CWS).

#### Special notes for your reviewer:

- Will need to update the datadog-operator chart dependency afterwards.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
