### PR TITLE
[CWS] improve clarity of changelog entry for 3.25.0 release

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.25.0
 
-* Enable CWS Security Profiles collection by default.
+* Automatically collect Security Profiles when CWS is enabled.
 
 ## 3.24.0
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The changelog entry of https://github.com/DataDog/helm-charts/pull/974 was not clear enough. This PR fixes this using https://github.com/DataDog/helm-charts/pull/974#discussion_r1152831351 feedback.

This PR specifically does not bump the version.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
