### PR TITLE
Operator configuration for maximumGoroutines and datadogAgentEnabled parameters

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.1
+
+* Add configuration for new Operator parameters `maximumGoroutines` and `datadogAgentEnabled`.
+
 ## 0.10.0
 
 * Add ability to use the conversion webhook

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.10.0
+version: 0.10.1
 appVersion: 1.0.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -32,7 +32,7 @@
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | logLevel | string | `"info"` | Set Datadog Operator log level (debug, info, error, panic, fatal) |
-| maximumGoroutines | int | `400` | Override default gouroutines threshold for the health check failure. |
+| maximumGoroutines | string | `nil` | Override default gouroutines threshold for the health check failure. |
 | metricsPort | int | `8383` | Port used for OpenMetrics endpoint |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Operator on specific nodes |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## Values
 
@@ -13,6 +13,7 @@
 | appKeyExistingSecret | string | `nil` | Use existing Secret which stores APP key instead of creating a new one |
 | collectOperatorMetrics | bool | `true` | Configures an openmetrics check to collect operator metrics |
 | containerSecurityContext | object | `{}` | A security context defines privileges and access control settings for a container. |
+| datadogAgent.enabled | bool | `true` | Enables Datadog Agetn controller |
 | datadogCRDs.crds.datadogAgents | bool | `true` |  |
 | datadogCRDs.crds.datadogMetrics | bool | `true` |  |
 | datadogCRDs.crds.datadogMonitors | bool | `true` |  |
@@ -31,6 +32,7 @@
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | logLevel | string | `"info"` | Set Datadog Operator log level (debug, info, error, panic, fatal) |
+| maximumGoroutines | int | `400` | Override default gouroutines threshold for the health check failure. |
 | metricsPort | int | `8383` | Port used for OpenMetrics endpoint |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Operator on specific nodes |

--- a/charts/datadog-operator/templates/NOTES.txt
+++ b/charts/datadog-operator/templates/NOTES.txt
@@ -31,7 +31,7 @@ The datadogAgent.enabled parameter isn't supported by the Operator 1.0.0-rc.12 a
 DatadogAgent is enabled by default and setting it to false will not have any effect.
     {{- end }}
 
-    {{- if (ne .Values.maximumGoroutines (atoi "400")) }}
+    {{- if .Values.maximumGoroutines }}
 ##############################################################################
 ####               WARNING: Unsupported parameter maximumGoroutines.      ####
 ##############################################################################

--- a/charts/datadog-operator/templates/NOTES.txt
+++ b/charts/datadog-operator/templates/NOTES.txt
@@ -19,3 +19,24 @@ This deployment will be incomplete until you get your APP key from Datadog.
 Create an application key at https://app.datadoghq.com/account/settings#api
     {{- end }}
 {{- end }}
+
+
+{{- if (semverCompare "<1.0.0-rc.13" .Values.image.tag) }}
+    {{- if (not .Values.datadogAgent.enabled) }}
+##############################################################################
+####               WARNING: Unsupported parameter datadogAgent.enabled.   ####
+##############################################################################
+
+The datadogAgent.enabled parameter isn't supported by the Operator 1.0.0-rc.12 and earlier.
+DatadogAgent is enabled by default and setting it to false will not have any effect.
+    {{- end }}
+
+    {{- if (ne .Values.maximumGoroutines (atoi "400")) }}
+##############################################################################
+####               WARNING: Unsupported parameter maximumGoroutines.      ####
+##############################################################################
+
+The maximumGoroutines parameter isn't supported by the Operator 1.0.0-rc.12 and earlier.
+Setting a value will not change the default defined in the Operator.
+    {{- end }}
+{{- end }}

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -102,11 +102,13 @@ spec:
           {{- if .Values.secretBackend.arguments }}
             - "-secretBackendArgs={{ .Values.secretBackend.arguments }}"
           {{- end }}
-          {{- if .Values.maximumGoroutines }}
+          {{- if (semverCompare ">=1.0.0-rc.13" .Values.image.tag) }}
             - "-maximumGoroutines={{ .Values.maximumGoroutines }}"
           {{- end }}
             - "-datadogMonitorEnabled={{ .Values.datadogMonitor.enabled }}"
+          {{- if (semverCompare ">=1.0.0-rc.13" .Values.image.tag) }}
             - "-datadogAgentEnabled={{ .Values.datadogAgent.enabled }}"
+          {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -102,7 +102,11 @@ spec:
           {{- if .Values.secretBackend.arguments }}
             - "-secretBackendArgs={{ .Values.secretBackend.arguments }}"
           {{- end }}
+          {{- if .Values.maximumGoroutines }}
+            - "-maximumGoroutines={{ .Values.maximumGoroutines }}"
+          {{- end }}
             - "-datadogMonitorEnabled={{ .Values.datadogMonitor.enabled }}"
+            - "-datadogAgentEnabled={{ .Values.datadogAgent.enabled }}"
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -53,7 +53,9 @@ nameOverride: ""
 fullnameOverride: ""
 # logLevel -- Set Datadog Operator log level (debug, info, error, panic, fatal)
 logLevel: "info"
-# supportExtendedDaemonset -- If true, supports using ExtendedDaemonSet CRD
+# maximumGoroutines -- Override default gouroutines threshold for the health check failure.
+maximumGoroutines: 400
+# supportExtendedDaemonset -- If true, supports using ExtendedDeamonSet CRD
 supportExtendedDaemonset: "false"
 # metricsPort -- Port used for OpenMetrics endpoint
 metricsPort: 8383
@@ -62,6 +64,9 @@ secretBackend:
   command: ""
   # secretBackend.arguments -- Specifies the space-separated arguments passed to the command that implements the secret backend api
   arguments: ""
+datadogAgent:
+  # datadogAgent.enabled -- Enables Datadog Agetn controller
+  enabled: true
 datadogMonitor:
   # datadogMonitor.enabled -- Enables the Datadog Monitor controller
   enabled: false

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -54,7 +54,7 @@ fullnameOverride: ""
 # logLevel -- Set Datadog Operator log level (debug, info, error, panic, fatal)
 logLevel: "info"
 # maximumGoroutines -- Override default gouroutines threshold for the health check failure.
-maximumGoroutines: 400
+maximumGoroutines:
 # supportExtendedDaemonset -- If true, supports using ExtendedDeamonSet CRD
 supportExtendedDaemonset: "false"
 # metricsPort -- Port used for OpenMetrics endpoint

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -55,7 +55,7 @@ fullnameOverride: ""
 logLevel: "info"
 # maximumGoroutines -- Override default gouroutines threshold for the health check failure.
 maximumGoroutines:
-# supportExtendedDaemonset -- If true, supports using ExtendedDeamonSet CRD
+# supportExtendedDaemonset -- If true, supports using ExtendedDaemonSet CRD
 supportExtendedDaemonset: "false"
 # metricsPort -- Port used for OpenMetrics endpoint
 metricsPort: 8383


### PR DESCRIPTION
#### What this PR does / why we need it:
PR adds two new configurations to Operator chart to control `maximumGoroutines` used in Operator health checks and `datadogAgentEnabled` to control whether Operator runs `DatadogAgent` reconciler (e.g. in case users only needs `DatadogMonitor`).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes # https://github.com/DataDog/datadog-operator/issues/666, https://github.com/DataDog/datadog-operator/issues/721

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
