### PR TITLE
Add emptyDir volume allowance to Cluster Agent PodSecurityPolicy

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.28.2
+
+* Add `emptyDir` volume allowance to Cluster Agent PodSecurityPolicy.
+
 ## 3.28.1
 
 * Add `memfd_create` syscall to seccomp profile for system-probe.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.28.1
+version: 3.28.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.28.1](https://img.shields.io/badge/Version-3.28.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.28.2](https://img.shields.io/badge/Version-3.28.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-psp.yaml
+++ b/charts/datadog/templates/cluster-agent-psp.yaml
@@ -10,6 +10,7 @@ spec:
     - configMap
     - hostPath
     - secret
+    - emptyDir
   fsGroup:
     rule: RunAsAny
   runAsUser:


### PR DESCRIPTION
#### What this PR does / why we need it:

With the change in https://github.com/DataDog/helm-charts/commit/2755128de694df782594c9a7f3272d11c4bdeb9c (and other similar changes), the cluster-agent uses `emptyDir` volumes.  The cluster-agent PodSecurityPolicy needs to allow this volume type.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
