### PR TITLE
fix: Remove duplicated `DD_PROVIDER_KIND` env vars from datadog agent…

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.28.2
+
+* Remove duplicated `DD_PROVIDER_KIND` env vars from datadog agent daemontSet.
+
 ## 3.28.1
 
 * Add `memfd_create` syscall to seccomp profile for system-probe.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.28.1
+version: 3.28.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.28.1](https://img.shields.io/badge/Version-3.28.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.28.2](https://img.shields.io/badge/Version-3.28.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -147,5 +147,4 @@ Return a list of env-vars if the cluster-agent is enabled
         name: {{ .Values.existingClusterAgent.tokenSecretName | quote }}
         key: token
 {{- end }}
-{{ include "provider-env" . }}
 {{- end -}}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -162,6 +162,9 @@ spec:
             value: {{ $healthPort | quote }}
           # Cluster checks (cluster-agent communication)
           {{- include "containers-cluster-agent-env" . | nindent 10 }}
+          {{- if .Values.providers.gke.autopilot }}
+          {{ include "provider-env" . | nindent 10 }}
+          {{- end }}
           # Safely run alongside the daemonset
           - name: DD_ENABLE_METADATA_COLLECTION
             value: "false"


### PR DESCRIPTION
… daemontSet.

#### What this PR does / why we need it:

This PR remove duplicated env vars from DaemonSet when providers gke autopilot is used.

Helm and Kubernetes allow to have duplicated env key but argocd doesn't allow it.

When we try to deploy Datadog-agent helm chart using argocd we have an issue that we can't bypass :

'error building typed results: error creating typedLive: errors: .spec.template.spec.containers[name="agent"].env: duplicate entries for key [name="DD_PROVIDER_KIND"] .spec.template.spec.containers[name="process-agent"].env: duplicate entries for key [name="DD_PROVIDER_KIND"]'

#### Special notes for your reviewer:

This is non blocking when we use helm to generate the chart. Kubernetes keep the first env vars in the DaemonSet.

#### Checklist
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the  `README.md`
