### PR TITLE
feat(datadog): add k8s unbundle events feature support

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Datadog changelog
 
+## 3.7.0
+
+* Add `datadog.kubernetesEvents.*` options to configure new Kubernetes unbundling events feature.
+  (This parameter exists only in agent 7.42.0 and above and cluster-agent 7.42.0 and above.)
+* Add `datadog.clusterTagger.*` options to configure the Kubernetes cluster-tagger feature.
+  (This parameter exists only in agent 7.42.0 and above and cluster-agent 7.42.0 and above.)
+
 ## 3.6.9
 
 * Add `auth_token` to all the containers.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -6,6 +6,7 @@
   (This parameter exists only in agent 7.42.0 and above and cluster-agent 7.42.0 and above.)
 * Add `datadog.clusterTagger.*` options to configure the Kubernetes cluster-tagger feature.
   (This parameter exists only in agent 7.42.0 and above and cluster-agent 7.42.0 and above.)
+* Create `components-common-env` to define shared environment variable between "agent" and "cluster-agent" containers, and refactor `containers-common-env`.
 
 ## 3.6.9
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.6.9
+version: 3.7.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.6.9](https://img.shields.io/badge/Version-3.6.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.7.0](https://img.shields.io/badge/Version-3.7.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -586,6 +586,7 @@ helm install <RELEASE_NAME> \
 | datadog.clusterChecks.enabled | bool | `true` | Enable the Cluster Checks feature on both the cluster-agents and the daemonset |
 | datadog.clusterChecks.shareProcessNamespace | bool | `false` | Set the process namespace sharing on the cluster checks agent |
 | datadog.clusterName | string | `nil` | Set a unique cluster name to allow scoping hosts and Cluster Checks easily |
+| datadog.clusterTagger.collectKubernetesTags | bool | `false` | Enables Kubernetes resources tags collection. |
 | datadog.collectEvents | bool | `true` | Enables this to start event collection from the kubernetes API |
 | datadog.confd | object | `{}` | Provide additional check configurations (static and Autodiscovery) |
 | datadog.containerExclude | string | `nil` | Exclude containers from the Agent Autodiscovery, as a space-sepatered list |
@@ -632,6 +633,8 @@ helm install <RELEASE_NAME> \
 | datadog.kubelet.hostCAPath | string | None (no mount from host) | Path (on host) where the Kubelet CA certificate is stored |
 | datadog.kubelet.podLogsPath | string | /var/log/pods on Linux, C:\var\log\pods on Windows | Path (on host) where the PODs logs are located |
 | datadog.kubelet.tlsVerify | string | true | Toggle kubelet TLS verification |
+| datadog.kubernetesEvents.collectedEventTypes | list | `[{"kind":"Pod","reasons":["Failed","BackOff","Unhealthy","FailedScheduling","FailedMount","FailedAttachVolume"]},{"kind":"Node","reasons":["TerminatingEvictedPod","NodeNotReady","Rebooted","HostPortConflict"]},{"kind":"CronJob","reasons":["SawCompletedJob"]}]` | Collects Helm values from a release and uses them as tags (Requires Cluster Agent 7.42.0+). This requires datadog.kubernetesEvents.unbundleEvents to be set to true |
+| datadog.kubernetesEvents.unbundleEvents | bool | `false` | Allow unbundling kubernetes events, 1:1 mapping between Kubernetes and Datadog events. (Requires Cluster Agent 7.42.0+). |
 | datadog.leaderElection | bool | `true` | Enables leader election mechanism for event collection |
 | datadog.leaderLeaseDuration | string | `nil` | Set the lease time for leader election in second |
 | datadog.logLevel | string | `"INFO"` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, off |

--- a/charts/datadog/ci/cluster-agent-values.yaml
+++ b/charts/datadog/ci/cluster-agent-values.yaml
@@ -5,6 +5,10 @@ datadog:
   kubeStateMetricsEnabled: false
   clusterChecks:
     enabled: true
+  kubernetesEvents:
+    unbundleEvents: true
+  clusterTagger:
+    collectKubernetesTags: true
   expvarPort: 6001
   env:
     - name: DD_FOOBAR

--- a/charts/datadog/templates/_components-common-env.yaml
+++ b/charts/datadog/templates/_components-common-env.yaml
@@ -1,0 +1,63 @@
+# The purpose of this template is to define a minimal set of environment
+# variables shared between components: agent, cluster-agent
+{{- define "components-common-env" -}}
+{{- if .Values.datadog.secretBackend.command }}
+- name: DD_SECRET_BACKEND_COMMAND
+  value: {{ .Values.datadog.secretBackend.command | quote }}
+{{- end }}
+{{- if .Values.datadog.secretBackend.arguments }}
+- name: DD_SECRET_BACKEND_ARGUMENTS
+  value: {{ .Values.datadog.secretBackend.arguments | quote }}
+{{- end }}
+{{- if .Values.datadog.secretBackend.timeout }}
+- name: DD_SECRET_BACKEND_TIMEOUT
+  value: {{ .Values.datadog.secretBackend.timeout | quote }}
+{{- end }}
+{{- if .Values.datadog.clusterName }}
+{{- template "check-cluster-name" . }}
+- name: DD_CLUSTER_NAME
+  value: {{ .Values.datadog.clusterName | quote }}
+{{- end }}
+{{- if .Values.datadog.tags }}
+- name: DD_TAGS
+  value: {{ tpl (.Values.datadog.tags | join " " | quote) . }}
+{{- end }}
+{{- if .Values.datadog.nodeLabelsAsTags }}
+- name: DD_KUBERNETES_NODE_LABELS_AS_TAGS
+  value: '{{ toJson .Values.datadog.nodeLabelsAsTags }}'
+{{- end }}
+{{- if .Values.datadog.podLabelsAsTags }}
+- name: DD_KUBERNETES_POD_LABELS_AS_TAGS
+  value: '{{ toJson .Values.datadog.podLabelsAsTags }}'
+{{- end }}
+{{- if .Values.datadog.podAnnotationsAsTags }}
+- name: DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS
+  value: '{{ toJson .Values.datadog.podAnnotationsAsTags }}'
+{{- end }}
+{{- if .Values.datadog.namespaceLabelsAsTags }}
+- name: DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS
+  value: '{{ toJson .Values.datadog.namespaceLabelsAsTags }}'
+{{- end }}
+- name: KUBERNETES
+  value: "yes"
+{{- if .Values.datadog.site }}
+- name: DD_SITE
+  value: {{ .Values.datadog.site | quote }}
+{{- end }}
+{{- if .Values.datadog.dd_url }}
+- name: DD_DD_URL
+  value: {{ .Values.datadog.dd_url | quote }}
+{{- end }}
+{{- if .Values.datadog.containerInclude }}
+- name: DD_CONTAINER_INCLUDE
+  value: {{ .Values.datadog.containerInclude | quote }}
+{{- end }}
+{{- if .Values.datadog.containerExclude }}
+- name: DD_CONTAINER_EXCLUDE
+  value: {{ .Values.datadog.containerExclude | quote }}
+{{- end }}
+{{- if not .Values.datadog.excludePauseContainer }}
+- name: DD_EXCLUDE_PAUSE_CONTAINER
+  value: "false"
+{{- end }}
+{{- end }}

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -11,18 +11,7 @@
       key: api-key
 - name: DD_AUTH_TOKEN_FILE_PATH
   value: /etc/datadog-agent/auth/token
-{{- if .Values.datadog.secretBackend.command }}
-- name: DD_SECRET_BACKEND_COMMAND
-  value: {{ .Values.datadog.secretBackend.command | quote }}
-{{- end }}
-{{- if .Values.datadog.secretBackend.arguments }}
-- name: DD_SECRET_BACKEND_ARGUMENTS
-  value: {{ .Values.datadog.secretBackend.arguments | quote }}
-{{- end }}
-{{- if .Values.datadog.secretBackend.timeout }}
-- name: DD_SECRET_BACKEND_TIMEOUT
-  value: {{ .Values.datadog.secretBackend.timeout | quote }}
-{{- end }}
+{{ include "components-common-env" . }}
 {{- if .Values.datadog.kubelet.host }}
 - name: DD_KUBERNETES_KUBELET_HOST
 {{ toYaml .Values.datadog.kubelet.host | indent 2 }}
@@ -39,46 +28,11 @@
 - name: DD_KUBERNETES_HTTPS_KUBELET_PORT
   value: "0"
 {{- end }}
-{{- if .Values.datadog.clusterName }}
-{{- template "check-cluster-name" . }}
-- name: DD_CLUSTER_NAME
-  value: {{ .Values.datadog.clusterName | quote }}
-{{- end }}
 {{- if eq .Values.targetSystem "linux" }}
 {{- if .Values.providers.eks.ec2.useHostnameFromFile }}
 - name: DD_HOSTNAME_FILE
   value: /var/lib/cloud/data/instance-id
 {{- end }}
-{{- end }}
-{{- if .Values.datadog.tags }}
-- name: DD_TAGS
-  value: {{ tpl (.Values.datadog.tags | join " " | quote) . }}
-{{- end }}
-{{- if .Values.datadog.nodeLabelsAsTags }}
-- name: DD_KUBERNETES_NODE_LABELS_AS_TAGS
-  value: '{{ toJson .Values.datadog.nodeLabelsAsTags }}'
-{{- end }}
-{{- if .Values.datadog.podLabelsAsTags }}
-- name: DD_KUBERNETES_POD_LABELS_AS_TAGS
-  value: '{{ toJson .Values.datadog.podLabelsAsTags }}'
-{{- end }}
-{{- if .Values.datadog.podAnnotationsAsTags }}
-- name: DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS
-  value: '{{ toJson .Values.datadog.podAnnotationsAsTags }}'
-{{- end }}
-{{- if .Values.datadog.namespaceLabelsAsTags }}
-- name: DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS
-  value: '{{ toJson .Values.datadog.namespaceLabelsAsTags }}'
-{{- end }}
-- name: KUBERNETES
-  value: "yes"
-{{- if .Values.datadog.site }}
-- name: DD_SITE
-  value: {{ .Values.datadog.site | quote }}
-{{- end }}
-{{- if .Values.datadog.dd_url }}
-- name: DD_DD_URL
-  value: {{ .Values.datadog.dd_url | quote }}
 {{- end }}
 {{- include "additional-env-entries" .Values.datadog.env }}
 {{- if .Values.datadog.acInclude }}
@@ -88,14 +42,6 @@
 {{- if .Values.datadog.acExclude }}
 - name: DD_AC_EXCLUDE
   value: {{ .Values.datadog.acExclude | quote }}
-{{- end }}
-{{- if .Values.datadog.containerInclude }}
-- name: DD_CONTAINER_INCLUDE
-  value: {{ .Values.datadog.containerInclude | quote }}
-{{- end }}
-{{- if .Values.datadog.containerExclude }}
-- name: DD_CONTAINER_EXCLUDE
-  value: {{ .Values.datadog.containerExclude | quote }}
 {{- end }}
 {{- if .Values.datadog.containerIncludeMetrics }}
 - name: DD_CONTAINER_INCLUDE_METRICS
@@ -112,10 +58,6 @@
 {{- if .Values.datadog.containerExcludeLogs }}
 - name: DD_CONTAINER_EXCLUDE_LOGS
   value: {{ .Values.datadog.containerExcludeLogs | quote }}
-{{- end }}
-{{- if not .Values.datadog.excludePauseContainer }}
-- name: DD_EXCLUDE_PAUSE_CONTAINER
-  value: "false"
 {{- end }}
 {{- if .Values.datadog.otlp }}
 {{- if .Values.datadog.otlp.receiver }}

--- a/charts/datadog/templates/_kubernetes_apiserver_config.yaml
+++ b/charts/datadog/templates/_kubernetes_apiserver_config.yaml
@@ -1,0 +1,10 @@
+{{- define "kubernetes_apiserver-config" -}}
+{{- if and .Values.datadog.collectEvents .Values.datadog.kubernetesEvents.unbundleEvents -}}
+kubernetes_apiserver.yaml: |-
+  init_config:
+  instances:
+    - unbundle_events: {{ .Values.datadog.kubernetesEvents.unbundleEvents }}
+      collected_event_types:
+{{ .Values.datadog.kubernetesEvents.collectedEventTypes | toYaml | nindent 8 }}
+{{- end -}}
+{{- end -}}

--- a/charts/datadog/templates/cluster-agent-confd-configmap.yaml
+++ b/charts/datadog/templates/cluster-agent-confd-configmap.yaml
@@ -18,6 +18,7 @@ data:
 {{- if .Values.datadog.helmCheck.enabled -}}
 {{ include "helmCheck-config" . | nindent 2 }}
 {{- end -}}
+{{ include "kubernetes_apiserver-config" . | nindent 2 }}
 {{- range $integration, $configs := $.Values.clusterAgent.advancedConfd }}
 {{- range $name, $config := $configs }}
   {{ printf "%s--%s: |" $integration $name }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -132,22 +132,7 @@ spec:
                 name: {{ template "datadog.apiSecretName" . }}
                 key: api-key
                 optional: true
-          {{- if .Values.datadog.secretBackend.command }}
-          - name: DD_SECRET_BACKEND_COMMAND
-            value: {{ .Values.datadog.secretBackend.command | quote }}
-          {{- end }}
-          {{- if .Values.datadog.secretBackend.arguments }}
-          - name: DD_SECRET_BACKEND_ARGUMENTS
-            value: {{ .Values.datadog.secretBackend.arguments | quote }}
-          {{- end }}
-          {{- if .Values.datadog.secretBackend.timeout }}
-          - name: DD_SECRET_BACKEND_TIMEOUT
-            value: {{ .Values.datadog.secretBackend.timeout | quote }}
-          {{- end }}
-          {{- if .Values.datadog.tags }}
-          - name: DD_TAGS
-            value: {{ tpl (.Values.datadog.tags | join " " | quote) . }}
-          {{- end }}
+          {{- include "components-common-env" . | nindent 10 }}
           {{- if .Values.clusterAgent.metricsProvider.enabled }}
           - name: DD_APP_KEY
             valueFrom:
@@ -199,19 +184,6 @@ spec:
           - name: DD_EXTRA_LISTENERS
             value: "kube_endpoints kube_services"
           {{- end }}
-          {{- if .Values.datadog.clusterName }}
-          {{- template "check-cluster-name" . }}
-          - name: DD_CLUSTER_NAME
-            value: {{ .Values.datadog.clusterName | quote }}
-          {{- end }}
-          {{- if .Values.datadog.site }}
-          - name: DD_SITE
-            value: {{ .Values.datadog.site | quote }}
-          {{- end }}
-          {{- if .Values.datadog.dd_url }}
-          - name: DD_DD_URL
-            value: {{ .Values.datadog.dd_url | quote }}
-          {{- end }}
           {{- if .Values.datadog.logLevel }}
           - name: DD_LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}
@@ -231,7 +203,7 @@ spec:
             value: {{ template "datadog.fullname" . }}token
           {{- if .Values.datadog.collectEvents }}
           - name: DD_COLLECT_KUBERNETES_EVENTS
-            value: {{ .Values.datadog.collectEvents | quote}}
+            value: {{ .Values.datadog.collectEvents | quote }}
           {{- end }}
           - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
             value: {{ template "datadog.fullname" . }}-cluster-agent
@@ -240,6 +212,8 @@ spec:
               secretKeyRef:
                 name: {{ template "clusterAgent.tokenSecretName" . }}
                 key: token
+          - name: DD_CLUSTER_AGENT_COLLECT_KUBERNETES_TAGS
+            value: {{ .Values.datadog.clusterTagger.collectKubernetesTags | quote }}
           - name: DD_KUBE_RESOURCES_NAMESPACE
             value: {{ .Release.Namespace }}
           - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
@@ -331,6 +305,10 @@ spec:
 {{- if .Values.datadog.helmCheck.enabled }}
             - key: helm.yaml
               path: helm.yaml
+{{- end }}
+{{- if and .Values.datadog.collectEvents .Values.datadog.kubernetesEvents.unbundleEvents }}
+            - key: kubernetes_apiserver.yaml
+              path: kubernetes_apiserver.yaml
 {{- end }}
 {{- range $integration, $configs := $.Values.clusterAgent.advancedConfd }}
 {{- range $name, $config := $configs }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -335,6 +335,39 @@ datadog:
   ## ref: https://docs.datadoghq.com/agent/kubernetes/#event-collection
   collectEvents: true
 
+  # Configure Kubernetes events collection
+  kubernetesEvents:
+    # datadog.kubernetesEvents.unbundleEvents -- Allow unbundling kubernetes events, 1:1 mapping between Kubernetes and Datadog events. (Requires Cluster Agent 7.42.0+).
+    unbundleEvents: false
+    # datadog.kubernetesEvents.collectedEventTypes -- Collects Helm values from a release and uses them as tags (Requires Cluster Agent 7.42.0+).
+    # This requires datadog.kubernetesEvents.unbundleEvents to be set to true
+    collectedEventTypes:
+    # - kind: <kubernetes resource kind> # (optional if `source`` is provided)
+    #   source: <controller name> # (optional if `kind`` is provided)
+    #   reasons: # (optional) if empty accept all event reasons
+    #   - <kubernetes event reason>
+      - kind: Pod
+        reasons:
+          - Failed
+          - BackOff
+          - Unhealthy
+          - FailedScheduling
+          - FailedMount
+          - FailedAttachVolume
+      - kind: Node
+        reasons:
+          - TerminatingEvictedPod
+          - NodeNotReady
+          - Rebooted
+          - HostPortConflict
+      - kind: CronJob
+        reasons:
+          - SawCompletedJob
+
+  clusterTagger:
+    # datadog.clusterTagger.collectKubernetesTags -- Enables Kubernetes resources tags collection.
+    collectKubernetesTags: false
+
   # datadog.leaderElection -- Enables leader election mechanism for event collection
   leaderElection: true
 


### PR DESCRIPTION
#### What this PR does / why we need it:

*  Create `components-common-env` to define shared environment variable between "agent" and "cluster-agent" containers, and refactor `containers-common-env`.
* Add `datadog.kubernetesEvents.*` options to configure new Kubernetes unbundling events feature.
  (This parameter exists only in agent 7.42.0 and above and cluster-agent 7.42.0 and above.)
* Add `datadog.clusterTagger.*` options to configure the Kubernetes cluster-tagger feature.
  (This parameter exists only in agent 7.42.0 and above and cluster-agent 7.42.0 and above.)


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
