### PR TITLE
Remove buggy chmod directive

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.34.0
+## 3.44.0
 
 * Remove buggy `chmod` directive in the init container of the cluster agent.
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.39.0
+
+* Remove buggy `chmod` directive in the init container of the cluster agent.
+
 ## 3.38.1
 
 * Enable Remote Config by default on the host agent only

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.38.1
+version: 3.39.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.38.1](https://img.shields.io/badge/Version-3.38.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.39.0](https://img.shields.io/badge/Version-3.39.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -106,12 +106,11 @@ spec:
 {{- end }}
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         command:
-          - bash
-          - -c
+          - cp
+          - -r
         args:
-          - |
-            chmod -R 744 /etc/datadog-agent;
-            cp -r /etc/datadog-agent /opt
+          - /etc/datadog-agent
+          - /opt
         volumeMounts:
           - name: config
             mountPath: /opt/datadog-agent


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove a buggy
```
chmod -R 744 /etc/datadog-agent
```
in the init container of the cluster agent:
* it recursively sets the execution bit for the user, even on non-executable, non-directory files.
* it doesn’t set the directory search bit for group and others on directories.

This `chmod` was introduced by #1096 to workaround an issue introduced by DataDog/datadog-agent#16347 and DataDog/datadog-agent#18069.
Let’s rather fix the issue at its root cause: inside the docker image thanks to DataDog/datadog-agent#19673.

#### Which issue this PR fixes

  - fixes CONS-5810

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
