### PR TITLE
Update datadog-crd chart to support cert manager

### DIFF
--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.5.9
+version: 0.6.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.1
+    {{- if .Values.migration.datadogAgents.useCertManager }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-serving-cert
+    {{- end }}
   creationTimestamp: null
   name: datadogagents.datadoghq.com
   labels:
@@ -12,6 +15,18 @@ metadata:
     app.kubernetes.io/name: '{{ include "datadog-crds.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'
 spec:
+  {{- if .Values.migration.datadogAgents.conversionWebhook.enabled }}
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: {{ .Values.migration.datadogAgents.conversionWebhook.namespace }}
+          name: {{ .Values.migration.datadogAgents.conversionWebhook.name }}
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  {{- end }}
   group: datadoghq.com
   names:
     kind: DatadogAgent

--- a/charts/datadog-crds/values.yaml
+++ b/charts/datadog-crds/values.yaml
@@ -12,7 +12,11 @@ crds:
 
 migration:
   datadogAgents:
-    # enabled: false # Will be used when we add the option to add the webhookConversion field in the CRD.
+    conversionWebhook:
+      enabled: false
+      name: datadog-operator-webhook-service
+      namespace: default
+    useCertManager: false
     version: "v1alpha1"
 
 # nameOverride -- Override name of app


### PR DESCRIPTION
#### What this PR does / why we need it:

I order to introduce a migration path for v1alpha1 users using the standard Certificate Manager, we need to add an annotation as well as document the webhook configuration.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
