### PR TITLE
[datadog] Fix R/W volume mounts in init containers on Windows

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.19.2
+
+* Fix R/W volume mounts in init containers on Windows
+
 # 3.19.1
 
 * Mount emptyDir volumes in `/etc/datadog-agent` and `/tmp` to allow the cluster-agent to write files in those

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.19.1
+version: 3.19.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.19.1](https://img.shields.io/badge/Version-3.19.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.19.2](https://img.shields.io/badge/Version-3.19.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_containers-init-windows.yaml
+++ b/charts/datadog/templates/_containers-init-windows.yaml
@@ -10,7 +10,7 @@
   volumeMounts:
     - name: config
       mountPath: C:/Temp/Datadog
-      readOnly: true
+      readOnly: false # Need RW for config path
     - name: installinfo
       mountPath: C:/Temp/install_info
       readOnly: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Make the `emptyDir` `config` volume [read-write in the `init-volume` init container on Windows](https://github.com/DataDog/helm-charts/pull/932/files#diff-cd8b7548c45e0257b7d9852440a7e1683c31795f1c9603f32cb83d8553f5a4c9R13) like [it already is on Linux](https://github.com/DataDog/helm-charts/pull/932/files#diff-2d5d99450009939b13edaea8bc6c04ed07dbdcb45f59247bc27b3fc63e6593f5R11).

#### Which issue this PR fixes

  - fixes https://github.com/DataDog/helm-charts/pull/932#issuecomment-1466252978

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
