### PR TITLE
chore: Remove license from observability-pipeline-worker

### DIFF
--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -15,7 +15,6 @@ maintainers:
     email: support@datadoghq.com
 appVersion: "1.5.0"
 annotations:
-  artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: Chart Source
-      url: https://github.com/DataDog/helm-charts
+      url: https://github.com/DataDog/helm-charts/tree/main/charts/observability-pipelines-worker


### PR DESCRIPTION
The way it is represented on ArtifactHub could cause users to assume the application is Apache 2.0 licensed even though the license only applies to the chart itself and not the observability-pipelines-worker image.

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
