### PR TITLE
Feat/enable kubelet logs

### DIFF
--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -6107,6 +6107,11 @@ spec:
                       type: object
                     logCollection:
                       properties:
+                        kubelet:
+                          enabled:
+                            type: boolean
+                          hostPath:
+                            type: string
                         containerCollectAll:
                           type: boolean
                         containerCollectUsingFiles:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -6094,6 +6094,11 @@ spec:
                       type: object
                     logCollection:
                       properties:
+                        kubelet:
+                          enabled:
+                            type: boolean
+                          hostPath:
+                            type: string
                         containerCollectAll:
                           type: boolean
                         containerCollectUsingFiles:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -665,8 +665,8 @@ helm install <RELEASE_NAME> \
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
-| datadog.logs.kubelet.enabled | bool | `false` | Enables this to activate Datadog Agent log collection for the Kubelet|
-| datadog.logs.kubelet.hostPath | bool | `false` | Sets the hostPath for the kubelet logs directory|
+| datadog.logs.kubelet.enabled | bool | `false` | Enables this to activate Datadog Agent log collection for the Kubelet |
+| datadog.logs.kubelet.hostPath | string | `""` | Sets the hostPath for the kubelet logs directory |
 | datadog.namespaceLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Namespace Labels to Datadog Tags |
 | datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
 | datadog.networkPolicy.cilium.dnsSelector | object | kube-dns in namespace kube-system | Cilium selector of the DNS server entity |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -246,6 +246,33 @@ then upgrade your Datadog Helm chart:
 helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
+### Enabling Kubelet log Collection
+
+Update your `datadog-values.yaml` file with the following log collection configuration:
+
+```yaml
+datadog:
+  # (...)
+  logs:
+    enabled: true
+    containerCollectAll: true
+    kubelet:
+      enabled: true
+      hostPath: /var/log/journal
+  confd:
+    kubelet_logs.yaml: |-
+      logs:
+        - type: journald
+          path: /var/log/journal/
+          include_units: kubelet.service
+```
+
+then upgrade your Datadog Helm chart:
+
+```bash
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
+```
+
 ### Enabling Process Collection
 
 Update your `datadog-values.yaml` file with the process collection configuration:
@@ -638,6 +665,8 @@ helm install <RELEASE_NAME> \
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
+| datadog.logs.kubelet.enabled | bool | `false` | Enables this to activate Datadog Agent log collection for the Kubelet|
+| datadog.logs.kubelet.hostPath | bool | `false` | Sets the hostPath for the kubelet logs directory|
 | datadog.namespaceLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Namespace Labels to Datadog Tags |
 | datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
 | datadog.networkPolicy.cilium.dnsSelector | object | kube-dns in namespace kube-system | Cilium selector of the DNS server entity |

--- a/charts/datadog/README.md.gotmpl
+++ b/charts/datadog/README.md.gotmpl
@@ -242,6 +242,33 @@ then upgrade your Datadog Helm chart:
 helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
+### Enabling Kubelet log Collection
+
+Update your `datadog-values.yaml` file with the following log collection configuration:
+
+```yaml
+datadog:
+  # (...)
+  logs:
+    enabled: true
+    containerCollectAll: true
+    kubelet:
+      enabled: true
+      hostPath: /var/log/journal
+  confd:
+    kubelet_logs.yaml: |-
+      logs:
+        - type: journald
+          path: /var/log/journal/
+          include_units: kubelet.service
+```
+
+then upgrade your Datadog Helm chart:
+
+```bash
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
+```
+
 ### Enabling Process Collection
 
 Update your `datadog-values.yaml` file with the process collection configuration:

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -201,6 +201,11 @@
       mountPath: /var/log/containers
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+    {{- if .values.datadog.logs.kubelet.enabled }}
+    - name: logskubeletpath
+      mountPath: {{ .Values.datadog.logs.kubelet.hostPath  }}
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
     {{- if not .Values.datadog.criSocketPath }}
     - name: logdockercontainerpath
       mountPath: /var/lib/docker/containers

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -201,7 +201,7 @@
       mountPath: /var/log/containers
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    {{- if .values.datadog.logs.kubelet.enabled }}
+    {{- if .Values.datadog.logs.kubelet.enabled }}
     - name: logskubeletpath
       mountPath: {{ .Values.datadog.logs.kubelet.hostPath  }}
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -168,7 +168,7 @@
 - hostPath:
     path: /var/log/containers
   name: logscontainerspath
-{{- if .values.datadog.logs.kubelet.enabled }}
+{{- if .Values.datadog.logs.kubelet.enabled }}
 - hostpath:
     path: {{ .Values.datadog.logs.kubelet.hostPath  }}
   name: logskubeletpath

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -168,6 +168,10 @@
 - hostPath:
     path: /var/log/containers
   name: logscontainerspath
+{{- if .values.datadog.logs.kubelet.enabled }}
+- hostpath:
+    path: {{ .Values.datadog.logs.kubelet.hostPath  }}
+  name: logskubeletpath
 {{- if not .Values.datadog.criSocketPath }}
 - hostPath:
     path: /var/lib/docker/containers

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -329,8 +329,13 @@ datadog:
     ## ref: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
     enabled: false
 
-    # datadog.logs.containerCollectAll -- Enable this to allow log collection for all containers
+    kubelet:
+    # datadog.logs.kubelet.enabled -- Enables this to activate Datadog Agent log collection for the Kubelet
+      enabled: false
+    # datadog.logs.kubelet.hostPath -- Sets the hostPath for the kubelet logs directory
+      hostPath: ""
 
+    # datadog.logs.containerCollectAll -- Enable this to allow log collection for all containers
     ## ref: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
     containerCollectAll: false
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -336,6 +336,7 @@ datadog:
       hostPath: ""
 
     # datadog.logs.containerCollectAll -- Enable this to allow log collection for all containers
+ 
     ## ref: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
     containerCollectAll: false
 

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -6090,6 +6090,11 @@ spec:
                       type: object
                     logCollection:
                       properties:
+                        kubelet:
+                          enabled:
+                            type: boolean
+                          hostPath:
+                            type: string
                         containerCollectAll:
                           type: boolean
                         containerCollectUsingFiles:


### PR DESCRIPTION
#### What this PR does / why we need it:
As described in #823 , we want the ability to grab kubelet logs for debugging production issues.

#### Which issue this PR fixes
  - fixes #823

#### Special notes for your reviewer:
My first PR, is the chart version bumped automatically and does the commit message automatically updated in the CHANGELOG.md?


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [x ] Variables are documented in the `README.md`
