### PR TITLE
Update Cilium Egress rule to kube-apiserver

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.16.2
+
+* Fix Cilium egress rules to kube-apiserver entities.
+
 ## 3.16.1
 
 * Fix `cluster-agent` deployment to allow the cluster-agent to write file in `/var/log/datadog` when it runs with

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.16.1
+version: 3.16.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.16.1](https://img.shields.io/badge/Version-3.16.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.16.2](https://img.shields.io/badge/Version-3.16.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-cilium-network-policy.yaml
+++ b/charts/datadog/templates/cluster-agent-cilium-network-policy.yaml
@@ -80,6 +80,7 @@ specs:
       # When the control plane is on the same cluster, we must allow connections
       # to the node entity.
       - toEntities:
+          - kube-apiserver
           - host
           - remote-node
         toPorts:

--- a/charts/datadog/templates/kube-state-metrics-cilium-network-policy.yaml
+++ b/charts/datadog/templates/kube-state-metrics-cilium-network-policy.yaml
@@ -22,6 +22,7 @@ specs:
       # When the control plane is on the same cluster, we must allow connections
       # to the node entity.
       - toEntities:
+          - kube-apiserver
           - host
           - remote-node
         toPorts:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR focus to update cilium egress rules to Kubernetes API server.
#### Which issue this PR fixes
#927 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
