### PR TITLE
Remove datadog.kubelet.tlsVerify override in Agent on AKS example

### DIFF
--- a/examples/datadog/agent_on_aks_values.yaml
+++ b/examples/datadog/agent_on_aks_values.yaml
@@ -16,7 +16,6 @@ datadog:
         fieldRef:
           fieldPath: spec.nodeName
     hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
-    tlsVerify: false # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
   logs:
     enabled: true
     containerCollectAll: false


### PR DESCRIPTION
#### What this PR does / why we need it:

What the title says. This is a change in example file - no chart/values/doc change.

`datadog.kubelet.tlsVerify: false` was necessary due to an issue in AKS distribution which was resolved late last year https://github.com/Azure/AKS/issues/2770. 

Documentation was updated to reflect the change here https://github.com/DataDog/documentation/pull/17436 so not updating it now. 

For testing provisioned AKS cluster, and did helm install with the example values override.

Related issue https://github.com/DataDog/helm-charts/issues/972

https://github.com/Azure/AKS/issues/2770
https://github.com/Azure/AgentBaker/pull/2352


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
