### PR TITLE
Run Github workflow Go test only for the datadog-operator chart

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -3,11 +3,11 @@ on:
   push:
     paths:
       - 'test/**'
-      - 'chart/datadog-operator/**'
+      - 'charts/datadog-operator/**'
   pull_request:
     paths:
       - 'test/**'
-      - 'chart/datadog-operator/**'
+      - 'charts/datadog-operator/**'
 env:
   GO111MODULE: "on"
   PROJECTNAME: "helm-charts"

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -1,5 +1,13 @@
 name: Go Test
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'test/**'
+      - 'chart/datadog-operator/**'
+  pull_request:
+    paths:
+      - 'test/**'
+      - 'chart/datadog-operator/**'
 env:
   GO111MODULE: "on"
   PROJECTNAME: "helm-charts"


### PR DESCRIPTION
#### What this PR does / why we need it:

Only run the github workflow `Go Test` when a pull request modified the `datadog-operator` chart.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
