### PR TITLE
[observability pipelines worker] 1.1.1 release

### DIFF
--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.1.0
 
+* Update `args` to use the `run` subcommand
+* Update default for `DATA_DIR`
 * `1.1.0` release
 
 ## 1.0.0

--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 1.1.0
+## 1.1.1
 
 * Update `args` to use the `run` subcommand
 * Update default for `DATA_DIR`
-* `1.1.0` release
+* `1.1.1` release
 
 ## 1.0.0
 

--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+* Fix `image.tag` value
+
 ## 1.0.0
 
 * GA release

--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 1.0.1
+## 1.1.0
 
-* Fix `image.tag` value
+* `1.1.0` release
 
 ## 1.0.0
 

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: "1.1.0"
+version: "1.1.1"
 description: Observability Pipelines Worker
 type: application
 keywords:

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: "1.0.1"
+version: "1.1.0"
 description: Observability Pipelines Worker
 type: application
 keywords:
@@ -13,11 +13,8 @@ icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
 maintainers:
   - name: Datadog
     email: support@datadoghq.com
-appVersion: "1.0.0"
+appVersion: "1"
 annotations:
-  artifacthub.io/images: |
-    - name: observability-pipelines-worker
-      image: gcr.io/datadoghq/observability-pipelines-worker:1.0.0
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: "1.0.0"
+version: "1.0.1"
 description: Observability Pipelines Worker
 type: application
 keywords:

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -81,7 +81,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Configure [affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). |
-| args | list | `["--config","/etc/opw/config.yaml"]` | Override default image arguments. |
+| args | list | `["run","/etc/opw/config.yaml"]` | Override default image arguments. |
 | autoscaling.behavior | object | `{}` | Configure separate scale-up and scale-down behaviors. |
 | autoscaling.enabled | bool | `false` | If **true**, create a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/). |
 | autoscaling.maxReplicas | int | `10` | Specify the maximum number of replicas. |

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -110,7 +110,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.pullPolicy | string | `"IfNotPresent"` | Specify the [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy). |
 | image.pullSecrets | list | `[]` | Specify the [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod). |
 | image.repository | string | `"gcr.io/datadoghq"` | Specify the image repository to use. |
-| image.tag | string | `"1.1.0"` | Specify the image tag to use. |
+| image.tag | string | `"1.1.1"` | Specify the image tag to use. |
 | ingress.annotations | object | `{}` | Specify annotations for the Ingress. |
 | ingress.className | string | `""` | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18. |
 | ingress.enabled | bool | `false` | If **true**, create an Ingress resource. |

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 
@@ -110,7 +110,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.pullPolicy | string | `"IfNotPresent"` | Specify the [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy). |
 | image.pullSecrets | list | `[]` | Specify the [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod). |
 | image.repository | string | `"gcr.io/datadoghq"` | Specify the image repository to use. |
-| image.tag | string | `"0.1.0"` | Specify the image tag to use. |
+| image.tag | string | `"1.0.0"` | Specify the image tag to use. |
 | ingress.annotations | object | `{}` | Specify annotations for the Ingress. |
 | ingress.className | string | `""` | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18. |
 | ingress.enabled | bool | `false` | If **true**, create an Ingress resource. |

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 
@@ -110,7 +110,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.pullPolicy | string | `"IfNotPresent"` | Specify the [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy). |
 | image.pullSecrets | list | `[]` | Specify the [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod). |
 | image.repository | string | `"gcr.io/datadoghq"` | Specify the image repository to use. |
-| image.tag | string | `"1.0.0"` | Specify the image tag to use. |
+| image.tag | string | `"1.1.0"` | Specify the image tag to use. |
 | ingress.annotations | object | `{}` | Specify annotations for the Ingress. |
 | ingress.className | string | `""` | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18. |
 | ingress.enabled | bool | `false` | If **true**, create an Ingress resource. |

--- a/charts/observability-pipelines-worker/ci/dupe-ports-values.yaml
+++ b/charts/observability-pipelines-worker/ci/dupe-ports-values.yaml
@@ -1,6 +1,4 @@
 config:
-  api:
-    enabled: false
   sources:
     syslog-tcp:
       type: syslog

--- a/charts/observability-pipelines-worker/ci/serviceHeadless-disabled.yaml
+++ b/charts/observability-pipelines-worker/ci/serviceHeadless-disabled.yaml
@@ -26,4 +26,3 @@ service:
   enabled: true
 serviceHeadless:
   enabled: false
-

--- a/charts/observability-pipelines-worker/ci/templated-config-values.yaml
+++ b/charts/observability-pipelines-worker/ci/templated-config-values.yaml
@@ -17,3 +17,7 @@ config:
       encoding:
         codec: json
       region: us-east-1
+service:
+  enabled: false
+serviceHeadless:
+  enabled: false

--- a/charts/observability-pipelines-worker/ci/templated-config-values.yaml
+++ b/charts/observability-pipelines-worker/ci/templated-config-values.yaml
@@ -1,15 +1,13 @@
 config:
   data_dir: /data
-  healthchecks:
-    enabled: false
   sources:
