### PR TITLE
add values to helm chart to enable secret and configmap count values

### DIFF
--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -6,9 +6,12 @@ kubernetes_state_core.yaml.default: |-
   init_config:
   instances:
     - collectors:
-{{- if .Values.datadog.kubeStateMetricsCore.collectSecretMetrics }}
+{{- if  or (.Values.datadog.kubeStateMetricsCore.collectSecretMetrics) (.Values.datadog.kubeStateMetricsCore.collectSecretCount) }}
       - secrets
 {{- end }}
+{{- if .Values.datadog.kubeStateMetricsCore.collectConfigMapCount }}
+      - configmaps
+{{- end}}
 {{- if .Values.datadog.kubeStateMetricsCore.collectVpaMetrics }}
       - verticalpodautoscalers
 {{- end }}
@@ -36,6 +39,12 @@ kubernetes_state_core.yaml.default: |-
 {{- if .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners }}
       skip_leader_election: true
 {{- end }}
+{{- if .Values.datadog.kubeStateMetricsCore.collectSecretCount }}
+      enable_secret_count: true 
+{{- end}}
+{{- if .Values.datadog.kubeStateMetricsCore.collectConfigMapCount }}
+      enable_configmap_count: true
+{{- end}}
       labels_as_tags:
 {{ .Values.datadog.kubeStateMetricsCore.labelsAsTags | toYaml | indent 8 }}
       annotations_as_tags:

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -9,6 +9,9 @@ rules:
 - apiGroups:
   - ""
   resources:
+{{- if .Values.datadog.kubeStateMetricsCore.collectConfigMapCount }}
+  - configmaps
+{{- end}}
   - services
   - endpoints
   - pods

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -156,6 +156,12 @@ datadog:
     ## Configuring this field will change the default kubernetes_state_core check configuration and the RBACs granted to Datadog Cluster Agent to run the kubernetes_state_core check.
     collectVpaMetrics: false
 
+    # datadog.kubeStateMetricsCore.collectSecretCount -- Enable this to collect the count of Secrets in the cluster 
+    collectSecretCount: false
+
+    # datadog.kubeStateMetricsCore.collectConfigMapCount -- Enable this to collect the count of ConfigMaps in the cluster
+    collectConfigMapCount: false
+
     # datadog.kubeStateMetricsCore.useClusterCheckRunners -- For large clusters where the Kubernetes State Metrics Check Core needs to be distributed on dedicated workers.
 
     ## Configuring this field will create a separate deployment which will run Cluster Checks, including Kubernetes State Metrics Core.


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds values to the Helm chart for enabling the new metrics `kubernetes_state.configmap.count` and `kubernetes_state.secret.count`, which are to be included through [this PR](https://github.com/DataDog/datadog-agent/pull/16699/files). Two new values are added:
- `datadog.kubeStateMetricsCore.collectSecretCount`
- `datadog.kubeStateMetricsCore.collectConfigMapCount`

These can be toggled to `true` or `false` depending on the customer's needs. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
