### PR TITLE
Updates small comment on kube-state-metrics reference

### DIFF
--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1839,7 +1839,7 @@ kube-state-metrics:
   # # kube-state-metrics.image -- Override default image information for the kube-state-metrics container.
   # image:
   #  # kube-state-metrics.repository -- Override default image registry for the kube-state-metrics container.
-  #  repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
+  #  repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
   #  # kube-state-metrics.tag -- Override default image tag for the kube-state-metrics container.
   #  tag: v1.9.8
   #  # kube-state-metrics.pullPolicy -- Override default image pullPolicy for the kube-state-metrics container.


### PR DESCRIPTION
Starting April 3, 2023, the Kubernetes project will stop publishing community-owned images (known as community images) to the old image registry k8s.gcr.io,  registry.k8s.io replaces it.

#### What this PR does / why we need it:
Just a small fix on a comment in the helm chart values.yaml

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
