### PR TITLE
fix(helmchecks): :bug: This fixes an issue with an empty line

### DIFF
--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.20.1
+version: 3.20.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/_helm_check_config.yaml
+++ b/charts/datadog/templates/_helm_check_config.yaml
@@ -7,5 +7,5 @@ helm.yaml: |-
   instances:
     - collect_events: {{ .Values.datadog.helmCheck.collectEvents }}
       helm_values_as_tags:
-{{ .Values.datadog.helmCheck.valuesAsTags | toYaml | nindent 8 }}
+{{- .Values.datadog.helmCheck.valuesAsTags | toYaml | nindent 8 }}
 {{- end -}}


### PR DESCRIPTION
This removes the empty line that gets created using the existing template, which was breaking the helm check valuesAsTags feature.

#### What this PR does / why we need it:
Related the feature added in this PR https://github.com/DataDog/helm-charts/pull/752
There is a bug where an empty line gets in the manifest and breaks the helm checks config file.

#### Which issue this PR fixes

  - fixes [ISSUE-953](https://github.com/DataDog/helm-charts/issues/953)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
