### PR TITLE
Remove /usr/src mount and add systemProbe.kernelHeadersDir config option

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.5.2
 
 * Remove `/usr/src` mount for default kernel headers.
+* Add `datadog.systemProbe.kernelHeadersDir` option for mounting kernel headers.
 
 ## 3.5.1
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.5.2
+
+* Remove `/usr/src` mount for default kernel headers.
+
 ## 3.5.1
 
 * Removing default value placeholder for the API Key in the values.yaml.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.5.1
+version: 3.5.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.5.2](https://img.shields.io/badge/Version-3.5.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -696,6 +696,7 @@ helm install <RELEASE_NAME> \
 | datadog.systemProbe.enableDefaultOsReleasePaths | bool | `true` | enable default os-release files mount |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
+| datadog.systemProbe.kernelHeadersDir | string | `""` | Enables mounting of path where kernel headers are stored |
 | datadog.systemProbe.maxTrackedConnections | int | `131072` | the maximum number of tracked connections |
 | datadog.systemProbe.mountPackageManagementDirs | list | `[]` | Enables mounting of specific package management directories when runtime compilation is enabled |
 | datadog.systemProbe.runtimeCompilationAssetDir | string | `"/var/tmp/datadog-agent/system-probe"` | Specify a directory for runtime compilation assets to live in |

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -83,10 +83,6 @@
       mountPath: /lib/modules
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    - name: src
-      mountPath: /usr/src
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
 {{- end }}
 {{- if and (or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.securityAgent.runtime.fimEnabled) .Values.datadog.securityAgent.runtime.policies.configMap }}
     - name: runtimepoliciesdir

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -78,18 +78,23 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
 {{- end }}
-{{- if and (eq (include "runtime-compilation-enabled" .) "true") .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}
-    - name: modules
-      mountPath: /lib/modules
-      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
-{{- end }}
 {{- if and (or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.securityAgent.runtime.fimEnabled) .Values.datadog.securityAgent.runtime.policies.configMap }}
     - name: runtimepoliciesdir
       mountPath: /etc/datadog-agent/runtime-security.d
       readOnly: true
 {{- end }}
 {{- if eq (include "runtime-compilation-enabled" .) "true" }}
+{{- if .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}
+    - name: modules
+      mountPath: /lib/modules
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
+{{- end }}
+{{- if .Values.datadog.systemProbe.kernelHeadersDir }}
+    - name: kernel-headers-dir
+      mountPath: {{ .Values.datadog.systemProbe.kernelHeadersDir }}
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+{{- end }}
     - name: runtime-compiler-output-dir
       mountPath: {{ .Values.datadog.systemProbe.runtimeCompilationAssetDir }}/build
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -78,12 +78,18 @@
   name: debugfs
 - name: sysprobe-socket-dir
   emptyDir: {}
-{{- if and (eq (include "runtime-compilation-enabled" .) "true") .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}
+{{- if eq (include "runtime-compilation-enabled" .) "true" }}
+{{- if .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}
 - hostPath:
     path: /lib/modules
   name: modules
 {{- end }}
-{{- if eq (include "runtime-compilation-enabled" .) "true" }}
+{{- if .Values.datadog.systemProbe.kernelHeadersDir }}
+- hostPath:
+    path: {{ .Values.datadog.systemProbe.kernelHeadersDir }}
+    type: DirectoryOrCreate
+  name: kernel-headers-dir
+{{- end }}
 - hostPath:
     path: {{ .Values.datadog.systemProbe.runtimeCompilationAssetDir }}/build
     type: DirectoryOrCreate

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -82,9 +82,6 @@
 - hostPath:
     path: /lib/modules
   name: modules
-- hostPath:
-    path: /usr/src
-  name: src
 {{- end }}
 {{- if eq (include "runtime-compilation-enabled" .) "true" }}
 - hostPath:

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -34,6 +34,7 @@ data:
       conntrack_max_state_size: {{ $.Values.datadog.systemProbe.conntrackMaxStateSize }}
       runtime_compiler_output_dir: {{ $.Values.datadog.systemProbe.runtimeCompilationAssetDir }}/build
       kernel_header_download_dir: {{ $.Values.datadog.systemProbe.runtimeCompilationAssetDir }}/kernel-headers
+      kernel_header_dirs: [{{ $.Values.datadog.systemProbe.kernelHeadersDir }}]
       apt_config_dir: /host/etc/apt
       yum_repos_dir: /host/etc/yum.repos.d
       zypper_repos_dir: /host/etc/zypp/repos.d

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -544,6 +544,11 @@ datadog:
     # datadog.systemProbe.enableDefaultKernelHeadersPaths -- Enable mount of default paths where kernel headers are stored
     enableDefaultKernelHeadersPaths: true
 
+    # datadog.systemProbe.kernelHeadersDir -- Enables mounting of path where kernel headers are stored
+    kernelHeadersDir: ""
+    ## For example, on an Amazon Linux 2 host running kernel 4.219-126.411.amzn2, after downloading kernel headers kernelHeadersDir should be
+    ## set to /usr/src/kernels/5.4.219-126.411.amzn2.x86_64 in order to mount the kernel headers to the system-probe container.
+
   orchestratorExplorer:
     # datadog.orchestratorExplorer.enabled -- Set this to false to disable the orchestrator explorer
 


### PR DESCRIPTION
#### What this PR does / why we need it:

- Removes the `/usr/src` mount for kernel headers
- Adds the `datadog.systemProbe.kernelHeadersDir` config option for mounting a directory where kernel headers are located

On Google Container-Optimized OS, the `/usr` directory is a read-only filesystem, and `/usr/src` does not exist by default (tested on COS version 97). 
When the system-probe container attempts to mount `/usr/src` on COS and finds that `/usr/src` does not exist on the host, it attempts to create it. The resulting `mkdir /usr/src` call returns an `Operation not permitted` error, causing the container to throw a `CreateContainerError`.
Thus, in order to support COS, we need to remove the `/usr/src` mount.

However, this creates a problem: Amazon Linux 2 kernel headers are stored at `/usr/src/kernels`, so by removing the `/usr/src` mount, it means we will no longer automatically find user-downloaded kernel headers on Amazon Linux 2.
The addition of the `datadog.systemProbe.kernelHeadersDir` config option solves this by providing a way for users to specify the path to their downloaded kernel headers.

(Note that this entire discussion only affects kernel headers download by customers; kernel headers downloaded via automatic kernel header downloading are not affected by this problem.)

####  Which issue this PR fixes

  - Fixes #829

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
