### PR TITLE
Datadog agent doesn't deploy on GKE Autopilot

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 3.20.1
+
+* Fix Datadog Agent not deploying on GKE Autopilot.
+
 # 3.20.0
 
 * Enable CWS network detections by default.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.20.0
+version: 3.20.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -21,10 +21,7 @@
     - bash
     - -c
   args:
-    - |
-      for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort); do
-        bash $script
-      done
+    - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
   volumeMounts:
     - name: logdatadog
       mountPath: /var/log/datadog


### PR DESCRIPTION
#### What this PR does / why we need it:
GKE clusters in Autopilot mode were rejecting the Agent from being deployed.

#### Which issue this PR fixes
Fixes https://github.com/DataDog/helm-charts/issues/947

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
