### PR TITLE
[NPM-2758] Update System Probe Chart to include liveness and readiness probes

### DIFF
--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -430,6 +430,9 @@ helm install <RELEASE_NAME> \
 | agents.containers.systemProbe.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off. If not set, fall back to the value of datadog.logLevel. |
 | agents.containers.systemProbe.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.systemProbe.resources | object | `{}` | Resource requests and limits for the system-probe container |
+| agents.containers.systemProbe.healthPort | int | `5558` | Port number to use in the system probe for the healthz endpoint |
+| agents.containers.systemProbe.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
+| agents.containers.systemProbe.readinessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent readiness probe settings |
 | agents.containers.systemProbe.securityContext | object | `{"capabilities":{"add":["SYS_ADMIN","SYS_RESOURCE","SYS_PTRACE","NET_ADMIN","NET_BROADCAST","NET_RAW","IPC_LOCK","CHOWN","DAC_READ_SEARCH"]},"privileged":false}` | Allows you to overwrite the default container SecurityContext for the system-probe container. |
 | agents.containers.traceAgent.env | list | `[]` | Additional environment variables for the trace-agent container |
 | agents.containers.traceAgent.envDict | object | `{}` | Set environment variables specific to trace-agent defined in a dict |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -209,6 +209,30 @@ More information about this change: https://github.com/DataDog/helm-charts/pull/
 {{- fail "You are using datadog.systemProbe.enabled which has been superseded by networkMonitoring.enabled, systemProbe.enableTCPQueueLength, systemProbe.enableOOMKill, and securityAgent.runtime.enabled. These options provide a more granular control of which features should be activated." }}
 {{- end }}
 
+{{- if eq (include "should-enable-system-probe" .) "true" }}
+  {{- $healthPort := .Values.agents.containers.systemProbe.healthPort }}
+  {{- with $liveness := .Values.agents.containers.systemProbe.livenessProbe.httpGet }}
+  {{- if and $liveness.port (ne $healthPort $liveness.port) }}
+
+  ##############################################################################
+  ####            ERROR: System Probe liveness probe misconfiguration       ####
+  ##############################################################################
+
+  System Probe liveness probe port ({{ $liveness.port }}) is different from the configured health port ({{ $healthPort }}).
+  {{- end }}
+  {{- end }}
+  {{- with $readiness := .Values.agents.containers.systemProbe.readinessProbe.httpGet }}
+  {{- if and $readiness.port (ne $healthPort $readiness.port) }}
+
+  ##############################################################################
+  ####           ERROR: System Probe readiness probe misconfiguration       ####
+  ##############################################################################
+
+  System Probe readiness probe port ({{ $readiness.port }}) is different from the configured health port ({{ $healthPort }}).
+  {{- end }}
+  {{- end }}
+{{- end }}
+
 {{- if and .Values.datadog.orchestratorExplorer.enabled (eq (include "cluster-agent-enabled" .) "false")}}
 
 #################################################################

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -21,6 +21,9 @@
     {{- include "containers-common-env" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.systemProbe.logLevel | default .Values.datadog.logLevel | quote }}
+    - name: DD_SYSTEM_PROBE_HEALTH_PORT
+    {{- $healthPort := .Values.agents.containers.systemProbe.healthPort }}
+      value: {{ $healthPort | quote }}
     {{- if .Values.datadog.serviceMonitoring.enabled }}
     - name: HOST_ROOT
       value: "/host/root"
@@ -151,4 +154,10 @@
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}
 {{- end }}
+  livenessProbe:
+{{- $live := .Values.agents.containers.systemProbe.livenessProbe }}
+{{ include "probe.http" (dict "path" "/live" "port" $healthPort "settings" $live) | indent 4 }}
+  readinessProbe:
+{{- $ready := .Values.agents.containers.systemProbe.readinessProbe }}
+{{ include "probe.http" (dict "path" "/ready" "port" $healthPort "settings" $ready) | indent 4 }}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1494,6 +1494,27 @@ agents:
       #    cpu: 100m
       #    memory: 200Mi
 
+      # agents.containers.systemProbe.healthPort -- Port number to use in the system probe for the healthz endpoint
+      healthPort: 5558
+
+      # agents.containers.systemProbe.livenessProbe -- Override default agent liveness probe settings
+      # @default -- Every 15s / 6 KO / 1 OK
+      livenessProbe:
+        initialDelaySeconds: 15
+        periodSeconds: 15
+        timeoutSeconds: 5
+        successThreshold: 1
+        failureThreshold: 6
+
+      # agents.containers.systemProbe.readinessProbe -- Override default agent readiness probe settings
+      # @default -- Every 15s / 6 KO / 1 OK
+      readinessProbe:
+        initialDelaySeconds: 15
+        periodSeconds: 15
+        timeoutSeconds: 5
+        successThreshold: 1
+        failureThreshold: 6
+
       # agents.containers.systemProbe.securityContext -- Allows you to overwrite the default container SecurityContext for the system-probe container.
 
       ## agents.podSecurity.capabilities must reflect the changed made in securityContext.capabilities.


### PR DESCRIPTION
#### What this PR does / why we need it:
As a follow up to https://github.com/DataDog/datadog-agent/pull/19297, this PR updates the external charts for `system-probe`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
