### PR TITLE
[CECO-1] Add parameter to enable/disable operator metrics forwarder

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.2
 
-* Add configuration for Operator parameter `operatorMetricsEnabled` : this parameter can be used to disable the Operator metrics forwarder.
+* Add configuration for Operator parameter `operatorMetricsEnabled` : this parameter can be used to disable the Operator metrics forwarder. This component is responsible to send metrics (such as whether or not a feature is enabled) and events related to the Datadog custom resources. It is enabled by default.
 
 ## 1.1.1
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.2
+
+* Add configuration for Operator parameter `operatorMetricsEnabled` : this parameter can be used to disable the Operator metrics forwarder.
+
 ## 1.1.1
 
 * Add permissions to curl `/metrics/slis` to operator cluster role.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.1.1
+version: 1.1.2
 appVersion: 1.1.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -25,7 +25,6 @@
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |
-| forwardOperatorMetrics | string | `"true"` | If false, disables sending operator metrics to Datadog |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
@@ -37,6 +36,7 @@
 | metricsPort | int | `8383` | Port used for OpenMetrics endpoint |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Operator on specific nodes |
+| operatorMetricsEnabled | string | `"true"` | If false, disables the metrics forwarder component of the Operator, responsible to send metrics and events related to the Datadog custom resources |
 | podAnnotations | object | `{}` | Allows setting additional annotations for Datadog Operator PODs |
 | podLabels | object | `{}` | Allows setting additional labels for for Datadog Operator PODs |
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 ## Values
 
@@ -25,6 +25,7 @@
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |
+| forwardOperatorMetrics | string | `"true"` | If false, disables sending operator metrics to Datadog |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -93,6 +93,7 @@ spec:
             - "-logEncoder=json"
             - "-metrics-addr=:{{ .Values.metricsPort }}"
             - "-loglevel={{ .Values.logLevel }}"
+            - "-operatorMetricsEnabled={{ .Values.forwardOperatorMetrics }}"
           {{- if and (not (empty .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled)) (semverCompare ">=1.0.0-0" .Values.image.tag ) }}
             - "-webhookEnabled={{ .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled }}"
           {{- else }}

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             - "-logEncoder=json"
             - "-metrics-addr=:{{ .Values.metricsPort }}"
             - "-loglevel={{ .Values.logLevel }}"
-            - "-operatorMetricsEnabled={{ .Values.forwardOperatorMetrics }}"
+            - "-operatorMetricsEnabled={{ .Values.operatorMetricsEnabled }}"
           {{- if and (not (empty .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled)) (semverCompare ">=1.0.0-0" .Values.image.tag ) }}
             - "-webhookEnabled={{ .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled }}"
           {{- else }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -58,8 +58,8 @@ logLevel: "info"
 maximumGoroutines:
 # supportExtendedDaemonset -- If true, supports using ExtendedDaemonSet CRD
 supportExtendedDaemonset: "false"
-# forwardOperatorMetrics -- If false, disables sending operator metrics to Datadog
-forwardOperatorMetrics: "true"
+# operatorMetricsEnabled -- If false, disables the metrics forwarder component of the Operator, responsible to send metrics and events related to the Datadog custom resources
+operatorMetricsEnabled: "true"
 # metricsPort -- Port used for OpenMetrics endpoint
 metricsPort: 8383
 secretBackend:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -58,6 +58,8 @@ logLevel: "info"
 maximumGoroutines:
 # supportExtendedDaemonset -- If true, supports using ExtendedDaemonSet CRD
 supportExtendedDaemonset: "false"
+# forwardOperatorMetrics -- If false, disables sending operator metrics to Datadog
+forwardOperatorMetrics: "true"
 # metricsPort -- Port used for OpenMetrics endpoint
 metricsPort: 8383
 secretBackend:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.1.1
+    helm.sh/chart: datadog-operator-1.1.2
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/managed-by: Helm
@@ -51,6 +51,7 @@ spec:
             - "-logEncoder=json"
             - "-metrics-addr=:8383"
             - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
             - "-webhookEnabled=false"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.1.1
+    helm.sh/chart: datadog-operator-1.1.2
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.1.0"
     app.kubernetes.io/managed-by: Helm
@@ -51,6 +51,7 @@ spec:
             - "-logEncoder=json"
             - "-metrics-addr=:8383"
             - "-loglevel=info"
+            - "-operatorMetricsEnabled=true"
             - "-webhookEnabled=true"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"


### PR DESCRIPTION
#### What this PR does / why we need it:
* This PR introduces the parameter `forwardOperatorMetrics` (`true` by default) to enable/disable the operator metrics forwarder component by modifying the args of the container : https://github.com/DataDog/datadog-operator/blob/35f34ae25e3c8ce43c1d548595f14ec8c5e4e0b4/main.go#L147

#### Which issue this PR fixes
* https://datadoghq.atlassian.net/browse/CECO-1 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
