### PR TITLE
Remove runtime compilation helm config options

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.4.1
+## 3.5.0
 
 * Remove runtime compilation-related config values `enableKernelHeaderDownload` and `enableRuntimeCompiler` in the system-probe.
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.4.1
+
+* Remove runtime compilation-related config values `enableKernelHeaderDownload` and `enableRuntimeCompiler` in the system-probe.
+
 ## 3.4.0
 
 * Add `datadog.systemProbe.btfPath` for mounting user-provided BTF files (see datadog-agent PRs #13962 and #14096 for more context).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.4.0
+version: 3.4.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.4.1
+version: 3.5.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.4.1](https://img.shields.io/badge/Version-3.4.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.4.1](https://img.shields.io/badge/Version-3.4.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -694,9 +694,7 @@ helm install <RELEASE_NAME> \
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableDefaultKernelHeadersPaths | bool | `true` | Enable mount of default paths where kernel headers are stored |
 | datadog.systemProbe.enableDefaultOsReleasePaths | bool | `true` | enable default os-release files mount |
-| datadog.systemProbe.enableKernelHeaderDownload | bool | `true` | Enable the downloading of kernel headers for runtime compilation of eBPF probes |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
-| datadog.systemProbe.enableRuntimeCompiler | bool | `false` | Enable the runtime compiler for eBPF probes |
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
 | datadog.systemProbe.maxTrackedConnections | int | `131072` | the maximum number of tracked connections |
 | datadog.systemProbe.mountPackageManagementDirs | list | `[]` | Enables mounting of specific package management directories when runtime compilation is enabled |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -134,6 +134,8 @@ The Datadog Agent is listening on port {{ $apmPort }} for APM service.
 
 The option `datadog.apm.enabled` is deprecated, please use `datadog.apm.portEnabled` to enable TCP communication to the trace-agent.
 The option `datadog.apm.socketEnabled` is enabled by default and can be used to rely on unix socket or name-pipe communication.
+The options `datadog.systemProbe.enableKernelHeaderDownload` and `datadog.systemProbe.enableRuntimeCompiler` are deprecated, please use
+the `DD_ENABLE_KERNEL_HEADER_DOWNLOAD` and `DD_ENABLE_RUNTIME_COMPILER` environment variables to control these features.
 
 {{- end }}
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -134,8 +134,6 @@ The Datadog Agent is listening on port {{ $apmPort }} for APM service.
 
 The option `datadog.apm.enabled` is deprecated, please use `datadog.apm.portEnabled` to enable TCP communication to the trace-agent.
 The option `datadog.apm.socketEnabled` is enabled by default and can be used to rely on unix socket or name-pipe communication.
-The options `datadog.systemProbe.enableKernelHeaderDownload` and `datadog.systemProbe.enableRuntimeCompiler` are deprecated, please use
-the `DD_ENABLE_KERNEL_HEADER_DOWNLOAD` and `DD_ENABLE_RUNTIME_COMPILER` environment variables to control these features.
 
 {{- end }}
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -137,6 +137,16 @@ The option `datadog.apm.socketEnabled` is enabled by default and can be used to 
 
 {{- end }}
 
+{{- if or .Values.datadog.systemProbe.enableKernelHeaderDownload .Values.datadog.systemProbe.enableRuntimeCompiler }}
+
+#################################################################
+####               WARNING: Deprecation notice               ####
+#################################################################
+
+The `enableKernelHeaderDownload` and `enableRuntimeCompiler` options are not supported anymore, in order to enable the runtime compiler, set the environment variable `DD_ENABLE_KERNEL_HEADER_DOWNLOAD` and `DD_ENABLE_RUNTIME_COMPILER` in the system probe.
+
+{{- end }}
+
 {{- if .Values.datadog.apm.useSocketVolume }}
 
 #################################################################

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -619,7 +619,7 @@ Return the local service name
 Return true if runtime compilation is enabled in the system-probe
 */}}
 {{- define "runtime-compilation-enabled" -}}
-{{- if or .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill .Values.datadog.systemProbe.enableRuntimeCompiler -}}
+{{- if or .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill .Values.datadog.serviceMonitoring.enabled -}}
 true
 {{- else -}}
 false

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -32,8 +32,6 @@ data:
       collect_dns_stats: {{ $.Values.datadog.systemProbe.collectDNSStats }}
       max_tracked_connections: {{ $.Values.datadog.systemProbe.maxTrackedConnections }}
       conntrack_max_state_size: {{ $.Values.datadog.systemProbe.conntrackMaxStateSize }}
-      enable_runtime_compiler: {{ $.Values.datadog.systemProbe.enableRuntimeCompiler }}
-      enable_kernel_header_download: {{ $.Values.datadog.systemProbe.enableKernelHeaderDownload }}
       runtime_compiler_output_dir: {{ $.Values.datadog.systemProbe.runtimeCompilationAssetDir }}/build
       kernel_header_download_dir: {{ $.Values.datadog.systemProbe.runtimeCompilationAssetDir }}/kernel-headers
       apt_config_dir: /host/etc/apt

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -511,12 +511,6 @@ datadog:
     # datadog.systemProbe.enableOOMKill -- Enable the OOM kill eBPF-based check
     enableOOMKill: false
 
-    # datadog.systemProbe.enableRuntimeCompiler -- Enable the runtime compiler for eBPF probes
-    enableRuntimeCompiler: false
-
-    # datadog.systemProbe.enableKernelHeaderDownload -- Enable the downloading of kernel headers for runtime compilation of eBPF probes
-    enableKernelHeaderDownload: true
-
     # datadog.systemProbe.mountPackageManagementDirs -- Enables mounting of specific package management directories when runtime compilation is enabled
     mountPackageManagementDirs: []
     ## For runtime compilation to be able to download kernel headers, the host's package management folders


### PR DESCRIPTION
#### What this PR does / why we need it:

Removes `enableKernelHeaderDownload` and `enableRuntimeCompiler` from the helm chart values. These settings should instead be configured via the `DD_ENABLE_KERNEL_HEADER_DOWNLOAD` and `DD_ENABLE_RUNTIME_COMPILER` environment variables.

#### Which issue this PR fixes

Runtime compilation and kernel header downloading are being slowly released to customers. At the current stage of this release, we want these features to be turned off by default for all customers except USM customers. This is achieved by having the system-probe turn on runtime compilation & kernel header downloading when customers have USM enabled, but **only if they haven't explicitly configured these features themselves** (that is, only if these configuration values are not set - see [here](https://github.com/DataDog/datadog-agent/blob/6a3d555a334cfd2dacd7e17c7f9614a2fd22ed28/pkg/network/config/config.go#L324-L332)). We do this so that USM customers have a way to turn off runtime compilation & kernel header downloading if they need to.

When we set default values for runtime compilation & kernel header downloading in the helm charts, the system-probe sees that these configuration values have been set, and so it never enables runtime compilation and kernel header downloading for USM customers. Thus, having default values set in the helm chart is interfering with our rollout of these features.

#### Special notes for your reviewer:

For the purposes of knowing when to mount runtime compilation-related files, we can simply assume runtime compilation is enabled when either the OOM Kill/TCP Queue length checks or service monitoring (USM) is enabled.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
