### PR TITLE
feat(datadog): add ksm-core annotationsAsTags option

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Datadog changelog
 
+## 3.6.3
+
+* Add `datadog.kubeStateMetricsCore.annotationsAsTags` that expose the `annotations_as_tags` parameter of the KSM core check.
+  This parameter exists only in agent 7.42.0 and above and cluster-agent 7.42.0 and above.
+
 # 3.6.2
 
 * Add CRDs to the cluster agent RBAC to be able to collect them using the Orchestrator Explorer.
 
-# 3.6.1
+## 3.6.1
 
 * Add `providers.aks.enabled` parameter to activate specific configuration options for AKS.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.6.2
+version: 3.6.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.6.2](https://img.shields.io/badge/Version-3.6.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.6.3](https://img.shields.io/badge/Version-3.6.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -617,6 +617,7 @@ helm install <RELEASE_NAME> \
 | datadog.helmCheck.valuesAsTags | object | `{}` | Collects Helm values from a release and uses them as tags (Requires Agent and Cluster Agent 7.40.0+). This requires datadog.HelmCheck.enabled to be set to true |
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.ignoreAutoConfig | list | `[]` | List of integration to ignore auto_conf.yaml. |
+| datadog.kubeStateMetricsCore.annotationsAsTags | object | `{}` | Extra annotations to collect from resources and to turn into datadog tag. |
 | datadog.kubeStateMetricsCore.collectSecretMetrics | bool | `true` | Enable watching secret objects and collecting their corresponding metrics kubernetes_state.secret.* |
 | datadog.kubeStateMetricsCore.collectVpaMetrics | bool | `false` | Enable watching VPA objects and collecting their corresponding metrics kubernetes_state.vpa.* |
 | datadog.kubeStateMetricsCore.enabled | bool | `true` | Enable the kubernetes_state_core check in the Cluster Agent (Requires Cluster Agent 1.12.0+) |

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -37,5 +37,7 @@ kubernetes_state_core.yaml.default: |-
       skip_leader_election: true
 {{- end }}
       labels_as_tags:
-{{ .Values.datadog.kubeStateMetricsCore.labelsAsTags | toYaml | indent 10 }}
+{{ .Values.datadog.kubeStateMetricsCore.labelsAsTags | toYaml | indent 8 }}
+      annotations_as_tags:
+{{ .Values.datadog.kubeStateMetricsCore.annotationsAsTags | toYaml | indent 8 }}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -188,7 +188,7 @@ datadog:
     ##   <resource2>:
     ##     <annotation3>: <tag3>
     ##
-    ## Warning: the label must match the transformation done by kube-state-metrics,
+    ## Warning: the annotation must match the transformation done by kube-state-metrics,
     ## for example tags.datadoghq.com/version becomes tags_datadoghq_com_version.
     annotationsAsTags: {}
     #  pod:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -178,6 +178,25 @@ datadog:
     #    zone: zone
     #    team: team
 
+    # datadog.kubeStateMetricsCore.annotationsAsTags -- Extra annotations to collect from resources and to turn into datadog tag.
+
+    ## It has the following structure:
+    ## annotationsAsTags:
+    ##   <resource1>:        # can be pod, deployment, node, etc.
+    ##     <annotation1>: <tag1>  # where <annotation1> is the kubernetes annotation and <tag1> is the datadog tag
+    ##     <annotation2>: <tag2>
+    ##   <resource2>:
+    ##     <annotation3>: <tag3>
+    ##
+    ## Warning: the label must match the transformation done by kube-state-metrics,
+    ## for example tags.datadoghq.com/version becomes tags_datadoghq_com_version.
+    annotationsAsTags: {}
+    #  pod:
+    #    app: app
+    #  node:
+    #    zone: zone
+    #    team: team
+
   ## Manage Cluster checks feature
 
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `datadog.kubeStateMetricsCore.annotationsAsTags` that expose the `annotations_as_tags`
parameter of the KSM core check.

This parameter exists only in agent 7.42.0 and above and cluster-agent 7.42.0 and above.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
