### PR TITLE
Skip references to `PodSecurityPolicy` on recent Kubernetes clusters

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.38.2
+
+* Skip references to PodSecurityPolicy where the support of this API has been dropped.
+
 ## 3.38.1
 
 * Enable Remote Config by default on the host agent only

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.38.1
+version: 3.38.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.38.1](https://img.shields.io/badge/Version-3.38.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.38.2](https://img.shields.io/badge/Version-3.38.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -249,6 +249,7 @@ rules:
   - namespaces
   verbs:
   - list
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 - apiGroups:
   - "policy"
   resources:
@@ -257,6 +258,7 @@ rules:
   - get
   - list
   - watch
+{{- end }}
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -272,6 +274,7 @@ rules:
   - list
 {{- end }}
 {{- end }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 - apiGroups:
   - policy
   resources:
@@ -280,6 +283,7 @@ rules:
   - use
   resourceNames:
   - {{ template "datadog.fullname" . }}-cluster-agent
+{{- end }}
 - apiGroups:
   - "security.openshift.io"
   resources:

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -83,6 +83,7 @@ rules:
   - endpoints
   verbs:
   - get
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 - apiGroups:
   - policy
   resources:
@@ -91,6 +92,7 @@ rules:
   - use
   resourceNames:
   - {{ template "datadog.fullname" . }}
+{{- end }}
 - apiGroups:
   - "security.openshift.io"
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

Skip references to `PodSecurityPolicy` objects on recent Kubernetes clusters where their support has been dropped.

#### Which issue this PR fixes

* CONS-5802

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
