### PR TITLE
Add additional cilium intakes for profiling, network, dbm, remote config to node Agent and CCR

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.33.6
+
+* Add additional intakes into `CiliumNetworkPolicy` for node Agent for profiling, network monitoring, dbm, and remote config
+
 ## 3.33.5
 
 * Daemonset includes `logdatadog` volume when rendered for `targetSystem: "windows"`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.33.5
+version: 3.33.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.33.6
+version: 3.33.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.33.6](https://img.shields.io/badge/Version-3.33.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.33.7](https://img.shields.io/badge/Version-3.33.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.33.5](https://img.shields.io/badge/Version-3.33.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.33.6](https://img.shields.io/badge/Version-3.33.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-cilium-network-policy.yaml
+++ b/charts/datadog/templates/agent-cilium-network-policy.yaml
@@ -92,6 +92,13 @@ specs:
           - matchName: "process.{{ $.Values.datadog.site }}"
           - matchName: "orchestrator.{{ $.Values.datadog.site }}"
           - matchName: "instrumentation-telemetry-intake.{{ $.Values.datadog.site }}"
+          - matchName: "intake.profile.{{ $.Values.datadog.site }}"
+          - matchName: "ndm-intake.{{ $.Values.datadog.site }}"
+          - matchName: "snmp-traps-intake.{{ $.Values.datadog.site }}"
+          - matchName: "ndmflow-intake.{{ $.Values.datadog.site }}"
+          - matchName: "config.{{ $.Values.datadog.site }}"
+          - matchName: "dbm-metrics-intake.{{ $.Values.datadog.site }}"
+          - matchName: "dbquery-intake.{{ $.Values.datadog.site }}"
           {{- else}}
           - matchPattern: "*-app.agent.datadoghq.com"
           - matchName: "app.datadoghq.com"
@@ -101,6 +108,13 @@ specs:
           - matchName: "process.datadoghq.com"
           - matchName: "orchestrator.datadoghq.com"
           - matchName: "instrumentation-telemetry-intake.datadoghq.com"
+          - matchName: "intake.profile.datadoghq.com"
+          - matchName: "ndm-intake.datadoghq.com"
+          - matchName: "snmp-traps-intake.datadoghq.com"
+          - matchName: "ndmflow-intake.datadoghq.com"
+          - matchName: "config.datadoghq.com"
+          - matchName: "dbm-metrics-intake.datadoghq.com"
+          - matchName: "dbquery-intake.datadoghq.com"
           {{- end}}
         toPorts:
           - ports:

--- a/charts/datadog/templates/agent-clusterchecks-cilium-network-policy.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-cilium-network-policy.yaml
@@ -41,11 +41,27 @@ specs:
           - matchName: {{ trimPrefix "https://" $.Values.datadog.dd_url }}
           {{- end}}
           {{- if $.Values.datadog.site}}
-          - matchName: "app.{{ $.Values.datadog.site }}"
           - matchPattern: "*-app.agent.{{ $.Values.datadog.site }}"
+          - matchName: "app.{{ $.Values.datadog.site }}"
+          - matchName: "api.{{ $.Values.datadog.site }}"
+          - matchName: "orchestrator.{{ $.Values.datadog.site }}"
+          - matchName: "ndm-intake.{{ $.Values.datadog.site }}"
+          - matchName: "snmp-traps-intake.{{ $.Values.datadog.site }}"
+          - matchName: "ndmflow-intake.{{ $.Values.datadog.site }}"
+          - matchName: "config.{{ $.Values.datadog.site }}"
+          - matchName: "dbm-metrics-intake.{{ $.Values.datadog.site }}"
+          - matchName: "dbquery-intake.{{ $.Values.datadog.site }}"
           {{- else}}
-          - matchName: "app.datadoghq.com"
           - matchPattern: "*-app.agent.datadoghq.com"
+          - matchName: "app.datadoghq.com"
+          - matchName: "api.datadoghq.com"
+          - matchName: "orchestrator.datadoghq.com"
+          - matchName: "ndm-intake.datadoghq.com"
+          - matchName: "snmp-traps-intake.datadoghq.com"
+          - matchName: "ndmflow-intake.datadoghq.com"
+          - matchName: "config.datadoghq.com"
+          - matchName: "dbm-metrics-intake.datadoghq.com"
+          - matchName: "dbquery-intake.datadoghq.com"
           {{- end}}
         toPorts:
           - ports:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the additional intakes for profiling, network, dbm, and remote config into the `CiliumNetworkPolicy` for the node Agent. Adds missing relative ones for Cluster Check Runner. Relative to the missing ones here:

- https://docs.datadoghq.com/agent/guide/network/?tab=agentv6v7

Excluding RUM and Synthetics since the Agent won't hit those. Excluding APM related ones on Cluster Check Runner. 

Can test with config like the following, with no `site` or the respective `site` to use. 

```yaml
datadog:
  apiKey: <API_KEY>
  site: datadoghq.com

  logLevel: debug
  
  networkPolicy:
    create: true
    flavor: cilium  
```

Can curl the endpoints within the Agent container to validate connectivity depending on the site like. Any response from server is good, will timeout if egress is invalid.
```
curl https://intake.profile.datadoghq.com

curl https://intake.profile.datadoghq.eu
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

**NOTE:** Does **not** do any changes for the Cluster Agent. This may warrant looking into the future for the Cluster Agent to double check kubelet connectivity as well as remote config for the Cluster Agent. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
