### PR TITLE
feat(datadog):  Secret annotations support

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.7.3
+
+* Add support for Secret Annotations using `datadog.SecretAnnotations` helm value
+
 ## 3.7.2
 
 * Rename dogstatsd port on the Agent Service to match the name of the dogstatsd port in the Agent pod (`dogstatsd -> dogstatsdport`).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.7.2
+version: 3.7.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.7.2](https://img.shields.io/badge/Version-3.7.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.7.3](https://img.shields.io/badge/Version-3.7.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -667,7 +667,7 @@ helm install <RELEASE_NAME> \
 | datadog.prometheusScrape.enabled | bool | `false` | Enable autodiscovering pods and services exposing prometheus metrics. |
 | datadog.prometheusScrape.serviceEndpoints | bool | `false` | Enable generating dedicated checks for service endpoints. |
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. |
-| datadog.secretAnnotations | object | `{}` | Annotations to add to the Secrets. | 
+| datadog.secretAnnotations | object | `{}` |  |
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |
 | datadog.secretBackend.command | string | `nil` | Configure the secret backend command, path to the secret backend binary. |
 | datadog.secretBackend.enableGlobalPermissions | bool | `true` | Whether to create a global permission allowing Datadog agents to read all secrets when `datadog.secretBackend.command` is set to `"/readsecret_multiple_providers.sh"`. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -667,6 +667,7 @@ helm install <RELEASE_NAME> \
 | datadog.prometheusScrape.enabled | bool | `false` | Enable autodiscovering pods and services exposing prometheus metrics. |
 | datadog.prometheusScrape.serviceEndpoints | bool | `false` | Enable generating dedicated checks for service endpoints. |
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. |
+| datadog.secretAnnotations | object | `{}` | Annotations to add to the Secrets. | 
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |
 | datadog.secretBackend.command | string | `nil` | Configure the secret backend command, path to the secret backend binary. |
 | datadog.secretBackend.enableGlobalPermissions | bool | `true` | Whether to create a global permission allowing Datadog agents to read all secrets when `datadog.secretBackend.command` is set to `"/readsecret_multiple_providers.sh"`. |

--- a/charts/datadog/ci/secret-with-dynamic-annotations-values.yaml
+++ b/charts/datadog/ci/secret-with-dynamic-annotations-values.yaml
@@ -1,0 +1,3 @@
+datadog:
+  secretAnnotations:
+    secret-annotation: "testing-purpose"

--- a/charts/datadog/templates/secret-api-key.yaml
+++ b/charts/datadog/templates/secret-api-key.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
 {{- if .Values.datadog.secretAnnotations }}
-  annotations: {{ toYaml .Values.datadog.secretAnnotations  | nindent 4 }}
+  annotations: {{ toYaml .Values.datadog.secretAnnotations | nindent 4 }}
 {{- end }}
 type: Opaque
 data:

--- a/charts/datadog/templates/secret-api-key.yaml
+++ b/charts/datadog/templates/secret-api-key.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}
+{{- if .Values.datadog.secretAnnotations }}
+  annotations: {{ toYaml .Values.datadog.secretAnnotations  | nindent 4 }}
+{{- end }}
 type: Opaque
 data:
   api-key: {{ default "MISSING" .Values.datadog.apiKey | b64enc | quote }}

--- a/charts/datadog/templates/secret-application-key.yaml
+++ b/charts/datadog/templates/secret-application-key.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}
+{{- if .Values.datadog.secretAnnotations }}
+  annotations: {{ toYaml .Values.datadog.secretAnnotations | nindent 4 }}
+{{- end }}
 type: Opaque
 data:
   app-key: {{ default "MISSING" .Values.datadog.appKey | b64enc | quote }}

--- a/charts/datadog/templates/secret-cluster-agent-token.yaml
+++ b/charts/datadog/templates/secret-cluster-agent-token.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}
+{{- if .Values.datadog.secretAnnotations }}
+  annotations: {{ toYaml .Values.datadog.secretAnnotations | nindent 4 }}
+{{- end }}
 type: Opaque
 data:
   {{ if .Values.clusterAgent.token -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -48,6 +48,10 @@ datadog:
   ## If set, this parameter takes precedence over "appKey".
   appKeyExistingSecret:  # <DATADOG_APP_KEY_SECRET>
 
+  # agents.secretAnnotations -- Annotations to add to the Secrets
+  secretAnnotations: {}
+  #   key: "value"
+
   ## Configure the secret backend feature https://docs.datadoghq.com/agent/guide/secrets-management
   ## Examples: https://docs.datadoghq.com/agent/guide/secrets-management/#setup-examples-1
   secretBackend:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds support for annotations on kubernetes Secrets deployed by the datadog helm chart

#### Which issue this PR fixes
  - fixes #882 

#### Special notes for your reviewer:

N/A

#### Checklist

- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
