### PR TITLE
Support custom resources and custom resource definitions collection in orchestrator explorer

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.39.2
+
+* Support custom resources and custom resource definitions collection in orchestrator explorer
+
 ## 3.39.1
 
 * Add `kubeStateMetricsCore.collectConfigMaps` config field to the Agent

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.39.1
+version: 3.39.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.39.1](https://img.shields.io/badge/Version-3.39.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.39.2](https://img.shields.io/badge/Version-3.39.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -672,6 +672,7 @@ helm install <RELEASE_NAME> \
 | datadog.networkPolicy.flavor | string | `"kubernetes"` | Flavor of the network policy to use. Can be: * kubernetes for networking.k8s.io/v1/NetworkPolicy * cilium     for cilium.io/v2/CiliumNetworkPolicy |
 | datadog.nodeLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Node Labels to Datadog Tags |
 | datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
+| datadog.orchestratorExplorer.customResources | list | `[]` | Defines custom resources for the orchestrator explorer to collect |
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
 | datadog.osReleasePath | string | `"/etc/os-release"` | Specify the path to your os-release file |
 | datadog.otlp.receiver.protocols.grpc.enabled | bool | `false` | Enable the OTLP/gRPC endpoint |

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -831,3 +831,19 @@ true
 false
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create RBACs for custom resources
+*/}}
+{{- define "orchestratorExplorer-config-crs" -}}
+{{- range $cr := .Values.datadog.orchestratorExplorer.customResources }}
+- apiGroups:
+  - {{ (splitList "/" $cr) | first | quote }}
+  resources:
+  - {{ (splitList "/" $cr) | last | quote }}
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+{{- end -}}

--- a/charts/datadog/templates/_orchestrator_explorer_config.yaml
+++ b/charts/datadog/templates/_orchestrator_explorer_config.yaml
@@ -1,0 +1,51 @@
+{{- define "orchestratorExplorer-add-crd-collection-config" -}}
+
+{{- $useCRDConfig := true -}}
+
+{{/*
+If custom config is provided in `clusterAgent.confd`, then we don't add crd collection config.
+*/}}
+{{- range $k, $v := .Values.clusterAgent.confd -}}
+{{- if or (eq "orchestrator.yaml" $k) (eq "orchestrator.yaml.default" $k)  -}}
+{{- $useCRDConfig = false -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+If custom config is provided in `clusterAgent.advancedConfd`, then we don't add crd collection config.
+*/}}
+{{- range $integration, $configs := .Values.clusterAgent.advancedConfd -}}
+{{- if and (eq "orchestrator.d" $integration) (gt (len $configs) 0) -}}
+{{- $useCRDConfig = false -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+If customResources is empty, then we don't add crd collection config.
+*/}}
+{{- if eq $useCRDConfig true  -}}
+{{- if eq (len $.Values.datadog.orchestratorExplorer.customResources) 0 }}
+{{- $useCRDConfig = false -}}
+{{- end -}}
+{{- end -}}
+
+{{- $useCRDConfig -}}
+
+{{- end -}}
+
+
+{{- define "orchestratorExplorer-config" -}}
+
+{{- if eq (include "orchestratorExplorer-add-crd-collection-config" .) "true" -}}
+orchestrator.yaml: |-
+  cluster_check: {{ .Values.clusterChecksRunner.enabled }}
+  init_config:
+  instances: 
+    - skip_leader_election: {{ .Values.clusterChecksRunner.enabled }}
+      {{- if gt (len $.Values.datadog.orchestratorExplorer.customResources) 0 }}
+      crd_collectors:
+      {{- toYaml $.Values.datadog.orchestratorExplorer.customResources | nindent 8 -}}
+      {{- end }}
+{{- end -}}
+
+{{- end -}}

--- a/charts/datadog/templates/cluster-agent-confd-configmap.yaml
+++ b/charts/datadog/templates/cluster-agent-confd-configmap.yaml
@@ -19,6 +19,9 @@ data:
 {{ include "helmCheck-config" . | nindent 2 }}
 {{- end -}}
 {{ include "kubernetes_apiserver-config" . | nindent 2 }}
+{{- if .Values.datadog.orchestratorExplorer.enabled -}}
+{{ include "orchestratorExplorer-config" . | nindent 2 }}
+{{- end -}}
 {{- range $integration, $configs := $.Values.clusterAgent.advancedConfd }}
 {{- range $name, $config := $configs }}
   {{ printf "%s--%s: |" $integration $name }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -390,6 +390,12 @@ spec:
             - key: kubernetes_apiserver.yaml
               path: kubernetes_apiserver.yaml
 {{- end }}
+{{- if .Values.datadog.orchestratorExplorer.enabled }}
+{{- if eq (include "orchestratorExplorer-add-crd-collection-config" .) "true" }}
+            - key: orchestrator.yaml
+              path: orchestrator.yaml
+{{- end }}
+{{- end }}
 {{- range $integration, $configs := $.Values.clusterAgent.advancedConfd }}
 {{- range $name, $config := $configs }}
             - key: {{ printf "%s--%s" $integration $name | quote }}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -298,6 +298,9 @@ rules:
   resources: ["secrets"]
   verbs: ["get"]
 {{- end }}
+{{- if .Values.datadog.orchestratorExplorer.enabled }}
+{{- include "orchestratorExplorer-config-crs" . }}
+{{- end }}
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -644,6 +644,15 @@ datadog:
     container_scrubbing:
       enabled: true
 
+    # datadog.orchestratorExplorer.customResources -- Defines custom resources for the orchestrator explorer to collect
+
+    # customResources is required for RBAC creation if a custom orchestrator explorer configuration is provided in `clusterAgent.confd` or `clusterAgent.advancedConfd`
+    # Each item should follow group/version/name, for example
+    # customResources:
+    #   - datadoghq.com/v1alpha1/datadogmetrics
+    #   - datadoghq.com/v1alpha1/watermarkpodautoscalers
+    customResources: []
+
   helmCheck:
     # datadog.helmCheck.enabled -- Set this to true to enable the Helm check (Requires Agent 7.35.0+ and Cluster Agent 1.19.0+)
     # This requires clusterAgent.enabled to be set to true


### PR DESCRIPTION
#### What this PR does / why we need it:

#### datadog agent

1. Add new field `orchestratorExplorer.customResourcesCollection` to collect custom resources
2. Update RBACs according to `orchestratorExplorer.customResourcesCollection`
3. Mount a default config if custom config is not provided



#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
