### PR TITLE
Disable the headless service by default

### DIFF
--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -224,7 +224,7 @@ service:
 
 serviceHeadless:
   # serviceHeadless.enabled -- If **true**, create a "headless" Service resource.
-  enabled: true
+  enabled: false
 
 ingress:
   # ingress.enabled -- If **true**, create an Ingress resource.


### PR DESCRIPTION
This isn't needed for OPW deployments since we explicitly recommend using cloud load balancers instead. Let's disable it by default unless someone needs it.

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
