### PR TITLE
Add support for sidecar containers

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.39.0
+
+* Enabling `sidecarContainer` support for the agent daemonset.
+
 ## 3.38.3
 
 * Update `fips.image.tag` to `0.6.0`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.38.3
+version: 3.39.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.38.3](https://img.shields.io/badge/Version-3.38.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.39.0](https://img.shields.io/badge/Version-3.39.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -424,6 +424,7 @@ helm install <RELEASE_NAME> \
 | agents.containers.securityAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off. If not set, fall back to the value of datadog.logLevel. |
 | agents.containers.securityAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.securityAgent.resources | object | `{}` | Resource requests and limits for the security-agent container |
+| agents.containers.sidecarContainers | list | `[]` | Additional containers to run alongside the Datadog Agent |
 | agents.containers.systemProbe.env | list | `[]` | Additional environment variables for the system-probe container |
 | agents.containers.systemProbe.envDict | object | `{}` | Set environment variables specific to system-probe defined in a dict |
 | agents.containers.systemProbe.envFrom | list | `[]` | Set environment variables specific to system-probe from configMaps and/or secrets |

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -124,6 +124,9 @@ spec:
         {{- if eq  (include "should-enable-security-agent" .) "true" }}
           {{- include "container-security-agent" . | nindent 6 }}
         {{- end }}
+        {{- with .Values.agents.containers.sidecarContainers }}
+        {{- toYaml . | nindent 6 }}
+        {{- end }}
       initContainers:
         {{- if eq .Values.targetSystem "windows" }}
           {{ include "containers-init-windows" . | nindent 6 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1556,6 +1556,21 @@ agents:
       # agents.containers.initContainers.securityContext -- Allows you to overwrite the default container SecurityContext for the init containers.
       securityContext: {}
 
+    # agents.containers.sidecarContainers -- Additional containers to run alongside the Datadog Agent
+    sidecarContainers: []
+    # sidecarContainers:
+    #   - name: cloud-sql-proxy
+    #     image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.3.0
+    #     args:
+    #       - "--private-ip"
+    #       - "--port=6000"
+    #     securityContext:
+    #       runAsNonRoot: true
+    #     resources:
+    #       requests:
+    #         memory: "2Gi"
+    #         cpu: "1"
+
   # agents.volumes -- Specify additional volumes to mount in the dd-agent container
   volumes: []
   #   - hostPath:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR makes it possible to add sidecar containers to datadog agent daemonset. This will allow users to run proxy containers alongside the agent.

#### Which issue this PR fixes
  - fixes #1111 
 
cc @brettcurtis @celenechang 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
