### PR TITLE
Add option to allow the use of APM with k8s service without using hostports

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.36.0
+
+* Add datadog.apm.serviceEnabled option to allow the use of APM with k8s service without enabling hostPort.
+
 ## 3.35.0
 
 * Default `Agent` and `Cluster-Agent` to `7.47.0` version.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.35.0
+version: 3.36.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.35.0](https://img.shields.io/badge/Version-3.35.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.36.0](https://img.shields.io/badge/Version-3.36.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -594,6 +594,7 @@ helm install <RELEASE_NAME> \
 | datadog.apm.hostSocketPath | string | `"/var/run/datadog/"` | Host path to the trace-agent socket |
 | datadog.apm.port | int | `8126` | Override the trace Agent port |
 | datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (port 8126 by default) |
+| datadog.apm.serviceEnabled | string | `nil` | Enable APM over k8s service. When not set, it will default to datadog.apm.portEnabled |
 | datadog.apm.socketEnabled | bool | `true` | Enable APM over Socket (Unix Socket or windows named pipe) |
 | datadog.apm.socketPath | string | `"/var/run/datadog/apm.socket"` | Path to the trace-agent socket |
 | datadog.apm.useSocketVolume | bool | `false` | Enable APM over Unix Domain Socket DEPRECATED. Use datadog.apm.socketEnabled instead |

--- a/charts/datadog/actual_values.yml
+++ b/charts/datadog/actual_values.yml
@@ -1,0 +1,78 @@
+agents:
+  image:
+    tag: 7.46.0
+  nodeSelector:
+    kubernetes.io/os: windows
+  priorityClassName: system-node-critical
+  tolerations:
+  - effect: NoSchedule
+    key: apps
+    operator: Equal
+    value: platform
+  - effect: NoSchedule
+    key: apps
+    operator: Equal
+    value: infra
+  - effect: NoSchedule
+    key: os
+    operator: Equal
+    value: windows
+  volumeMounts:
+  - mountPath: /var/log/mounted
+    name: log-volume
+    readOnly: true
+  volumes:
+  - hostPath:
+      path: C:\volumes\logs
+    name: log-volume
+datadog:
+  apiKeyExistingSecret: datadog-apikey
+  apm:
+    # enabled: true
+    socketEnabled: true
+    serviceEnabled: true
+    portEnabled: false
+  clusterChecks:
+    enabled: true
+  clusterName: platform-pci-nonprod
+  dogstatsd:
+    hostSocketPath: /var/run/datadog/
+    nonLocalTraffic: true
+    port: 8125
+    socketPath: /var/run/datadog/dsd.socket
+    useHostPort: true
+    useSocketVolume: true
+  kubeStateMetricsEnabled: false
+  logs:
+    containerCollectAll: true
+    containerCollectUsingFiles: true
+    enabled: true
+  networkMonitoring:
+    enabled: true
+  otlp:
+    receiver:
+      protocols:
+        http:
+          enabled: true
+  processAgent:
+    processCollection: true
+  prometheusScrape:
+    enabled: true
+  serviceMonitoring:
+    enabled: true
+  site: datadoghq.eu
+  tags:
+  - env:platform-nonprod
+  - clusterFriendlyName:platform-pci
+datadog-crds:
+  crds:
+    datadogMetrics: false
+existingClusterAgent:
+  join: true
+  serviceName: datadog-agent-linux-cluster-agent
+  tokenSecretName: datadog-agent-linux-cluster-agent
+kube-state-metrics:
+  nodeSelector:
+    kubernetes.io/os: windows
+registry: public.ecr.aws/datadog
+targetSystem: windows

--- a/charts/datadog/ci/apm-service-enabled-admission-controller-values.yaml
+++ b/charts/datadog/ci/apm-service-enabled-admission-controller-values.yaml
@@ -1,0 +1,7 @@
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  apm:
+    portEnabled: false
+    serviceEnabled: true
+    socketEnabled: true

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -459,11 +459,32 @@ false
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Use the value of datadog.apm.serviceEnabled if set otherwise matches datadog.apm.portEnabled.
+*/}}
+{{- define "trace-agent-use-service" -}}
+{{- default (include "trace-agent-use-host-port" .) .Values.datadog.apm.serviceEnabled -}}
+{{- end -}}
+
+
+{{/*
+Return true if a host port is desired for APM.
+*/}}
+{{- define "trace-agent-use-host-port" -}}
+{{- if or .Values.datadog.apm.portEnabled .Values.datadog.apm.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+
 {{/*
 Return true if a traffic over TCP is configured for APM.
 */}}
 {{- define "trace-agent-use-tcp-port" -}}
-{{- if or .Values.datadog.apm.portEnabled .Values.datadog.apm.enabled -}}
+{{- if or (eq  (include "trace-agent-use-host-port" .) "true") (eq  (include "trace-agent-use-service" .) "true") -}}
 true
 {{- else -}}
 false

--- a/charts/datadog/templates/agent-psp.yaml
+++ b/charts/datadog/templates/agent-psp.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   privileged: {{ .Values.agents.podSecurity.privileged }}
   hostNetwork: {{ .Values.agents.useHostNetwork }}
-  {{- if or .Values.datadog.dogstatsd.useHostPort (eq  (include "trace-agent-use-tcp-port" .) "true") }}
+  {{- if or .Values.datadog.dogstatsd.useHostPort (eq  (include "trace-agent-use-host-port" .) "true") }}
   hostPorts:
   - min: 8125
     max: 8126

--- a/charts/datadog/templates/agent-services.yaml
+++ b/charts/datadog/templates/agent-services.yaml
@@ -84,7 +84,7 @@ spec:
       port: {{ .Values.datadog.dogstatsd.port }}
       targetPort: {{ .Values.datadog.dogstatsd.port }}
       name: dogstatsdport
-{{- if eq  (include "trace-agent-use-tcp-port" .) "true" }}
+{{- if eq  (include "trace-agent-use-service" .) "true" }}
     - protocol: TCP
       port: {{ .Values.datadog.apm.port }}
       targetPort: {{ .Values.datadog.apm.port }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -205,7 +205,7 @@ spec:
             value: {{ .Values.clusterAgent.admissionController.configMode }}
             {{- else if eq (include "trace-agent-use-uds" .) "true" }}
             value: socket
-            {{- else if or (eq (include "trace-agent-use-tcp-port" .) "true") ( .Values.providers.gke.autopilot )}}
+            {{- else if or (eq (include "trace-agent-use-host-port" .) "true") ( .Values.providers.gke.autopilot )}}
             value: hostip
             {{- else if or (not .Values.datadog.apm.enabled ) (and (eq (include "trace-agent-use-tcp-port" .) "true") (eq (include "trace-agent-use-uds" .) "true")) }}
             value: socket

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -426,6 +426,9 @@ datadog:
     ## ref: https://docs.datadoghq.com/agent/kubernetes/apm/
     portEnabled: false
 
+    # datadog.apm.serviceEnabled -- Enable APM over k8s service. When not set, it will default to datadog.apm.portEnabled
+    serviceEnabled:
+
     # datadog.apm.enabled -- Enable this to enable APM and tracing, on port 8126
     # DEPRECATED. Use datadog.apm.portEnabled instead
 


### PR DESCRIPTION
Add option to allow the use of APM with k8s service without using hostports

#### What this PR does / why we need it:

To be able to use APM without using hostports

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
