### PR TITLE
Only include RBAC for PodSecurityPolicies when enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datadog Helm Charts
 
-[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/datadog)](https://artifacthub.io/packages/search?repo=datadog) 
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/datadog)](https://artifacthub.io/packages/search?repo=datadog)
 
 Official Helm charts for Datadog products. Currently supported:
 - [Datadog Agents](charts/datadog/README.md) (datadog/datadog)
@@ -9,7 +9,7 @@ Official Helm charts for Datadog products. Currently supported:
 
 You need to add this repository to your Helm repositories:
 
-```
+```shell
 helm repo add datadog https://helm.datadoghq.com
 helm repo update
 ```

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.40.2
+
+* Gate `PodSecurityPolicy` RBAC for k8s versions which no longer support this deprecated API.
+
 ## 3.40.1
 
 * Add support for initContainer volume mounts

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.40.1
+version: 3.40.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.40.1](https://img.shields.io/badge/Version-3.40.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.40.2](https://img.shields.io/badge/Version-3.40.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -225,7 +225,7 @@ rules:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
-  resourceNames: 
+  resourceNames:
     - {{ .Values.clusterAgent.admissionController.webhookName | quote }}
   verbs: ["get", "list", "watch", "update"]
 - apiGroups:
@@ -249,7 +249,7 @@ rules:
   - namespaces
   verbs:
   - list
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.clusterAgent.podSecurity.podSecurityPolicy.create (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 - apiGroups:
   - "policy"
   resources:
@@ -274,7 +274,7 @@ rules:
   - list
 {{- end }}
 {{- end }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.clusterAgent.podSecurity.podSecurityPolicy.create (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 - apiGroups:
   - policy
   resources:

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -98,7 +98,7 @@ rules:
   - endpoints
   verbs:
   - get
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.clusterAgent.podSecurity.podSecurityPolicy.create (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 - apiGroups:
   - policy
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

Most resources related to the deprecated `PodSecurityPolicies` have already been gated with `if` statements, however there are a few misses specifically related to RBAC. In GKE we are getting deprecation warnings for `io.k8s.policy.v1beta1.podsecuritypolicies.list` which seem to come from the Datadog Cluster Agent (user agent: `datadog-cluster-agent/v0.0.0 (linux/amd64) kubernetes/$Format`).

This PR simply gates the related RBAC using existing flags and checks used to enabled / disable the other `PodSecurityPolicy` resources.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes # n/a

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
