### PR TITLE
Update operator chart for 1.1.0 release

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.4
+
+* Update Datadog Operator version to 1.1.0.
+
 ## 1.0.8
 
 * Minor spelling corrections in the `datadog-operator` chart.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 1.0.1
-digest: sha256:e882fa60c39302a3092cc43bcbf0a8412a2c63933efc9767740c4c6144c5b0b4
-generated: "2023-06-22T11:55:54.905315-04:00"
+  version: 1.1.0
+digest: sha256:17463862a93cb95f29cb0d47fb41c2706c4d56dc3f16b5ebd2cd402c19d68799
+generated: "2023-08-04T13:55:46.85905-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.0.8
-appVersion: 1.0.3
+version: 1.1.0
+appVersion: 1.1.0
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "=1.0.1"
+  version: "=1.1.0"
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square) ![AppVersion: 1.0.3](https://img.shields.io/badge/AppVersion-1.0.3-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 ## Values
 
@@ -28,7 +28,7 @@
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.0.3"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.1.0"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | logLevel | string | `"info"` | Set Datadog Operator log level (debug, info, error, panic, fatal) |
@@ -93,7 +93,7 @@ and for the Datadog Operator chart:
 
 ```
 NAME                    	CHART VERSION	APP VERSION	DESCRIPTION
-datadog/datadog-operator	1.0.4        	1.0.3      	Datadog Operator
+datadog/datadog-operator	1.1.0        	1.1.0      	Datadog Operator
 ```
 
 Then you will need to install the cert manager if you don't have it already, add the chart:
@@ -115,7 +115,7 @@ You can update with the following:
 ```
 helm upgrade \
     datadog-operator datadog/datadog-operator \
-    --set image.tag=1.0.3 \
+    --set image.tag=1.1.0 \
     --set datadogCRDs.migration.datadogAgents.version=v2alpha1 \
     --set datadogCRDs.migration.datadogAgents.useCertManager=true \
     --set datadogCRDs.migration.datadogAgents.conversionWebhook.enabled=true

--- a/charts/datadog-operator/README.md.gotmpl
+++ b/charts/datadog-operator/README.md.gotmpl
@@ -46,7 +46,7 @@ and for the Datadog Operator chart:
 
 ```
 NAME                    	CHART VERSION	APP VERSION	DESCRIPTION
-datadog/datadog-operator	1.0.4        	1.0.3      	Datadog Operator
+datadog/datadog-operator	1.1.0        	1.1.0      	Datadog Operator
 ```
 
 Then you will need to install the cert manager if you don't have it already, add the chart:
@@ -68,7 +68,7 @@ You can update with the following:
 ```
 helm upgrade \
     datadog-operator datadog/datadog-operator \
-    --set image.tag=1.0.3 \
+    --set image.tag=1.1.0 \
     --set datadogCRDs.migration.datadogAgents.version=v2alpha1 \
     --set datadogCRDs.migration.datadogAgents.useCertManager=true \
     --set datadogCRDs.migration.datadogAgents.conversionWebhook.enabled=true

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -43,7 +43,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.0.3
+  tag: 1.1.0
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
 # imagePullSecrets -- Datadog Operator repository pullSecret (ex: specify docker registry credentials)

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -8,7 +8,7 @@ metadata:
   creationTimestamp: null
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-1.0.1'
+    helm.sh/chart: 'datadogCRDs-1.1.0'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -5978,6 +5978,16 @@ spec:
                           type: object
                         enabled:
                           type: boolean
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                         syscallMonitorEnabled:
                           type: boolean
                       type: object
@@ -6187,6 +6197,11 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
                         ddUrl:
                           type: string
                         enabled:
@@ -6232,6 +6247,11 @@ spec:
                           type: boolean
                         version:
                           type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     tcpQueueLength:
                       properties:

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_with_certManager.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_with_certManager.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-1.0.1'
+    helm.sh/chart: 'datadogCRDs-1.1.0'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -5989,6 +5989,16 @@ spec:
                           type: object
                         enabled:
                           type: boolean
+                        network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        securityProfiles:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                         syscallMonitorEnabled:
                           type: boolean
                       type: object
@@ -6198,6 +6208,11 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        customResources:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
                         ddUrl:
                           type: string
                         enabled:
@@ -6243,6 +6258,11 @@ spec:
                           type: boolean
                         version:
                           type: integer
+                      type: object
+                    remoteConfiguration:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     tcpQueueLength:
                       properties:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.0.7
+    helm.sh/chart: datadog-operator-1.1.0
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.0.3"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.0.3"
+          image: "gcr.io/datadoghq/operator:1.1.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.0.7
+    helm.sh/chart: datadog-operator-1.1.0
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.0.3"
+    app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.0.3"
+          image: "gcr.io/datadoghq/operator:1.1.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -130,7 +130,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "gcr.io/datadoghq/operator:1.0.3", operatorContainer.Image)
+	assert.Equal(t, "gcr.io/datadoghq/operator:1.1.0", operatorContainer.Image)
 	assert.Contains(t, operatorContainer.Args, "-webhookEnabled=false")
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Update `datadog-operator` chart for v1.1.0 release

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
