### PR TITLE
[synthetics] Bump private location chart with release 1.34.1

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.15.12
+
+* Update private location image version to `1.34.1`.
+
 ## 0.15.11
 
 * Update private location image version to `1.34.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.11
-appVersion: 1.34.0
+version: 0.15.12
+appVersion: 1.34.1
 description: Datadog Synthetics Private Location
 keywords:
 - monitoring

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.11](https://img.shields.io/badge/Version-0.15.11-informational?style=flat-square) ![AppVersion: 1.34.0](https://img.shields.io/badge/AppVersion-1.34.0-informational?style=flat-square)
+![Version: 0.15.12](https://img.shields.io/badge/Version-0.15.12-informational?style=flat-square) ![AppVersion: 1.34.1](https://img.shields.io/badge/AppVersion-1.34.1-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -39,7 +39,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | hostAliases | list | `[]` | Add entries to Datadog Synthetics Private Location PODs' /etc/hosts |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Synthetics Private Location image |
 | image.repository | string | `"gcr.io/datadoghq/synthetics-private-location-worker"` | Repository to use for Datadog Synthetics Private Location image |
-| image.tag | string | `"1.34.0"` | Define the Datadog Synthetics Private Location version to use |
+| image.tag | string | `"1.34.1"` | Define the Datadog Synthetics Private Location version to use |
 | imagePullSecrets | list | `[]` | Datadog Synthetics Private Location repository pullSecret (ex: specify docker registry credentials) |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Synthetics Private Location on specific nodes |

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -15,7 +15,7 @@ image:
   # image.pullPolicy -- Define the pullPolicy for Datadog Synthetics Private Location image
   pullPolicy: IfNotPresent
   # image.tag -- Define the Datadog Synthetics Private Location version to use
-  tag: 1.34.0
+  tag: 1.34.1
 
 # imagePullSecrets -- Datadog Synthetics Private Location repository pullSecret (ex: specify docker registry credentials)
 imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump the Synthetics private location chart to 0.5.12 for the new PL 1.34.1 release.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
