### PR TITLE
Datadog Operator GA chart update

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0
+
+* Default image is now `1.0.0`
+* Updated documentation.
+* Stored Version is v2alpha1 by default:
+    * If you are using a chart 0.X, refer to the [Migration Steps](https://github.com/DataDog/helm-charts/blob/main/charts/datadog-operator/README.md#migrating-to-the-version-10-of-the-datadog-operator).
+* Added Failure exceptions to avoid breaking changes:
+    * Added exception when using unsopported version of the DatadogAgent object for the configured version of the Datadog Operator.
+
 ## 0.10.1
 
 * Add configuration for new Operator parameters `maximumGoroutines` and `datadogAgentEnabled`.

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Stored Version is v2alpha1 by default:
     * If you are using a chart 0.X, refer to the [Migration Steps](https://github.com/DataDog/helm-charts/blob/main/charts/datadog-operator/README.md#migrating-to-the-version-10-of-the-datadog-operator).
 * Added Failure exceptions to avoid breaking changes:
-    * Added exception when using unsopported version of the DatadogAgent object for the configured version of the Datadog Operator.
+    * Added exception when using unsupported version of the DatadogAgent object for the configured version of the Datadog Operator.
 
 ## 0.10.1
 

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 0.6.1
-digest: sha256:bbebf7e0049b5ebaeb6b6828ec3926965f69ec62b53f3524591f453f098136ed
-generated: "2023-03-27T17:13:21.699269-04:00"
+  version: 1.0.0
+digest: sha256:46c620716bf7ab9e1ffd7eaf39dfd44b5a8cab49a5acb70de071dcbad4c7ee86
+generated: "2023-04-03T15:45:41.953207-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 0.10.1
+version: 1.0.0
 appVersion: 1.0.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "=0.6.1"
+  version: "=1.0.0"
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## Values
 
@@ -21,14 +21,14 @@
 | datadogCRDs.migration.datadogAgents.conversionWebhook.name | string | `"datadog-operator-webhook-service"` |  |
 | datadogCRDs.migration.datadogAgents.conversionWebhook.namespace | string | `"default"` |  |
 | datadogCRDs.migration.datadogAgents.useCertManager | bool | `false` |  |
-| datadogCRDs.migration.datadogAgents.version | string | `"v1alpha1"` |  |
+| datadogCRDs.migration.datadogAgents.version | string | `"v2alpha1"` |  |
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"0.8.4"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.0.0"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | logLevel | string | `"info"` | Set Datadog Operator log level (debug, info, error, panic, fatal) |
@@ -78,10 +78,6 @@ As part of the General Availability release of the Datadog Operator, we are offe
 
 The Datadog Operator v1.X reconciles the version `v2alpha1` of the DatadogAgent custom resource, while the v0.X reconciles `v1alpha1`.
 
-In the following documentation, you will find mentions of the image with a `rc` (release candidate) tag. We will update it to the official `1.0.0` tag upon releasing.
-
-Consider the following steps with the same maturity (beta) level as the project.
-
 ### Requirements
 
 If you are using the v1alpha1 with a v0.X version of the Datadog Operator and would like to upgrade, you will need to use the Conversion Webhook feature.
@@ -97,7 +93,7 @@ and for the Datadog Operator chart:
 
 ```
 NAME                    	CHART VERSION	APP VERSION	DESCRIPTION
-datadog/datadog-operator	0.10.0        	1.0.0      	Datadog Operator
+datadog/datadog-operator	1.0.0        	1.0.0      	Datadog Operator
 ```
 
 Then you will need to install the cert manager if you don't have it already, add the chart:
@@ -119,11 +115,17 @@ You can update with the following:
 ```
 helm upgrade \
     datadog-operator datadog/datadog-operator \
-    --set image.tag=1.0.0-rc.12 \
+    --set image.tag=1.0.0 \
     --set datadogCRDs.migration.datadogAgents.version=v2alpha1 \
     --set datadogCRDs.migration.datadogAgents.useCertManager=true \
     --set datadogCRDs.migration.datadogAgents.conversionWebhook.enabled=true
 ```
+
+### Notes
+
+Starting at the version 1.0.0 of the datadog-operator chart, the fields `image.tag` has a default values of `1.0.0` and `datadogCRDs.migration.datadogAgents.version` is `v2alpha1`.
+
+We set them in the command here to illustrate the migration of going from a Datadog Operator version < 1.0.0 with a stored version of `v1alpha1` to the GA version of `1.0.0` with a stored version of `v2alpha1`.
 
 ### Implementation details
 

--- a/charts/datadog-operator/README.md.gotmpl
+++ b/charts/datadog-operator/README.md.gotmpl
@@ -31,10 +31,6 @@ As part of the General Availability release of the Datadog Operator, we are offe
 
 The Datadog Operator v1.X reconciles the version `v2alpha1` of the DatadogAgent custom resource, while the v0.X reconciles `v1alpha1`.
 
-In the following documentation, you will find mentions of the image with a `rc` (release candidate) tag. We will update it to the official `1.0.0` tag upon releasing.
-
-Consider the following steps with the same maturity (beta) level as the project.
-
 ### Requirements
 
 If you are using the v1alpha1 with a v0.X version of the Datadog Operator and would like to upgrade, you will need to use the Conversion Webhook feature.
@@ -50,7 +46,7 @@ and for the Datadog Operator chart:
 
 ```
 NAME                    	CHART VERSION	APP VERSION	DESCRIPTION
-datadog/datadog-operator	0.10.0        	1.0.0      	Datadog Operator
+datadog/datadog-operator	1.0.0        	1.0.0      	Datadog Operator
 ```
 
 Then you will need to install the cert manager if you don't have it already, add the chart:
@@ -72,11 +68,17 @@ You can update with the following:
 ```
 helm upgrade \
     datadog-operator datadog/datadog-operator \
-    --set image.tag=1.0.0-rc.12 \
+    --set image.tag=1.0.0 \
     --set datadogCRDs.migration.datadogAgents.version=v2alpha1 \
     --set datadogCRDs.migration.datadogAgents.useCertManager=true \
     --set datadogCRDs.migration.datadogAgents.conversionWebhook.enabled=true
 ```
+
+### Notes
+
+Starting at the version 1.0.0 of the datadog-operator chart, the fields `image.tag` has a default values of `1.0.0` and `datadogCRDs.migration.datadogAgents.version` is `v2alpha1`.
+
+We set them in the command here to illustrate the migration of going from a Datadog Operator version < 1.0.0 with a stored version of `v1alpha1` to the GA version of `1.0.0` with a stored version of `v2alpha1`.
 
 ### Implementation details
 

--- a/charts/datadog-operator/templates/NOTES.txt
+++ b/charts/datadog-operator/templates/NOTES.txt
@@ -20,7 +20,6 @@ Create an application key at https://app.datadoghq.com/account/settings#api
     {{- end }}
 {{- end }}
 
-<<<<<<< HEAD
 
 {{- if (semverCompare "<1.0.0-rc.13" .Values.image.tag) }}
     {{- if (not .Values.datadogAgent.enabled) }}
@@ -41,8 +40,6 @@ The maximumGoroutines parameter isn't supported by the Operator 1.0.0-rc.12 and 
 Setting a value will not change the default defined in the Operator.
     {{- end }}
 {{- end }}
-=======
 {{- if not (and (semverCompare ">=1.0.0-0" .Values.image.tag) (eq .Values.datadogCRDs.migration.datadogAgents.version "v2alpha1")) }}
 {{- fail "The Datadog Operator `1.0.0` reconciles `DatadogAgent` versions `v2alpha1`. Using an old version of the Datadog Operator (< 1.0.0) with the new version of the DatadogAgent Customer Resource, or the Datadog Operator `1.X` with the `v1alpha1` as stored version of the DatadogAgent is not supported. If you are using a DatadogAgent `v1alpha1`, refer to the Migration Steps: https://github.com/DataDog/helm-charts/blob/main/charts/datadog-operator/README.md#migrating-to-the-version-10-of-the-datadog-operator."}}
 {{- end }}
->>>>>>> 8105801 (Major update of the Helm chart for the Datadog Operator for the release of the Datadog Operator)

--- a/charts/datadog-operator/templates/NOTES.txt
+++ b/charts/datadog-operator/templates/NOTES.txt
@@ -20,6 +20,7 @@ Create an application key at https://app.datadoghq.com/account/settings#api
     {{- end }}
 {{- end }}
 
+<<<<<<< HEAD
 
 {{- if (semverCompare "<1.0.0-rc.13" .Values.image.tag) }}
     {{- if (not .Values.datadogAgent.enabled) }}
@@ -40,3 +41,8 @@ The maximumGoroutines parameter isn't supported by the Operator 1.0.0-rc.12 and 
 Setting a value will not change the default defined in the Operator.
     {{- end }}
 {{- end }}
+=======
+{{- if not (and (semverCompare ">=1.0.0-0" .Values.image.tag) (eq .Values.datadogCRDs.migration.datadogAgents.version "v2alpha1")) }}
+{{- fail "The Datadog Operator `1.0.0` reconciles `DatadogAgent` versions `v2alpha1`. Using an old version of the Datadog Operator (< 1.0.0) with the new version of the DatadogAgent Customer Resource, or the Datadog Operator `1.X` with the `v1alpha1` as stored version of the DatadogAgent is not supported. If you are using a DatadogAgent `v1alpha1`, refer to the Migration Steps: https://github.com/DataDog/helm-charts/blob/main/charts/datadog-operator/README.md#migrating-to-the-version-10-of-the-datadog-operator."}}
+{{- end }}
+>>>>>>> 8105801 (Major update of the Helm chart for the Datadog Operator for the release of the Datadog Operator)

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
           {{- if .Values.secretBackend.arguments }}
             - "-secretBackendArgs={{ .Values.secretBackend.arguments }}"
           {{- end }}
-          {{- if (semverCompare ">=1.0.0-rc.13" .Values.image.tag) }}
+          {{- if and .Values.maximumGoroutines (semverCompare ">=1.0.0-rc.13" .Values.image.tag) }}
             - "-maximumGoroutines={{ .Values.maximumGoroutines }}"
           {{- end }}
             - "-datadogMonitorEnabled={{ .Values.datadogMonitor.enabled }}"

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -42,7 +42,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 0.8.4
+  tag: 1.0.0
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
 # imagePullSecrets -- Datadog Operator repository pullSecret (ex: specify docker registry credentials)
@@ -118,7 +118,7 @@ datadogCRDs:
         name: datadog-operator-webhook-service
         namespace: default
       useCertManager: false
-      version: "v1alpha1"
+      version: "v2alpha1"
 
 # podAnnotations -- Allows setting additional annotations for Datadog Operator PODs
 podAnnotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

As part of the General Availability of the Datadog Operator, we are making a major chart update that includes:
- Update the default image to 1.0
- Update the dependency on the `datadog-crd` chart
- Set the default stored version as `v2alpha`
- Add a safeguard in case users try to run the old operator with the new chart or the new operator with `v1alpha1` as the stored version.
- Remove the mention of the RC/beta.

#### Special notes for your reviewer:

- Need to wait for https://github.com/DataDog/helm-charts/pull/982 to be merged to update the dependency.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
