### PR TITLE
Remove mountPropagation for /etc/os-release files

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.33.8
+
+* Remove `mountPropagation` for `/etc/os-release` files.
+
 ## 3.33.7
 
 * Add additional intakes into `CiliumNetworkPolicy` for node Agent and Cluster Check Runner for profiling, network monitoring, dbm, and remote config

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.33.7
+version: 3.33.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.33.7](https://img.shields.io/badge/Version-3.33.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.33.8](https://img.shields.io/badge/Version-3.33.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-host-release-volumemounts.yaml
+++ b/charts/datadog/templates/_container-host-release-volumemounts.yaml
@@ -2,12 +2,10 @@
 {{- if eq (include "should-enable-system-probe" .) "true" }}
 - name: os-release-file
   mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
-  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
   readOnly: true
 {{- else if not .Values.providers.gke.autopilot}}
 - name: os-release-file
   mountPath: /host{{ .Values.datadog.osReleasePath }}
-  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
   readOnly: true
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Removes `mountPropagation` for `/etc/os-release` files which were in a separate template from the fixes in #810 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
