### PR TITLE
[datadog] make `/etc/datadog-agent` and `/tmp` writable by the cluster-agent.

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+# 3.19.1
+
+* Mount emptyDir volumes in `/etc/datadog-agent` and `/tmp` to allow the cluster-agent to write files in those
+  locations with read-only root filesystem.
+
 # 3.19.0
 
 * Declare `readOnly` in volumeMounts.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.19.0
+version: 3.19.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.19.0](https://img.shields.io/badge/Version-3.19.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.19.1](https://img.shields.io/badge/Version-3.19.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -2,9 +2,12 @@
 - name: init-volume
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command: ["bash", "-c"]
+  command:
+    - cp
   args:
-    - cp -r /etc/datadog-agent /opt
+    - -r
+    - /etc/datadog-agent
+    - /opt
   volumeMounts:
     - name: config
       mountPath: /opt/datadog-agent
@@ -14,9 +17,14 @@
 - name: init-config
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command: ["bash", "-c"]
+  command:
+    - bash
+    - -c
   args:
-    - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+    - |
+      for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort); do
+        bash $script
+      done
   volumeMounts:
     - name: logdatadog
       mountPath: /var/log/datadog

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -94,6 +94,19 @@ spec:
       securityContext:
         {{ toYaml .Values.clusterAgent.securityContext | nindent 8 }}
       {{- end }}
+      initContainers:
+      - name: init-volume
+        image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterAgent.image) }}"
+        imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
+        command:
+          - cp
+        args:
+          - -r
+          - /etc/datadog-agent
+          - /opt
+        volumeMounts:
+          - name: config
+            mountPath: /opt/datadog-agent
       containers:
       - name: cluster-agent
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterAgent.image) }}"
@@ -273,6 +286,9 @@ spec:
           - name: varlog
             mountPath: /var/log/datadog
             readOnly: false
+          - name: tmpdir
+            mountPath: /tmp
+            readOnly: false
           - name: installinfo
             subPath: install_info
             {{- if eq .Values.targetSystem "windows" }}
@@ -302,10 +318,14 @@ spec:
             readOnly: true
 {{- end}}
 {{- end}}
+          - name: config
+            mountPath: /etc/datadog-agent
       volumes:
         - name: datadogrun
           emptyDir: {}
         - name: varlog
+          emptyDir: {}
+        - name: tmpdir
           emptyDir: {}
         - name: installinfo
           configMap:
@@ -350,7 +370,8 @@ spec:
             name: {{ .Values.datadog.securityAgent.compliance.configMap }}
 {{- end}}
 {{- end}}
-
+        - name: config
+          emptyDir: {}
 {{- if .Values.clusterAgent.volumes }}
 {{ toYaml .Values.clusterAgent.volumes | indent 8 }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Explicitly mount `emptyDir` volumes in `/etc/datadog-agent` and `/tmp` in the `cluster-agent` container to allow it to write to those locations even with a read-only root filesystem (see #934).
This is a follow-up of #938 and #940.

#### Which issue this PR fixes

  - fixes #937

#### Special notes for your reviewer:

The issue this PR is fixing seems to be specific to OpenShift / `cri-o`.
On other Kubernetes distributions with `containerd`, there were already writable volumes mounted at those locations thanks to a `VOLUME` statement in the `cluster-agent` `Dockerfile`: https://github.com/DataDog/datadog-agent/blob/14b9337b0ad7ccb583249e5d13e63932e5b51113/Dockerfiles/cluster-agent/Dockerfile#L91-L92 .

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
