### PR TITLE
Revert enabling remote configuration by default

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.37.1
+
+* Temporarily revert enabling Remote Config by default
+
 ## 3.37.0
 
 * Rename `datadog.securityAgent.compliance.xccdf.enabled` parameter to `datadog.securityAgent.compliance.host_benchmarks.enabled`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.37.0
+version: 3.37.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.37.0](https://img.shields.io/badge/Version-3.37.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.37.1](https://img.shields.io/badge/Version-3.37.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -490,7 +490,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.admissionController.failurePolicy | string | `"Ignore"` | Set the failure policy for dynamic admission control.' |
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |
 | clusterAgent.admissionController.port | int | `8000` | Set port of cluster-agent admission controller service |
-| clusterAgent.admissionController.remoteInstrumentation.enabled | bool | `true` | Enable polling and applying library injection using Remote Config. # This feature is in beta, and enables Remote Config in the Cluster Agent. It also requires Cluster Agent version 7.43+. # Enabling this feature grants the Cluster Agent the permissions to patch Deployment objects in the cluster. |
+| clusterAgent.admissionController.remoteInstrumentation.enabled | bool | `false` | Enable polling and applying library injection using Remote Config. # This feature is in beta, and enables Remote Config in the Cluster Agent. It also requires Cluster Agent version 7.43+. # Enabling this feature grants the Cluster Agent the permissions to patch Deployment objects in the cluster. |
 | clusterAgent.admissionController.webhookName | string | `"datadog-webhook"` | Name of the mutatingwebhookconfigurations created by the cluster-agent |
 | clusterAgent.advancedConfd | object | `{}` | Provide additional cluster check configurations. Each key is an integration containing several config files. |
 | clusterAgent.affinity | object | `{}` | Allow the Cluster Agent Deployment to schedule using affinity rules |
@@ -688,7 +688,7 @@ helm install <RELEASE_NAME> \
 | datadog.prometheusScrape.enabled | bool | `false` | Enable autodiscovering pods and services exposing prometheus metrics. |
 | datadog.prometheusScrape.serviceEndpoints | bool | `false` | Enable generating dedicated checks for service endpoints. |
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. |
-| datadog.remoteConfiguration.enabled | bool | `true` | Set to true to enable remote configuration. Consider using remoteConfiguration.enabled instead |
+| datadog.remoteConfiguration.enabled | bool | `false` | Set to true to enable remote configuration. Consider using remoteConfiguration.enabled instead |
 | datadog.secretAnnotations | object | `{}` |  |
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |
 | datadog.secretBackend.command | string | `nil` | Configure the secret backend command, path to the secret backend binary. |
@@ -762,7 +762,7 @@ helm install <RELEASE_NAME> \
 | providers.gke.autopilot | bool | `false` | Enables Datadog Agent deployment on GKE Autopilot |
 | providers.gke.cos | bool | `false` | Enables Datadog Agent deployment on GKE with Container-Optimized OS (COS) |
 | registry | string | `"gcr.io/datadoghq"` | Registry to use for all Agent images (default gcr.io) |
-| remoteConfiguration.enabled | bool | `true` | Set to true to enable remote configuration on the Cluster Agent (if set) and the node agent. Can be overriden if `datadog.remoteConfiguration.enabled` or `clusterAgent.admissionController.remoteInstrumentation.enabled` is set to `false`. Preferred way to enable Remote Configuration. |
+| remoteConfiguration.enabled | bool | `false` | Set to true to enable remote configuration on the Cluster Agent (if set) and the node agent. This will override `datadog.remoteConfiguration.enabled` and `clusterAgent.admissionController.remoteInstrumentation.enabled`. Preferred way to enable Remote Configuration. |
 | targetSystem | string | `"linux"` | Target OS for this deployment (possible values: linux, windows) |
 
 ## Configuration options for Windows deployments

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -814,7 +814,7 @@ false
 Returns whether Remote Configuration should be enabled in the agent
 */}}
 {{- define "datadog-remoteConfiguration-enabled" -}}
