### PR TITLE
Adds community integrations installation at entrypoint

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.33.0
+
+* Adds `datadog.communityIntegrations` to permit the installation of community integrations at deployment time, instead of resorting to a custom image.
+
 ## 3.32.7
 
 * Update the cluster agent network policy to allow telemetry submission.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.32.7
+version: 3.33.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.32.7](https://img.shields.io/badge/Version-3.32.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.33.0](https://img.shields.io/badge/Version-3.33.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -604,6 +604,7 @@ helm install <RELEASE_NAME> \
 | datadog.clusterName | string | `nil` | Set a unique cluster name to allow scoping hosts and Cluster Checks easily |
 | datadog.clusterTagger.collectKubernetesTags | bool | `false` | Enables Kubernetes resources tags collection. |
 | datadog.collectEvents | bool | `true` | Enables this to start event collection from the kubernetes API |
+| datadog.communityIntegrations | list | `[]` | Install community integrations in the Datadog Daemonset. |
 | datadog.confd | object | `{}` | Provide additional check configurations (static and Autodiscovery) |
 | datadog.containerExclude | string | `nil` | Exclude containers from the Agent Autodiscovery, as a space-sepatered list |
 | datadog.containerExcludeLogs | string | `nil` | Exclude logs from the Agent Autodiscovery, as a space-separated list |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -2,7 +2,14 @@
 - name: agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
+{{- if .Values.datadog.communityIntegrations }}
+  command:
+  - bash
+  - -c
+  - {{ range .Values.datadog.communityIntegrations }} agent integration install -t -r datadog-{{ .name }}=={{ .version }} && {{- end}} agent run
+{{- else }}
   command: ["agent", "run"]
+{{- end}}
 {{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.agent.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | indent 2 }}
   resources:
 {{ toYaml .Values.agents.containers.agent.resources | indent 4 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -386,6 +386,16 @@ datadog:
   # datadog.leaderLeaseDuration -- Set the lease time for leader election in second
   leaderLeaseDuration:  # 60
 
+  # datadog.communityIntegrations -- Install community integrations in the Datadog Daemonset.
+
+  ## Specify community integrations (ref: https://docs.datadoghq.com/agent/guide/use-community-integrations/) for the Datadog Daemonset.
+  ## Warning: Ensure the integration version you are installing is compatible with the Agent version you are using.
+  communityIntegrations: []
+  # - name: neo4j
+  #   version: 3.0.0
+  # - name: aws_pricing
+  #   version: 1.0.0
+
   remoteConfiguration:
     # datadog.remoteConfiguration.enabled -- Set to true to enable remote configuration.
     # Consider using remoteConfiguration.enabled instead


### PR DESCRIPTION
## CLOSING REASON
* This introduces an important operational risk : if the `agent integration install` command fails (for instance, missing intermediate certificates, non-responding servers, wrong integration/versions), the pod will be in CLBO and thus losing monitoring, which is not worth the tradeoff of easiness of setup

---

#### What this PR does / why we need it:
* Adds a new parameter `datadog.communityIntegrations` giving the possibility to install community integrations at deployment time without requiring a custom image

#### Motivation
* This is a common support request, e.g. how can I use this integration in Kubernetes and the usual reply is to create a custom image and reference it in the deployment. Instead, modifying the entrypoint of the `agent` container allows the usage of the base image and a smoother experience.
* This PR is linked to https://github.com/DataDog/documentation/pull/18804 for documentation.

#### Q/A:
* Ensure an empty value leads to current/previous behaviour with the entrypoint of `agent` being `agent run`
* Ensure you can install community integrations properly by : 
    1. Populating `datadog.communityIntegrations`
    2. Executing in the Agent and listing the version of the installed integration with `agent integration show datadog-<INTEGRATION_NAME>` and confirming it matches
<img width="909" alt="Image 2023-07-05 at 1 09 21 PM" src="https://github.com/DataDog/helm-charts/assets/97530782/7c9775de-254d-4423-84f2-f0964dec935c">

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
