### PR TITLE
Add various Datadog log configurations

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## 3.7.3
 
 * Add the following Datadog log related configurations:
-  * `datadog.logs.autoMultiLineDefault.matchThreshold`
-  * `datadog.logs.autoMultiLineDefault.matchTimeout`
-  * `datadog.logs.autoMultiLineDefault.sampleSize`
+  * `datadog.logs.overrideAutoMultiLineDefault.matchThreshold`
+  * `datadog.logs.overrideAutoMultiLineDefault.matchTimeout`
+  * `datadog.logs.overrideAutoMultiLineDefault.sampleSize`
   * `datadog.logs.auditorTTL`
   * `datadog.logs.expectedTagsDuration`
   * `datadog.logs.processingRules`

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Datadog changelog
 
+## 3.6.5
+
+* Add the following Datadog log related configurations:
+  * `datadog.logs.autoMultiLineDefault.matchThreshold`
+  * `datadog.logs.autoMultiLineDefault.matchTimeout`
+  * `datadog.logs.autoMultiLineDefault.sampleSize`
+  * `datadog.logs.auditorTTL`
+  * `datadog.logs.expectedTagsDuration`
+  * `datadog.logs.processingRules`
+
 ## 3.6.4
 
 * Change nesting for `providers.aks.enabled` parameter in Helm template.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.6.4
