### PR TITLE
[helm][dca][rbac] Fix create permission for leases in DCA

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.30.3
+
+* Remove resourceName field from `create` permission of `leases` in `cluster-agent-rbac`.
+
 ## 3.30.2
 
 * Add `get`, `create`, `update` permissions of `leases` to `cluster-agent-rbac`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.30.2
+version: 3.30.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.30.2](https://img.shields.io/badge/Version-3.30.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.30.3](https://img.shields.io/badge/Version-3.30.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -75,6 +75,11 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
   - create
 {{- if .Values.clusterAgent.metricsProvider.enabled }}
 - apiGroups:


### PR DESCRIPTION
#### What this PR does / why we need it:

Follow-up to https://github.com/DataDog/helm-charts/pull/1050

The change was still not fixing the problem. It appears to be because of issues restricting creation of leases to specific resource names (see [kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources))

We are already using a similar pattern for the configmap permission, I assume for the same reason

#### Special notes for your reviewer:

I validated this locally via minikube

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