-    generator:
-      type: generator
+    demo_logs:
+      type: demo_logs
       format: json
   sinks:
     s3:
       type: aws_s3
-      inputs: [generator]
+      inputs: [demo_logs]
       bucket: logs-archive
       key_prefix: >-
         {{ print "{{kubernetes.pod_labels.\"app.kubernetes.io/client-id\"}}/%Y/%m/%d/{{kubernetes.pod_name}}/" }}

--- a/charts/observability-pipelines-worker/ci/templated-config-values.yaml
+++ b/charts/observability-pipelines-worker/ci/templated-config-values.yaml
@@ -1,8 +1,5 @@
 config:
   data_dir: /data
-  api:
-    enabled: true
-    address: 127.0.0.1:8686
   healthchecks:
     enabled: false
   sources:

--- a/charts/observability-pipelines-worker/templates/_pod.tpl
+++ b/charts/observability-pipelines-worker/templates/_pod.tpl
@@ -80,7 +80,7 @@ containers:
 {{- end }}
     volumeMounts:
       - name: data
-        mountPath: "{{ .Values.config.data_dir | default "/var/lib/datadog-observability-pipelines-worker" }}"
+        mountPath: "{{ .Values.config.data_dir | default "/var/lib/observability-pipelines-worker" }}"
       - name: config
         mountPath: "/etc/opw/"
         readOnly: true

--- a/charts/observability-pipelines-worker/templates/_pod.tpl
+++ b/charts/observability-pipelines-worker/templates/_pod.tpl
@@ -80,7 +80,7 @@ containers:
 {{- end }}
     volumeMounts:
       - name: data
-        mountPath: "{{ .Values.config.data_dir | default "/var/lib/opw" }}"
+        mountPath: "{{ .Values.config.data_dir | default "/var/lib/datadog-observability-pipelines-worker" }}"
       - name: config
         mountPath: "/etc/opw/"
         readOnly: true

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -250,7 +250,7 @@ ingress:
 # config -- This section supports using Helm templates to populate dynamic values. See Observability Pipelines'
 # [configuration documentation](https://docs.datadoghq.com/observability_pipelines/reference/) for all options.
 config: {}
-#  data_dir: "/var/lib/datadog-observability-pipelines-worker"
+#  data_dir: "/var/lib/observability-pipelines-worker"
 #  sources:
 #    datadog_agents:
 #      type: datadog_agent

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -36,7 +36,7 @@ image:
   # image.name -- Specify the image name to use (relative to `image.repository`).
   name: observability-pipelines-worker
   # image.tag -- Specify the image tag to use.
-  tag: 1.0.0
+  tag: 1.1.0
   # image.digest -- (string) Specify the image digest to use; takes precedence over `image.tag`.
   digest:
   ## Currently, we offer images at:

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -120,7 +120,7 @@ command: []
 
 # args -- Override default image arguments.
 args:
-  - --config
+  - run
   - "/etc/opw/config.yaml"
 
 # env -- Define environment variables.
@@ -250,7 +250,7 @@ ingress:
 # config -- This section supports using Helm templates to populate dynamic values. See Observability Pipelines'
 # [configuration documentation](https://docs.datadoghq.com/observability_pipelines/reference/) for all options.
 config: {}
-#  data_dir: "/var/lib/opw/"
+#  data_dir: "/var/lib/datadog-observability-pipelines-worker"
 #  sources:
 #    datadog_agents:
 #      type: datadog_agent

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -36,7 +36,7 @@ image:
   # image.name -- Specify the image name to use (relative to `image.repository`).
   name: observability-pipelines-worker
   # image.tag -- Specify the image tag to use.
-  tag: 1.1.0
+  tag: 1.1.1
   # image.digest -- (string) Specify the image digest to use; takes precedence over `image.tag`.
   digest:
   ## Currently, we offer images at:

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -36,7 +36,7 @@ image:
   # image.name -- Specify the image name to use (relative to `image.repository`).
   name: observability-pipelines-worker
   # image.tag -- Specify the image tag to use.
-  tag: 0.1.0
+  tag: 1.0.0
   # image.digest -- (string) Specify the image digest to use; takes precedence over `image.tag`.
   digest:
   ## Currently, we offer images at:


### PR DESCRIPTION
#### What this PR does / why we need it:

~~The original PR intending to GA the chart and application missed the `image.tag` value, this wasn't a _huge_ deal as the `1.0.0` was a retag of the old `0.1.0` so by happy accident nothing was broken for users.
I've updated the release documentation to include this change as well, but also considering removing the number of places this needs to be updated to avoid future mistakes.~~

Repurposing for the upcoming release, given the we're moving past the `1.0` quickly. I also removed the extra places that needed version bumps to streamline releases.

#### Which issue this PR fixes

  - closes [OPB-806](https://datadoghq.atlassian.net/browse/OPB-608)
 
#### Special notes for your reviewer:

~~The image was incorrectly published as `v1.0.0`, this PR can't merge until the correct image has been released.~~

Awaiting the upcoming `1.1.1` release for OPW.

#### Checklist

- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