+version: 3.6.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.6.4](https://img.shields.io/badge/Version-3.6.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.6.5](https://img.shields.io/badge/Version-3.6.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -635,10 +635,16 @@ helm install <RELEASE_NAME> \
 | datadog.leaderElection | bool | `true` | Enables leader election mechanism for event collection |
 | datadog.leaderLeaseDuration | string | `nil` | Set the lease time for leader election in second |
 | datadog.logLevel | string | `"INFO"` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, off |
+| datadog.logs.auditorTTL | string | `nil` | This variable can be used to allow for longer TTLs to be set. This is useful when some inputs don't emit logs for longer than the default of 23h |
+| datadog.logs.autoMultiLineDefault.matchThreshold | string | `nil` | The ratio of logs that must match a pattern in order for the source to be considered multi-line |
+| datadog.logs.autoMultiLineDefault.matchTimeout | string | `nil` | The timeout to apply to detecting multi-line logs |
+| datadog.logs.autoMultiLineDefault.sampleSize | string | `nil` | The sample size to use when detecting multi-line logs |
 | datadog.logs.autoMultiLineDetection | bool | `false` | Allows the Agent to detect common multi-line patterns automatically. |
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
+| datadog.logs.expectedTagsDuration | string | `nil` | Duration during which the host tags will be submitted with log events |
+| datadog.logs.processingRules | string | `nil` | The global filtering rules to apply to ingested log lines |
 | datadog.namespaceLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Namespace Labels to Datadog Tags |
 | datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
 | datadog.networkPolicy.cilium.dnsSelector | object | kube-dns in namespace kube-system | Cilium selector of the DNS server entity |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -639,14 +639,14 @@ helm install <RELEASE_NAME> \
 | datadog.leaderLeaseDuration | string | `nil` | Set the lease time for leader election in second |
 | datadog.logLevel | string | `"INFO"` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, off |
 | datadog.logs.auditorTTL | string | `nil` | This variable can be used to allow for longer TTLs to be set. This is useful when some inputs don't emit logs for longer than the default of 23h |
-| datadog.logs.autoMultiLineDefault.matchThreshold | string | `nil` | The ratio of logs that must match a pattern in order for the source to be considered multi-line |
-| datadog.logs.autoMultiLineDefault.matchTimeout | string | `nil` | The timeout to apply to detecting multi-line logs |
-| datadog.logs.autoMultiLineDefault.sampleSize | string | `nil` | The sample size to use when detecting multi-line logs |
 | datadog.logs.autoMultiLineDetection | bool | `false` | Allows the Agent to detect common multi-line patterns automatically. |
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
 | datadog.logs.expectedTagsDuration | string | `nil` | Duration during which the host tags will be submitted with log events |
+| datadog.logs.overrideAutoMultiLineDefault.matchThreshold | string | `nil` | The ratio of logs that must match a pattern in order for the source to be considered multi-line |
+| datadog.logs.overrideAutoMultiLineDefault.matchTimeout | string | `nil` | The timeout to apply to detecting multi-line logs |
+| datadog.logs.overrideAutoMultiLineDefault.sampleSize | string | `nil` | The sample size to use when detecting multi-line logs |
 | datadog.logs.processingRules | string | `nil` | The global filtering rules to apply to ingested log lines |
 | datadog.namespaceLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Namespace Labels to Datadog Tags |
 | datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -105,6 +105,30 @@
       value: {{ .Values.datadog.logs.containerCollectUsingFiles | quote }}
     - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
       value: {{ .Values.datadog.logs.autoMultiLineDetection | quote }}
+    {{- if .Values.datadog.logs.autoMultiLineDefault.matchThreshold }}
+    - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DEFAULT_MATCH_THRESHOLD
+      value: {{ .Values.datadog.logs.autoMultiLineDefault.matchThreshold | quote }}
+    {{- end }}
+    {{- if .Values.datadog.logs.autoMultiLineDefault.matchTimeout }}
+    - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DEFAULT_MATCH_TIMEOUT
+      value: {{ .Values.datadog.logs.autoMultiLineDefault.matchTimeout | quote }}
+    {{- end }}
+    {{- if .Values.datadog.logs.autoMultiLineDefault.sampleSize }}
+    - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DEFAULT_SAMPLE_SIZE
+      value: {{ .Values.datadog.logs.autoMultiLineDefault.sampleSize | quote }}
+    {{- end }}
+    {{- if .Values.datadog.logs.auditorTTL }}
+    - name: DD_LOGS_CONFIG_AUDITOR_TTL
+      value: {{ .Values.datadog.logs.auditorTTL | quote }}
+    {{- end }}
+    {{- if .Values.datadog.logs.expectedTagsDuration }}
+    - name: DD_LOGS_CONFIG_EXPECTED_TAGS_DURATION
+      value: {{ .Values.datadog.logs.expectedTagsDuration | quote }}
+    {{- end }}
+    {{- if .Values.datadog.logs.processingRules }}
+    - name: DD_LOGS_CONFIG_PROCESSING_RULES
+      value: {{ .Values.datadog.logs.processingRules | quote }}
+    {{- end }}
     - name: DD_HEALTH_PORT
     {{- $healthPort := .Values.agents.containers.agent.healthPort }}
       value: {{ $healthPort | quote }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -105,17 +105,17 @@
       value: {{ .Values.datadog.logs.containerCollectUsingFiles | quote }}
     - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
       value: {{ .Values.datadog.logs.autoMultiLineDetection | quote }}
-    {{- if .Values.datadog.logs.autoMultiLineDefault.matchThreshold }}
+    {{- if .Values.datadog.logs.overrideAutoMultiLineDefault.matchThreshold }}
     - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DEFAULT_MATCH_THRESHOLD
-      value: {{ .Values.datadog.logs.autoMultiLineDefault.matchThreshold | quote }}
+      value: {{ .Values.datadog.logs.overrideAutoMultiLineDefault.matchThreshold | quote }}
     {{- end }}
-    {{- if .Values.datadog.logs.autoMultiLineDefault.matchTimeout }}
+    {{- if .Values.datadog.logs.overrideAutoMultiLineDefault.matchTimeout }}
     - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DEFAULT_MATCH_TIMEOUT
-      value: {{ .Values.datadog.logs.autoMultiLineDefault.matchTimeout | quote }}
+      value: {{ .Values.datadog.logs.overrideAutoMultiLineDefault.matchTimeout | quote }}
     {{- end }}
-    {{- if .Values.datadog.logs.autoMultiLineDefault.sampleSize }}
+    {{- if .Values.datadog.logs.overrideAutoMultiLineDefault.sampleSize }}
     - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DEFAULT_SAMPLE_SIZE
-      value: {{ .Values.datadog.logs.autoMultiLineDefault.sampleSize | quote }}
+      value: {{ .Values.datadog.logs.overrideAutoMultiLineDefault.sampleSize | quote }}
     {{- end }}
     {{- if .Values.datadog.logs.auditorTTL }}
     - name: DD_LOGS_CONFIG_AUDITOR_TTL

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -397,15 +397,15 @@ datadog:
     ## ref: https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile#automatic-multi-line-aggregation
     autoMultiLineDetection: false
 
-    ## Enable logs configurations related to multi-line defaults
-    autoMultiLineDefault:
-      # datadog.logs.autoMultiLineDefault.matchThreshold -- The ratio of logs that must match a pattern in order for the source to be considered multi-line
+    ## Override logs configurations related to multi-line defaults
+    overrideAutoMultiLineDefault:
+      # datadog.logs.overrideAutoMultiLineDefault.matchThreshold -- The ratio of logs that must match a pattern in order for the source to be considered multi-line
       matchThreshold:
 
-      # datadog.logs.autoMultiLineDefault.matchTimeout -- The timeout to apply to detecting multi-line logs
+      # datadog.logs.overrideAutoMultiLineDefault.matchTimeout -- The timeout to apply to detecting multi-line logs
       matchTimeout:
 
-      # datadog.logs.autoMultiLineDefault.sampleSize -- The sample size to use when detecting multi-line logs
+      # datadog.logs.overrideAutoMultiLineDefault.sampleSize -- The sample size to use when detecting multi-line logs
       sampleSize:
 
     # datadog.logs.auditorTTL -- This variable can be used to allow for longer TTLs to be set. This is useful when some inputs don't emit logs for longer than the default of 23h

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -364,6 +364,28 @@ datadog:
     ## ref: https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile#automatic-multi-line-aggregation
     autoMultiLineDetection: false
 
+    ## Enable logs configurations related to multi-line defaults
+    autoMultiLineDefault:
+      # datadog.logs.autoMultiLineDefault.matchThreshold -- The ratio of logs that must match a pattern in order for the source to be considered multi-line
+      matchThreshold:
+
+      # datadog.logs.autoMultiLineDefault.matchTimeout -- The timeout to apply to detecting multi-line logs
+      matchTimeout:
+
+      # datadog.logs.autoMultiLineDefault.sampleSize -- The sample size to use when detecting multi-line logs
+      sampleSize:
+
+    # datadog.logs.auditorTTL -- This variable can be used to allow for longer TTLs to be set. This is useful when some inputs don't emit logs for longer than the default of 23h
+    auditorTTL:
+
+    # datadog.logs.expectedTagsDuration -- Duration during which the host tags will be submitted with log events
+    expectedTagsDuration:
+
+    # datadog.logs.processingRules -- The global filtering rules to apply to ingested log lines
+
+    ## ref: https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=helm#global-processing-rules
+    processingRules:
+
   ## Enable apm agent and provide custom configs
   apm:
     # datadog.apm.socketEnabled -- Enable APM over Socket (Unix Socket or windows named pipe)


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds configurations to manipulate the following environment variables:

```
DD_LOGS_CONFIG_AUDITOR_TTL
DD_LOGS_CONFIG_AUTO_MULTI_LINE_DEFAULT_MATCH_THRESHOLD
DD_LOGS_CONFIG_AUTO_MULTI_LINE_DEFAULT_MATCH_TIMEOUT
DD_LOGS_CONFIG_AUTO_MULTI_LINE_DEFAULT_SAMPLE_SIZE
DD_LOGS_CONFIG_EXPECTED_TAGS_DURATION
DD_LOGS_CONFIG_PROCESSING_RULES
```

#### Which issue this PR fixes
  - fixes #767

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
