### PR TITLE
chore: Update CODEOWNERS for observability-pipelines-worker chart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@ charts/datadog/templates/container-system-probe.yaml @DataDog/ebpf-platform @Dat
 charts/datadog/templates/system-probe-configmap.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/system-probe-init.yaml      @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/synthetics-private-location/                  @Datadog/synthetics
-charts/observability-pipelines-worker                @DataDog/observability-pipelines
+charts/observability-pipelines-worker                @DataDog/observability-pipelines-worker


### PR DESCRIPTION
This is now owned by the @DataDog/observability-pipelines-worker team.
