### PR TITLE
Allow enabling SBOM collection for host and container images

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.40.5
+
+* Allow enabling SBOM collection for host and container images.
+
 ## 3.40.4
 
 * Add the option `clusterAgent.metricsProvider.registerAPIService` to allow user to disable registering external-metrics server as an `APIService`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.40.4
+version: 3.40.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.40.4](https://img.shields.io/badge/Version-3.40.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.40.5](https://img.shields.io/badge/Version-3.40.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -634,6 +634,9 @@ helm install <RELEASE_NAME> \
 | datadog.envFrom | list | `[]` | Set environment variables for all Agents directly from configMaps and/or secrets |
 | datadog.excludePauseContainer | bool | `true` | Exclude pause containers from the Agent Autodiscovery. |
 | datadog.expvarPort | int | `6000` | Specify the port to expose pprof and expvar to not interfer with the agentmetrics port from the cluster-agent, which defaults to 5000 |
+| datadog.features.containerMonitoring.containerImageCollection.enabled | bool | `false` | Enable collection of container images metadata |
+| datadog.features.sbom.containerImage.enabled | bool | `false` | Enable SBOM collection for container images |
+| datadog.features.sbom.host.enabled | bool | `false` | Enable SBOM collection for host filesystem |
 | datadog.helmCheck.collectEvents | bool | `false` | Set this to true to enable event collection in the Helm Check (Requires Agent 7.36.0+ and Cluster Agent 1.20.0+) This requires datadog.HelmCheck.enabled to be set to true |
 | datadog.helmCheck.enabled | bool | `false` | Set this to true to enable the Helm check (Requires Agent 7.35.0+ and Cluster Agent 1.19.0+) This requires clusterAgent.enabled to be set to true |
 | datadog.helmCheck.valuesAsTags | object | `{}` | Collects Helm values from a release and uses them as tags (Requires Agent and Cluster Agent 7.40.0+). This requires datadog.HelmCheck.enabled to be set to true |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -612,6 +612,7 @@ helm install <RELEASE_NAME> \
 | datadog.containerExclude | string | `nil` | Exclude containers from the Agent Autodiscovery, as a space-sepatered list |
 | datadog.containerExcludeLogs | string | `nil` | Exclude logs from the Agent Autodiscovery, as a space-separated list |
 | datadog.containerExcludeMetrics | string | `nil` | Exclude metrics from the Agent Autodiscovery, as a space-separated list |
+| datadog.containerImageCollection.enabled | bool | `false` | Enable collection of container image metadata |
 | datadog.containerInclude | string | `nil` | Include containers in the Agent Autodiscovery, as a space-separated list.  If a container matches an include rule, it’s always included in the Autodiscovery |
 | datadog.containerIncludeLogs | string | `nil` | Include logs in the Agent Autodiscovery, as a space-separated list |
 | datadog.containerIncludeMetrics | string | `nil` | Include metrics in the Agent Autodiscovery, as a space-separated list |
@@ -634,9 +635,6 @@ helm install <RELEASE_NAME> \
 | datadog.envFrom | list | `[]` | Set environment variables for all Agents directly from configMaps and/or secrets |
 | datadog.excludePauseContainer | bool | `true` | Exclude pause containers from the Agent Autodiscovery. |
 | datadog.expvarPort | int | `6000` | Specify the port to expose pprof and expvar to not interfer with the agentmetrics port from the cluster-agent, which defaults to 5000 |
-| datadog.features.containerMonitoring.containerImageCollection.enabled | bool | `false` | Enable collection of container images metadata |
-| datadog.features.sbom.containerImage.enabled | bool | `false` | Enable SBOM collection for container images |
-| datadog.features.sbom.host.enabled | bool | `false` | Enable SBOM collection for host filesystem |
 | datadog.helmCheck.collectEvents | bool | `false` | Set this to true to enable event collection in the Helm Check (Requires Agent 7.36.0+ and Cluster Agent 1.20.0+) This requires datadog.HelmCheck.enabled to be set to true |
 | datadog.helmCheck.enabled | bool | `false` | Set this to true to enable the Helm check (Requires Agent 7.35.0+ and Cluster Agent 1.19.0+) This requires clusterAgent.enabled to be set to true |
 | datadog.helmCheck.valuesAsTags | object | `{}` | Collects Helm values from a release and uses them as tags (Requires Agent and Cluster Agent 7.40.0+). This requires datadog.HelmCheck.enabled to be set to true |
@@ -697,6 +695,8 @@ helm install <RELEASE_NAME> \
 | datadog.prometheusScrape.serviceEndpoints | bool | `false` | Enable generating dedicated checks for service endpoints. |
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. |
 | datadog.remoteConfiguration.enabled | bool | `true` | Set to true to enable remote configuration. Consider using remoteConfiguration.enabled instead |
+| datadog.sbom.containerImage.enabled | bool | `false` | Enable SBOM collection for container images |
+| datadog.sbom.host.enabled | bool | `false` | Enable SBOM collection for host filesystems |
 | datadog.secretAnnotations | object | `{}` |  |
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |
 | datadog.secretBackend.command | string | `nil` | Configure the secret backend command, path to the secret backend binary. |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -156,6 +156,22 @@
       value: {{ .Values.datadog.expvarPort | quote }}
     - name: DD_COMPLIANCE_CONFIG_ENABLED
       value: {{ .Values.datadog.securityAgent.compliance.enabled | quote }}
+    {{- if eq (include "should-enable-container-image-collection" .) "true" }}
+    - name: DD_CONTAINER_IMAGE_ENABLED
+      value: "true"
+    {{- end }}
+    {{- if or .Values.datadog.features.sbom.host.enabled (eq (include "should-enable-sbom-container-image-collection" .) "true") }}
+    - name: DD_SBOM_ENABLED
+      value: "true"
+    {{- if eq (include "should-enable-sbom-container-image-collection" .) "true" }}
+    - name: DD_SBOM_CONTAINER_IMAGE_ENABLED
+      value: "true"
+    {{- end }}
+    {{- if .Values.datadog.features.sbom.host.enabled }}
+    - name: DD_SBOM_HOST_ENABLED
+      value: "true"
+    {{- end }}
+    {{- end }}
     {{- include "additional-env-entries" .Values.agents.containers.agent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.agent.envDict | indent 4 }}
   volumeMounts:

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -160,14 +160,14 @@
     - name: DD_CONTAINER_IMAGE_ENABLED
       value: "true"
     {{- end }}
-    {{- if or .Values.datadog.features.sbom.host.enabled (eq (include "should-enable-sbom-container-image-collection" .) "true") }}
+    {{- if or .Values.datadog.sbom.host.enabled (eq (include "should-enable-sbom-container-image-collection" .) "true") }}
     - name: DD_SBOM_ENABLED
       value: "true"
     {{- if eq (include "should-enable-sbom-container-image-collection" .) "true" }}
     - name: DD_SBOM_CONTAINER_IMAGE_ENABLED
       value: "true"
     {{- end }}
-    {{- if .Values.datadog.features.sbom.host.enabled }}
+    {{- if .Values.datadog.sbom.host.enabled }}
     - name: DD_SBOM_HOST_ENABLED
       value: "true"
     {{- end }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -846,4 +846,33 @@ Create RBACs for custom resources
   - list
   - watch
 {{- end }}
+{{- end }}
+
+{{/*
+  Return true if container image collection is enabled
+*/}}
+{{- define "should-enable-container-image-collection" -}}
+  {{- if and (not .Values.datadog.containerRuntimeSupport.enabled)
+      (or .Values.datadog.features.containerMonitoring.containerImageCollection.enabled .Values.datadog.features.sbom.containerImage.enabled) -}}
+    {{- fail "Container runtime support has to be enabled for container image collection to work. Please enable it using `datadog.containerRuntimeSupport.enabled`." -}}
+  {{- end -}}
+  {{- if or .Values.datadog.features.containerMonitoring.containerImageCollection.enabled .Values.datadog.features.sbom.containerImage.enabled -}}
+    true
+  {{- else -}}
+    false
+  {{- end -}}
+{{- end -}}
+
+{{/*
+  Return true if SBOM collection for container image is enabled
+*/}}
+{{- define "should-enable-sbom-container-image-collection" -}}
+  {{- if .Values.datadog.features.sbom.containerImage.enabled -}}
+    {{- if not (eq (include "should-enable-container-image-collection" .) "true") -}}
+      {{- fail "Container runtime support has to be enabled for SBOM collection to work. Please enable it using `datadog.containerRuntimeSupport.enabled`." -}}
+    {{- end -}}
+    true
+  {{- else -}}
+    false
+  {{- end -}}
 {{- end -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -853,10 +853,10 @@ Create RBACs for custom resources
 */}}
 {{- define "should-enable-container-image-collection" -}}
   {{- if and (not .Values.datadog.containerRuntimeSupport.enabled)
-      (or .Values.datadog.features.containerMonitoring.containerImageCollection.enabled .Values.datadog.features.sbom.containerImage.enabled) -}}
+      (or .Values.datadog.containerImageCollection.enabled .Values.datadog.sbom.containerImage.enabled) -}}
     {{- fail "Container runtime support has to be enabled for container image collection to work. Please enable it using `datadog.containerRuntimeSupport.enabled`." -}}
   {{- end -}}
