### PR TITLE
Exclusively mount /usr/src for OOM Kill / TCP Queue Length checks

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.5.2
+
+* Remove /usr/src mount for kernel headers when service monitoring is enabled (fix for issue #829).
+
 ## 3.5.1
 
 * Removing default value placeholder for the API Key in the values.yaml.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.5.1
+version: 3.5.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.5.2](https://img.shields.io/badge/Version-3.5.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -83,10 +83,12 @@
       mountPath: /lib/modules
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+{{- if or .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill }}
     - name: src
       mountPath: /usr/src
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+{{- end }}
 {{- end }}
 {{- if and (or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.securityAgent.runtime.fimEnabled) .Values.datadog.securityAgent.runtime.policies.configMap }}
     - name: runtimepoliciesdir

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -82,9 +82,11 @@
 - hostPath:
     path: /lib/modules
   name: modules
+{{- if or .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill }}
 - hostPath:
     path: /usr/src
   name: src
+{{- end }}
 {{- end }}
 {{- if eq (include "runtime-compilation-enabled" .) "true" }}
 - hostPath:


### PR DESCRIPTION
#### What this PR does / why we need it:

- Prevents `/usr/src` from being mounted unless the TCP Queue Length or OOM Kill check are enabled (and `enableDefaultKernelHeadersPaths` is enabled)

In 3.5.0, we started mounting default kernel header directories (including `/usr/src`) when universal service monitoring is enabled -  see https://github.com/DataDog/helm-charts/pull/813. We did this because USM now uses runtime compilation by default, so it requires access to kernel headers.

However, this change exposed a pre-existing issue we were unaware of: `/usr/src` cannot be mounted in Google Container Optimized OS (see details below). This was brought to our attention in issue https://github.com/DataDog/helm-charts/issues/829.

Unfortunately, Amazon Linux kernel headers are stored under `/usr/src`, so removing `/usr/src` from our mounts would be a breaking change for current Amazon Linux customers who have downloaded their own kernel headers for the OOM Kill and TCP Queue Length checks.

So, instead of removing the `/usr/src` mount entirely, we are choosing to leave `/usr/src` mounted for OOM Kill and TCP Queue Length customers exclusively. Note this does mean that in order to run the OOM Kill and TCP Queue Length checks on Container Optimized OS, users must set `systemProbe.enableDefaultKernelHeadersPaths` to `false`, otherwise they will encounter a `CreateContainerError` on the system-probe container.

(Note that this entire discussion only affects kernel headers download by customers; kernel headers downloaded via automatic kernel header downloading are not affected by this problem.)

_Details on why `/usr/src` can't be mounted in COS:_
On COS, the `/usr` directory is a read-only filesystem, and `/usr/src` does not exist by default (tested on COS version 97). When the system-probe container attempts to mount `/usr/src` on COS and finds that `/usr/src` does not exist on the host, it attempts to create it. The resulting `mkdir /usr/src` call returns an `Operation not permitted error`, causing the container to throw a `CreateContainerError`.

#### Which issue this PR fixes

  - fixes #829

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
