### PR TITLE
[datadog] Fix R/W volume mounts for CRI on Windows

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Datadog changelog
 
+# 3.20.2
+
+* Fix R/W volume mounts for CRI on Windows
+
 # 3.20.1
 
-* Fix command args in linux init container to prevent blocking deployment in GKE Autopilot.  
+* Fix command args in linux init container to prevent blocking deployment in GKE Autopilot.
 
 # 3.20.0
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.20.1
+version: 3.20.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.20.1](https://img.shields.io/badge/Version-3.20.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.20.2](https://img.shields.io/badge/Version-3.20.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-cri-volumemounts.yaml
+++ b/charts/datadog/templates/_container-cri-volumemounts.yaml
@@ -9,11 +9,9 @@
 {{- if eq .Values.targetSystem "windows" }}
 - name: runtimesocket
   mountPath: {{ template "datadog.dockerOrCriSocketPath" . }}
-  readOnly: true
 {{- if not .Values.datadog.criSocketPath }}
-- name: containerdsocket 
+- name: containerdsocket
   mountPath: \\.\pipe\containerd-containerd
-  readOnly: true
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove the `readOnly: true` option on the CRI named-pipe volume mounts on Windows because it causes the following error:
```
Error: Error response from daemon: invalid volume specification: '\\.\pipe\docker_engine:\\.\pipe\docker_engine:ro': invalid mount config for type "npipe": field ReadOnly must not be specified
```

This was a regression introduced by https://github.com/DataDog/helm-charts/pull/932/files#diff-7adecba9235479e1b29b031bdb0c4cd8c07c69c8f7252e0df99c00562c257b81

#### Which issue this PR fixes

  - fixes #955

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
