### PR TITLE
Add automountServiceAccountToken option

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.12.0
+
+* Add `automountServiceAccountToken` option to configure automatic mounting of ServiceAccount's API credentials
+
 ## 3.11.0
 
 * Default `Agent` and `Cluster-Agent` image tags to `7.43.0`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.11.0
+version: 3.12.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.11.0](https://img.shields.io/badge/Version-3.11.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.12.0](https://img.shields.io/badge/Version-3.12.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -466,6 +466,7 @@ helm install <RELEASE_NAME> \
 | agents.priorityClassName | string | `nil` | Sets PriorityClassName if defined |
 | agents.priorityClassValue | int | `1000000000` | Value used to specify the priority of the scheduling of Datadog Agent's Daemonset pods. |
 | agents.priorityPreemptionPolicyValue | string | `"PreemptLowerPriority"` | Set to "Never" to change the PriorityClass to non-preempting |
+| agents.rbac.automountServiceAccountToken | bool | `true` | If true, automatically mount the ServiceAccount's API credentials if agents.rbac.create is true |
 | agents.rbac.create | bool | `true` | If true, create & use RBAC resources |
 | agents.rbac.serviceAccountAnnotations | object | `{}` | Annotations to add to the ServiceAccount if agents.rbac.create is true |
 | agents.rbac.serviceAccountName | string | `"default"` | Specify a preexisting ServiceAccount to use if agents.rbac.create is false |
@@ -517,6 +518,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.podSecurity.podSecurityPolicy.create | bool | `false` | If true, create a PodSecurityPolicy resource for Cluster Agent pods |
 | clusterAgent.podSecurity.securityContextConstraints.create | bool | `false` | If true, create a SCC resource for Cluster Agent pods |
 | clusterAgent.priorityClassName | string | `nil` | Name of the priorityClass to apply to the Cluster Agent |
+| clusterAgent.rbac.automountServiceAccountToken | bool | `true` | If true, automatically mount the ServiceAccount's API credentials if clusterAgent.rbac.create is true |
 | clusterAgent.rbac.create | bool | `true` | If true, create & use RBAC resources |
 | clusterAgent.rbac.serviceAccountAnnotations | object | `{}` | Annotations to add to the ServiceAccount if clusterAgent.rbac.create is true |
 | clusterAgent.rbac.serviceAccountName | string | `"default"` | Specify a preexisting ServiceAccount to use if clusterAgent.rbac.create is false |
@@ -555,6 +557,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.podAnnotations | object | `{}` | Annotations to add to the cluster-checks-runner's pod(s) |
 | clusterChecksRunner.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | clusterChecksRunner.priorityClassName | string | `nil` | Name of the priorityClass to apply to the Cluster checks runners |
+| clusterChecksRunner.rbac.automountServiceAccountToken | bool | `true` | If true, automatically mount the ServiceAccount's API credentials if clusterChecksRunner.rbac.create is true |
 | clusterChecksRunner.rbac.create | bool | `true` | If true, create & use RBAC resources |
 | clusterChecksRunner.rbac.dedicated | bool | `false` | If true, use a dedicated RBAC resource for the cluster checks agent(s) |
 | clusterChecksRunner.rbac.serviceAccountAnnotations | object | `{}` | Annotations to add to the ServiceAccount if clusterChecksRunner.rbac.dedicated is true |

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -55,7 +55,7 @@ spec:
       serviceAccountName: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}
       {{- end }}
       {{- if .Values.clusterChecksRunner.rbac.create  }}
-      automountServiceAccountToken: {{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken | default "true" }}
+      automountServiceAccountToken: {{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken }}
       {{- end }}
       imagePullSecrets:
 {{ toYaml .Values.clusterChecksRunner.image.pullSecrets | indent 8 }}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -54,7 +54,7 @@ spec:
       {{- else }}
       serviceAccountName: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}
       {{- end }}
-      automountServiceAccountToken: {{ if .Values.clusterChecksRunner.rbac.create  }}{{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken }}{{ end }}
+      automountServiceAccountToken: {{ if .Values.clusterChecksRunner.rbac.create  }}{{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken | default "true" }}{{ end }}
       imagePullSecrets:
 {{ toYaml .Values.clusterChecksRunner.image.pullSecrets | indent 8 }}
       {{- if .Values.clusterChecksRunner.priorityClassName }}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -54,7 +54,9 @@ spec:
       {{- else }}
       serviceAccountName: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}
       {{- end }}
-      automountServiceAccountToken: {{ if .Values.clusterChecksRunner.rbac.create  }}{{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken | default "true" }}{{ end }}
+      {{- if .Values.clusterChecksRunner.rbac.create  }}
+      automountServiceAccountToken: {{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken | default "true" }}
+      {{- end }}
       imagePullSecrets:
 {{ toYaml .Values.clusterChecksRunner.image.pullSecrets | indent 8 }}
       {{- if .Values.clusterChecksRunner.priorityClassName }}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -54,6 +54,7 @@ spec:
       {{- else }}
       serviceAccountName: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}
       {{- end }}
