### PR TITLE
Add configuration value for mounting custom BTFs

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.4.0
 
-* Add CO-RE configuration values `datadog.systemProbe.btfPath` and `datadog.systemProbe.enableCORE` (see datadog-agent PRs #13962 and #14096 for more context).
+* Add `datadog.systemProbe.btfPath` for mounting user-provided BTF files (see datadog-agent PRs #13962 and #14096 for more context).
 
 ## 3.3.3
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.4.0
+
+* Add CO-RE configuration values `datadog.systemProbe.btfPath` and `datadog.systemProbe.enableCORE` (see datadog-agent PRs #13962 and #14096 for more context).
+
 ## 3.3.3
 
 * Add a warning note to alert users about suboptimal configuration of Cluster Checks Runner.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.3.3
+version: 3.4.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.3.3](https://img.shields.io/badge/Version-3.3.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -686,10 +686,12 @@ helm install <RELEASE_NAME> \
 | datadog.site | string | `nil` | The site of the Datadog intake to send Agent data to. (documentation: https://docs.datadoghq.com/getting_started/site/) |
 | datadog.systemProbe.apparmor | string | `"unconfined"` | Specify a apparmor profile for system-probe |
 | datadog.systemProbe.bpfDebug | bool | `false` | Enable logging for kernel debug |
+| datadog.systemProbe.btfPath | string | `""` | Specify the path to a BTF file for your kernel |
 | datadog.systemProbe.collectDNSStats | bool | `true` | Enable DNS stat collection |
 | datadog.systemProbe.conntrackInitTimeout | string | `"10s"` | the time to wait for conntrack to initialize before failing |
 | datadog.systemProbe.conntrackMaxStateSize | int | `131072` | the maximum size of the userspace conntrack cache |
 | datadog.systemProbe.debugPort | int | `0` | Specify the port to expose pprof and expvar for system-probe agent |
+| datadog.systemProbe.enableCORE | bool | `true` | Enables Compile Once - Run Everywhere (CO-RE) for eBPF probes |
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableDefaultKernelHeadersPaths | bool | `true` | Enable mount of default paths where kernel headers are stored |
 | datadog.systemProbe.enableDefaultOsReleasePaths | bool | `true` | enable default os-release files mount |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -691,7 +691,6 @@ helm install <RELEASE_NAME> \
 | datadog.systemProbe.conntrackInitTimeout | string | `"10s"` | the time to wait for conntrack to initialize before failing |
 | datadog.systemProbe.conntrackMaxStateSize | int | `131072` | the maximum size of the userspace conntrack cache |
 | datadog.systemProbe.debugPort | int | `0` | Specify the port to expose pprof and expvar for system-probe agent |
-| datadog.systemProbe.enableCORE | bool | `true` | Enables Compile Once - Run Everywhere (CO-RE) for eBPF probes |
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableDefaultKernelHeadersPaths | bool | `true` | Enable mount of default paths where kernel headers are stored |
 | datadog.systemProbe.enableDefaultOsReleasePaths | bool | `true` | enable default os-release files mount |

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -130,7 +130,7 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if and .Values.datadog.systemProbe.enableCORE .Values.datadog.systemProbe.btfPath }}
+{{- if .Values.datadog.systemProbe.btfPath }}
     - name: btf-path
       mountPath: {{ .Values.datadog.systemProbe.btfPath }}
       readOnly: true

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -130,25 +130,10 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if .Values.datadog.systemProbe.enableCORE }}
-{{- if .Values.datadog.systemProbe.btfPath }}
+{{- if and .Values.datadog.systemProbe.enableCORE .Values.datadog.systemProbe.btfPath }}
     - name: btf-path
       mountPath: {{ .Values.datadog.systemProbe.btfPath }}
       readOnly: true
-{{- else }}
-  - name: lib-modules
-    mountPath: /lib/modules
-    mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-    readOnly: true
-  - name: usr-lib-modules
-    mountPath: /usr/lib/modules
-    mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-    readOnly: true
-  - name: usr-lib-debug
-    mountPath: /usr/lib/debug
-    mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-    readOnly: true
-{{- end }}
 {{- end }}
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -78,7 +78,7 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
 {{- end }}
-{{- if and (or (eq (include "runtime-compilation-enabled" .) "true") .Values.datadog.systemProbe.enableCORE) .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}
+{{- if and (eq (include "runtime-compilation-enabled" .) "true") .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}
     - name: modules
       mountPath: /lib/modules
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
@@ -130,10 +130,25 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if and .Values.datadog.systemProbe.enableCORE .Values.datadog.systemProbe.btfPath }}
+{{- if .Values.datadog.systemProbe.enableCORE }}
+{{- if .Values.datadog.systemProbe.btfPath }}
     - name: btf-path
       mountPath: {{ .Values.datadog.systemProbe.btfPath }}
       readOnly: true
+{{- else }}
+  - name: lib-modules
+    mountPath: /lib/modules
+    mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+    readOnly: true
+  - name: usr-lib-modules
+    mountPath: /usr/lib/modules
+    mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+    readOnly: true
+  - name: usr-lib-debug
+    mountPath: /usr/lib/debug
+    mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+    readOnly: true
+{{- end }}
 {{- end }}
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -78,7 +78,7 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
 {{- end }}