-  {{- if or .Values.datadog.features.containerMonitoring.containerImageCollection.enabled .Values.datadog.features.sbom.containerImage.enabled -}}
+  {{- if or .Values.datadog.containerImageCollection.enabled .Values.datadog.sbom.containerImage.enabled -}}
     true
   {{- else -}}
     false
@@ -867,7 +867,7 @@ Create RBACs for custom resources
   Return true if SBOM collection for container image is enabled
 */}}
 {{- define "should-enable-sbom-container-image-collection" -}}
-  {{- if .Values.datadog.features.sbom.containerImage.enabled -}}
+  {{- if .Values.datadog.sbom.containerImage.enabled -}}
     {{- if not (eq (include "should-enable-container-image-collection" .) "true") -}}
       {{- fail "Container runtime support has to be enabled for SBOM collection to work. Please enable it using `datadog.containerRuntimeSupport.enabled`." -}}
     {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -629,6 +629,11 @@ datadog:
     # datadog.systemProbe.enableDefaultKernelHeadersPaths -- Enable mount of default paths where kernel headers are stored
     enableDefaultKernelHeadersPaths: true
 
+
+  containerImageCollection:
+    # datadog.containerImageCollection.enabled -- Enable collection of container image metadata
+    enabled: false
+
   orchestratorExplorer:
     # datadog.orchestratorExplorer.enabled -- Set this to false to disable the orchestrator explorer
 
@@ -674,6 +679,16 @@ datadog:
   serviceMonitoring:
     # datadog.serviceMonitoring.enabled -- Enable Universal Service Monitoring
     enabled: false
+
+  # Software Bill of Materials configuration
+  sbom:
+    containerImage:
+      # datadog.sbom.containerImage.enabled -- Enable SBOM collection for container images
+      enabled: false
+
+    host:
+      # datadog.sbom.host.enabled -- Enable SBOM collection for host filesystems
+      enabled: false
 
   ## Enable security agent and provide custom configs
   securityAgent:
@@ -823,24 +838,6 @@ datadog:
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#pause-containers
   excludePauseContainer: true
-
-  features:
-
-    # Container monitoring
-    containerMonitoring:
-      containerImageCollection:
-        # datadog.features.containerMonitoring.containerImageCollection.enabled -- Enable collection of container images metadata
-        enabled: false
-
-    # (Software Bill Of Materials) configuration
-    sbom:
-      containerImage:
-        # datadog.features.sbom.containerImage.enabled -- Enable SBOM collection for container images
-        enabled: false
-
-      host:
-        # datadog.features.sbom.host.enabled -- Enable SBOM collection for host filesystem
-        enabled: false
 
 ## This is the Datadog Cluster Agent implementation that handles cluster-wide
 ## metrics more cleanly, separates concerns for better rbac, and implements

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -824,6 +824,24 @@ datadog:
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#pause-containers
   excludePauseContainer: true
 
+  features:
+
+    # Container monitoring
+    containerMonitoring:
+      containerImageCollection:
+        # datadog.features.containerMonitoring.containerImageCollection.enabled -- Enable collection of container images metadata
+        enabled: false
+
+    # (Software Bill Of Materials) configuration
+    sbom:
+      containerImage:
+        # datadog.features.sbom.containerImage.enabled -- Enable SBOM collection for container images
+        enabled: false
+
+      host:
+        # datadog.features.sbom.host.enabled -- Enable SBOM collection for host filesystem
+        enabled: false
+
 ## This is the Datadog Cluster Agent implementation that handles cluster-wide
 ## metrics more cleanly, separates concerns for better rbac, and implements
 ## the external metrics API so you can autoscale HPAs based on datadog metrics


### PR DESCRIPTION
#### What this PR does / why we need it:

Add:
- datadog.features.containerMonitoring.containerImageCollection.enabled to enable collection of container image metadata
- datadog.features.sbom.containerImage.enabled to enable SBOM collection for container images
- datadog.features.sbom.host.enabled to enable SBOM collection for host filesystem

Right now, we rely on environment variables which is not optimal as it makes checks on required
features complicated : for instance, SBOM collection relies on container runtime support to be enabled.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
