### PR TITLE
Use .Release.Name for conversion webhook certificate/issuer name

### DIFF
--- a/charts/datadog-operator/templates/certificate_conversion.yaml
+++ b/charts/datadog-operator/templates/certificate_conversion.yaml
@@ -5,7 +5,7 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "datadog-operator.name" . }}-selfsigned-issuer
+  name: {{ .Release.Name }}-selfsigned-issuer
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
@@ -13,7 +13,7 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "datadog-operator.name" . }}-serving-cert
+  name: {{ .Release.Name }}-serving-cert
   namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
@@ -21,6 +21,6 @@ spec:
   - {{ .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.name }}.{{ .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: {{ include "datadog-operator.name" . }}-selfsigned-issuer
-  secretName: {{ include "datadog-operator.name" . }}-webhook-server-cert
+    name: {{ .Release.Name }}-selfsigned-issuer
+  secretName: {{ .Release.Name }}-webhook-server-cert
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR ensures the name for the conversion webhook certificate is generated in the same way between the `datadog-crds` chart and the `datadog-operator` chart.

The reason for using `.Release.Name` is that this is shared amongst the `datadog-operator` chart and `datadog-crds` sub-chart, whereas `{{ include "datadog-operator.name" . }}-serving-cert` which is currently used uses

```
{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
```

`.Chart.Name` is obviously not the same for `datadog-operator` and `datadog-crds`

#### Which issue this PR fixes

  - fixes #1005

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
