### PR TITLE
feat(datadog): add clusterAgent.initContainers.resources option

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.26.0
+
+* Add the option `clusterAgent.initContainers.resources` to configure the cluster-agent init-container's resources.
+
 ## 3.25.1
 
 * Fix CI to unblock release of charts

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.25.1
+version: 3.26.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.25.1](https://img.shields.io/badge/Version-3.25.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.26.0](https://img.shields.io/badge/Version-3.26.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -510,6 +510,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
 | clusterAgent.image.tag | string | `"7.43.1"` | Cluster Agent image tag to use |
+| clusterAgent.initContainers.resources | object | `{}` | Resource requests and limits for the init containers |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
 | clusterAgent.metricsProvider.createReaderRbac | bool | `true` | Create `external-metrics-reader` RBAC automatically (to allow HPA to read data from Cluster Agent) |

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -98,6 +98,7 @@ spec:
       - name: init-volume
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterAgent.image) }}"
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
+{{ toYaml .Values.clusterAgent.initContainers.resources | indent 10 }}
         command:
           - cp
         args:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -838,6 +838,16 @@ clusterAgent:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
 
+  initContainers:
+    # clusterAgent.initContainers.resources -- Resource requests and limits for the init containers
+    resources: {}
+    #  requests:
+    #    cpu: 100m
+    #    memory: 200Mi
+    #  limits:
+    #    cpu: 100m
+    #    memory: 200Mi
+
   # clusterAgent.command -- Command to run in the Cluster Agent container as entrypoint
   command: []
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Add the option `clusterAgent.initContainers.resources` to configure the cluster-agent init-container's resources.

It will allow users to deploy the `datadog` chart on Kubernetes cluster on which it is enforce to have "resources" defined for every containers.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
