### PR TITLE
[operator] Add rule to allow operator cluster role to curl `/metrics/slis`

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1
+
+* Add permissions to curl `/metrics/slis` to operator cluster role.
+
 ## 1.0.4
 
 * Update Datadog Operator version to 1.1.0.

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Add permissions to curl `/metrics/slis` to operator cluster role.
 
-## 1.0.4
+## 1.1.0
 
 * Update Datadog Operator version to 1.1.0.
 

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.1.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
 - nonResourceURLs:
   - /metrics
+  - /metrics/slis
   verbs:
   - get
 - apiGroups:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.1.0
+    helm.sh/chart: datadog-operator-1.1.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.1.0
+    helm.sh/chart: datadog-operator-1.1.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:
A rule was added to the operator cluster role to curl `/metrics/slis`, exposing the SLI metrics provided by Kubernetes as a part of the changes made in https://github.com/DataDog/integrations-core/pull/15731. A similar change was applied to the agent role in https://github.com/DataDog/helm-charts/pull/1155.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
