### PR TITLE
Update reference to webhook certificate secret name in deployment.yaml for datadog-operator

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.2
+
+* Use `.Release.Name` for reference to conversion webhook certificate in datadog-operator deployment.yaml
+
+
 ## 1.0.1
 
 * Use `.Release.Name` for conversion webhook certificate / issuer name to align with the certificate name generated in datadog-crds sub-chart

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.0.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -152,5 +152,5 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: {{ include "datadog-operator.name" . }}-webhook-server-cert
+          secretName: {{ .Release.Name }}-webhook-server-cert
     {{- end }}


### PR DESCRIPTION

#### What this PR does / why we need it:

This PR updates the webhook certificate name in datadog-operator's deployment.yaml to match how the certificate name is generated (i.e. using `.Release.Name` since #1006)

Apologies for missing this on the previous version.

#### Which issue this PR fixes

- follow up from #1006 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
