### PR TITLE
feat(datadog): use registry.k8s.io for ksm image

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Datadog changelog
 
-# 3.23.0
+## 3.24.0
+
+* Move `kube-state-metrics` default image registry from k8s.gcr.io to registry.k8s.io.
+
+## 3.23.0
 
 * Injects additional environment variables in the Cluster Agent
 * Add `clusterAgent.rbac.flareAdditionalPermissions` parameter to enable user Helm values retrieval in DCA flare (`true` by default)
 
-# 3.22.0
+## 3.22.0
 
 * Auto-configure `clusterAgent.admissionController.configMode` based on `datadog.apm.socketEnabled|portEnabled`.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.23.0
+version: 3.24.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.23.0](https://img.shields.io/badge/Version-3.23.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.24.0](https://img.shields.io/badge/Version-3.24.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -727,6 +727,7 @@ helm install <RELEASE_NAME> \
 | existingClusterAgent.serviceName | string | `nil` | Existing service name to use for reaching the external Cluster Agent |
 | existingClusterAgent.tokenSecretName | string | `nil` | Existing secret name to use for external Cluster Agent token |
 | fullnameOverride | string | `nil` | Override the full qualified app name |
+| kube-state-metrics.image.repository | string | `"registry.k8s.io/kube-state-metrics/kube-state-metrics"` | Default kube-state-metrics image repository. |
 | kube-state-metrics.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for KSM. KSM only supports Linux. |
 | kube-state-metrics.rbac.create | bool | `true` | If true, create & use RBAC resources |
 | kube-state-metrics.resources | object | `{}` | Resource requests and limits for the kube-state-metrics container. |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1806,6 +1806,10 @@ datadog-crds:
     datadogMetrics: true
 
 kube-state-metrics:
+  # kube-state-metrics.image.repository -- Default kube-state-metrics image repository.
+  image:
+    repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+
   rbac:
     # kube-state-metrics.rbac.create -- If true, create & use RBAC resources
     create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

* Move `kube-state-metrics` default image registry from k8s.gcr.io to registry.k8s.io.

#### Which issue this PR fixes

  - fixes #967

#### Special notes for your reviewer:

According to the [announcement](https://kubernetes.io/blog/2023/03/10/image-registry-redirect/) k8s.gcr.io will be redirected to registry.k8s.io and then later sunset.

I tested that the image tag exist in this registry too.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
