### PR TITLE
Add process language detection settings in the publich helm chart

### DIFF
--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.33.3
+version: 3.34.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.33.3](https://img.shields.io/badge/Version-3.33.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.34.0](https://img.shields.io/badge/Version-3.34.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -592,6 +592,8 @@ helm install <RELEASE_NAME> \
 | datadog.apm.hostSocketPath | string | `"/var/run/datadog/"` | Host path to the trace-agent socket |
 | datadog.apm.port | int | `8126` | Override the trace Agent port |
 | datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (port 8126 by default) |
+| datadog.apm.process_language_detection.enabled | bool | `false` | Set to true to enable process language detection which gather information about the language associated with each process. This information  is then used to inject the appropriate Datadog library specific to that language. |
+| datadog.apm.process_language_detection.port | int | `6262` | Set the process-agent port exposing the process metadata to the core agent |
 | datadog.apm.socketEnabled | bool | `true` | Enable APM over Socket (Unix Socket or windows named pipe) |
 | datadog.apm.socketPath | string | `"/var/run/datadog/apm.socket"` | Path to the trace-agent socket |
 | datadog.apm.useSocketVolume | bool | `false` | Enable APM over Unix Domain Socket DEPRECATED. Use datadog.apm.socketEnabled instead |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -100,6 +100,12 @@
     {{- end }}
     - name: DD_APM_ENABLED
       value: "false"
+    - name: DD_WORKLOADMETA_REMOTE_PROCESS_COLLECTOR_ENABLED # Enable the workloadmeta remote process collector only in the core agent
+      value: {{ (default false (or .Values.datadog.apm.process_language_detection.enabled)) | quote }}
+    - name: DD_PROCESS_CONFIG_LANGUAGE_DETECTION_ENABLED # Does nothing in the core agent but is printed in the output of agent config
+      value: {{ (default false (or .Values.datadog.apm.process_language_detection.enabled)) | quote }}
+    - name: DD_PROCESS_CONFIG_LANGUAGE_DETECTION_GRPC_PORT
+      value: {{ $.Values.config.process_language_detection.grpc_port | quote }}
     - name: DD_LOGS_ENABLED
       value: {{  (default false (or .Values.datadog.logs.enabled .Values.datadog.logsEnabled)) | quote}}
     - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -50,6 +50,10 @@
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
     {{- end }}
+    - name: DD_PROCESS_CONFIG_LANGUAGE_DETECTION_ENABLED
+      value: {{ (default false (or .Values.datadog.apm.process_language_detection.enabled)) | quote }}
+    - name: DD_PROCESS_CONFIG_LANGUAGE_DETECTION_GRPC_PORT
+      value: {{ $.Values.config.process_language_detection.grpc_port | quote }}
     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
       value: {{ (include "should-enable-k8s-resource-monitoring" .) | quote }}
     {{- include "additional-env-entries" .Values.agents.containers.processAgent.env | indent 4 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -451,7 +451,7 @@ datadog:
 
     process_language_detection:
       # datadog.apm.process_language_detection.enabled -- Set to true to enable process language detection
-      # which gather information about the language associated with each process. This information 
+      # which gather information about the language associated with each process. This information
       # is then used to inject the appropriate Datadog library specific to that language.
       enabled: false
       # datadog.apm.process_language_detection.port -- Set the process-agent port exposing the process

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -449,6 +449,15 @@ datadog:
     # datadog.apm.hostSocketPath -- Host path to the trace-agent socket
     hostSocketPath: /var/run/datadog/
 
+    process_language_detection:
+      # datadog.apm.process_language_detection.enabled -- Set to true to enable process language detection
+      # which gather information about the language associated with each process. This information 
+      # is then used to inject the appropriate Datadog library specific to that language.
+      enabled: false
+      # datadog.apm.process_language_detection.port -- Set the process-agent port exposing the process
+      # metadata to the core agent
+      port: 6262
+
   ## OTLP ingest related configuration
   otlp:
     receiver:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds parameters to configure process language detection for APM library injection.

#### Special notes for your reviewer:
- Since we only use this metadata for APM, this setting is currently under `datadog.apm.*`. However, I think we could have a different prefix if we have other use cases.
- `DD_PROCESS_CONFIG_LANGUAGE_DETECTION_ENABLED` is currently not used in the core agent but it is set only for `agent config`. Should we remove it ?
- `DD_WORKLOADMETA_REMOTE_PROCESS_COLLECTOR_ENABLED` is not used in the process agent.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