-{{- if and (.Values.remoteConfiguration.enabled) (.Values.datadog.remoteConfiguration.enabled) -}}
+{{- if or .Values.remoteConfiguration.enabled .Values.datadog.remoteConfiguration.enabled -}}
 true
 {{- else -}}
 false
@@ -825,7 +825,7 @@ false
 Returns whether Remote Configuration should be enabled in the cluster agent
 */}}
 {{- define "clusterAgent-remoteConfiguration-enabled" -}}
-{{- if and (.Values.remoteConfiguration.enabled) (.Values.clusterAgent.admissionController.remoteInstrumentation.enabled) -}}
+{{- if or .Values.remoteConfiguration.enabled .Values.clusterAgent.admissionController.remoteInstrumentation.enabled -}}
 true
 {{- else -}}
 false

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -389,7 +389,7 @@ datadog:
   remoteConfiguration:
     # datadog.remoteConfiguration.enabled -- Set to true to enable remote configuration.
     # Consider using remoteConfiguration.enabled instead
-    enabled: true
+    enabled: false
 
   ## Enable logs agent and provide custom configs
   logs:
@@ -982,7 +982,7 @@ clusterAgent:
       # clusterAgent.admissionController.remoteInstrumentation.enabled -- Enable polling and applying library injection using Remote Config.
       ## This feature is in beta, and enables Remote Config in the Cluster Agent. It also requires Cluster Agent version 7.43+.
       ## Enabling this feature grants the Cluster Agent the permissions to patch Deployment objects in the cluster.
-      enabled: true
+      enabled: false
 
     # clusterAgent.admissionController.port -- Set port of cluster-agent admission controller service
     port: 8000
@@ -1957,6 +1957,6 @@ providers:
 
 remoteConfiguration:
   # remoteConfiguration.enabled -- Set to true to enable remote configuration on the Cluster Agent (if set) and the node agent.
-  # Can be overriden if `datadog.remoteConfiguration.enabled` or `clusterAgent.admissionController.remoteInstrumentation.enabled` is set to `false`.
+  # This will override `datadog.remoteConfiguration.enabled` and `clusterAgent.admissionController.remoteInstrumentation.enabled`.
   # Preferred way to enable Remote Configuration.
-  enabled: true
+  enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

This temporarily reverts https://github.com/DataDog/helm-charts/pull/1157 .

Why we need this is a long story. There is a crash loop in the cluster agent that a customer on GovCloud reported. I am fixing that crash loop in https://github.com/DataDog/datadog-agent/pull/19596 for the 7.49 build of the agent. I am backporting the fix in https://github.com/DataDog/datadog-agent/pull/19657 to the 7.48 build of the agent. However, right now we are still 1-2 weeks away from releasing 7.48, and we need a workaround to make the cluster agent not crash until then.

The crash only happens when the following conditions are true:

- `admission_controller.auto_instrumentation.patcher.enabled` is true - otherwise we will [never call StartControllers](https://github.com/DataDog/datadog-agent/blob/c0487d93f9b1cf0dd3ca4ef46bacfb513c167edb/cmd/cluster-agent/subcommands/start/command.go#L293) and the crash won't trigger
- `remote_configuration.enabled` [is false or this is a GovCloud customer](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config.go#L2024) - otherwise [ctx.RcClient won't be nil in StartControllers](https://github.com/DataDog/datadog-agent/blob/c0487d93f9b1cf0dd3ca4ef46bacfb513c167edb/pkg/clusteragent/admission/patch/start.go#L32) and the crash won't happen

https://github.com/DataDog/helm-charts/pull/1157 enables the first flag by default and thus makes the crash inevitable for GovCloud customers. So I would like to revert it until the permanent fix takes effect in 7.48.

#### Which issue this PR fixes

Jira: [Fix a crash loop in the cluster agent](https://datadoghq.atlassian.net/browse/AIT-8403)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
