### PR TITLE
Add `memfd_create` to seccomp for system-probe

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Datadog changelog
 
-# 3.28.0
+## 3.28.1
+
+* Add `memfd_create` syscall to seccomp profile for system-probe.
+
+## 3.28.0
 
 * Adding support to use a FIPS compliant side car container in the Datadog Cluster Agent, the Datadog Agent, and the Datadog Cluster Check Runners pods.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.28.0
+version: 3.28.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.28.0](https://img.shields.io/badge/Version-3.28.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.28.1](https://img.shields.io/badge/Version-3.28.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -166,6 +166,7 @@ data:
             "lstat",
             "lstat64",
             "madvise",
+            "memfd_create",
             "mkdir",
             "mkdirat",
             "mmap",


### PR DESCRIPTION
#### What this PR does / why we need it:
Add `memfd_create` to system-probe seccomp policy.
Needed for runtime compilation sealed memfd feature from https://github.com/DataDog/datadog-agent/pull/15726

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
