### PR TITLE
[CWS] Also mount tracefs for eBPF

### DIFF
--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -40,6 +40,9 @@
     - name: debugfs
       mountPath: /sys/kernel/debug
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+    - name: tracefs
+      mountPath: /sys/kernel/tracing
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -76,6 +76,9 @@
 - hostPath:
     path: /sys/kernel/debug
   name: debugfs
+- hostPath:
+    path: /sys/kernel/tracing
+  name: tracefs
 - name: sysprobe-socket-dir
   emptyDir: {}
 {{- if and (eq (include "runtime-compilation-enabled" .) "true") .Values.datadog.systemProbe.enableDefaultKernelHeadersPaths }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This will mount tracefs into `/sys/kernel/tracing`. Tracefs is needed for eBPF purposes. It should be already mounted on most systems, but sometimes it's mountet at /sys/kernel/debug/tracing, and sometimes it's not mounted at all.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
