### PR TITLE
ccdaniele/seccomp-imagepullpolicy-3.10.6

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.10.6
+
+* Includes the imagePullPolicy key for the seccomp-setup container template
+
 ## 3.10.5
 
 * Only expose the shared volume for the auth-token in non autopilot environments.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.10.5
+version: 3.10.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.10.5](https://img.shields.io/badge/Version-3.10.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.10.6](https://img.shields.io/badge/Version-3.10.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_system-probe-init.yaml
+++ b/charts/datadog/templates/_system-probe-init.yaml
@@ -1,6 +1,7 @@
 {{- define "system-probe-init" -}}
 - name: seccomp-setup
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
+  imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
   command:
   - cp
   - /etc/config/system-probe-seccomp.json


### PR DESCRIPTION
#### What this PR does / why we need it:

Includes the imagePullPolicy key for the seccomp-setup container template

#### Which issue this PR fixes

https://datadoghq.atlassian.net/browse/CONTECO-240 

#### Special notes for your reviewer:

Datadog chart, CHANGELOG, README updated- 3.10.6

