### PR TITLE
add DD_TAGS to clusterchecks

### DIFF
--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -147,6 +147,10 @@ spec:
           - name: DD_LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}
           {{- end }}
+          {{- if .Values.datadog.tags }}
+          - name: DD_TAGS
+            value: {{ tpl (.Values.datadog.tags | join " " | quote) . }}
+          {{- end }}
           - name: DD_EXTRA_CONFIG_PROVIDERS
             value: "clusterchecks"
           - name: DD_HEALTH_PORT


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds DD_TAGS to clusterChecks pods. Ensures global tags are attached to metrics collected by this pod

#### Which issue this PR fixes

  - fixes #831

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
