### PR TITLE
feat: open container port 8000 for admission controller

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.34.2
+
+* Add containerPort 8000/TCP to `cluster-agent` deployment for Admission Controller.
+
 ## 3.34.1
 
 * Fix `clusterAgent.admissionController.webhookName` RBAC to avoid restricting `create` by resource name.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.34.1
+version: 3.34.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.34.1](https://img.shields.io/badge/Version-3.34.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.34.2](https://img.shields.io/badge/Version-3.34.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -489,6 +489,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.admissionController.enabled | bool | `true` | Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods |
 | clusterAgent.admissionController.failurePolicy | string | `"Ignore"` | Set the failure policy for dynamic admission control.' |
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |
+| clusterAgent.admissionController.port | int | `8000` | Set port of cluster-agent admission controller service |
 | clusterAgent.admissionController.remoteInstrumentation.enabled | bool | `false` | Enable polling and applying library injection using Remote Config. # This feature is in beta, and enables Remote Config in the Cluster Agent. It also requires Cluster Agent version 7.43+. # Enabling this feature grants the Cluster Agent the permissions to patch Deployment objects in the cluster. |
 | clusterAgent.admissionController.webhookName | string | `"datadog-webhook"` | Name of the mutatingwebhookconfigurations created by the cluster-agent |
 | clusterAgent.advancedConfd | object | `{}` | Provide additional cluster check configurations. Each key is an integration containing several config files. |

--- a/charts/datadog/templates/agent-services.yaml
+++ b/charts/datadog/templates/agent-services.yaml
@@ -57,7 +57,9 @@ spec:
     app: {{ template "datadog.fullname" . }}-cluster-agent
   ports:
   - port: 443
-    targetPort: 8000
+    targetPort: {{ .Values.clusterAgent.admissionController.port }}
+    name: datadog-webhook
+    protocol: TCP
 {{ end }}
 
 {{- if eq (include "enable-service-internal-traffic-policy" .) "true" }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -141,6 +141,11 @@ spec:
           name: metricsapi
           protocol: TCP
         {{- end }}
+        {{- if .Values.clusterAgent.admissionController.enabled }}
+        - containerPort: 8000
+          name: webhook
+          protocol: TCP
+        {{- end }}
 {{- if or .Values.datadog.envFrom .Values.clusterAgent.envFrom }}
         envFrom:
 {{- if .Values.datadog.envFrom }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -142,8 +142,8 @@ spec:
           protocol: TCP
         {{- end }}
         {{- if .Values.clusterAgent.admissionController.enabled }}
-        - containerPort: 8000
-          name: webhook
+        - containerPort: {{ .Values.clusterAgent.admissionController.port }}
+          name: datadog-webhook
           protocol: TCP
         {{- end }}
 {{- if or .Values.datadog.envFrom .Values.clusterAgent.envFrom }}
@@ -220,6 +220,8 @@ spec:
           {{- end }}
           - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
             value: {{ .Values.clusterAgent.admissionController.failurePolicy | quote }}
+          - name: DD_ADMISSION_CONTROLLER_PORT
+            value: {{ .Values.clusterAgent.admissionController.port | quote }}
           {{- end }}
           {{- if eq (include "clusterAgent-remoteConfiguration-enabled" .) "true" }}
           - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PATCHER_ENABLED

--- a/charts/datadog/templates/cluster-agent-network-policy.yaml
+++ b/charts/datadog/templates/cluster-agent-network-policy.yaml
@@ -38,7 +38,7 @@ spec:
 {{- end }}
 {{- if .Values.clusterAgent.admissionController.enabled }}
     - ports:
-        - port: 8000
+        - port: {{ .Values.clusterAgent.admissionController.port }}
 {{- end }}
 {{- if .Values.clusterAgent.metricsProvider.enabled }}
     - # Ingress from API server for external metrics

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -976,6 +976,9 @@ clusterAgent:
       ## Enabling this feature grants the Cluster Agent the permissions to patch Deployment objects in the cluster.
       enabled: false
 
+    # clusterAgent.admissionController.port -- Set port of cluster-agent admission controller service
+    port: 8000
+
   # clusterAgent.confd -- Provide additional cluster check configurations. Each key will become a file in /conf.d.
 
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR opens port 8000/TCP for `cluster-agent` container to communicate with the Admission Controller.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #848

#### Special notes for your reviewer:

NetworkPolicy ingress rule has already been implemented in #152

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
