### PR TITLE
add a parameter to enable remote configuration

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,19 +1,23 @@
 # Datadog changelog
 
-# 3.20.3
+## 3.21.0
+
+* Add `datadog.remoteConfiguration.enabled` parameter to enable remote configuration.
+
+## 3.20.3
 
 * Fix command script in linux init container to prevent blocking deployment in GKE Autopilot on Rapid release channel.
 * Only mount DogStatsD socket in non-Autopilot environments.
 
-# 3.20.2
+## 3.20.2
 
 * Fix R/W volume mounts for CRI on Windows
 
-# 3.20.1
+## 3.20.1
 
 * Fix command args in linux init container to prevent blocking deployment in GKE Autopilot.
 
-# 3.20.0
+## 3.20.0
 
 * Enable CWS network detections by default.
 
@@ -21,12 +25,12 @@
 
 * Fix R/W volume mounts in init containers on Windows
 
-# 3.19.1
+## 3.19.1
 
 * Mount emptyDir volumes in `/etc/datadog-agent` and `/tmp` to allow the cluster-agent to write files in those
   locations with read-only root filesystem.
 
-# 3.19.0
+## 3.19.0
 
 * Declare `readOnly` in volumeMounts.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.20.3
+version: 3.21.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.20.3](https://img.shields.io/badge/Version-3.20.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.21.0](https://img.shields.io/badge/Version-3.21.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -679,6 +679,7 @@ helm install <RELEASE_NAME> \
 | datadog.prometheusScrape.enabled | bool | `false` | Enable autodiscovering pods and services exposing prometheus metrics. |
 | datadog.prometheusScrape.serviceEndpoints | bool | `false` | Enable generating dedicated checks for service endpoints. |
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. |
+| datadog.remoteConfiguration.enabled | bool | `false` | Set to true to enable remote configuration. |
 | datadog.secretAnnotations | object | `{}` |  |
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |
 | datadog.secretBackend.command | string | `nil` | Configure the secret backend command, path to the secret backend binary. |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -149,6 +149,10 @@
       value: {{ .Values.datadog.expvarPort | quote }}
     {{- include "additional-env-entries" .Values.agents.containers.agent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.agent.envDict | indent 4 }}
+    {{- if .Values.datadog.remoteConfiguration.enabled }}
+    - name: DD_REMOTE_CONFIGURATION_ENABLED
+      value: "true"
+    {{- end }}
   volumeMounts:
     {{- if eq .Values.targetSystem "linux" }}
     - name: installinfo

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -53,6 +53,8 @@ data:
         enabled: {{ $.Values.datadog.securityAgent.runtime.syscallMonitor.enabled }}
       network:
         enabled: {{ $.Values.datadog.securityAgent.runtime.network.enabled }}
+      remote_configuration:
+        enabled: {{ if and .Values.datadog.securityAgent.runtime.enabled .Values.datadog.remoteConfiguration.enabled -}} true {{else -}} false {{end}}
 {{- if .Values.datadog.securityAgent.runtime.activityDump.enabled }}
       activity_dump:
         enabled: true

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -378,6 +378,10 @@ datadog:
   # datadog.leaderLeaseDuration -- Set the lease time for leader election in second
   leaderLeaseDuration:  # 60
 
+  remoteConfiguration:
+    # datadog.remoteConfiguration.enabled -- Set to true to enable remote configuration.
+    enabled: false
+
   ## Enable logs agent and provide custom configs
   logs:
     # datadog.logs.enabled -- Enables this to activate Datadog Agent log collection


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds a parameter to enable the remote configuration service of the agent.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
