### PR TITLE
Add a parameter for `apiservices` metrics collection in KSM core

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.30.6
+
+* Add a feature flag to gate the collection of `apiservices` metrics in the `kubernetes_state_core` check.
+
 ## 3.30.5
 
 * Add `list` and `watch` permissions of `apiservices` resources for the `kubernetes_state_core` check.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.30.5
+version: 3.30.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.30.5](https://img.shields.io/badge/Version-3.30.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.30.6](https://img.shields.io/badge/Version-3.30.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -637,6 +637,7 @@ helm install <RELEASE_NAME> \
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.ignoreAutoConfig | list | `[]` | List of integration to ignore auto_conf.yaml. |
 | datadog.kubeStateMetricsCore.annotationsAsTags | object | `{}` | Extra annotations to collect from resources and to turn into datadog tag. |
+| datadog.kubeStateMetricsCore.collectApiServicesMetrics | bool | `false` | Enable watching API Services objects and collecting their corresponding metrics kubernetes_state.apiservice.* |
 | datadog.kubeStateMetricsCore.collectCrdMetrics | bool | `false` | Enable watching CRD objects and collecting their corresponding metrics kubernetes_state.crd.* |
 | datadog.kubeStateMetricsCore.collectSecretMetrics | bool | `true` | Enable watching secret objects and collecting their corresponding metrics kubernetes_state.secret.* |
 | datadog.kubeStateMetricsCore.collectVpaMetrics | bool | `false` | Enable watching VPA objects and collecting their corresponding metrics kubernetes_state.vpa.* |

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -12,7 +12,9 @@ kubernetes_state_core.yaml.default: |-
 {{- if .Values.datadog.kubeStateMetricsCore.collectVpaMetrics }}
       - verticalpodautoscalers
 {{- end }}
+{{- if .Values.datadog.kubeStateMetricsCore.collectApiServicesMetrics }}
       - apiservices
+{{- end }}
 {{- if .Values.datadog.kubeStateMetricsCore.collectCrdMetrics }}
       - customresourcedefinitions
 {{- end }}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -194,6 +194,7 @@ rules:
   - list
   - get
   - watch
+{{- if .Values.datadog.kubeStateMetricsCore.collectApiServicesMetrics }}
 - apiGroups:
     - apiregistration.k8s.io
   resources:
@@ -202,6 +203,7 @@ rules:
     - list
     - get
     - watch
+{{- end }}
 - apiGroups:
     - apiextensions.k8s.io
   resources:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -161,6 +161,11 @@ datadog:
     ## Configuring this field will change the default kubernetes_state_core check configuration to run the kubernetes_state_core check.
     collectCrdMetrics: false
 
+    # datadog.kubeStateMetricsCore.collectApiServicesMetrics -- Enable watching API Services objects and collecting their corresponding metrics kubernetes_state.apiservice.*
+
+    ## Configuring this field will change the default kubernetes_state_core check configuration to run the kubernetes_state_core check.
+    collectApiServicesMetrics: false
+
     # datadog.kubeStateMetricsCore.useClusterCheckRunners -- For large clusters where the Kubernetes State Metrics Check Core needs to be distributed on dedicated workers.
 
     ## Configuring this field will create a separate deployment which will run Cluster Checks, including Kubernetes State Metrics Core.


### PR DESCRIPTION
#### What this PR does / why we need it:

Add a feature flag to gate the collection of `apiservices` metrics collection in the `kubernetes_state_core` check (introduced by DataDog/datadog-agent#16570).
Unconditionally trying to collect them might fail on clusters powered by an old version of Kubernetes.

#### Which issue this PR fixes

  - fixes #1056

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
