### PR TITLE
Update volumeMounts with `readOnly` fields

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 3.12.1
+
+* Declare `readOnly` in volumeMounts.
+
 ## 3.12.0
 
 * Add `automountServiceAccountToken` option to configure automatic mounting of ServiceAccount's API credentials

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.12.0
+version: 3.12.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.15.0](https://img.shields.io/badge/Version-3.15.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.15.1](https://img.shields.io/badge/Version-3.15.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.12.0](https://img.shields.io/badge/Version-3.12.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.12.1](https://img.shields.io/badge/Version-3.12.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -180,6 +180,7 @@
     {{- if eq .Values.targetSystem "linux" }}
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
+      readOnly: false
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -189,6 +189,7 @@
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml
+      readOnly: true
     {{- end }}
     - name: procdir
       mountPath: /host/proc

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -156,6 +156,7 @@
       readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog
+      readOnly: false
     - name: tmpdir
       mountPath: /tmp
       readOnly: false

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -199,6 +199,7 @@
     - name: pointerdir
       mountPath: /opt/datadog-agent/run
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: false
     - name: logpodpath
       mountPath: /var/log/pods
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
@@ -219,6 +220,7 @@
     {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
     - name: pointerdir
       mountPath: C:/var/log
+      readOnly: false
     - name: logpodpath
       mountPath: C:/var/log/pods
       readOnly: true

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -156,19 +156,19 @@
       readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog
-      readOnly: false
+      readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp
-      readOnly: false
+      readOnly: false # Need RW to write to /tmp directory
     {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
     {{- end }}
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
-      readOnly: false
+      readOnly: false # Need RW to mount to config path
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
-      readOnly: false
+      readOnly: false # Need RW to write auth token
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
@@ -203,7 +203,7 @@
     - name: pointerdir
       mountPath: /opt/datadog-agent/run
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: false
+      readOnly: false # Need RW for logs pointer
     - name: logpodpath
       mountPath: /var/log/pods
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
@@ -224,7 +224,7 @@
     {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
     - name: pointerdir
       mountPath: C:/var/log
-      readOnly: false
+      readOnly: false # Need RW for logs pointer
     - name: logpodpath
       mountPath: C:/var/log/pods
       readOnly: true

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -163,6 +163,7 @@
     {{- end }}
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
+      readOnly: false
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -176,6 +176,7 @@
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
+      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     - name: dsdsocket

--- a/charts/datadog/templates/_container-cri-volumemounts.yaml
+++ b/charts/datadog/templates/_container-cri-volumemounts.yaml
@@ -9,9 +9,11 @@
 {{- if eq .Values.targetSystem "windows" }}
 - name: runtimesocket
   mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
+  readOnly: true
 {{- if not .Values.datadog.criSocketPath }}
 - name: containerdsocket 
   mountPath: \\.\pipe\containerd-containerd
+  readOnly: true
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -64,6 +64,7 @@
     {{- end }}
     - name: logdatadog
       mountPath: /var/log/datadog
+      readOnly: false
     - name: tmpdir
       mountPath: /tmp
       readOnly: false

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -76,6 +76,7 @@
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
+      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     - name: cgroups

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -100,6 +100,7 @@
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml
+      readOnly: true
     {{- end }}
     {{- end }}
     {{- if .Values.datadog.kubelet.hostCAPath }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -64,10 +64,10 @@
     {{- end }}
     - name: logdatadog
       mountPath: /var/log/datadog
-      readOnly: false
+      readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp
-      readOnly: false
+      readOnly: false # Need RW to write to tmp directory
     {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
@@ -92,7 +92,7 @@
       readOnly: true
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-      readOnly: false
+      readOnly: false # Need RW for UDS DSD socket
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -92,7 +92,7 @@
       readOnly: true
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-      readOnly: true
+      readOnly: false
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -55,6 +55,7 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
+      readOnly: true
     {{- if eq .Values.targetSystem "linux" }}
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -116,6 +116,7 @@
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml
+      readOnly: true
     {{- end }}
     {{- end }}
 {{- if .Values.agents.volumeMounts }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -61,6 +61,7 @@
     {{- if eq .Values.targetSystem "linux" }}
     - name: logdatadog
       mountPath: /var/log/datadog
+      readOnly: false
     - name: tmpdir
       mountPath: /tmp
       readOnly: false

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -61,13 +61,13 @@
     {{- if eq .Values.targetSystem "linux" }}
     - name: logdatadog
       mountPath: /var/log/datadog
-      readOnly: false
+      readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp
-      readOnly: false
+      readOnly: false # Need RW to write to tmp directory
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-      readOnly: false
+      readOnly: false # Need RW for UDS DSD socket
     {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -52,6 +52,7 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
+      readOnly: true
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -76,6 +76,7 @@
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
+      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     {{- if .Values.datadog.securityAgent.compliance.enabled }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -67,7 +67,7 @@
       readOnly: false
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-      readOnly: true
+      readOnly: false
     {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -55,8 +55,10 @@
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml
+      readOnly: true
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
+      readOnly: false
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
@@ -106,6 +108,7 @@
     - name: runtime-compiler-output-dir
       mountPath: {{ .Values.datadog.systemProbe.runtimeCompilationAssetDir }}/build
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
     - name: kernel-headers-download-dir
       mountPath: {{ .Values.datadog.systemProbe.runtimeCompilationAssetDir }}/kernel-headers
       readOnly: false

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -34,14 +34,14 @@
       readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog
-      readOnly: false
+      readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp
-      readOnly: false
+      readOnly: false # Need RW for tmp directory to instantiate self tests
     - name: debugfs
       mountPath: /sys/kernel/debug
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: false
+      readOnly: false # Need RW for kprobe_events
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
       readOnly: true
@@ -58,7 +58,7 @@
       readOnly: true
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
-      readOnly: false
+      readOnly: false # Need RW for sys-probe socket
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
@@ -111,7 +111,7 @@
       readOnly: true
     - name: kernel-headers-download-dir
       mountPath: {{ .Values.datadog.systemProbe.runtimeCompilationAssetDir }}/kernel-headers
-      readOnly: false
+      readOnly: false # Need RW for sys-probe kernel headers
 {{- if not .Values.datadog.systemProbe.mountPackageManagementDirs }}
     - name: apt-config-dir
       mountPath: /host/etc/apt

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -41,7 +41,7 @@
     - name: debugfs
       mountPath: /sys/kernel/debug
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
+      readOnly: false
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
       readOnly: true

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -50,6 +50,7 @@
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
+      readOnly: true
     {{- end }}
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -42,6 +42,7 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
+      readOnly: true
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.useConfigMap }}
     - name: datadog-yaml

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -34,6 +34,7 @@
       readOnly: true
     - name: logdatadog
       mountPath: /var/log/datadog
+      readOnly: false
     - name: tmpdir
       mountPath: /tmp
       readOnly: false

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -109,7 +109,7 @@
     - name: runtime-compiler-output-dir
       mountPath: {{ .Values.datadog.systemProbe.runtimeCompilationAssetDir }}/build
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
+      readOnly: false
     - name: kernel-headers-download-dir
       mountPath: {{ .Values.datadog.systemProbe.runtimeCompilationAssetDir }}/kernel-headers
       readOnly: false # Need RW for sys-probe kernel headers

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -41,6 +41,7 @@
     - name: debugfs
       mountPath: /sys/kernel/debug
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
       readOnly: true

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -53,6 +53,7 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
+      readOnly: true
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -63,6 +63,7 @@
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
+      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     {{- if not .Values.providers.gke.autopilot }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -83,9 +83,11 @@
       readOnly: false
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
+      readOnly: false
     {{- if and (eq (include "trace-agent-use-uds" .) "true") (ne (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath)) }}
     - name: apmsocket
       mountPath: {{ (dir .Values.datadog.apm.socketPath) }}
+      readOnly: false
     {{- end }}
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -77,6 +77,7 @@
     {{- end }}
     - name: logdatadog
       mountPath: /var/log/datadog
+      readOnly: false
     - name: tmpdir
       mountPath: /tmp
       readOnly: false

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -78,17 +78,17 @@
     {{- end }}
     - name: logdatadog
       mountPath: /var/log/datadog
-      readOnly: false
+      readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp
-      readOnly: false
+      readOnly: false # Need RW for tmp directory
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-      readOnly: false
+      readOnly: false # Need RW for UDS DSD socket
     {{- if and (eq (include "trace-agent-use-uds" .) "true") (ne (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath)) }}
     - name: apmsocket
       mountPath: {{ (dir .Values.datadog.apm.socketPath) }}
-      readOnly: false
+      readOnly: false # Need RW for UDS APM socket
     {{- end }}
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -23,6 +23,7 @@
       readOnly: false
     - name: config
       mountPath: /etc/datadog-agent
+      readOnly: false
     {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
     - name: confd
       mountPath: /conf.d

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -8,6 +8,7 @@
   volumeMounts:
     - name: config
       mountPath: /opt/datadog-agent
+      readOnly: false
   resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 4 }}
 - name: init-config

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -42,6 +42,7 @@
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml
+      readOnly: true
     {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -8,7 +8,7 @@
   volumeMounts:
     - name: config
       mountPath: /opt/datadog-agent
-      readOnly: false
+      readOnly: false # Need RW for config path
   resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 4 }}
 - name: init-config
@@ -20,10 +20,10 @@
   volumeMounts:
     - name: logdatadog
       mountPath: /var/log/datadog
-      readOnly: false
+      readOnly: false # Need RW to write logs
     - name: config
       mountPath: /etc/datadog-agent
-      readOnly: false
+      readOnly: false # Need RW for config path
     {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
     - name: confd
       mountPath: /conf.d

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -19,6 +19,7 @@
   volumeMounts:
     - name: logdatadog
       mountPath: /var/log/datadog
+      readOnly: false
     - name: config
       mountPath: /etc/datadog-agent
     {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}

--- a/charts/datadog/templates/_containers-init-windows.yaml
+++ b/charts/datadog/templates/_containers-init-windows.yaml
@@ -25,7 +25,7 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
-      readOnly: false
+      readOnly: false # Need RW for config path
     {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
     - name: confd
       mountPath: C:/conf.d

--- a/charts/datadog/templates/_containers-init-windows.yaml
+++ b/charts/datadog/templates/_containers-init-windows.yaml
@@ -25,7 +25,7 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
-      #readOnly: true
+      readOnly: false
     {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
     - name: confd
       mountPath: C:/conf.d

--- a/charts/datadog/templates/_containers-init-windows.yaml
+++ b/charts/datadog/templates/_containers-init-windows.yaml
@@ -10,10 +10,10 @@
   volumeMounts:
     - name: config
       mountPath: C:/Temp/Datadog
-      #readOnly: true
+      readOnly: true
     - name: installinfo
       mountPath: C:/Temp/install_info
-      #readOnly: true
+      readOnly: true
   resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 4 }}
 - name: init-config

--- a/charts/datadog/templates/_containers-init-windows.yaml
+++ b/charts/datadog/templates/_containers-init-windows.yaml
@@ -10,8 +10,10 @@
   volumeMounts:
     - name: config
       mountPath: C:/Temp/Datadog
+      #readOnly: true
     - name: installinfo
       mountPath: C:/Temp/install_info
+      #readOnly: true
   resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 4 }}
 - name: init-config
@@ -23,6 +25,7 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
+      #readOnly: true
     {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
     - name: confd
       mountPath: C:/conf.d

--- a/charts/datadog/templates/_system-probe-init.yaml
+++ b/charts/datadog/templates/_system-probe-init.yaml
@@ -13,7 +13,7 @@
   - name: seccomp-root
     mountPath: /host/var/lib/kubelet/seccomp
     mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-    readOnly: false
+    readOnly: false # Need RW for seccomp-root
   resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 4 }}
 {{- end -}}

--- a/charts/datadog/templates/_system-probe-init.yaml
+++ b/charts/datadog/templates/_system-probe-init.yaml
@@ -9,9 +9,11 @@
   volumeMounts:
   - name: datadog-agent-security
     mountPath: /etc/config
+    readOnly: true
   - name: seccomp-root
     mountPath: /host/var/lib/kubelet/seccomp
     mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+    readOnly: false
   resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 4 }}
 {{- end -}}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -80,6 +80,7 @@ spec:
         volumeMounts:
           - name: config
             mountPath: /opt/datadog-agent
+            readOnly: false
         resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 10 }}
       - name: init-config

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         volumeMounts:
           - name: config
             mountPath: /opt/datadog-agent
-            readOnly: false
+            readOnly: false # Need RW for writing agent config files
         resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 10 }}
       - name: init-config
