### PR TITLE
add support for initContainer volume mounts

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.40.1
+
+* Add support for initContainer volume mounts
+
 ## 3.40.0
 
 * Default `Agent` and `Cluster-Agent` to `7.48.0` version.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.40.0
+version: 3.40.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.40.0](https://img.shields.io/badge/Version-3.40.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.40.1](https://img.shields.io/badge/Version-3.40.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -411,6 +411,7 @@ helm install <RELEASE_NAME> \
 | agents.containers.agent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the agent container. |
 | agents.containers.initContainers.resources | object | `{}` | Resource requests and limits for the init containers |
 | agents.containers.initContainers.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the init containers. |
+| agents.containers.initContainers.volumeMounts | list | `[]` | Specify additional volumes to mount for the init containers |
 | agents.containers.processAgent.env | list | `[]` | Additional environment variables for the process-agent container |
 | agents.containers.processAgent.envDict | object | `{}` | Set environment variables specific to process-agent defined in a dict |
 | agents.containers.processAgent.envFrom | list | `[]` | Set environment variables specific to process-agent from configMaps and/or secrets |

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -53,6 +53,9 @@
       subPath: system-probe.yaml
       readOnly: true
     {{- end }}
+    {{- if .Values.agents.containers.initContainers.volumeMounts }}
+    {{ toYaml .Values.agents.containers.initContainers.volumeMounts | nindent 4 }}
+    {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}
     {{- if and (eq (include "cluster-agent-enabled" .) "false") .Values.datadog.leaderElection }}

--- a/charts/datadog/templates/_containers-init-windows.yaml
+++ b/charts/datadog/templates/_containers-init-windows.yaml
@@ -45,6 +45,9 @@
       readOnly: true
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
+    {{- if .Values.agents.containers.initContainers.volumeMounts }}
+    {{ toYaml .Values.agents.containers.initContainers.volumeMounts | nindent 4 }}
+    {{- end }}
   env:
     {{- include "containers-common-env" . | nindent 4 }}
   resources:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1576,6 +1576,8 @@ agents:
       #    memory: 200Mi
       # agents.containers.initContainers.securityContext -- Allows you to overwrite the default container SecurityContext for the init containers.
       securityContext: {}
+      # agents.containers.initContainers.volumeMounts -- Specify additional volumes to mount for the init containers
+      volumeMounts: []
 
   # agents.volumes -- Specify additional volumes to mount in the dd-agent container
   volumes: []


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds support for volume mounts inside the initContainers. For my use case, this allows custom shell scripts to be placed in `/etc/cont-init.d` to run when the container starts up.

#### Which issue this PR fixes

While there isn't an issue _specifically_ for this, there are a number of issues that would be solved with this change:

- #286 requests support for additional initContainers. This is an option, but with a larger blast radius to consider.
- #294 was submitted over 2 years ago to fix the issue above, but was never discussed or merged.
- #1107 added direct support for community integrations, but it was closed due to operational risk. This change uses an existing mechanism built into the image rather than change the startup command.
- #1149 requests community integration installation support. The datadog-agent image already supports custom scripts via the `/etc/cont-init.d` directory; this change would allow for a custom installation script to be mounted in the initContainer.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
- [X] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
