### PR TITLE
[RBAC][KSM] Update config to monitor `apiservices`

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.30.5
+
+* Add `list` and `watch` permissions of `apiservices` resources for the `kubernetes_state_core` check.
+
 ## 3.30.4
 
 * Remove USM private beta comments.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.30.4
+version: 3.30.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.30.4](https://img.shields.io/badge/Version-3.30.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.30.5](https://img.shields.io/badge/Version-3.30.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -12,6 +12,7 @@ kubernetes_state_core.yaml.default: |-
 {{- if .Values.datadog.kubeStateMetricsCore.collectVpaMetrics }}
       - verticalpodautoscalers
 {{- end }}
+      - apiservices
 {{- if .Values.datadog.kubeStateMetricsCore.collectCrdMetrics }}
       - customresourcedefinitions
 {{- end }}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -195,7 +195,15 @@ rules:
   - get
   - watch
 - apiGroups:
-    - "apiextensions.k8s.io"
+    - apiregistration.k8s.io
+  resources:
+    - apiservices
+  verbs:
+    - list
+    - get
+    - watch
+- apiGroups:
+    - apiextensions.k8s.io
   resources:
     - customresourcedefinitions
   verbs:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds RBAC permissions to the ksm core rbac and configures the check to monitor `apiservices` since metrics are currently available for this resource.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
