### PR TITLE
(rcm) enable RC even if the cluster agent is disabled

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.25.3
+
+* Remote Config is now enabled even if the Cluster Agent is disabled.
+
 ## 3.25.2
 
 * Fix a bug with `datadog.remoteConfiguration.enabled` where Remote Config was only enabled for the main agent container but not other containers such as the trace-agent.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.25.2
+version: 3.25.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.25.2](https://img.shields.io/badge/Version-3.25.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.25.3](https://img.shields.io/badge/Version-3.25.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -9,6 +9,10 @@
     secretKeyRef:
       name: {{ template "datadog.apiSecretName" . }}
       key: api-key
+{{- if .Values.datadog.remoteConfiguration.enabled }}
+- name: DD_REMOTE_CONFIGURATION_ENABLED
+  value: "true"
+{{- end }}
 {{- if (not .Values.providers.gke.autopilot) }}
 - name: DD_AUTH_TOKEN_FILE_PATH
   value: {{ template "datadog.confPath" . }}/auth/token
@@ -142,10 +146,6 @@ Return a list of env-vars if the cluster-agent is enabled
     secretKeyRef:
         name: {{ .Values.existingClusterAgent.tokenSecretName | quote }}
         key: token
-{{- end }}
-{{- if .Values.datadog.remoteConfiguration.enabled }}
-- name: DD_REMOTE_CONFIGURATION_ENABLED
-  value: "true"
 {{- end }}
 {{ include "provider-env" . }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

RC should be enabled even if the cluster agent is disabled.

https://github.com/DataDog/helm-charts/pull/994 added the env var in `{{- define "containers-cluster-agent-env" -}}` instead of `{{- define "containers-common-env" -}}`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