+      automountServiceAccountToken: {{ if .Values.clusterChecksRunner.rbac.create  }}{{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken }}{{ end }}
       imagePullSecrets:
 {{ toYaml .Values.clusterChecksRunner.image.pullSecrets | indent 8 }}
       {{- if .Values.clusterChecksRunner.priorityClassName }}

--- a/charts/datadog/templates/agent-clusterchecks-rbac.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-rbac.yaml
@@ -16,6 +16,7 @@ subjects:
 ---
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken }}
 metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}

--- a/charts/datadog/templates/agent-clusterchecks-rbac.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-rbac.yaml
@@ -16,7 +16,7 @@ subjects:
 ---
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: {{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken | default "true" }}
+automountServiceAccountToken: {{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken }}
 metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}

--- a/charts/datadog/templates/agent-clusterchecks-rbac.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-rbac.yaml
@@ -16,7 +16,7 @@ subjects:
 ---
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: {{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.clusterChecksRunner.rbac.automountServiceAccountToken | default "true" }}
 metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -78,6 +78,7 @@ spec:
 {{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}
       {{- end }}
       serviceAccountName: {{ if .Values.clusterAgent.rbac.create }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.rbac.serviceAccountName }}"{{ end }}
+      automountServiceAccountToken: {{ if .Values.clusterAgent.rbac.create  }}{{ .Values.clusterAgent.rbac.automountServiceAccountToken }}{{ end }}
       {{- if .Values.clusterAgent.useHostNetwork }}
       hostNetwork: {{ .Values.clusterAgent.useHostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -79,7 +79,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ if .Values.clusterAgent.rbac.create }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.rbac.serviceAccountName }}"{{ end }}
       {{- if .Values.clusterAgent.rbac.create  }}
