### PR TITLE
[synthetics] Bump to 0.15.16 with Private Location 1.38.0

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.15.16
+
+* Update private location image version to `1.38.0`.
+
 ## 0.15.15
 
 * Update private location image version to `1.37.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.15
-appVersion: 1.37.0
+version: 0.15.16
+appVersion: 1.38.0
 description: Datadog Synthetics Private Location
 keywords:
 - monitoring

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.15](https://img.shields.io/badge/Version-0.15.15-informational?style=flat-square) ![AppVersion: 1.37.0](https://img.shields.io/badge/AppVersion-1.37.0-informational?style=flat-square)
+![Version: 0.15.16](https://img.shields.io/badge/Version-0.15.16-informational?style=flat-square) ![AppVersion: 1.38.0](https://img.shields.io/badge/AppVersion-1.38.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -15,7 +15,7 @@ image:
   # image.pullPolicy -- Define the pullPolicy for Datadog Synthetics Private Location image
   pullPolicy: IfNotPresent
   # image.tag -- Define the Datadog Synthetics Private Location version to use
-  tag: 1.37.0
+  tag: 1.38.0
 
 # imagePullSecrets -- Datadog Synthetics Private Location repository pullSecret (ex: specify docker registry credentials)
 imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump the Synthetics private location chart to 0.5.16 for the new PL 1.38.0 release.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
