### PR TITLE
Adding support for the FIPS sidecar container.

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 3.28.0
 
-* Adding support to use a FIPS compliant side car container in the Datadog Cluster Agent, the Datadog Agent and the Datadog Cluster Check Runners pods.
+* Adding support to use a FIPS compliant side car container in the Datadog Cluster Agent, the Datadog Agent, and the Datadog Cluster Check Runners pods.
 
 ## 3.27.0
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 3.28.0
+
+* Adding support to use a FIPS compliant side car container in the Datadog Cluster Agent, the Datadog Agent and the Datadog Cluster Check Runners pods.
+
 ## 3.27.0
 
 * Default `Agent` and `Cluster-Agent` to `7.44.0` version.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.27.0
+version: 3.28.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -731,7 +731,7 @@ helm install <RELEASE_NAME> \
 | existingClusterAgent.serviceName | string | `nil` | Existing service name to use for reaching the external Cluster Agent |
 | existingClusterAgent.tokenSecretName | string | `nil` | Existing secret name to use for external Cluster Agent token |
 | fips.enabled | bool | `false` |  |
-| fips.image.digest | string | `""` | Define the FIPS sidecar image digest to use, takes precedence over tag if specified |
+| fips.image.digest | string | `""` | Define the FIPS sidecar image digest to use, takes precedence over `fips.image.tag` if specified. |
 | fips.image.name | string | `"fips-proxy"` |  |
 | fips.image.pullPolicy | string | `"IfNotPresent"` | Datadog the FIPS sidecar image pull policy |
 | fips.image.repository | string | `nil` |  |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.27.0](https://img.shields.io/badge/Version-3.27.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.28.0](https://img.shields.io/badge/Version-3.28.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -730,6 +730,17 @@ helm install <RELEASE_NAME> \
 | existingClusterAgent.join | bool | `false` | set this to true if you want the agents deployed by this chart to connect to a Cluster Agent deployed independently |
 | existingClusterAgent.serviceName | string | `nil` | Existing service name to use for reaching the external Cluster Agent |
 | existingClusterAgent.tokenSecretName | string | `nil` | Existing secret name to use for external Cluster Agent token |
+| fips.enabled | bool | `false` |  |
+| fips.image.digest | string | `""` | Define the FIPS sidecar image digest to use, takes precedence over tag if specified |
+| fips.image.name | string | `"fips-proxy"` |  |
+| fips.image.pullPolicy | string | `"IfNotPresent"` | Datadog the FIPS sidecar image pull policy |
+| fips.image.repository | string | `nil` |  |
+| fips.image.tag | string | `"0.5.0"` |  |
+| fips.local_address | string | `"127.0.0.1"` |  |
+| fips.port | int | `9803` |  |
+| fips.portRange | int | `15` |  |
+| fips.resources | object | `{}` | Resource requests and limits for the FIPS sidecar container. |
+| fips.use_https | bool | `false` |  |
 | fullnameOverride | string | `nil` | Override the full qualified app name |
 | kube-state-metrics.image.repository | string | `"registry.k8s.io/kube-state-metrics/kube-state-metrics"` | Default kube-state-metrics image repository. |
 | kube-state-metrics.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for KSM. KSM only supports Linux. |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -57,6 +57,7 @@
 {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}
+    {{- include "fips-envvar" . | nindent 4 }}
     {{- if .Values.datadog.logLevel }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}

--- a/charts/datadog/templates/_container-fips-proxy.yaml
+++ b/charts/datadog/templates/_container-fips-proxy.yaml
@@ -1,0 +1,32 @@
+{{- define "fips-proxy" -}}
+- name: fips-proxy
+  image: "{{ include "image-path" (dict "root" .Values "image" .Values.fips.image) }}"
+  imagePullPolicy: {{ .Values.fips.image.pullPolicy }}
+  ports:
+  {{- $portMax := add (.Values.fips.port | int) (.Values.fips.portRange | int) -}}
+  {{- $portRange :=  untilStep (.Values.fips.port | int) ($portMax | int) 1 }}
+  {{- range $index, $port := $portRange }}
+    - name: port-{{ $index }}
+      containerPort: {{ $port }}
+      protocol: TCP
+  {{- end }}
+  env:
+  - name: DD_FIPS_LOCAL_ADDRESS
+    value: {{ .Values.fips.local_address | quote }}
+  resources:
+{{ toYaml .Values.fips.resources | indent 4 }}
+    # TODO Add config to monitor journald
+{{- end -}}
+
+{{- define "fips-envvar" -}}
+{{- if eq  (include "should-enable-fips" .) "true" }}
+- name: DD_FIPS_ENABLED
+  value: {{ .Values.fips.enabled | quote }}
+- name: DD_FIPS_PORT_RANGE_START
+  value: {{ .Values.fips.port | quote }}
+- name: DD_FIPS_HTTPS
+  value: {{ .Values.fips.use_https | quote }}
+- name: DD_FIPS_LOCAL_ADDRESS
+  value: {{ .Values.fips.local_address | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -27,6 +27,7 @@
   env:
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
+    {{- include "fips-envvar" . | nindent 4 }}
     {{- if .Values.datadog.processAgent.processCollection }}
     - name: DD_PROCESS_AGENT_ENABLED
       value: "true"

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -26,6 +26,7 @@
   env:
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
+    {{- include "fips-envvar" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.securityAgent.logLevel | default .Values.datadog.logLevel | quote }}
     - name: DD_COMPLIANCE_CONFIG_ENABLED

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -33,6 +33,7 @@
   env:
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
+    {{- include "fips-envvar" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.traceAgent.logLevel | default .Values.datadog.logLevel | quote }}
     - name: DD_APM_ENABLED

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -27,6 +27,11 @@
   name: etc-lsb-release
 {{- end }}
 {{- end -}}
+{{- if eq (include "should-enable-fips" .) "true" }}
+- name: fips-config
+  configMap:
+    name: {{ template "datadog.fullname" . }}-fips-config
+{{- end }}
 {{- if eq (include "should-mount-hostPath-for-dsd-socket" .) "true" }}
 - hostPath:
     path: {{ .Values.datadog.dogstatsd.hostSocketPath }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -306,6 +306,17 @@ false
 {{- end -}}
 
 {{/*
+Return true if the fips side car container should be created.
+*/}}
+{{- define "should-enable-fips" -}}
+{{- if and (not .Values.providers.gke.autopilot) (eq .Values.targetSystem "linux") .Values.fips.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return true if the security-agent container should be created.
 */}}
 {{- define "should-enable-security-agent" -}}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -101,6 +101,9 @@ spec:
         resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 10 }}
       containers:
+        {{- if eq  (include "should-enable-fips" .) "true" }}
+          {{- include "fips-proxy" . | nindent 6 }}
+        {{- end }}
       - name: agent
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterChecksRunner.image) }}"
         command: ["bash", "-c"]
