### PR TITLE
Updating DatadogAgent and DatadogMonitor CRDs

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.9
+
+* Updating DatadogMonitors CRD and DatadogAgents CRDs.
+
 ## 0.5.8
 
 * Updating CRD of the Datadog Operator for Kubernetes cluster < 1.21.0.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.5.8
+version: 0.5.9
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.5.8](https://img.shields.io/badge/Version-0.5.8-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 0.5.9](https://img.shields.io/badge/Version-0.5.9-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -2116,6 +2116,29 @@ spec:
                         flavor:
                           type: string
                       type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
                     priorityClassName:
                       type: string
                     process:
@@ -5861,6 +5884,8 @@ spec:
                           type: string
                         enabled:
                           type: boolean
+                        failurePolicy:
+                          type: string
                         mutateUnlabelled:
                           type: boolean
                         serviceName:
@@ -6212,6 +6237,8 @@ spec:
                           type: boolean
                         enabled:
                           type: boolean
+                        version:
+                          type: integer
                       type: object
                     tcpQueueLength:
                       properties:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -12,22 +12,6 @@ metadata:
     app.kubernetes.io/name: '{{ include "datadog-crds.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.conditions[?(@.type=='Active')].status
-      name: active
-      type: string
-    - JSONPath: .status.agent.status
-      name: agent
-      type: string
-    - JSONPath: .status.clusterAgent.status
-      name: cluster-agent
-      type: string
-    - JSONPath: .status.clusterChecksRunner.status
-      name: cluster-checks-runner
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
   group: datadoghq.com
   names:
     kind: DatadogAgent
@@ -39,8 +23,25 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  version: v1alpha1
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - JSONPath: .status.conditions[?(@.type=='Active')].status
+          name: active
+          type: string
+        - JSONPath: .status.agent.status
+          name: agent
+          type: string
+        - JSONPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - JSONPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           properties:
@@ -2117,6 +2118,29 @@ spec:
                           x-kubernetes-list-type: atomic
                         flavor:
                           type: string
+                      type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
                       type: object
                     priorityClassName:
                       type: string
@@ -5828,7 +5852,20 @@ spec:
       served: true
       storage: false
       {{- end }}
-    - name: v2alpha1
+    - additionalPrinterColumns:
+        - JSONPath: .status.agent.status
+          name: agent
+          type: string
+        - JSONPath: .status.clusterAgent.status
+          name: cluster-agent
+          type: string
+        - JSONPath: .status.clusterChecksRunner.status
+          name: cluster-checks-runner
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v2alpha1
       schema:
         openAPIV3Schema:
           properties:
@@ -5848,6 +5885,8 @@ spec:
                           type: string
                         enabled:
                           type: boolean
+                        failurePolicy:
+                          type: string
                         mutateUnlabelled:
                           type: boolean
                         serviceName:
@@ -6199,6 +6238,8 @@ spec:
                           type: boolean
                         enabled:
                           type: boolean
+                        version:
+                          type: integer
                       type: object
                     tcpQueueLength:
                       properties:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -78,7 +78,7 @@ spec:
                     locked:
                       description: Whether or not the monitor is locked (only editable by creator and admins).
                       type: boolean
-                    newHostDelay:
+                    newGroupDelay:
                       description: Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer.
                       format: int64
                       type: integer

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
@@ -78,7 +78,7 @@ spec:
                 locked:
                   description: Whether or not the monitor is locked (only editable by creator and admins).
                   type: boolean
-                newHostDelay:
+                newGroupDelay:
                   description: Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer.
                   format: int64
                   type: integer

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -2110,6 +2110,29 @@ spec:
                         flavor:
                           type: string
                       type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
                     priorityClassName:
                       type: string
                     process:
@@ -5814,13 +5837,10 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=='Active')].status
-          name: active
-          type: string
         - jsonPath: .status.agent.status
           name: agent
           type: string
@@ -5853,6 +5873,8 @@ spec:
                           type: string
                         enabled:
                           type: boolean
+                        failurePolicy:
+                          type: string
                         mutateUnlabelled:
                           type: boolean
                         serviceName:
@@ -5891,26 +5913,31 @@ spec:
                           type: string
                         customBenchmarks:
                           properties:
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                  - key
-                                  - path
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                                - key
-                              x-kubernetes-list-type: map
-                            name:
+                            configData:
                               type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
                           type: object
                         enabled:
                           type: boolean
@@ -5919,35 +5946,35 @@ spec:
                       properties:
                         customPolicies:
                           properties:
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                  - key
-                                  - path
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                                - key
-                              x-kubernetes-list-type: map
-                            name:
+                            configData:
                               type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
                           type: object
                         enabled:
                           type: boolean
                         syscallMonitorEnabled:
-                          type: boolean
-                      type: object
-                    datadogMonitor:
-                      properties:
-                        enabled:
                           type: boolean
                       type: object
                     dogstatsd:
@@ -6087,6 +6114,10 @@ spec:
                       properties:
                         enabled:
                           type: boolean
+                        scrubProcessArguments:
+                          type: boolean
+                        stripProcessArguments:
+                          type: boolean
                       type: object
                     logCollection:
                       properties:
@@ -6164,6 +6195,29 @@ spec:
                         scrubContainers:
                           type: boolean
                       type: object
+                    otlp:
+                      properties:
+                        receiver:
+                          properties:
+                            protocols:
+                              properties:
+                                grpc:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                  type: object
+                                http:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    endpoint:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
                     prometheusScrape:
                       properties:
                         additionalConfigs:
@@ -6172,6 +6226,8 @@ spec:
                           type: boolean
                         enabled:
                           type: boolean
+                        version:
+                          type: integer
                       type: object
                     tcpQueueLength:
                       properties:
