### PR TITLE
Fix serviceAccountName for Secrets RoleBinding in GKE Autopilot

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.35.2
+
+* Fix Agent Service Account Name used in `RoleBinding` for Secret Backend permissions when in GKE Autopliot
+
+
 ## 3.35.1
 
 * Add permissions to curl `/metrics/slis` to agent cluster role.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.35.1
+version: 3.35.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.35.1](https://img.shields.io/badge/Version-3.35.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.35.2](https://img.shields.io/badge/Version-3.35.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -168,7 +168,7 @@ metadata:
 {{ include "datadog.labels" $ | indent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "datadog.fullname" $ }}
+    name: {{ include "agents.serviceAccountName" $ }}
     apiGroup: ""
     namespace: {{ $.Release.Namespace }}
 roleRef:


### PR DESCRIPTION
#### What this PR does / why we need it:

Our Helm Chart has the helper function for `agents.serviceAccountName` to set the Service Account Name to the `datadog.fullname` OR if in GKE AutoPilot force this to `datadog-agent`. This is used in our normal `ClusterRoleBinding` for the Agent. However, the extra `RoleBinding` when granting permissions to specific secrets uses the old `datadog.fullname` value. This can cause that mismatch in GKE Autopilot where the RoleBinding is referencing the "wrong" service account name, so the Agent won't have the right permissions to fetch those secrets.

Helper 
https://github.com/DataDog/helm-charts/blob/datadog-3.35.1/charts/datadog/templates/_helpers.tpl#L505-L516

ClusterRoleBinding with correct reference
https://github.com/DataDog/helm-charts/blob/datadog-3.35.1/charts/datadog/templates/rbac.yaml#L116-L129


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

https://datadoghq.atlassian.net/browse/CONS-5811

#### Special notes for your reviewer:
Can test with setup like:

```
kubectl create namespace test
kubectl create secret generic test-secret --from-literal "hello=world"
```


```yaml
datadog:
  apiKey: <KEY>
  
  secretBackend:
    command: "/readsecret_multiple_providers.sh"
    enableGlobalPermissions: false
    roles: 
     - namespace: test
       secrets:
         - test-secret

providers:
  gke: 
    autopilot: true
```

Then validate permissions before/after with
```
kubectl auth can-i get secret/test-secret -n test --as system:serviceaccount:default:datadog-agent
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
