### PR TITLE
upgrade(datadog): Always set the Remote Configuration environment variable

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.32.8
+
+* Always set the Remote Configuration environment variable
+
 ## 3.32.7
 
 * Update the cluster agent network policy to allow telemetry submission.
@@ -27,7 +31,7 @@
 ## 3.32.1
 
 * Add AP1 Site Comment at `value.yaml`.
-* Fix CVE in the FIPS compliant side car container  
+* Fix CVE in the FIPS compliant side car container
 
 ## 3.32.0
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.32.7
+version: 3.32.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.32.7](https://img.shields.io/badge/Version-3.32.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.32.8](https://img.shields.io/badge/Version-3.32.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -9,10 +9,8 @@
     secretKeyRef:
       name: {{ template "datadog.apiSecretName" . }}
       key: api-key
-{{- if eq (include "datadog-remoteConfiguration-enabled" .) "true" }}
 - name: DD_REMOTE_CONFIGURATION_ENABLED
-  value: "true"
-{{- end }}
+  value: {{ include "datadog-remoteConfiguration-enabled" . | quote }}
 {{- if (not .Values.providers.gke.autopilot) }}
 - name: DD_AUTH_TOKEN_FILE_PATH
   value: {{ template "datadog.confPath" . }}/auth/token

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -217,9 +217,9 @@ spec:
           {{- if eq (include "clusterAgent-remoteConfiguration-enabled" .) "true" }}
           - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PATCHER_ENABLED
             value: "true"
-          - name: DD_REMOTE_CONFIGURATION_ENABLED
-            value: "true"
           {{- end }}
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: {{ include "clusterAgent-remoteConfiguration-enabled" . | quote }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED
             value: {{ .Values.datadog.clusterChecks.enabled | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:
As we plan to enable Remote Configuration by default in the future, we need to make sure that RC being disabled in the chart actually disables RC in the agent. This is what this PR does by enforcing the presence of the RC enablement env var.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