-{{- if and (or .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill) .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}
+{{- if and (or (eq (include "runtime-compilation-enabled" .) "true") .Values.datadog.systemProbe.enableCORE) .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}
     - name: modules
       mountPath: /lib/modules
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
@@ -129,6 +129,11 @@
       readOnly: true
 {{- end }}
 {{- end }}
+{{- end }}
+{{- if and .Values.datadog.systemProbe.enableCORE .Values.datadog.systemProbe.btfPath }}
+    - name: btf-path
+      mountPath: {{ .Values.datadog.systemProbe.btfPath }}
+      readOnly: true
 {{- end }}
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -78,7 +78,7 @@
   name: debugfs
 - name: sysprobe-socket-dir
   emptyDir: {}
-{{- if and (or .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill) .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}
+{{- if and (eq (include "runtime-compilation-enabled" .) "true") .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}
 - hostPath:
     path: /lib/modules
   name: modules
@@ -125,10 +125,22 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if and .Values.datadog.systemProbe.enableCORE .Values.datadog.systemProbe.btfPath }}
+{{- if .Values.datadog.systemProbe.enableCORE }}
+{{- if .Values.datadog.systemProbe.btfPath }}
 - hostPath:
     path: {{ .Values.datadog.systemProbe.btfPath }}
   name: btf-path
+{{- else }}
+- hostPath:
+    path: /lib/modules
+  name: lib-modules
+- hostPath:
+    path: /usr/lib/modules
+  name: usr-lib-modules
+- hostPath:
+    path: /usr/lib/debug
+  name: usr-lib-debug
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if or .Values.datadog.processAgent.enabled (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true") }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -125,6 +125,11 @@
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if and .Values.datadog.systemProbe.enableCORE .Values.datadog.systemProbe.btfPath }}
+- hostPath:
+    path: {{ .Values.datadog.systemProbe.btfPath }}
+  name: btf-path
+{{- end }}
 {{- end }}
 {{- if or .Values.datadog.processAgent.enabled (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true") }}
 - hostPath:

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -125,7 +125,7 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if and .Values.datadog.systemProbe.enableCORE .Values.datadog.systemProbe.btfPath }}
+{{- if .Values.datadog.systemProbe.btfPath }}
 - hostPath:
     path: {{ .Values.datadog.systemProbe.btfPath }}
   name: btf-path

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -125,22 +125,10 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if .Values.datadog.systemProbe.enableCORE }}
-{{- if .Values.datadog.systemProbe.btfPath }}
+{{- if and .Values.datadog.systemProbe.enableCORE .Values.datadog.systemProbe.btfPath }}
 - hostPath:
     path: {{ .Values.datadog.systemProbe.btfPath }}
   name: btf-path
-{{- else }}
-- hostPath:
-    path: /lib/modules
-  name: lib-modules
-- hostPath:
-    path: /usr/lib/modules
-  name: usr-lib-modules
-- hostPath:
-    path: /usr/lib/debug
-  name: usr-lib-debug
-{{- end }}
 {{- end }}
 {{- end }}
 {{- if or .Values.datadog.processAgent.enabled (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true") }}

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -39,6 +39,8 @@ data:
       apt_config_dir: /host/etc/apt
       yum_repos_dir: /host/etc/yum.repos.d
       zypper_repos_dir: /host/etc/zypp/repos.d
+      enable_co_re: {{ $.Values.datadog.systemProbe.enableCORE }}
+      btf_path: {{ $.Values.datadog.systemProbe.btfPath }}
     network_config:
       enabled: {{ $.Values.datadog.networkMonitoring.enabled }}
       conntrack_init_timeout: {{ $.Values.datadog.systemProbe.conntrackInitTimeout }}

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -39,7 +39,6 @@ data:
       apt_config_dir: /host/etc/apt
       yum_repos_dir: /host/etc/yum.repos.d
       zypper_repos_dir: /host/etc/zypp/repos.d
-      enable_co_re: {{ $.Values.datadog.systemProbe.enableCORE }}
       btf_path: {{ $.Values.datadog.systemProbe.btfPath }}
     network_config:
       enabled: {{ $.Values.datadog.networkMonitoring.enabled }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -529,9 +529,6 @@ datadog:
     # datadog.systemProbe.runtimeCompilationAssetDir -- Specify a directory for runtime compilation assets to live in
     runtimeCompilationAssetDir: /var/tmp/datadog-agent/system-probe
 
-    # datadog.systemProbe.enableCORE -- Enables Compile Once - Run Everywhere (CO-RE) for eBPF probes
-    enableCORE: true
-
     # datadog.systemProbe.btfPath -- Specify the path to a BTF file for your kernel
     btfPath: ""
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -529,6 +529,12 @@ datadog:
     # datadog.systemProbe.runtimeCompilationAssetDir -- Specify a directory for runtime compilation assets to live in
     runtimeCompilationAssetDir: /var/tmp/datadog-agent/system-probe
 
+    # datadog.systemProbe.enableCORE -- Enables Compile Once - Run Everywhere (CO-RE) for eBPF probes
+    enableCORE: true
+
+    # datadog.systemProbe.btfPath -- Specify the path to a BTF file for your kernel
+    btfPath: ""
+
     # datadog.systemProbe.collectDNSStats -- Enable DNS stat collection
     collectDNSStats: true
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `datadog.systemProbe.btfPath` for mounting user-provided BTF files for Compile Once Run Everywhere (CO-RE) (see [#13962](https://github.com/DataDog/datadog-agent/pull/13962) and [#14096](https://github.com/DataDog/datadog-agent/pull/14096) for more context).

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
