### PR TITLE
Remove defaults for enableKernelHeaderDownload and enableRuntimeCompiler

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.2.1
+
+* Remove default values for `datadog.systemProbe.enableKernelHeaderDownload` and `datadog.systemProbe.enableRuntimeCompiler`.
+
 ## 3.2.0
 
 * Default "Agent" and "Cluster-Agent" image tag to `7.40.0`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.2.0
+version: 3.2.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -693,9 +693,7 @@ helm install <RELEASE_NAME> \
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableDefaultKernelHeadersPaths | bool | `true` | Enable mount of default paths where kernel headers are stored |
 | datadog.systemProbe.enableDefaultOsReleasePaths | bool | `true` | enable default os-release files mount |
-| datadog.systemProbe.enableKernelHeaderDownload | bool | `true` | Enable the downloading of kernel headers for runtime compilation of eBPF probes |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
-| datadog.systemProbe.enableRuntimeCompiler | bool | `false` | Enable the runtime compiler for eBPF probes |
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
 | datadog.systemProbe.maxTrackedConnections | int | `131072` | the maximum number of tracked connections |
 | datadog.systemProbe.mountPackageManagementDirs | list | `[]` | Enables mounting of specific package management directories when runtime compilation is enabled |

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -32,8 +32,12 @@ data:
       collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
       max_tracked_connections: {{ $.Values.datadog.systemProbe.maxTrackedConnections }}
       conntrack_max_state_size: {{ $.Values.datadog.systemProbe.conntrackMaxStateSize }}
+      {{- if hasKey $.Values.datadog.systemProbe  "enableRuntimeCompiler" }}
       enable_runtime_compiler: {{ $.Values.datadog.systemProbe.enableRuntimeCompiler }}
+      {{- end }}
+      {{- if hasKey $.Values.datadog.systemProbe  "enableKernelHeaderDownload" }}
       enable_kernel_header_download: {{ $.Values.datadog.systemProbe.enableKernelHeaderDownload }}
+      {{- end }}
       runtime_compiler_output_dir: {{ $.Values.datadog.systemProbe.runtimeCompilationAssetDir }}/build
       kernel_header_download_dir: {{ $.Values.datadog.systemProbe.runtimeCompilationAssetDir }}/kernel-headers
       apt_config_dir: /host/etc/apt

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -503,10 +503,10 @@ datadog:
     enableOOMKill: false
 
     # datadog.systemProbe.enableRuntimeCompiler -- Enable the runtime compiler for eBPF probes
-    enableRuntimeCompiler: false
+    # enableRuntimeCompiler: false
 
     # datadog.systemProbe.enableKernelHeaderDownload -- Enable the downloading of kernel headers for runtime compilation of eBPF probes
-    enableKernelHeaderDownload: true
+    # enableKernelHeaderDownload: false
 
     # datadog.systemProbe.mountPackageManagementDirs -- Enables mounting of specific package management directories when runtime compilation is enabled
     mountPackageManagementDirs: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Removes the default values for `datadog.systemProbe.enableKernelHeaderDownload` and `datadog.systemProbe.enableRuntimeCompiler`, and only set those values in the system-probe's configuration file if those fields have been manually set.

#### Which issue this PR fixes

The system-probe enables runtime compilation & kernel header downloading by default when USM has been enabled, but only when those features have not been manually enabled/disabled. By setting default values here, the system-probe thinks those values have always been manually set, and so it fails to enable the features for USM customers.

#### Special notes for your reviewer:

This will affect the OOMKill and TCP Queue Length checks, as kernel header downloading is no longer going to be enabled by default; if that behavior is desired, those checks should enable kernel header downloading by default in their config settings.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
