### PR TITLE
Fix conversionWebhook.enabled parameter to set user-configured value

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.6
 
-* Fix conversionWebhook.enabled parameter to set user-configured value.
+* Fix conversionWebhook.enabled parameter to correctly set user-configured value when enabling the conversion webhook. 
 
 ## 1.0.5
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.6
+
+* Fix conversionWebhook.enabled parameter to set user-configured value.
+
 ## 1.0.5
 
 * Add AP1 Site Comment in `values.yaml`.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.0.5
+version: 1.0.6
 appVersion: 1.0.3
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: 1.0.3](https://img.shields.io/badge/AppVersion-1.0.3-informational?style=flat-square)
+![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![AppVersion: 1.0.3](https://img.shields.io/badge/AppVersion-1.0.3-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -93,7 +93,9 @@ spec:
             - "-logEncoder=json"
             - "-metrics-addr=:{{ .Values.metricsPort }}"
             - "-loglevel={{ .Values.logLevel }}"
-          {{- if and (not .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled) (semverCompare ">=1.0.0-0" .Values.image.tag ) }}
+          {{- if and (not (empty .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled)) (semverCompare ">=1.0.0-0" .Values.image.tag ) }}
+            - "-webhookEnabled={{ .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled }}"
+          {{- else }}
             - "-webhookEnabled=false"
           {{- end }}
           {{- if .Values.secretBackend.command }}

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.0.5
+    helm.sh/chart: datadog-operator-1.0.6
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.0.3"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -51,6 +51,7 @@ spec:
             - "-logEncoder=json"
             - "-metrics-addr=:8383"
             - "-loglevel=info"
+            - "-webhookEnabled=true"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
           ports:

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.0.5
+    helm.sh/chart: datadog-operator-1.0.6
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.0.3"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -59,7 +59,7 @@ func Test_operator_chart(t *testing.T) {
 			skipTest:   SkipTest,
 		},
 		{
-			name: "Verify Operator 1.0 conversionWebhook.enabled=true arg",
+			name: "Verify Operator 1.0 conversionWebhook.enabled=true",
 			command: common.HelmCommand{
 				ReleaseName: "random-string-as-release-name",
 				ChartPath:   "../../charts/datadog-operator",
@@ -73,7 +73,7 @@ func Test_operator_chart(t *testing.T) {
 			skipTest:   SkipTest,
 		},
 		{
-			name: "Verify Operator 1.0 conversionWebhook.enabled=false arg",
+			name: "Verify Operator 1.0 conversionWebhook.enabled=false",
 			command: common.HelmCommand{
 				ReleaseName: "random-string-as-release-name",
 				ChartPath:   "../../charts/datadog-operator",
@@ -82,6 +82,17 @@ func Test_operator_chart(t *testing.T) {
 				Overrides: map[string]string{
 					"datadogCRDs.migration.datadogAgents.conversionWebhook.enabled": "false",
 				},
+			},
+			assertions: verifyConversionWebhookEnabledFalse,
+			skipTest:   SkipTest,
+		},
+		{
+			name: "Verify Operator 1.0 conversionWebhook.enabled default",
+			command: common.HelmCommand{
+				ReleaseName: "random-string-as-release-name",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
 			},
 			assertions: verifyConversionWebhookEnabledFalse,
 			skipTest:   SkipTest,

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -59,6 +59,34 @@ func Test_operator_chart(t *testing.T) {
 			skipTest:   SkipTest,
 		},
 		{
+			name: "Verify Operator 1.0 conversionWebhook.enabled=true arg",
+			command: common.HelmCommand{
+				ReleaseName: "random-string-as-release-name",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"datadogCRDs.migration.datadogAgents.conversionWebhook.enabled": "true",
+				},
+			},
+			assertions: verifyConversionWebhookEnabledTrue,
+			skipTest:   SkipTest,
+		},
+		{
+			name: "Verify Operator 1.0 conversionWebhook.enabled=false arg",
+			command: common.HelmCommand{
+				ReleaseName: "random-string-as-release-name",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"datadogCRDs.migration.datadogAgents.conversionWebhook.enabled": "false",
+				},
+			},
+			assertions: verifyConversionWebhookEnabledFalse,
+			skipTest:   SkipTest,
+		},
+		{
 			name: "Rendering all does not fail",
 			command: common.HelmCommand{
 				ReleaseName: "datadog-operator",
@@ -109,6 +137,20 @@ func verifyDeploymentCertSecretName(t *testing.T, manifest string) {
 			},
 		},
 	})
+}
+
+func verifyConversionWebhookEnabledTrue(t *testing.T, manifest string) {
+	var deployment appsv1.Deployment
+	common.Unmarshal(t, manifest, &deployment)
+	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, operatorContainer.Args, "-webhookEnabled=true")
+}
+
+func verifyConversionWebhookEnabledFalse(t *testing.T, manifest string) {
+	var deployment appsv1.Deployment
+	common.Unmarshal(t, manifest, &deployment)
+	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, operatorContainer.Args, "-webhookEnabled=false")
 }
 
 func verifyAll(t *testing.T, manifest string) {


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the datadog-operator deployment template to correctly set the user-configured `datadogCRDs.migration.datadogAgents.conversionWebhook.enabled` parameter. 

Previously, the `-webhookEnabled` container arg was not being set on the datadog-operator deployment.yaml when `datadogCRDs.migration.datadogAgents.conversionWebhook.enabled` was set to `true`. It was only set when the config was set to `false`. This bug was obscured by the `datadog-operator` binary which has the default behavior of `webhookEnabled: true`. 

When the default behavior in the datadog-operator is updated to `webhookEnabled: false` in a future version, users using the conversion webhook must upgrade their datadog-operator helm chart to the latest version in order to avoid any interruption in the conversion webhook.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
