### PR TITLE
Updated pointerdir mountPath for Win deploy

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.30.10
+
+* Updated pointerdir mountPath for Windows deployments.
+
 ## 3.30.9
 
 * Pass its pod name to the cluster-agent. This is used by cluster agent 7.46+ to make leader election work when using host network.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.30.9
+version: 3.30.10
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.30.9](https://img.shields.io/badge/Version-3.30.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.30.10](https://img.shields.io/badge/Version-3.30.10-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -225,7 +225,7 @@
     {{- if eq .Values.targetSystem "windows" }}
     {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
     - name: pointerdir
-      mountPath: C:/var/log
+      mountPath: c:/programdata/datadog/run
       readOnly: false # Need RW for logs pointer
     - name: logpodpath
       mountPath: C:/var/log/pods


### PR DESCRIPTION
Currently pointdir is mounted on C:/var/log but we look for registry.json by [default](https://github.com/DataDog/datadog-agent/blob/85eac7ff934d3f0b5525d960e2f03684cfa68d6d/pkg/config/config_windows.go#L19) at `c:/programdata/datadog/run`. This location is currently mapped to an ephemeral volume, `config`.

Because of it, when an agent container is restarted for whatever reason, most commonly configuration updates, it loses the pointers for the logs.  It results in customers ingesting multiple times the same log entries.