### PR TITLE
feat: Expose admission webhook cert config

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.11.1
+
+* Add `Cluster-Agent` admission controller webhook certificate `validtyBound`, `expirationThreshold` and `secretName`.
+
 ## 3.11.0
 
 * Default `Agent` and `Cluster-Agent` image tags to `7.43.0`.

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -482,6 +482,10 @@ helm install <RELEASE_NAME> \
 | clusterAgent.admissionController.enabled | bool | `true` | Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods |
 | clusterAgent.admissionController.failurePolicy | string | `"Ignore"` | Set the failure policy for dynamic admission control.' |
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |
+| clusterAgent.admissionController.webhookCertificateOverrides.enabled | bool | `false` | Enable the admissionController webhook certificate config overrides |
+| clusterAgent.admissionController.webhookCertificateOverrides.expirationThreshold | int | `720` | Set the admission controller webhook certificate expiration threshold. |
+| clusterAgent.admissionController.webhookCertificateOverrides.secretName | string | `"webhook-certificate"` | Set the admission controller webhook certificate k8s secret name. |
+| clusterAgent.admissionController.webhookCertificateOverrides.validityBound | int | `8760` | Set the admission controller webhook certificate validity. |
 | clusterAgent.advancedConfd | object | `{}` | Provide additional cluster check configurations. Each key is an integration containing several config files. |
 | clusterAgent.affinity | object | `{}` | Allow the Cluster Agent Deployment to schedule using affinity rules |
 | clusterAgent.command | list | `[]` | Command to run in the Cluster Agent container as entrypoint |

--- a/charts/datadog/ci/cluster-agent-admission-controller-values.yaml
+++ b/charts/datadog/ci/cluster-agent-admission-controller-values.yaml
@@ -6,3 +6,8 @@ clusterAgent:
   admissionController:
     enabled: true
     mutateUnlabelled: true
+  webhookCertificateOverrides:
+    enabled: true
+    validityBound: 8760
+    expirationThreshold: 720
+    secretName: webhook-certificate

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -175,6 +175,14 @@ spec:
           {{- end }}
           - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
             value: {{ .Values.clusterAgent.admissionController.failurePolicy | quote }}
+          {{- if .Values.clusterAgent.admissionController.webhookCertificateOverrides.enabled }}
+          - name: DD_ADMISSION_CONTROLLER_CERTIFICATE_VALIDITY_BOUND
+            value: {{ .Values.clusterAgent.admissionController.webhookCertificateOverrides.validyBound | quote }}
+          - name: DD_ADMISSION_CONTROLLER_CERTIFICATE_EXPIRATION_THRESHOLD
+            value: {{ .Values.clusterAgent.admissionController.webhookCertificateOverrides.expirationThreshold | quote }}
+          - name: DD_ADMISSION_CONTROLLER_CERTIFICATE_SECRET_NAME
+            value: {{ .Values.clusterAgent.admissionController.webhookCertificateOverrides.secretName }}
+          {{- end }}
           {{- end }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -931,6 +931,28 @@ clusterAgent:
     ## Setting to Fail will require the admission controller to be present and pods to be injected before they are allowed to run.
     failurePolicy: Ignore
 
+    webhookCertificateOverrides:
+      # clusterAgent.admissionController.webhookCertificateOverrides.enabled -- Enable the admissionController webhook certificate config overrides
+      enabled: false
+
+      # clusterAgent.admissionController.webhookCertificateOverrides.validityBound -- Set the admission controller webhook certificate validity.
+
+      ## Translates to DD_ADMISSION_CONTROLLER_CERTIFICATE_VALIDITY_BOUND on cluster agent.
+      ## The certificate's validity bound in hours, default 1 year (365*24).
+      validityBound: 8760
+
+      # clusterAgent.admissionController.webhookCertificateOverrides.expirationThreshold -- Set the admission controller webhook certificate expiration threshold.
+
+      ## Translates to DD_ADMISSION_CONTROLLER_CERTIFICATE_EXPIRATION_THRESHOLD on cluster agent.
+      ## The certificate's refresh threshold in hours, default 1 month (30*24).
+      expirationThreshold: 720
+
+      # clusterAgent.admissionController.webhookCertificateOverrides.secretName -- Set the admission controller webhook certificate k8s secret name.
+
+      ## Translates to DD_ADMISSION_CONTROLLER_CERTIFICATE_SECRET_NAME on cluster agent.
+      ## Name of the Secret object containing the webhook certificate.
+      secretName: webhook-certificate
+
   # clusterAgent.confd -- Provide additional cluster check configurations. Each key will become a file in /conf.d.
 
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/


### PR DESCRIPTION
#### What this PR does / why we need it:

Exposes Cluster Agent Admission Controller webhook certificate-related env config.

#### Special notes for your reviewer:
None.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