-      automountServiceAccountToken: {{ .Values.clusterAgent.rbac.automountServiceAccountToken | default "true" }}
+      automountServiceAccountToken: {{ .Values.clusterAgent.rbac.automountServiceAccountToken }}
       {{- end }}
       {{- if .Values.clusterAgent.useHostNetwork }}
       hostNetwork: {{ .Values.clusterAgent.useHostNetwork }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -78,7 +78,7 @@ spec:
 {{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}
       {{- end }}
       serviceAccountName: {{ if .Values.clusterAgent.rbac.create }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.rbac.serviceAccountName }}"{{ end }}
-      automountServiceAccountToken: {{ if .Values.clusterAgent.rbac.create  }}{{ .Values.clusterAgent.rbac.automountServiceAccountToken }}{{ end }}
+      automountServiceAccountToken: {{ if .Values.clusterAgent.rbac.create  }}{{ .Values.clusterAgent.rbac.automountServiceAccountToken | default "true" }}{{ end }}
       {{- if .Values.clusterAgent.useHostNetwork }}
       hostNetwork: {{ .Values.clusterAgent.useHostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -78,7 +78,9 @@ spec:
 {{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}
       {{- end }}
       serviceAccountName: {{ if .Values.clusterAgent.rbac.create }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.rbac.serviceAccountName }}"{{ end }}
-      automountServiceAccountToken: {{ if .Values.clusterAgent.rbac.create  }}{{ .Values.clusterAgent.rbac.automountServiceAccountToken | default "true" }}{{ end }}
+      {{- if .Values.clusterAgent.rbac.create  }}
+      automountServiceAccountToken: {{ .Values.clusterAgent.rbac.automountServiceAccountToken | default "true" }}
+      {{- end }}
       {{- if .Values.clusterAgent.useHostNetwork }}
       hostNetwork: {{ .Values.clusterAgent.useHostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -287,6 +287,7 @@ subjects:
 ---
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.clusterAgent.rbac.automountServiceAccountToken }}
 metadata:
   labels:
     app: "{{ template "datadog.fullname" . }}"

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -287,7 +287,7 @@ subjects:
 ---
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: {{ .Values.clusterAgent.rbac.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.clusterAgent.rbac.automountServiceAccountToken | default "true" }}
 metadata:
   labels:
     app: "{{ template "datadog.fullname" . }}"

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -287,7 +287,7 @@ subjects:
 ---
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: {{ .Values.clusterAgent.rbac.automountServiceAccountToken | default "true" }}
+automountServiceAccountToken: {{ .Values.clusterAgent.rbac.automountServiceAccountToken }}
 metadata:
   labels:
     app: "{{ template "datadog.fullname" . }}"

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -173,6 +173,7 @@ spec:
       affinity:
 {{ toYaml .Values.agents.affinity | indent 8 }}
       serviceAccountName: {{ include "agents.serviceAccountName" . | quote }}
+      automountServiceAccountToken: {{ if .Values.agents.rbac.create }}{{.Values.agents.rbac.automountServiceAccountToken }}{{ end }}
       nodeSelector:
         {{ template "label.os" . }}: {{ .Values.targetSystem }}
       {{- if .Values.agents.nodeSelector }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -173,7 +173,7 @@ spec:
       affinity:
 {{ toYaml .Values.agents.affinity | indent 8 }}
       serviceAccountName: {{ include "agents.serviceAccountName" . | quote }}
-      automountServiceAccountToken: {{ if .Values.agents.rbac.create }}{{.Values.agents.rbac.automountServiceAccountToken }}{{ end }}
+      automountServiceAccountToken: {{ if .Values.agents.rbac.create }}{{.Values.agents.rbac.automountServiceAccountToken | default "true" }}{{ end }}
       nodeSelector:
         {{ template "label.os" . }}: {{ .Values.targetSystem }}
       {{- if .Values.agents.nodeSelector }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -174,7 +174,7 @@ spec:
 {{ toYaml .Values.agents.affinity | indent 8 }}
       serviceAccountName: {{ include "agents.serviceAccountName" . | quote }}
       {{- if .Values.agents.rbac.create }}
-      automountServiceAccountToken: {{.Values.agents.rbac.automountServiceAccountToken | default "true" }}
+      automountServiceAccountToken: {{.Values.agents.rbac.automountServiceAccountToken }}
       {{- end }}
       nodeSelector:
         {{ template "label.os" . }}: {{ .Values.targetSystem }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -173,7 +173,9 @@ spec:
       affinity:
 {{ toYaml .Values.agents.affinity | indent 8 }}
       serviceAccountName: {{ include "agents.serviceAccountName" . | quote }}
-      automountServiceAccountToken: {{ if .Values.agents.rbac.create }}{{.Values.agents.rbac.automountServiceAccountToken | default "true" }}{{ end }}
+      {{- if .Values.agents.rbac.create }}
+      automountServiceAccountToken: {{.Values.agents.rbac.automountServiceAccountToken | default "true" }}
+      {{- end }}
       nodeSelector:
         {{ template "label.os" . }}: {{ .Values.targetSystem }}
       {{- if .Values.agents.nodeSelector }}

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -129,6 +129,7 @@ subjects:
 ---
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.agents.rbac.automountServiceAccountToken }}
 metadata:
   name: {{ include "agents.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -129,7 +129,7 @@ subjects:
 ---
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: {{ .Values.agents.rbac.automountServiceAccountToken | default "true" }}
+automountServiceAccountToken: {{ .Values.agents.rbac.automountServiceAccountToken }}
 metadata:
   name: {{ include "agents.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -129,7 +129,7 @@ subjects:
 ---
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: {{ .Values.agents.rbac.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.agents.rbac.automountServiceAccountToken | default "true" }}
 metadata:
   name: {{ include "agents.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -854,6 +854,9 @@ clusterAgent:
     # clusterAgent.rbac.serviceAccountAnnotations -- Annotations to add to the ServiceAccount if clusterAgent.rbac.create is true
     serviceAccountAnnotations: {}
 
+    # clusterAgent.rbac.automountServiceAccountToken -- If true, automatically mount the ServiceAccount's API credentials if clusterAgent.rbac.create is true
+    automountServiceAccountToken: true
+
   ## Provide Cluster Agent pod security configuration
   podSecurity:
     podSecurityPolicy:
@@ -1159,6 +1162,9 @@ agents:
 
     # agents.rbac.serviceAccountAnnotations -- Annotations to add to the ServiceAccount if agents.rbac.create is true
     serviceAccountAnnotations: {}
+
+    # agents.rbac.automountServiceAccountToken -- If true, automatically mount the ServiceAccount's API credentials if agents.rbac.create is true
+    automountServiceAccountToken: true
 
   ## Provide Daemonset PodSecurityPolicy configuration
   podSecurity:
@@ -1594,6 +1600,9 @@ clusterChecksRunner:
 
     # clusterChecksRunner.rbac.serviceAccountAnnotations -- Annotations to add to the ServiceAccount if clusterChecksRunner.rbac.dedicated is true
     serviceAccountAnnotations: {}
+
+    # clusterChecksRunner.rbac.automountServiceAccountToken -- If true, automatically mount the ServiceAccount's API credentials if clusterChecksRunner.rbac.create is true
+    automountServiceAccountToken: true
 
     # clusterChecksRunner.rbac.serviceAccountName -- Specify a preexisting ServiceAccount to use if clusterChecksRunner.rbac.create is false
     serviceAccountName: default


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `automountServiceAccountToken` to the agent, cluster-agent and clustercheck runner chart templates. By default, the option is set to True. This new option allows users to configure whether the created RBAC ServiceAccount token should be mounted.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
