### PR TITLE
[datadog] Fix cluster agent pod failing to start when securityContext is set

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.32.6
+
+* Fix cluster agent pod failing to start when securityContext is set.
+
 ## 3.32.5
 
 * Fix comment for datadog.kubernetesEvents.collectedEventTypes in values.yaml.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.32.5
+version: 3.32.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.32.5](https://img.shields.io/badge/Version-3.32.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.32.6](https://img.shields.io/badge/Version-3.32.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -106,11 +106,12 @@ spec:
 {{- end }}
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         command:
-          - cp
+          - bash
+          - -c
         args:
-          - -r
-          - /etc/datadog-agent
-          - /opt
+          - |
+            chmod -R 744 /etc/datadog-agent;
+            cp -r /etc/datadog-agent /opt
         volumeMounts:
           - name: config
             mountPath: /opt/datadog-agent


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the script used by the cluster agent initContainer to update the permissions of the files in /etc/datadog-agent before copying them to /opt/datadog-agent.

As a consequence of [this change](https://github.com/DataDog/datadog-agent/pull/16347) introduced to the cluster agent image, the init container would fail if `securityContext` was set to anything non-root with the following error:

```
cp: cannot stat '/etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default': Permission denied
cp: cannot stat '/etc/datadog-agent/conf.d/orchestrator.d/conf.yaml.default': Permission denied
```

This is fixed by changing the permissions of this directory from 644 to 744.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
