### PR TITLE
Auto-configure admissionController.configMode based on apm.socketEnabled|portEnabled

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 3.20.0
+
+* Auto-configure `clusterAgent.admissionController.configMode` based on `datadog.apm.socketEnabled|portEnabled`.
+
 # 3.19.1
 
 * Mount emptyDir volumes in `/etc/datadog-agent` and `/tmp` to allow the cluster-agent to write files in those

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.19.1
+version: 3.20.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.19.1](https://img.shields.io/badge/Version-3.19.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.20.0](https://img.shields.io/badge/Version-3.20.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/ci/apm-enabled-legacy-admission-controller-values.yaml
+++ b/charts/datadog/ci/apm-enabled-legacy-admission-controller-values.yaml
@@ -1,0 +1,9 @@
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  apm:
+    enabled: true
+clusterAgent:
+  enabled: true
+  admissionController:
+    enabled: true

--- a/charts/datadog/ci/apm-port-enabled-admission-controller-values.yaml
+++ b/charts/datadog/ci/apm-port-enabled-admission-controller-values.yaml
@@ -1,0 +1,9 @@
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  apm:
+    portEnabled: true
+clusterAgent:
+  enabled: true
+  admissionController:
+    enabled: true

--- a/charts/datadog/ci/apm-socket-enabled-admission-controller-values.yaml
+++ b/charts/datadog/ci/apm-socket-enabled-admission-controller-values.yaml
@@ -1,0 +1,9 @@
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  apm:
+    socketEnabled: true
+clusterAgent:
+  enabled: true
+  admissionController:
+    enabled: true

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -178,13 +178,17 @@ spec:
             value: {{ .Values.clusterAgent.admissionController.mutateUnlabelled | quote }}
           - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
             value: {{ template "datadog.fullname" . }}-cluster-agent-admission-controller
-          {{- if .Values.clusterAgent.admissionController.configMode }}
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE
-            value: {{ .Values.clusterAgent.admissionController.configMode | quote }}
-          {{- if eq .Values.clusterAgent.admissionController.configMode "service" }}
+            {{- if or (eq (default .Values.datadog.apm.portEnabled false) true) (eq (default .Values.datadog.apm.enabled false) true) }}
+            value: service
+            {{- else if (eq (default .Values.datadog.apm.socketEnabled true) true) }}
+            value: socket
+            {{- else }}
+            value: {{ .Values.clusterAgent.admissionController.configMode | default "socket" }}
+            {{- end }}
+          {{- if or (eq (default .Values.clusterAgent.admissionController.configMode "socket") "service") (eq (default .Values.datadog.apm.portEnabled false) true) (eq (default .Values.datadog.apm.enabled false) true)}}
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
             value: {{ template "localService.name" . }}
-          {{- end }}
           {{- end }}
           {{- if .Values.providers.aks.enabled }}
           - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -179,12 +179,12 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
             value: {{ template "datadog.fullname" . }}-cluster-agent-admission-controller
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE
-            {{- if or (eq (default .Values.datadog.apm.portEnabled false) true) (eq (default .Values.datadog.apm.enabled false) true) }}
+            {{- if .Values.clusterAgent.admissionController.configMode }}
+            value: {{ .Values.clusterAgent.admissionController.configMode | default "socket" }}
+            {{- else if or (eq (default .Values.datadog.apm.portEnabled false) true) (eq (default .Values.datadog.apm.enabled false) true) }}
             value: service
             {{- else if (eq (default .Values.datadog.apm.socketEnabled true) true) }}
             value: socket
-            {{- else }}
-            value: {{ .Values.clusterAgent.admissionController.configMode | default "socket" }}
             {{- end }}
           {{- if or (eq (default .Values.clusterAgent.admissionController.configMode "socket") "service") (eq (default .Values.datadog.apm.portEnabled false) true) (eq (default .Values.datadog.apm.enabled false) true)}}
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -933,7 +933,9 @@ clusterAgent:
 
     # clusterAgent.admissionController.configMode -- The kind of configuration to be injected, it can be "hostip", "service", or "socket".
 
-    ## If clusterAgent.admissionController.configMode is not set, the Admission Controller defaults to hostip.
+    ## If clusterAgent.admissionController.configMode is not set, the Admission Controller defaults to socket.
+    ## If clusterAgent.admissionController.configMode is not set and datadog.apm.socketEnabled is true, the Admission Controller uses socket.
+    ## If clusterAgent.admissionController.configMode is not set and datadog.apm.portEnabled is true, the Admission Controller uses service.
     ## Note: "service" mode relies on the internal traffic service to target the agent running on the local node (requires Kubernetes v1.22+).
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/#configure-apm-and-dogstatsd-communication-mode
     configMode:  # "hostip", "socket" or "service"


### PR DESCRIPTION
#### What this PR does / why we need it:

Auto-configure `clusterAgent.admissionController.configMode` based on `datadog.apm.socketEnabled|portEnabled` for a better user experience. 

* If `datadog.apm.socketEnabled: true`, then `socket` config mode is used
* If `datadog.apm.portEnabled: true`, then `service` config mode is used

Default config mode is `socket` if `clusterAgent.admissionController.configMode` is not set.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
