### PR TITLE
Set the OpenShift SCC priority to null

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.32.2
+
+* Set the `priority` field of the OpenShift’s SCC to `null` in order to not have a higher priority than the OpenShift 4.11+ default `restricted-v2` SCC.
+
 ## 3.32.1
 
 * Add AP1 Site Comment at `value.yaml`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.32.1
+version: 3.32.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.32.1](https://img.shields.io/badge/Version-3.32.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.32.2](https://img.shields.io/badge/Version-3.32.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-scc.yaml
+++ b/charts/datadog/templates/agent-scc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "datadog.labels" . | indent 4 }}
 users:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ include "agents.serviceAccountName" . }}
-priority: 8
+priority: null
 # Allow host ports for dsd / trace intake
 allowHostPorts: {{ or .Values.datadog.dogstatsd.useHostPort .Values.datadog.apm.enabled .Values.datadog.apm.portEnabled .Values.agents.useHostNetwork }}
 # Allow host PID for dogstatsd origin detection

--- a/charts/datadog/templates/cluster-agent-scc.yaml
+++ b/charts/datadog/templates/cluster-agent-scc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "datadog.labels" . | indent 4 }}
 users:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ template "datadog.fullname" . }}-cluster-agent
-priority: 8
+priority: null
 # Allow host ports if hostNetwork
 allowHostPorts: {{ .Values.clusterAgent.useHostNetwork }}
 allowHostNetwork: {{ .Values.clusterAgent.useHostNetwork}}


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

Upgrading an OpenShift cluster to 4.11+ after the datadog agent has been deployed fails because the datadog SCC has a higher priority than the OpenShift `restricted-v2` one.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
