### PR TITLE
Update comment on line 68

### DIFF
--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -65,7 +65,7 @@ secretBackend:
   # secretBackend.arguments -- Specifies the space-separated arguments passed to the command that implements the secret backend api
   arguments: ""
 datadogAgent:
-  # datadogAgent.enabled -- Enables Datadog Agetn controller
+  # datadogAgent.enabled -- Enables Datadog Agent controller
   enabled: true
 datadogMonitor:
   # datadogMonitor.enabled -- Enables the Datadog Monitor controller


### PR DESCRIPTION
There was a typo on like 68, which is a comment. Agent was misspelled, now it's not.
The line:
`#  datadogAgent.enabled -- Enables Datadog Agent controller`

#### What this PR does / why we need it:
This is a trivial change but necessary at some point.

#### Which issue this PR fixes
  - fixes a typo on line 68, which is a commented line.

#### Special notes for your reviewer:
Is it important to go through the checklist below? I am not sure what Chart Version bumped means in this context, but am happy to learn. Thank you!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
