### PR TITLE
[datadog] trace-agent: now uses cobra so --switch style cli

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.34.0
+
+* After changes to the trace-agent CLI, arguments now require `--` double-hyphen.
+
 ## 3.33.3
 
 * Remove `datadog.dataStreamsMonitoring.enabled` parameter.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.33.3
+version: 3.34.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -3,10 +3,10 @@
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
   {{- if eq .Values.targetSystem "linux" }}
-  command: ["trace-agent", "-config={{ template "datadog.confPath" . }}/datadog.yaml"]
+  command: ["trace-agent", "--config={{ template "datadog.confPath" . }}/datadog.yaml"]
   {{- end -}}
   {{- if eq .Values.targetSystem "windows" }}
-  command: ["trace-agent", "-foreground", "-config={{ template "datadog.confPath" . }}/datadog.yaml"]
+  command: ["trace-agent", "--foreground", "--config={{ template "datadog.confPath" . }}/datadog.yaml"]
   {{- end -}}
 {{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.traceAgent.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | indent 2 }}
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
After merging this PR: https://github.com/DataDog/datadog-agent/pull/16387 in the datadog-agent repository, the CLI behavior for the `trace-agent` changed. Now using `--` two hyphens prepending CLI switches. This PR tries to address that.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
We shouldn't really merge this until the `7.47.x` agent has been released and the chart updated to use that as default value. These changes will affect 7.48.0+ and would break deployments for prior versions of the trace-agent. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