@@ -6188,6 +6244,15 @@ spec:
                   properties:
                     clusterAgentToken:
                       type: string
+                    clusterAgentTokenSecret:
+                      properties:
+                        keyName:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - secretName
+                      type: object
                     clusterName:
                       type: string
                     credentials:
@@ -6988,6 +7053,39 @@ spec:
                                     x-kubernetes-int-or-string: true
                                   type: object
                               type: object
+                            seccompConfig:
+                              properties:
+                                customProfile:
+                                  properties:
+                                    configData:
+                                      type: string
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - key
+                                          x-kubernetes-list-type: map
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                customRootPath:
+                                  type: string
+                              type: object
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -7174,8 +7272,10 @@ spec:
                         x-kubernetes-list-type: map
                       extraChecksd:
                         properties:
-                          configData:
-                            type: string
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
                           configMap:
                             properties:
                               items:
@@ -7202,8 +7302,10 @@ spec:
                         type: object
                       extraConfd:
                         properties:
-                          configData:
-                            type: string
+                          configDataMap:
+                            additionalProperties:
+                              type: string
+                            type: object
                           configMap:
                             properties:
                               items:
@@ -7265,38 +7367,6 @@ spec:
                       replicas:
                         format: int32
                         type: integer
-                      secCompCustomProfile:
-                        properties:
-                          configData:
-                            type: string
-                          configMap:
-                            properties:
-                              items:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    mode:
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      type: string
-                                  required:
-                                    - key
-                                    - path
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                  - key
-                                x-kubernetes-list-type: map
-                              name:
-                                type: string
-                            type: object
-                        type: object
-                      secCompProfileName:
-                        type: string
-                      secCompRootPath:
-                        type: string
                       securityContext:
                         properties:
                           fsGroup:
@@ -7359,6 +7429,148 @@ spec:
                                 type: boolean
                               runAsUserName:
                                 type: string
+                            type: object
+                        type: object
+                      securityContextConstraints:
+                        properties:
+                          create:
+                            type: boolean
+                          customConfiguration:
+                            properties:
+                              allowHostDirVolumePlugin:
+                                type: boolean
+                              allowHostIPC:
+                                type: boolean
+                              allowHostNetwork:
+                                type: boolean
+                              allowHostPID:
+                                type: boolean
+                              allowHostPorts:
+                                type: boolean
+                              allowPrivilegedContainer:
+                                type: boolean
+                              allowedCapabilities:
+                                items:
+                                  type: string
+                                type: array
+                              allowedFlexVolumes:
+                                items:
+                                  properties:
+                                    driver:
+                                      type: string
+                                  type: object
+                                type: array
+                              apiVersion:
+                                type: string
+                              defaultAddCapabilities:
+                                items:
+                                  type: string
+                                type: array
+                              fsGroup:
+                                properties:
+                                  ranges:
+                                    items:
+                                      properties:
+                                        max:
+                                          format: int64
+                                          type: integer
+                                        min:
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                                type: object
+                              groups:
+                                items:
+                                  type: string
+                                type: array
+                              kind:
+                                type: string
+                              metadata:
+                                type: object
+                              priority:
+                                format: int32
+                                type: integer
+                              readOnlyRootFilesystem:
+                                type: boolean
+                              requiredDropCapabilities:
+                                items:
+                                  type: string
+                                type: array
+                              runAsUser:
+                                properties:
+                                  type:
+                                    type: string
+                                  uid:
+                                    format: int64
+                                    type: integer
+                                  uidRangeMax:
+                                    format: int64
+                                    type: integer
+                                  uidRangeMin:
+                                    format: int64
+                                    type: integer
+                                type: object
+                              seLinuxContext:
+                                properties:
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  type:
+                                    type: string
+                                type: object
+                              seccompProfiles:
+                                items:
+                                  type: string
+                                type: array
+                              supplementalGroups:
+                                properties:
+                                  ranges:
+                                    items:
+                                      properties:
+                                        max:
+                                          format: int64
+                                          type: integer
+                                        min:
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  type:
+                                    type: string
+                                type: object
+                              users:
+                                items:
+                                  type: string
+                                type: array
+                              volumes:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - allowHostDirVolumePlugin
+                              - allowHostIPC
+                              - allowHostNetwork
+                              - allowHostPID
+                              - allowHostPorts
+                              - allowPrivilegedContainer
+                              - allowedCapabilities
+                              - allowedFlexVolumes
+                              - defaultAddCapabilities
+                              - priority
+                              - readOnlyRootFilesystem
+                              - requiredDropCapabilities
+                              - volumes
                             type: object
                         type: object
                       serviceAccountName:
@@ -8206,8 +8418,8 @@ spec:
                   x-kubernetes-list-type: map
               type: object
           type: object
-      served: false
-      storage: false
+      served: true
+      storage: true
       subresources:
         status: {}
 status:

--- a/crds/datadoghq.com_datadogmonitors.yaml
+++ b/crds/datadoghq.com_datadogmonitors.yaml
@@ -88,7 +88,7 @@ spec:
                     description: Whether or not the monitor is locked (only editable
                       by creator and admins).
                     type: boolean
-                  newHostDelay:
+                  newGroupDelay:
                     description: Time (in seconds) to allow a host to boot and applications
                       to fully start before starting the evaluation of monitor results.
                       Should be a non negative integer.


### PR DESCRIPTION
#### What this PR does / why we need it:

Using the Datadog Operator 0.8.4 (and 1.0.0-rc.4) supports `newGroupDelay`  (`newHostDelay` is deprecated), this updates the CRDs to reflect this.

TODO: Update the dependency in the Datadog Operator chart on the minimum image installed.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
