### PR TITLE
Fixes for GKE Autopilot mountPoints and hostPid settings

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.3.2
+
+* Fix GKE Autopilot mounts in the `trace-agent` container and `hostPid` setting for the Agent pods
+
 ## 3.3.1
 
 * Remove `mountPropagation` for `*-release` files in `/etc`. It is not needed for individual files.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.3.1
+version: 3.3.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.3.2](https://img.shields.io/badge/Version-3.3.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -59,6 +59,7 @@
       subPath: datadog.yaml
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
+    {{- if not .Values.providers.gke.autopilot }}
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
@@ -67,6 +68,7 @@
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+    {{- end }}
     - name: logdatadog
       mountPath: /var/log/datadog
     - name: tmpdir

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -339,6 +339,17 @@ false
 {{- end -}}
 
 {{/*
+Return true if the hostPid features should be enabled for the Agent pod.
+*/}}
+{{- define "should-enable-host-pid" -}}
+{{- if and (not .Values.providers.gke.autopilot) (or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID .Values.datadog.useHostPID) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return true if .Values.existingClusterAgent is fully configured
 */}}
 {{- define "existingClusterAgent-configured" -}}

--- a/charts/datadog/templates/agent-psp.yaml
+++ b/charts/datadog/templates/agent-psp.yaml
@@ -20,7 +20,7 @@ spec:
   - min: 8125
     max: 8126
   {{- end }}
-  hostPID: {{ or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID .Values.datadog.useHostPID }}
+  hostPID: {{ include "should-enable-host-pid" . }}
   allowedCapabilities:
 {{ toYaml .Values.agents.podSecurity.capabilities | indent 4 }}
   allowedUnsafeSysctls:

--- a/charts/datadog/templates/agent-scc.yaml
+++ b/charts/datadog/templates/agent-scc.yaml
@@ -11,7 +11,7 @@ priority: 8
 # Allow host ports for dsd / trace intake
 allowHostPorts: {{ or .Values.datadog.dogstatsd.useHostPort .Values.datadog.apm.enabled .Values.datadog.apm.portEnabled .Values.agents.useHostNetwork }}
 # Allow host PID for dogstatsd origin detection
-allowHostPID: {{ or .Values.datadog.securityAgent.compliance.enabled .Values.datadog.dogstatsd.useHostPID .Values.datadog.useHostPID }}
+allowHostPID: {{ include "should-enable-host-pid" . }}
 # Allow host network for the CRIO check to reach Prometheus through localhost
 allowHostNetwork: {{ .Values.agents.useHostNetwork }}
 # Allow hostPath for docker / process metrics

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -97,7 +97,7 @@ spec:
       dnsConfig:
 {{ toYaml .Values.agents.dnsConfig | indent 8 }}
       {{- end }}
-      {{- if or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID .Values.datadog.useHostPID }}
+      {{- if (eq  (include "should-enable-host-pid" .) "true") }}
       hostPID: true
       {{- end }}
       {{- if .Values.agents.image.pullSecrets }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Add fixes relative to changes made in:

3.2.2 - Add new mounts to the `trace-agent` by default
- https://github.com/DataDog/helm-charts/pull/803

3.3.0 - Move to `datadog.hostPID` and enable by default
- https://github.com/DataDog/helm-charts/pull/790

As these were preventing the Agent from being deployed on GKE Autopilot. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
