### PR TITLE
fix(datadog): added otlp ports to network policy

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.7.3
+
+* Add ports to agent network policy ingress for both OTLP/gRPC and OTLP/HTTP ports when OTLP is enabled.
+
 ## 3.7.2
 
 * Rename dogstatsd port on the Agent Service to match the name of the dogstatsd port in the Agent pod (`dogstatsd -> dogstatsdport`).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.7.2
+version: 3.7.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.7.2](https://img.shields.io/badge/Version-3.7.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.7.3](https://img.shields.io/badge/Version-3.7.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-network-policy.yaml
+++ b/charts/datadog/templates/agent-network-policy.yaml
@@ -26,6 +26,18 @@ spec:
         - port: {{ $.Values.datadog.apm.port }}
           protocol: TCP
 {{- end }}
+{{- if $.Values.datadog.otlp.receiver.protocols.grpc.enabled }}
+    - # Ingress for OTLP/gRPC
+      ports:
+        - port: {{ .Values.datadog.otlp.receiver.protocols.grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+          protocol: TCP
+{{- end }}
+{{- if $.Values.datadog.otlp.receiver.protocols.http.enabled }}
+    - # Ingress for OTLP/HTTP
+      ports:
+        - port: {{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
+          protocol: TCP
+{{- end }}
   egress:
     - # Egress to
       # * Datadog intake


### PR DESCRIPTION
#### What this PR does / why we need it:

This allows the DataDog agent Network Policy to receive ingress traffic from the ports defined in `.Values.datadog.otlp.receiver.protocols.http.endpoint` and `.Values.datadog.otlp.receiver.protocols.grpc.endpoint` only when they are enabled.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] Chart Version bumped
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
