### PR TITLE
Downgrade Ubuntu to 20.04 to keep k8s 1.18 support in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,19 +103,18 @@ jobs:
 
   install-chart:
     name: install-chart
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - lint-chart
       - kubeval-chart
     strategy:
       matrix:
         k8s:
-          # - v1.14.10 (deprecated with kind 1.16)
           - v1.16.15
           - v1.18.20
           - v1.22.9
           - v1.24.2
-          # v1.25.2 (when agent 7.40 is out)
+          - v1.25.2
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
#### What this PR does / why we need it:

downgrading to ubuntu-20.04 allow us to keep supporting k8s 1.18.x in the CI. 
The issue is that in 22.04 cgroupv2 is enabled by default.

#### Which issue this PR fixes

Fix the CI when PR are validated on kubernetes 1.18.x.

#### Special notes for your reviewer:

you can check this CI action https://github.com/DataDog/helm-charts/actions/runs/3585666025 to see that it worked with a fake `datadog` chart update.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