@@ -92,7 +92,7 @@ spec:
         volumeMounts:
           - name: config
             mountPath: /etc/datadog-agent
-            readOnly: false
+            readOnly: false # Need RW for writing datadog.yaml config file
           {{- if .Values.datadog.checksd }}
           - name: checksd
             mountPath: /checks.d
@@ -205,7 +205,7 @@ spec:
             readOnly: true
           - name: config
             mountPath: {{ template "datadog.confPath" . }}
-            readOnly: false
+            readOnly: false # Need RW for config path
 {{- if .Values.clusterChecksRunner.volumeMounts }}
 {{ toYaml .Values.clusterChecksRunner.volumeMounts | indent 10 }}
 {{- end }}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -92,6 +92,7 @@ spec:
         volumeMounts:
           - name: config
             mountPath: /etc/datadog-agent
+            readOnly: false
           {{- if .Values.datadog.checksd }}
           - name: checksd
             mountPath: /checks.d
@@ -204,6 +205,7 @@ spec:
             readOnly: true
           - name: config
             mountPath: {{ template "datadog.confPath" . }}
+            readOnly: false
 {{- if .Values.clusterChecksRunner.volumeMounts }}
 {{ toYaml .Values.clusterChecksRunner.volumeMounts | indent 10 }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Add `readOnly` option to all mounted volumes to improve security of the datadog-agent installation. Makes sure volumes are `readOnly: true` where possible and exceptions are noted with a reason. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
