### PR TITLE
fix(datadog): fix security-agent config with hostCAPath option

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Datadog changelog
 
-# 3.6.5
+## 3.6.6
+
+* Fix missing volumeMount in `security-agent` container when `datadog.kubelet.hostCAPath` is provided.
+
+## 3.6.5
 
 * Fix missing Cluster Agent configuration in `security-agent` if CSPM is not actived.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.6.5
+version: 3.6.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.6.5](https://img.shields.io/badge/Version-3.6.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.6.6](https://img.shields.io/badge/Version-3.6.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -87,6 +87,9 @@
     - name: procdir
       mountPath: /host/proc
       readOnly: true
+    {{- if .Values.datadog.kubelet.hostCAPath }}
+{{ include "datadog.kubelet.volumeMount" . | indent 4 }}
+    {{- end }}
     {{- if .Values.datadog.securityAgent.compliance.configMap }}
     - name: complianceconfigdir
       mountPath: /etc/datadog-agent/compliance.d


### PR DESCRIPTION
#### What this PR does / why we need it:

* Fix missing volumeMount in `security-agent` container when `datadog.kubelet.hostCAPath` is provided.

#### Which issue this PR fixes

Because the `workload-metadata-store` component is used in the `security-agent` container, this container requires to use mount the host CA certificat to communicate with the kubelet.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
