### PR TITLE
Update repository.datadog.yml

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,6 +1,7 @@
 ---
 schema-version: v1
 kind: mergequeue
+gitlab_check_enable: false
 github_teams_restrictions:
   - agent-all
   - container-app


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR disables the gitlab integration for the mergequeue