### PR TITLE
[datadog] Update `fips.image.tag` to 0.5.2

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.30.8
+
+* Fix Windows support of `agents.customAgentConfig` to avoid bind mount of a file.
+
 ## 3.30.7
 
 * Fix Windows support of `agents.customAgentConfig` to avoid bind mount of a file.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.30.7
+version: 3.30.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.30.7](https://img.shields.io/badge/Version-3.30.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.30.8](https://img.shields.io/badge/Version-3.30.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -739,7 +739,7 @@ helm install <RELEASE_NAME> \
 | fips.image.name | string | `"fips-proxy"` |  |
 | fips.image.pullPolicy | string | `"IfNotPresent"` | Datadog the FIPS sidecar image pull policy |
 | fips.image.repository | string | `nil` |  |
-| fips.image.tag | string | `"0.5.0"` |  |
+| fips.image.tag | string | `"0.5.2"` | Define the FIPS sidecar container version to use. |
 | fips.local_address | string | `"127.0.0.1"` |  |
 | fips.port | int | `9803` |  |
 | fips.portRange | int | `15` |  |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1173,8 +1173,8 @@ fips:
     ## fips.image.name -- Define the FIPS sidecar container image name.
     name: fips-proxy
 
-    # agents.image.tag -- Define the FIPS sidecar container version to use.
-    tag: 0.5.0
+    # fips.image.tag -- Define the FIPS sidecar container version to use.
+    tag: 0.5.2
 
     # fips.image.pullPolicy -- Datadog the FIPS sidecar image pull policy
     pullPolicy: IfNotPresent


### PR DESCRIPTION


#### What this PR does / why we need it:

This change bumps the default version of the fips-proxy image used to fix issues with DNS handling in restricted environments.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
