### PR TITLE
avoid creating the DD_PROVIDER_KIND env var two times

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Datadog changelog
 
-## 3.33.9 
+## 3.33.10
+
+* Avoid creating the `DD_PROVIDER_KIND` environment variable twice for containers.
+
+## 3.33.9
 
 * Add `fips.customFipsConfig` parameter to allow configuring FIPS proxy sidecar `datadog-fips-proxy.cfg` using a ConfigMap.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.33.9
+version: 3.33.10
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.33.9](https://img.shields.io/badge/Version-3.33.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.33.10](https://img.shields.io/badge/Version-3.33.10-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -145,5 +145,4 @@ Return a list of env-vars if the cluster-agent is enabled
         name: {{ .Values.existingClusterAgent.tokenSecretName | quote }}
         key: token
 {{- end }}
-{{ include "provider-env" . }}
 {{- end -}}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -194,6 +194,7 @@ spec:
           - name: DD_CLUSTER_NAME
             value: {{ .Values.datadog.clusterName | quote }}
           {{- end }}
+          {{- include "provider-env" . | nindent 10 }}
           {{- include "fips-envvar" . | nindent 10 }}
           {{- include "additional-env-entries" .Values.clusterChecksRunner.env | indent 10 }}
           {{- include "additional-env-dict-entries" .Values.clusterChecksRunner.envDict | indent 10 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes DaemonSets getting stuck in Autopilot when the same env var is defined multiple times.
Currently, `DD_PROVIDER_KIND` is defined twice. This is a spec violation but the validation currently is not enforced during creation. But this prevents the pod GC from removing pods because it seems at that time a different validation is used.
See https://github.com/kubernetes/kubernetes/issues/118261

#### Which issue this PR fixes
  - fixes #1142

#### Special notes for your reviewer:
`provider-env` is currently included in both `containers-cluster-agent-env` and `containers-common-env`. Containers that use `containers-common-env` also use `containers-cluster-agent-env` most of the time. `containers-cluster-agent-env` is only used without `containers-common-env` in `charts/datadog/templates/agent-clusterchecks-deployment.yaml`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
   _This fails for me locally for the operator which I did not touch._