### PR TITLE
feat: add DD_EXTERNAL_METRICS_PROVIDER_MAX_AGE and DD_EXTERNAL_METRIC…

### DIFF
--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -156,6 +156,10 @@ spec:
                 key: app-key
           - name: DD_EXTERNAL_METRICS_PROVIDER_ENABLED
             value: {{ .Values.clusterAgent.metricsProvider.enabled | quote }}
+          - name: DD_EXTERNAL_METRICS_PROVIDER_MAX_AGE
+            value: {{ .Values.clusterAgent.metricsProvider.maxAge | quote }}
+          - name: DD_EXTERNAL_METRICS_PROVIDER_BUCKET_SIZE
+            value: {{ .Values.clusterAgent.metricsProvider.bucketSize | quote }}
           - name: DD_EXTERNAL_METRICS_PROVIDER_PORT
             value: {{ include "clusterAgent.metricsProvider.port" . | quote }}
           - name: DD_EXTERNAL_METRICS_PROVIDER_WPA_CONTROLLER

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -806,6 +806,8 @@ clusterAgent:
 
     # clusterAgent.metricsProvider.endpoint -- Override the external metrics provider endpoint. If not set, the cluster-agent defaults to `datadog.site`
     endpoint:  # https://api.datadoghq.com
+    maxAge: 900
+    bucketSize: 900
 
   # clusterAgent.env -- Set environment variables specific to Cluster Agent
 


### PR DESCRIPTION
…S_PROVIDER_BUCKET_SIZE for cluster agent

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
