### PR TITLE
introduce container-helm-chart-maintainers in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,9 @@
 *.md             @DataDog/documentation @DataDog/container-helm-chart-maintainers
 
 # Charts
-charts/datadog-crds                                 @DataDog/container-helm-chart-maintainers
-charts/datadog-operator                              @DataDog/container-helm-chart-maintainers
-charts/extended-daemon-set                           @DataDog/container-helm-chart-maintainers
+charts/datadog-crds                                  @DataDog/container-ecosystems
+charts/datadog-operator                              @DataDog/container-ecosystems
+charts/extended-daemon-set                           @DataDog/container-ecosystems
 charts/datadog                                       @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/container-system-probe.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/system-probe-configmap.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Code owners for charts
 
-*  @DataDog/container-integrations @DataDog/container-ecosystems
+*  @DataDog/container-helm-chart-maintainers
 
 # Documentation
-*.md             @DataDog/documentation @DataDog/container-integrations @DataDog/container-ecosystems
+*.md             @DataDog/documentation container-helm-chart-maintainers
 
 # Charts
-charts/datadog/templates/container-system-probe.yaml @DataDog/ebpf-platform @DataDog/container-integrations
-charts/datadog/templates/system-probe-configmap.yaml @DataDog/ebpf-platform @DataDog/container-integrations
-charts/datadog/templates/system-probe-init.yaml      @DataDog/ebpf-platform @DataDog/container-integrations
+charts/datadog/templates/container-system-probe.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
+charts/datadog/templates/system-probe-configmap.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
+charts/datadog/templates/system-probe-init.yaml      @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/synthetics-private-location/                  @Datadog/synthetics

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,13 @@
 *  @DataDog/container-helm-chart-maintainers
 
 # Documentation
-*.md             @DataDog/documentation container-helm-chart-maintainers
+*.md             @DataDog/documentation @DataDog/container-helm-chart-maintainers
 
 # Charts
+charts/datadog-crds                                 @DataDog/container-helm-chart-maintainers
+charts/datadog-operator                              @DataDog/container-helm-chart-maintainers
+charts/extended-daemon-set                           @DataDog/container-helm-chart-maintainers
+charts/datadog                                       @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/container-system-probe.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/system-probe-configmap.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/system-probe-init.yaml      @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers


### PR DESCRIPTION
#### What this PR does / why we need it:

Replace @DataDog/containter-integration and @DataDog/container-ecosystems by @DataDog/container-helm-chart-maintainers in CODEOWNERS file to simplify code-reviews.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
