### PR TITLE
Fix auth token path and default hostPid=true on Windows

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.10.3
+
+* Fix default `hostPid` value set to true on Windows.
+* Fix auth token path value on Windows.
+
 ## 3.10.1
 
 * Fix: add missing `DAC_READ_SEARCH` capability in agent PSP and SCC (openshift)

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.10.2
+version: 3.10.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.10.2](https://img.shields.io/badge/Version-3.10.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.10.3](https://img.shields.io/badge/Version-3.10.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -154,8 +154,6 @@
       subPath: install_info
       mountPath: /etc/datadog-agent/install_info
       readOnly: true
-    - name: auth-token
-      mountPath: /etc/datadog-agent/auth
     - name: logdatadog
       mountPath: /var/log/datadog
     - name: tmpdir
@@ -165,6 +163,8 @@
     {{- end }}
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
+    - name: auth-token
+      mountPath: {{ template "datadog.confPath" . }}/auth
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -52,10 +52,10 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
-    {{- if eq .Values.targetSystem "linux" }}
     - name: auth-token
-      mountPath: /etc/datadog-agent/auth
+      mountPath: {{ template "datadog.confPath" . }}/auth
       readOnly: true
+    {{- if eq .Values.targetSystem "linux" }}
     - name: logdatadog
       mountPath: /var/log/datadog
     - name: tmpdir

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -30,7 +30,7 @@
 {{ toYaml .Values.agents.containers.systemProbe.resources | indent 4 }}
   volumeMounts:
     - name: auth-token
-      mountPath: /etc/datadog-agent/auth
+      mountPath: {{ template "datadog.confPath" . }}/auth
       readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -53,6 +53,9 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
+    - name: auth-token
+      mountPath: {{ template "datadog.confPath" . }}/auth
+      readOnly: true
     {{- if .Values.agents.useConfigMap }}
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
@@ -69,9 +72,6 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
     {{- end }}
-    - name: auth-token
-      mountPath: /etc/datadog-agent/auth
-      readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog
     - name: tmpdir

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -10,7 +10,7 @@
       name: {{ template "datadog.apiSecretName" . }}
       key: api-key
 - name: DD_AUTH_TOKEN_FILE_PATH
-  value: /etc/datadog-agent/auth/token
+  value: {{ template "datadog.confPath" . }}/auth/token
 {{ include "components-common-env" . }}
 {{- if .Values.datadog.kubelet.host }}
 - name: DD_KUBERNETES_KUBELET_HOST

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -342,7 +342,9 @@ false
 Return true if the hostPid features should be enabled for the Agent pod.
 */}}
 {{- define "should-enable-host-pid" -}}
-{{- if and (not .Values.providers.gke.autopilot) (or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID .Values.datadog.useHostPID) -}}
+{{- if eq .Values.targetSystem "windows" -}}
+false
+{{- else if and (not .Values.providers.gke.autopilot) (or (eq  (include "should-enable-compliance" .) "true") .Values.datadog.dogstatsd.useHostPID .Values.datadog.useHostPID) -}}
 true
 {{- else -}}
 false


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix default `hostPid` value set to true on Windows.
Fix auth token path value on Windows.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
