### PR TITLE
Fix linux init container command args

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 3.20.1
+
+* Fix command args in linux init container to prevent blocking deployment in GKE Autopilot.  
+
 # 3.20.0
 
 * Enable CWS network detections by default.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.20.0
+version: 3.20.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.20.0](https://img.shields.io/badge/Version-3.20.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.20.1](https://img.shields.io/badge/Version-3.20.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -21,10 +21,7 @@
     - bash
     - -c
   args:
-    - |
-      for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort); do
-        bash $script
-      done
+    - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
   volumeMounts:
     - name: logdatadog
       mountPath: /var/log/datadog


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR reverts the `args` change introduced in https://github.com/DataDog/helm-charts/pull/943/files#diff-2d5d99450009939b13edaea8bc6c04ed07dbdcb45f59247bc27b3fc63e6593f5R24-R27. This change is breaking deployments in GKE Autopilot and I think it's because the GKE Warden expects the exact command arg as written in the `allowlistedworkload` exemption. See https://github.com/DataDog/helm-charts/issues/947. 

#### Which issue this PR fixes
https://github.com/DataDog/helm-charts/issues/947

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
