### PR TITLE
Fix API Key check following change of default value (+ fix CI)

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.5.2
+
+* Fix API Key check in NOTES.txt following change of default value for `datadog.apiKey`.
+* Fix failure if PSP activated in Kubernetes 1.25 (PSP have been removed).
+
 ## 3.5.1
 
 * Removing default value placeholder for the API Key in the values.yaml.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.5.1
+version: 3.5.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.5.2](https://img.shields.io/badge/Version-3.5.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- if (or (.Values.datadog.apiKeyExistingSecret) (not (eq .Values.datadog.apiKey "<DATADOG_API_KEY>"))) }}
+{{- if (or (.Values.datadog.apiKeyExistingSecret) (.Values.datadog.apiKey)) }}
 Datadog agents are spinning up on each node in your cluster. After a few
 minutes, you should see your agents starting in your event stream:
     https://app.datadoghq.com/event/explorer
@@ -6,7 +6,6 @@ minutes, you should see your agents starting in your event stream:
   {{- if .Values.datadog.apiKeyExistingSecret }}
 You disabled creation of Secret containing API key, therefore it is expected
 that you create Secret named '{{ .Values.datadog.apiKeyExistingSecret }}' which includes a key called 'api-key' containing the API key.
-  {{- else if not (eq .Values.datadog.apiKey "<DATADOG_API_KEY>") }}
   {{- end }}
 
 {{- else }}
@@ -448,4 +447,13 @@ To send OTLP data to the Agent use the Service created by specifying "http://{{ 
 You have enabled OTLP Ingest for the HTTP port without the Host Port enabled.
 
 To send OTLP data to the Agent use the Service created by specifying "http://{{ template "localService.name" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}" as the endpoint.
+{{- end }}
+
+{{- if and (or .Values.clusterAgent.podSecurity.podSecurityPolicy.create .Values.agents.podSecurity.podSecurityPolicy.create) (not (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy")) }}
+#################################################################
+####               WARNING: Incompatibility                  ####
+#################################################################
+You have enabled creataion of PodSecurityPolicy, however PSP have been removed from Kubernetes >= 1.25, thus PSP will not be created.
+
+You should deactivate these options: clusterAgent.podSecurity.podSecurityPolicy.create and/or agents.podSecurity.podSecurityPolicy.create
 {{- end }}

--- a/charts/datadog/templates/agent-psp.yaml
+++ b/charts/datadog/templates/agent-psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agents.podSecurity.podSecurityPolicy.create}}
+{{- if and .Values.agents.podSecurity.podSecurityPolicy.create (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/datadog/templates/cluster-agent-psp.yaml
+++ b/charts/datadog/templates/cluster-agent-psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterAgent.podSecurity.podSecurityPolicy.create }}
+{{- if and .Values.clusterAgent.podSecurity.podSecurityPolicy.create (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

* Fix API Key check in NOTES.txt following change of default value for `datadog.apiKey`.
* Fix failure if PSP activated in Kubernetes 1.25 (PSP have been removed).

#### Which issue this PR fixes

Fixes #832 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
