### PR TITLE
fix(datadog): allow DCA to write logs

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Datadog changelog
 
+## 3.16.1
+
+* Fix `cluster-agent` deployment to allow the cluster-agent to write file in `/var/log/datadog` when it runs with
+  read-only root filesystem.
+
+## 3.16.0
+
+* Add new checksum to cluster agent deployment base on all cluster-agent configmap configuration.
+
 ## 3.15.0
 
 * Beta: Enable remote configuration if `clusterAgent.admissionController.remoteInstrumentation` is enabled.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.16.0
+version: 3.16.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.16.0](https://img.shields.io/badge/Version-3.16.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.16.1](https://img.shields.io/badge/Version-3.16.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -266,6 +266,9 @@ spec:
 {{ toYaml .Values.clusterAgent.containers.clusterAgent.securityContext | indent 10 }}
 {{- end }}
         volumeMounts:
+          - name: varlog
+            mountPath: /var/log/datadog
+            readOnly: false
           - name: installinfo
             subPath: install_info
             {{- if eq .Values.targetSystem "windows" }}
@@ -296,6 +299,8 @@ spec:
 {{- end}}
 {{- end}}
       volumes:
+        - name: varlog
+          emptyDir: {}
         - name: installinfo
           configMap:
             name: {{ include "agents-install-info-configmap-name" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add new EmptyDir in Cluster-Agent deployment to allow creation of log file in `/var/log/datadog` even when the container is using read-only root filesystem (since v3.14.0 helm chart)
* Add missing entry in the CHANGELOG for 3.16.0 datadog chart version.

#### Which issue this PR fixes

  - fixes #937

#### Special notes for your reviewer:

the change in 3.14.0 was tested on Kubernetes with containerd, and it was working, thanks to the fact that the `/var/log/datadog` folder is listed as a VOLUME  in the Dockerfile. So it seems that containerd set this folder a read/write even if the container is configured with root-only filesystem in the Pod spec.

Openshift (and so maybe CRIO) seems to not have the same behaviour. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] Chart Version bumped
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
