### PR TITLE
Add rule to allow agent role to curl `/metrics/slis`

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.35.1
+
+* Add permissions to curl `/metrics/slis` to agent cluster role.
+
 ## 3.35.0
 
 * Default `Agent` and `Cluster-Agent` to `7.47.0` version.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.35.0
+version: 3.35.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.35.0](https://img.shields.io/badge/Version-3.35.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.35.1](https://img.shields.io/badge/Version-3.35.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -65,6 +65,7 @@ rules:
 {{- end }}
 - nonResourceURLs:
   - "/metrics"
+  - "/metrics/slis"
   verbs:
   - get
 - apiGroups:  # Kubelet connectivity


### PR DESCRIPTION
#### What this PR does / why we need it:
A rule was added to allow the agent to curl `/metrics/slis`, exposing the SLI metrics provided by Kubernetes as a part of the changes made in https://github.com/DataDog/integrations-core/pull/15731

#### Special notes for your reviewer:
Does the corresponding change need to be made in the operator as well?
 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
