### PR TITLE
feat: add customresourcedefinitions to kubernetes_state_core_config.yaml

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.29.1
+
+* Add `customresourcedefinitions` to collectors `charts/datadog/templates/_kubernetes_state_core_config.yaml`.
+
 ## 3.29.0
 
 * Add `datadog.securityAgent.compliance.xccdf.enabled` parameter to enable XCCDF feature in CSPM.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.29.0
+version: 3.29.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.29.0](https://img.shields.io/badge/Version-3.29.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.29.1](https://img.shields.io/badge/Version-3.29.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -12,6 +12,7 @@ kubernetes_state_core.yaml.default: |-
 {{- if .Values.datadog.kubeStateMetricsCore.collectVpaMetrics }}
       - verticalpodautoscalers
 {{- end }}
+      - customresourcedefinitions
       - nodes
       - pods
       - services


### PR DESCRIPTION
#### What this PR does / why we need it:

https://github.com/DataDog/datadog-agent/pull/16141 and https://github.com/DataDog/helm-charts/pull/999 added support to crd metrics.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:

[The Datadog document](https://github.com/DataDog/documentation/blob/df1844018e87f9b8876e7e0106c96b4d40f3e3e2/content/en/integrations/kubernetes_state_core.md?plain=1#L334-L338) introduces `kubernetes_state.crd.*`.
 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
