### PR TITLE
[datadog] Make `/opt/datadog-agent/run` writable by the cluster agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.16.2
+
+* Mount an emptyDir volume in `/opt/datadog-agent/run` to allow the cluster-agent to write files in that location
+  with read-only root filesystem.
+
 ## 3.16.1
 
 * Fix `cluster-agent` deployment to allow the cluster-agent to write file in `/var/log/datadog` when it runs with

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.16.1
+version: 3.16.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.16.1](https://img.shields.io/badge/Version-3.16.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.16.2](https://img.shields.io/badge/Version-3.16.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -266,6 +266,9 @@ spec:
 {{ toYaml .Values.clusterAgent.containers.clusterAgent.securityContext | indent 10 }}
 {{- end }}
         volumeMounts:
+          - name: datadogrun
+            mountPath: /opt/datadog-agent/run
+            readOnly: false
           - name: varlog
             mountPath: /var/log/datadog
             readOnly: false
@@ -299,6 +302,8 @@ spec:
 {{- end}}
 {{- end}}
       volumes:
+        - name: datadogrun
+          emptyDir: {}
         - name: varlog
           emptyDir: {}
         - name: installinfo


### PR DESCRIPTION
#### What this PR does / why we need it:

Mount an `emptyDir` volume at `/opt/datadog-agent/run` in the cluster-agent container to allow it to write files there even when running with a read-only root filesystem.

#### Which issue this PR fixes

```
2023-03-08 14:16:58 UTC | CLUSTER | ERROR | (comp/core/log/logger.go:84 in Errorf) | Failed to start remote-configuration: unable to create remote-config service: failed to create rc db dir: (/opt/datadog-agent/run/remote-config.db): mkdir /opt/datadog-agent/run: read-only file system
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