@@ -191,6 +194,7 @@ spec:
           - name: DD_CLUSTER_NAME
             value: {{ .Values.datadog.clusterName | quote }}
           {{- end }}
+          {{- include "fips-envvar" . | nindent 10 }}
           {{- include "additional-env-entries" .Values.clusterChecksRunner.env | indent 10 }}
           {{- include "additional-env-dict-entries" .Values.clusterChecksRunner.envDict | indent 10 }}
         resources:

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -66,7 +66,6 @@ spec:
       {{- if .Values.clusterAgent.podAnnotations }}
 {{ tpl (toYaml .Values.clusterAgent.podAnnotations) . | indent 8 }}
       {{- end }}
-
     spec:
       {{- if .Values.clusterAgent.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.clusterAgent.shareProcessNamespace }}
@@ -116,6 +115,9 @@ spec:
           - name: config
             mountPath: /opt/datadog-agent
       containers:
+        {{- if eq  (include "should-enable-fips" .) "true" }}
+          {{- include "fips-proxy" . | nindent 6 }}
+        {{- end }}
       - name: cluster-agent
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterAgent.image) }}"
         {{- with .Values.clusterAgent.command }}
@@ -287,6 +289,7 @@ spec:
             value: {{ .Values.datadog.prometheusScrape.version | quote }}
           {{- end }}
           {{- end }}
