### PR TITLE
Updating dependency on CRD Chart

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+* Updating dependency to CRD to allow all fields.
+
 ## 0.9.0
 
 * Add option to deactivate the conversion webhook for usecases where v2alpha1 is solely used.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 0.5.6
-digest: sha256:ea0a6ac02d15be41292f4914b259d53700e7a13a3840927d69cde17665d08393
-generated: "2022-11-04T16:28:33.274701-04:00"
+  version: 0.5.7
+digest: sha256:3909a16ab2942dfd1a50f78ffbd558d6599ddb6a606d30426e90a2f9b63e185f
+generated: "2022-11-09T18:40:11.919707-05:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.8.3
 description: Datadog Operator
 keywords:
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "=0.5.6"
+  version: "=0.5.7"
   repository: https://helm.datadoghq.com
   condition: installCRDs
   tags:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: 0.8.3](https://img.shields.io/badge/AppVersion-0.8.3-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 0.8.3](https://img.shields.io/badge/AppVersion-0.8.3-informational?style=flat-square)
 
 ## Values
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Follow up of  https://github.com/DataDog/helm-charts/pull/805
Bumping dependency to the DatadogAgent crd in the Datadog Operator chart.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
