### PR TITLE
(rcm) fix partial enablement of RC

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.25.2
 
-* Fix a bug with `datadog.remoteConfiguration.enabled` where Remote Config was only enabled for the core agent.
+* Fix a bug with `datadog.remoteConfiguration.enabled` where Remote Config was only enabled for the main agent container but not other containers such as the trace-agent.
 
 ## 3.25.1
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.25.2
+
+* Fix a bug with `datadog.remoteConfiguration.enabled` where Remote Config was only enabled for the core agent.
+
 ## 3.25.1
 
 * Fix CI to unblock release of charts

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.25.1
+version: 3.25.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.25.1](https://img.shields.io/badge/Version-3.25.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.25.2](https://img.shields.io/badge/Version-3.25.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -149,10 +149,6 @@
       value: {{ .Values.datadog.expvarPort | quote }}
     {{- include "additional-env-entries" .Values.agents.containers.agent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.agent.envDict | indent 4 }}
-    {{- if .Values.datadog.remoteConfiguration.enabled }}
-    - name: DD_REMOTE_CONFIGURATION_ENABLED
-      value: "true"
-    {{- end }}
   volumeMounts:
     {{- if eq .Values.targetSystem "linux" }}
     - name: installinfo

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -143,5 +143,9 @@ Return a list of env-vars if the cluster-agent is enabled
         name: {{ .Values.existingClusterAgent.tokenSecretName | quote }}
         key: token
 {{- end }}
+{{- if .Values.datadog.remoteConfiguration.enabled }}
+- name: DD_REMOTE_CONFIGURATION_ENABLED
+  value: "true"
+{{- end }}
 {{ include "provider-env" . }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

The `DD_REMOTE_CONFIGURATION_ENABLED` setting needs to be set not only on the core agent but also on all the other processes.

Without this most features will remain disabled:
- `trace-agent` proxy to forward tracers Remote Config requests, making it impossible to use ASM/DI/etc... with RC.
- `APM_SAMPLING` / `CWS_*`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
