### PR TITLE
[datadog] Comment clarifying relationship between clusterChecksRunner and useClusterCheckRunners configurations and corresponding Helm warning note.

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.3.2
+
+* Add a warning note to alert users about suboptimal configuration of Cluster Checks Runner.
+
 ## 3.3.1
 
 * Remove `mountPropagation` for `*-release` files in `/etc`. It is not needed for individual files.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.3.3
+
+* Add a warning note to alert users about suboptimal configuration of Cluster Checks Runner.
+
 ## 3.3.2
 
 * Fix GKE Autopilot mounts in the `trace-agent` container and `hostPid` setting for the Agent pods

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.3.1
+version: 3.3.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.3.2
+version: 3.3.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.3.2](https://img.shields.io/badge/Version-3.3.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.3.2](https://img.shields.io/badge/Version-3.3.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.3.3](https://img.shields.io/badge/Version-3.3.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -362,7 +362,7 @@ To enable it please set clusterAgent.enabled to 'true'.
 ###################################################################################
 
 You have `datadog.kubeStateMetricsCore.useClusterCheckRunners` enabled and `clusterChecksRunner.enabled` disabled.
-This configuration will create Cluster Checks Runner deployment but some of the cluster checks may still run on Node Agents.
+This configuration will create a Cluster Checks Runner deployment but some of the cluster checks may still run on Node Agents.
 To make sure all cluster check run on Cluster Checks Runner set `clusterChecksRunner.enabled` to 'true'.
 
 {{- end }}

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -363,7 +363,7 @@ To enable it please set clusterAgent.enabled to 'true'.
 
 You have `datadog.kubeStateMetricsCore.useClusterCheckRunners` enabled and `clusterChecksRunner.enabled` disabled.
 This configuration will create a Cluster Checks Runner deployment but some of the cluster checks may still run on Node Agents.
-To make sure all cluster check run on Cluster Checks Runner set `clusterChecksRunner.enabled` to 'true'.
+To make sure all cluster checks run on Cluster Checks Runners set `clusterChecksRunner.enabled` to 'true'.
 
 {{- end }}
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -355,6 +355,18 @@ You are using datadog.kubeStateMetricsCore.enabled but you disabled the cluster 
 To enable it please set clusterAgent.enabled to 'true'.
 {{- end }}
 
+{{- if and .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners (not .Values.clusterChecksRunner.enabled)}}
+
+###################################################################################
+####               WARNING: Suboptimal Cluster Checks Runner configuration     ####
+###################################################################################
+
+You have `datadog.kubeStateMetricsCore.useClusterCheckRunners` enabled and `clusterChecksRunner.enabled` disabled.
+This configuration will create Cluster Checks Runner deployment but some of the cluster checks may still run on Node Agents.
+To make sure all cluster check run on Cluster Checks Runner set `clusterChecksRunner.enabled` to 'true'.
+
+{{- end }}
+
 
 {{- if or .Values.datadog.acInclude .Values.datadog.acExclude }}
 #################################################################

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -155,7 +155,7 @@ datadog:
     # datadog.kubeStateMetricsCore.useClusterCheckRunners -- For large clusters where the Kubernetes State Metrics Check Core needs to be distributed on dedicated workers.
 
     ## Configuring this field will create a separate deployment which will run Cluster Checks, including Kubernetes State Metrics Core.
-    ## If clusterChecksRunner.enabled is true, it's recommended to set this flag to true as well to better utilize dedicated workers and reduce load on Cluster Agent.
+    ## If clusterChecksRunner.enabled is true, it's recommended to set this flag to true as well to better utilize dedicated workers and reduce load on the Cluster Agent.
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/clusterchecksrunner?tab=helm
     useClusterCheckRunners: false
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -155,6 +155,7 @@ datadog:
     # datadog.kubeStateMetricsCore.useClusterCheckRunners -- For large clusters where the Kubernetes State Metrics Check Core needs to be distributed on dedicated workers.
 
     ## Configuring this field will create a separate deployment which will run Cluster Checks, including Kubernetes State Metrics Core.
+    ## If clusterChecksRunner.enabled is true, it's recommended to set this flag to true as well to better utilize dedicated workers and reduce load on Cluster Agent.
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/clusterchecksrunner?tab=helm
     useClusterCheckRunners: false
 
@@ -1491,6 +1492,7 @@ agents:
 clusterChecksRunner:
   # clusterChecksRunner.enabled -- If true, deploys agent dedicated for running the Cluster Checks instead of running in the Daemonset's agents.
 
+  ## If both clusterChecksRunner.enabled and datadog.kubeStateMetricsCore.enabled are true, consider enabling datadog.kubeStateMetricsCore.useClusterCheckRunners as well.
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
   enabled: false
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1493,6 +1493,7 @@ clusterChecksRunner:
   # clusterChecksRunner.enabled -- If true, deploys agent dedicated for running the Cluster Checks instead of running in the Daemonset's agents.
 
   ## If both clusterChecksRunner.enabled and datadog.kubeStateMetricsCore.enabled are true, consider enabling datadog.kubeStateMetricsCore.useClusterCheckRunners as well.
+  ## If datadog.kubeStateMetricsCore.useClusterCheckRunners is enabled, it's recommended to enabled this flag as well so all Cluster Checks run on Cluster Checks Runner instead of node agents.
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
   enabled: false
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1493,7 +1493,7 @@ clusterChecksRunner:
   # clusterChecksRunner.enabled -- If true, deploys agent dedicated for running the Cluster Checks instead of running in the Daemonset's agents.
 
   ## If both clusterChecksRunner.enabled and datadog.kubeStateMetricsCore.enabled are true, consider enabling datadog.kubeStateMetricsCore.useClusterCheckRunners as well.
-  ## If datadog.kubeStateMetricsCore.useClusterCheckRunners is enabled, it's recommended to enabled this flag as well so all Cluster Checks run on Cluster Checks Runner instead of node agents.
+  ## If datadog.kubeStateMetricsCore.useClusterCheckRunners is enabled, it's recommended to enable this flag as well so all Cluster Checks run on Cluster Checks Runners instead of node agents.
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
   enabled: false
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Certain combinations of `clusterChecksRunner.enabled` and `kubeStateMetricsCore.useClusterCheckRunners` settings may lead to poor utilization of Cluster Checks Runner and overloading of DCA or Node Agents. Change adds documentation to the helm chart and and a warning about config leading to such issues.

#### Which issue this PR fixes
* Addresses CONTECO-286

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