+          {{- include "fips-envvar" . | nindent 10 }}
           {{- include "additional-env-entries" .Values.clusterAgent.env | indent 10 }}
           {{- include "additional-env-dict-entries" .Values.clusterAgent.envDict | indent 10 }}
         livenessProbe:

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -112,6 +112,9 @@ spec:
         {{- if eq (include "should-enable-trace-agent" .) "true" }}
           {{- include "container-trace-agent" . | nindent 6 }}
         {{- end }}
+        {{- if eq  (include "should-enable-fips" .) "true" }}
+          {{- include "fips-proxy" . | nindent 6 }}
+        {{- end }}
         {{- if .Values.datadog.processAgent.enabled }}
           {{- include "container-process-agent" . | nindent 6 }}
         {{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1130,6 +1130,48 @@ existingClusterAgent:
   # existingClusterAgent.clusterchecksEnabled -- set this to false if you don’t want the agents to run the cluster checks of the joined external cluster agent
   clusterchecksEnabled: true
 
+# fips is used to enable the fips sidecar container for GOVCLOUD environments.
+fips:
+
+  enabled: false
+
+  # TODO: Option to override config of the FIPS side car: /etc/datadog-fips-proxy/datadog-fips-proxy.cfg
+  # customConfig: false
+
+  # fips.port specifies which port is used by the containers to communicate to the FIPS sidecar.
+  port: 9803
+
+  # fips.portRange specifies the number of ports used, defaults to 13  https://github.com/DataDog/datadog-agent/blob/7.44.x/pkg/config/config.go#L1564-L1577
+  portRange: 15
+
+  use_https: false
+  # fips.resources -- Resource requests and limits for the FIPS sidecar container.
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 20m
+    #   memory: 64Mi
+
+  local_address: "127.0.0.1"
+  ## Define the Datadog image to work with
+  image:
+    ## fips.image.name -- Define the FIPS sidecar container image name.
+    name: fips-proxy
+
+    # agents.image.tag -- Define the FIPS sidecar container version to use
+    tag: 0.5.0
+
+    # fips.image.pullPolicy -- Datadog the FIPS sidecar image pull policy
+    pullPolicy: IfNotPresent
+
+    # fips.image.digest -- Define the FIPS sidecar image digest to use, takes precedence over tag if specified
+    digest: ""
+
+    # agents.image.repository -- Override default registry + image.name for Agent
+    repository:
+
 agents:
   # agents.enabled -- You should keep Datadog DaemonSet enabled!
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1160,13 +1160,13 @@ fips:
     ## fips.image.name -- Define the FIPS sidecar container image name.
     name: fips-proxy
 
-    # agents.image.tag -- Define the FIPS sidecar container version to use
+    # agents.image.tag -- Define the FIPS sidecar container version to use.
     tag: 0.5.0
 
     # fips.image.pullPolicy -- Datadog the FIPS sidecar image pull policy
     pullPolicy: IfNotPresent
 
-    # fips.image.digest -- Define the FIPS sidecar image digest to use, takes precedence over tag if specified
+    # fips.image.digest -- Define the FIPS sidecar image digest to use, takes precedence over `fips.image.tag` if specified.
     digest: ""
 
     # agents.image.repository -- Override default registry + image.name for Agent


### PR DESCRIPTION
#### What this PR does / why we need it:

For customers using GOVCLOUD, the FIPS compliant side car proxy is necessary to forward data to the backend.
This PR introduces the logic to add the side car to the Agent, the Cluster Agent and the Cluster Level Check Workers.

The side car opens 13 ports by default (only to the local pod network namespace, not on the node) for each feature, per [this config](https://github.com/DataDog/datadog-agent/blob/7.44.x/pkg/config/config.go#L1564-L1577).
Environment variables are added to the Agent containers (trace, process, security...), DCA and CLCW for the forwarders to use the side car.

TODO: 
- [x] add documentation in the README.
- [x] check if we need to support a custom config right away
- [x] check the orchestrator explorer port.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
