### PR TITLE
added repository config mirroring the repo access settings

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,0 +1,19 @@
+---
+schema-version: v1
+kind: mergequeue
+github_teams_restrictions:
+  - agent-all
+  - container-app
+  - container-ecosystems
+  - container-helm-chart-maintainers
+  - container-integrations
+  - container-t2
+  - Synthetics
+  - Documentation
+  - Observability Pipelines
+  - Telemetry and Analytics
+  - Vector
+github_users_restrictions:
+  - cahillsf
+  - clamoriniere
+  - hkaj


### PR DESCRIPTION
#### What this PR does / why we need it:

when using the mergequeue, we need to restrict who can actually merge using the commands.

