### PR TITLE
Add DD_REMOTE_CONFIGURATION_ENABLED env in trace-agent

### DIFF
--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -49,6 +49,10 @@
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
     {{- end }}
+    {{- if .Values.datadog.remoteConfiguration.enabled }}
+    - name: DD_REMOTE_CONFIGURATION_ENABLED
+      value: "true"
+    {{- end }}    
     {{- include "additional-env-entries" .Values.agents.containers.traceAgent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.traceAgent.envDict | indent 4 }}
   volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds DD_REMOTE_CONFIGURATION_ENABLED to the trace-agent container.

#### Which issue this PR fixes
The trace agent supports remote configuration endpoints `{{TRACE_ENDPOINT}}/v0.7/config` by ENV `DD_REMOTE_CONFIGURATION_ENABLED=true`.
Currently, we are only injecting the remote configuration ENV into the agent container.