### PR TITLE
Updated mountPath of pointerdir on Windows deployments

### DIFF
--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -225,7 +225,7 @@
     {{- if eq .Values.targetSystem "windows" }}
     {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
     - name: pointerdir
-      mountPath: C:/var/log
+      mountPath: c:/programdata/datadog/run
       readOnly: false # Need RW for logs pointer
     - name: logpodpath
       mountPath: C:/var/log/pods


### PR DESCRIPTION
Currently pointdir is mounted on C:/var/log but we look for registry.json by [default](https://github.com/DataDog/datadog-agent/blob/85eac7ff934d3f0b5525d960e2f03684cfa68d6d/pkg/config/config_windows.go#L19) at `c:/programdata/datadog/run`. This location is currently mapped to an ephemeral volume, `config`.

Because of it, when an agent container is restarted for whatever reason, most commonly configuration updates, it loses the pointers for the logs.  It results in customers ingesting multiple times the same log entries.