### PR TITLE
Fix dogstatsd socketpath mount and container script for gke autopilot rapid release channel

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+# 3.20.2
+
+* Only mount DogStatsD socket in non-Autopilot environments.
+* Fix command script in linux init container to prevent blocking deployment in GKE Autopilot on Rapid release channel. 
+
 # 3.20.1
 
 * Fix command args in linux init container to prevent blocking deployment in GKE Autopilot.  

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.20.1
+version: 3.20.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.20.1](https://img.shields.io/badge/Version-3.20.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.20.2](https://img.shields.io/badge/Version-3.20.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -62,6 +62,9 @@
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
       readOnly: true
+    - name: dsdsocket
+      mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
+      readOnly: false # Need RW for UDS DSD socket
     {{- end }}
     - name: logdatadog
       mountPath: /var/log/datadog
@@ -91,9 +94,6 @@
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    - name: dsdsocket
-      mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-      readOnly: false # Need RW for UDS DSD socket
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -54,7 +54,6 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
       readOnly: true
-    {{- if eq .Values.targetSystem "linux" }}
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
@@ -63,6 +62,7 @@
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: false # Need RW for UDS DSD socket
     {{- end }}
+    {{- if eq .Values.targetSystem "linux" }}
     - name: logdatadog
       mountPath: /var/log/datadog
       readOnly: false # Need RW to write logs

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -54,21 +54,21 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
       readOnly: true
+    {{- if eq .Values.targetSystem "linux" }}
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
       readOnly: true
+    - name: dsdsocket
+      mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
+      readOnly: false # Need RW for UDS DSD socket
     {{- end }}
-    {{- if eq .Values.targetSystem "linux" }}
     - name: logdatadog
       mountPath: /var/log/datadog
       readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp
       readOnly: false # Need RW to write to tmp directory
-    - name: dsdsocket
-      mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-      readOnly: false # Need RW for UDS DSD socket
     {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -2,12 +2,9 @@
 - name: init-volume
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  command:
-    - cp
+  command: ["bash", "-c"]
   args:
-    - -r
-    - /etc/datadog-agent
-    - /opt
+    - cp -r /etc/datadog-agent /opt
   volumeMounts:
     - name: config
       mountPath: /opt/datadog-agent


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes to allow Datadog Agent deployment in GKE Autopilot on the rapid release channel:
* Only mount dogstatsd socketpath in non-autopilot environments
* Fix init container script to match the expected script in the GKE Autopilot AllowlistedWorkload resource

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
