### PR TITLE
Update the CRD default storedVersion

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0
+
+* Default DatadogAgent stored version is `v2alpha1` to align with the GA of the Datadog Operator.
+
 ## 0.6.1
 
 * Add missing `nodeLabelsAsTags` and `namespaceLabelsAsTags` to the v2alpha1 spec. 

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 0.6.1
+version: 1.0.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -30,7 +30,7 @@ But the recommended Kubernetes versions are `1.16+`.
 | migration.datadogAgents.conversionWebhook.name | string | `"datadog-operator-webhook-service"` |  |
 | migration.datadogAgents.conversionWebhook.namespace | string | `"default"` |  |
 | migration.datadogAgents.useCertManager | bool | `false` |  |
-| migration.datadogAgents.version | string | `"v1alpha1"` |  |
+| migration.datadogAgents.version | string | `"v2alpha1"` |  |
 | nameOverride | string | `""` | Override name of app |
 
 ## Developers

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/values.yaml
+++ b/charts/datadog-crds/values.yaml
@@ -17,7 +17,7 @@ migration:
       name: datadog-operator-webhook-service
       namespace: default
     useCertManager: false
-    version: "v1alpha1"
+    version: "v2alpha1"
 
 # nameOverride -- Override name of app
 nameOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

- Change the default of the stored version in the CRDs chart.

Once merged I will update the dependency in the datadog-operator chart.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
