### PR TITLE
Add emptyDir and volumeMount for Agent's logs for Windows containers

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.33.2
+
+* Add emptyDir and volumeMounts for Agent log files in Windows containers to fix log file access
+
 # 3.33.0
 
 * Default `Agent` and `Cluster-Agent` to `7.46.0` version.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.33.1
+version: 3.33.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.33.1](https://img.shields.io/badge/Version-3.33.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.33.2](https://img.shields.io/badge/Version-3.33.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -153,14 +153,14 @@
     {{- include "additional-env-entries" .Values.agents.containers.agent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.agent.envDict | indent 4 }}
   volumeMounts:
+    - name: logdatadog
+      mountPath: {{ template "datadog.logDirectoryPath" . }}
+      readOnly: false # Need RW to write logs
     {{- if eq .Values.targetSystem "linux" }}
     - name: installinfo
       subPath: install_info
       mountPath: /etc/datadog-agent/install_info
       readOnly: true
-    - name: logdatadog
-      mountPath: /var/log/datadog
-      readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp
       readOnly: false # Need RW to write to /tmp directory

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -58,6 +58,9 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
       readOnly: true
+    - name: logdatadog
+      mountPath: {{ template "datadog.logDirectoryPath" . }}
+      readOnly: false # Need RW to write logs
     {{- if eq .Values.targetSystem "linux" }}
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
@@ -67,9 +70,6 @@
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: false # Need RW for UDS DSD socket
     {{- end }}
-    - name: logdatadog
-      mountPath: /var/log/datadog
-      readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp
       readOnly: false # Need RW to write to tmp directory

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -59,6 +59,9 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
       readOnly: true
+    - name: logdatadog
+      mountPath: {{ template "datadog.logDirectoryPath" . }}
+      readOnly: false # Need RW to write logs
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
@@ -68,9 +71,6 @@
       readOnly: false # Need RW for UDS DSD socket
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
-    - name: logdatadog
-      mountPath: /var/log/datadog
-      readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp
       readOnly: false # Need RW to write to tmp directory

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -34,7 +34,7 @@
       mountPath: {{ template "datadog.confPath" . }}/auth
       readOnly: true
     - name: logdatadog
-      mountPath: /var/log/datadog
+      mountPath: {{ template "datadog.logDirectoryPath" . }}
       readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -56,6 +56,9 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
       readOnly: true
+    - name: logdatadog
+      mountPath: {{ template "datadog.logDirectoryPath" . }}
+      readOnly: false # Need RW to write logs
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
@@ -78,9 +81,6 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
     {{- end }}
-    - name: logdatadog
-      mountPath: /var/log/datadog
-      readOnly: false # Need RW to write logs
     - name: tmpdir
       mountPath: /tmp
       readOnly: false # Need RW for tmp directory

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -27,7 +27,7 @@
     - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
   volumeMounts:
     - name: logdatadog
-      mountPath: /var/log/datadog
+      mountPath: {{ template "datadog.logDirectoryPath" . }}
       readOnly: false # Need RW to write logs
     - name: config
       mountPath: /etc/datadog-agent

--- a/charts/datadog/templates/_daemonset-volumes-windows.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-windows.yaml
@@ -35,3 +35,5 @@
 {{- end }}
 {{- end }}
 {{- end -}}
+- name: logdatadog
+  emptyDir: {}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -186,6 +186,18 @@ Return the container runtime socket
 {{- end -}}
 
 {{/*
+Return agent log directory path
+*/}}
+{{- define "datadog.logDirectoryPath" -}}
+{{- if eq .Values.targetSystem "linux" -}}
+/var/log/datadog
+{{- end -}}
+{{- if eq .Values.targetSystem "windows" -}}
+C:/ProgramData/Datadog/logs
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return agent config path
 */}}
 {{- define "datadog.confPath" -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the emptyDir volume and respective volumeMounts in Window's containers for the Agent log files (`agent.log`, `process-agent.log`, and `trace-agent.log`) at `C:/ProgramData/Datadog/logs`. Doing this as currently the parent volume of `C:/ProgramData/Datadog` is `readOnly: true` for both the `trace-agent` and `process-agent` container. 

This was preventing the `trace-agent` and `process-agent` from creating their respective log files. Giving errors in the logs and preventing those files from coming across in flares.

This matches the pattern between linux/windows containers for a `logdatadog` emptyDir volume mounted in. This change was added to all the containers referencing this for consistency. Even though the Windows setup doesn't use system-probe, security-agent, or the linux init containers.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
The `3.33.1` version of the Helm chart did not have a Changelog note, so that is why this goes straight from `3.33.0` -> `3.33.2`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
