### PR TITLE
add auth_token support

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.6.9
+
+* Add `auth_token` to all the containers.
+
 ## 3.6.8
 
 * Add missing RBAC rules for collection of Vertical Pod Autoscaler resources in the Orchestrator Explorer.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.6.8
+version: 3.6.9
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.6.8](https://img.shields.io/badge/Version-3.6.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.6.9](https://img.shields.io/badge/Version-3.6.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -154,6 +154,8 @@
       subPath: install_info
       mountPath: /etc/datadog-agent/install_info
       readOnly: true
+    - name: auth-token
+      mountPath: /etc/datadog-agent/auth
     - name: logdatadog
       mountPath: /var/log/datadog
     - name: tmpdir

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -56,6 +56,9 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
     {{- if eq .Values.targetSystem "linux" }}
+    - name: auth-token
+      mountPath: /etc/datadog-agent/auth
+      readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog
     - name: tmpdir

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -53,6 +53,9 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
     {{- if eq .Values.targetSystem "linux" }}
+    - name: auth-token
+      mountPath: /etc/datadog-agent/auth
+      readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog
     - name: tmpdir

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -29,6 +29,9 @@
   resources:
 {{ toYaml .Values.agents.containers.systemProbe.resources | indent 4 }}
   volumeMounts:
+    - name: auth-token
+      mountPath: /etc/datadog-agent/auth
+      readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog
     - name: tmpdir

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -69,6 +69,9 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
     {{- end }}
+    - name: auth-token
+      mountPath: /etc/datadog-agent/auth
+      readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog
     - name: tmpdir

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -9,6 +9,8 @@
     secretKeyRef:
       name: {{ template "datadog.apiSecretName" . }}
       key: api-key
+- name: DD_AUTH_TOKEN_FILE_PATH
+  value: /etc/datadog-agent/auth/token
 {{- if .Values.datadog.secretBackend.command }}
 - name: DD_SECRET_BACKEND_COMMAND
   value: {{ .Values.datadog.secretBackend.command | quote }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -132,6 +132,8 @@ spec:
           {{ include "system-probe-init" . | nindent 6 }}
         {{- end }}
       volumes:
+      - name: auth-token
+        emptyDir: {}
       - name: installinfo
         configMap:
           name: {{ include "agents-install-info-configmap-name" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This aims to fix auth_token not available from system-probe which avoid using remote-config and the remote-tagger.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
