### PR TITLE
Update CRDs from Operator v1.2.0 tag

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+* Update CRDs from Datadog Operator v1.2.0 tag.
+
 ## 1.1.0
 * Update CRDs from Datadog Operator v1.1.0-rc.1 tag.
 

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 1.1.0
+version: 1.2.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -5904,6 +5904,8 @@ spec:
                           type: boolean
                         serviceName:
                           type: string
+                        webhookName:
+                          type: string
                       type: object
                     apm:
                       properties:
@@ -5966,6 +5968,11 @@ spec:
                           type: object
                         enabled:
                           type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                       type: object
                     cws:
                       properties:
@@ -6000,6 +6007,11 @@ spec:
                         enabled:
                           type: boolean
                         network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
                           properties:
                             enabled:
                               type: boolean
@@ -6059,6 +6071,11 @@ spec:
                             path:
                               type: string
                           type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     eventCollection:
                       properties:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -5893,6 +5893,8 @@ spec:
                           type: boolean
                         serviceName:
                           type: string
+                        webhookName:
+                          type: string
                       type: object
                     apm:
                       properties:
@@ -5955,6 +5957,11 @@ spec:
                           type: object
                         enabled:
                           type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                       type: object
                     cws:
                       properties:
@@ -5989,6 +5996,11 @@ spec:
                         enabled:
                           type: boolean
                         network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
                           properties:
                             enabled:
                               type: boolean
@@ -6048,6 +6060,11 @@ spec:
                             path:
                               type: string
                           type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     eventCollection:
                       properties:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -160,11 +160,13 @@ spec:
                   items:
                     type: string
                   type: array
+                  x-kubernetes-list-type: set
                 tags:
                   description: Tags is the monitor tags associated with your monitor
                   items:
                     type: string
                   type: array
+                  x-kubernetes-list-type: set
                 type:
                   description: Type is the monitor type
                   type: string
@@ -261,8 +263,13 @@ spec:
                       state:
                         description: DatadogMonitorState represents the overall DatadogMonitor state
                         type: string
+                    required:
+                      - monitorGroup
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
               type: object
           type: object
       served: true

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
@@ -160,11 +160,13 @@ spec:
               items:
                 type: string
               type: array
+              x-kubernetes-list-type: set
             tags:
               description: Tags is the monitor tags associated with your monitor
               items:
                 type: string
               type: array
+              x-kubernetes-list-type: set
             type:
               description: Type is the monitor type
               type: string
@@ -261,8 +263,13 @@ spec:
                   state:
                     description: DatadogMonitorState represents the overall DatadogMonitor state
                     type: string
+                required:
+                  - monitorGroup
                 type: object
               type: array
+              x-kubernetes-list-map-keys:
+                - monitorGroup
+              x-kubernetes-list-type: map
           type: object
       type: object
   version: v1alpha1

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -5878,6 +5878,8 @@ spec:
                           type: boolean
                         serviceName:
                           type: string
+                        webhookName:
+                          type: string
                       type: object
                     apm:
                       properties:
@@ -5940,6 +5942,11 @@ spec:
                           type: object
                         enabled:
                           type: boolean
+                        hostBenchmarks:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                       type: object
                     cws:
                       properties:
@@ -5974,6 +5981,11 @@ spec:
                         enabled:
                           type: boolean
                         network:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        remoteConfiguration:
                           properties:
                             enabled:
                               type: boolean
@@ -6033,6 +6045,11 @@ spec:
                             path:
                               type: string
                           type: object
+                      type: object
+                    ebpfCheck:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     eventCollection:
                       properties:

--- a/crds/datadoghq.com_datadogmetrics.yaml
+++ b/crds/datadoghq.com_datadogmetrics.yaml
@@ -16,111 +16,101 @@ spec:
     singular: datadogmetric
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=='Active')].status
-      name: active
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Valid')].status
-      name: valid
-      type: string
-    - jsonPath: .status.currentValue
-      name: value
-      type: string
-    - jsonPath: .status.autoscalerReferences
-      name: references
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Updated')].lastUpdateTime
-      name: update time
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: DatadogMetric allows autoscaling on arbitrary Datadog query
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: DatadogMetricSpec defines the desired state of DatadogMetric
-            properties:
-              externalMetricName:
-                description: ExternalMetricName is reserved for internal use
-                type: string
-              maxAge:
-                description: MaxAge provides the max age for the metric query (overrides
-                  the default setting `external_metrics_provider.max_age`)
-                type: string
-              query:
-                description: Query is the raw datadog query
-                type: string
-              timeWindow:
-                description: TimeWindow provides the time window for the metric query,
-                  defaults to MaxAge.
-                type: string
-            type: object
-          status:
-            description: DatadogMetricStatus defines the observed state of DatadogMetric
-            properties:
-              autoscalerReferences:
-                description: List of autoscalers currently using this DatadogMetric
-                type: string
-              conditions:
-                description: Conditions Represents the latest available observations
-                  of a DatadogMetric's current state.
-                items:
-                  description: DatadogMetricCondition describes the state of a DatadogMetric
-                    at a certain point.
-                  properties:
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    lastUpdateTime:
-                      description: Last time the condition was updated.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A human readable message indicating details about
-                        the transition.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of DatadogMetric condition.
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              currentValue:
-                description: Value is the latest value of the metric
-                type: string
-            required:
-            - currentValue
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Active')].status
+          name: active
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Valid')].status
+          name: valid
+          type: string
+        - jsonPath: .status.currentValue
+          name: value
+          type: string
+        - jsonPath: .status.autoscalerReferences
+          name: references
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Updated')].lastUpdateTime
+          name: update time
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMetric allows autoscaling on arbitrary Datadog query
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMetricSpec defines the desired state of DatadogMetric
+              properties:
+                externalMetricName:
+                  description: ExternalMetricName is reserved for internal use
+                  type: string
+                maxAge:
+                  description: MaxAge provides the max age for the metric query (overrides the default setting `external_metrics_provider.max_age`)
+                  type: string
+                query:
+                  description: Query is the raw datadog query
+                  type: string
+                timeWindow:
+                  description: TimeWindow provides the time window for the metric query, defaults to MaxAge.
+                  type: string
+              type: object
+            status:
+              description: DatadogMetricStatus defines the observed state of DatadogMetric
+              properties:
+                autoscalerReferences:
+                  description: List of autoscalers currently using this DatadogMetric
+                  type: string
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMetric's current state.
+                  items:
+                    description: DatadogMetricCondition describes the state of a DatadogMetric at a certain point.
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMetric condition.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                currentValue:
+                  description: Value is the latest value of the metric
+                  type: string
+              required:
+                - currentValue
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/crds/datadoghq.com_datadogmonitors.yaml
+++ b/crds/datadoghq.com_datadogmonitors.yaml
@@ -16,304 +16,260 @@ spec:
     singular: datadogmonitor
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.id
-      name: id
-      type: string
-    - jsonPath: .status.monitorState
-      name: monitor state
-      type: string
-    - jsonPath: .status.monitorStateLastTransitionTime
-      name: last state transition
-      type: string
-    - format: date
-      jsonPath: .status.monitorStateLastUpdateTime
-      name: last state sync
-      type: string
-    - jsonPath: .status.syncStatus
-      name: sync status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: DatadogMonitor allows to define and manage Monitors from your
-          Kubernetes Cluster
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: DatadogMonitorSpec defines the desired state of DatadogMonitor
-            properties:
-              controllerOptions:
-                description: ControllerOptions are the optional parameters in the
-                  DatadogMonitor controller
-                properties:
-                  disableRequiredTags:
-                    description: DisableRequiredTags disables the automatic addition
-                      of required tags to monitors.
-                    type: boolean
-                type: object
-              message:
-                description: Message is a message to include with notifications for
-                  this monitor
-                type: string
-              name:
-                description: Name is the monitor name
-                type: string
-              options:
-                description: Options are the optional parameters associated with your
-                  monitor
-                properties:
-                  enableLogsSample:
-                    description: A Boolean indicating whether to send a log sample
-                      when the log monitor triggers.
-                    type: boolean
-                  escalationMessage:
-                    description: A message to include with a re-notification.
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.monitorState
+          name: monitor state
+          type: string
+        - jsonPath: .status.monitorStateLastTransitionTime
+          name: last state transition
+          type: string
+        - format: date
+          jsonPath: .status.monitorStateLastUpdateTime
+          name: last state sync
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogMonitor controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to monitors.
+                      type: boolean
+                  type: object
+                message:
+                  description: Message is a message to include with notifications for this monitor
+                  type: string
+                name:
+                  description: Name is the monitor name
+                  type: string
+                options:
+                  description: Options are the optional parameters associated with your monitor
+                  properties:
+                    enableLogsSample:
+                      description: A Boolean indicating whether to send a log sample when the log monitor triggers.
+                      type: boolean
+                    escalationMessage:
+                      description: A message to include with a re-notification.
+                      type: string
+                    evaluationDelay:
+                      description: Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min), the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                      format: int64
+                      type: integer
+                    includeTags:
+                      description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
+                      type: boolean
+                    locked:
+                      description: Whether or not the monitor is locked (only editable by creator and admins).
+                      type: boolean
+                    newGroupDelay:
+                      description: Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer.
+                      format: int64
+                      type: integer
+                    noDataTimeframe:
+                      description: The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.
+                      format: int64
+                      type: integer
+                    notifyAudit:
+                      description: A Boolean indicating whether tagged users are notified on changes to this monitor.
+                      type: boolean
+                    notifyNoData:
+                      description: A Boolean indicating whether this monitor notifies when data stops reporting.
+                      type: boolean
+                    renotifyInterval:
+                      description: The number of minutes after the last notification before a monitor re-notifies on the current status. It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    requireFullWindow:
+                      description: A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                      type: boolean
+                    thresholdWindows:
+                      description: A struct of the alerting time window options.
+                      properties:
+                        recoveryWindow:
+                          description: Describes how long an anomalous metric must be normal before the alert recovers.
+                          type: string
+                        triggerWindow:
+                          description: Describes how long a metric must be anomalous before an alert triggers.
+                          type: string
+                      type: object
+                    thresholds:
+                      description: A struct of the different monitor threshold values.
+                      properties:
+                        critical:
+                          description: The monitor CRITICAL threshold.
+                          type: string
+                        criticalRecovery:
+                          description: The monitor CRITICAL recovery threshold.
+                          type: string
+                        ok:
+                          description: The monitor OK threshold.
+                          type: string
+                        unknown:
+                          description: The monitor UNKNOWN threshold.
+                          type: string
+                        warning:
+                          description: The monitor WARNING threshold.
+                          type: string
+                        warningRecovery:
+                          description: The monitor WARNING recovery threshold.
+                          type: string
+                      type: object
+                    timeoutH:
+                      description: The number of hours of the monitor not reporting data before it automatically resolves from a triggered state.
+                      format: int64
+                      type: integer
+                  type: object
+                priority:
+                  description: Priority is an integer from 1 (high) to 5 (low) indicating alert severity
+                  format: int64
+                  type: integer
+                query:
+                  description: Query is the Datadog monitor query
+                  type: string
+                restrictedRoles:
+                  description: RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor. `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`, see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                  items:
                     type: string
-                  evaluationDelay:
-                    description: Time (in seconds) to delay evaluation, as a non-negative
-                      integer. For example, if the value is set to 300 (5min), the
-                      timeframe is set to last_5m and the time is 7:00, the monitor
-                      evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch
-                      and other backfilled metrics to ensure the monitor always has
-                      data during evaluation.
-                    format: int64
-                    type: integer
-                  includeTags:
-                    description: A Boolean indicating whether notifications from this
-                      monitor automatically inserts its triggering tags into the title.
-                    type: boolean
-                  locked:
-                    description: Whether or not the monitor is locked (only editable
-                      by creator and admins).
-                    type: boolean
-                  newGroupDelay:
-                    description: Time (in seconds) to allow a host to boot and applications
-                      to fully start before starting the evaluation of monitor results.
-                      Should be a non negative integer.
-                    format: int64
-                    type: integer
-                  noDataTimeframe:
-                    description: The number of minutes before a monitor notifies after
-                      data stops reporting. Datadog recommends at least 2x the monitor
-                      timeframe for metric alerts or 2 minutes for service checks.
-                      If omitted, 2x the evaluation timeframe is used for metric alerts,
-                      and 24 hours is used for service checks.
-                    format: int64
-                    type: integer
-                  notifyAudit:
-                    description: A Boolean indicating whether tagged users are notified
-                      on changes to this monitor.
-                    type: boolean
-                  notifyNoData:
-                    description: A Boolean indicating whether this monitor notifies
-                      when data stops reporting.
-                    type: boolean
-                  renotifyInterval:
-                    description: The number of minutes after the last notification
-                      before a monitor re-notifies on the current status. It only
-                      re-notifies if it’s not resolved.
-                    format: int64
-                    type: integer
-                  requireFullWindow:
-                    description: A Boolean indicating whether this monitor needs a
-                      full window of data before it’s evaluated. We highly recommend
-                      you set this to false for sparse metrics, otherwise some evaluations
-                      are skipped. Default is false.
-                    type: boolean
-                  thresholdWindows:
-                    description: A struct of the alerting time window options.
-                    properties:
-                      recoveryWindow:
-                        description: Describes how long an anomalous metric must be
-                          normal before the alert recovers.
-                        type: string
-                      triggerWindow:
-                        description: Describes how long a metric must be anomalous
-                          before an alert triggers.
-                        type: string
-                    type: object
-                  thresholds:
-                    description: A struct of the different monitor threshold values.
-                    properties:
-                      critical:
-                        description: The monitor CRITICAL threshold.
-                        type: string
-                      criticalRecovery:
-                        description: The monitor CRITICAL recovery threshold.
-                        type: string
-                      ok:
-                        description: The monitor OK threshold.
-                        type: string
-                      unknown:
-                        description: The monitor UNKNOWN threshold.
-                        type: string
-                      warning:
-                        description: The monitor WARNING threshold.
-                        type: string
-                      warningRecovery:
-                        description: The monitor WARNING recovery threshold.
-                        type: string
-                    type: object
-                  timeoutH:
-                    description: The number of hours of the monitor not reporting
-                      data before it automatically resolves from a triggered state.
-                    format: int64
-                    type: integer
-                type: object
-              priority:
-                description: Priority is an integer from 1 (high) to 5 (low) indicating
-                  alert severity
-                format: int64
-                type: integer
-              query:
-                description: Query is the Datadog monitor query
-                type: string
-              restrictedRoles:
-                description: RestrictedRoles is a list of unique role identifiers
-                  to define which roles are allowed to edit the monitor. `restricted_roles`
-                  is the successor of `locked`. For more information about `locked`
-                  and `restricted_roles`, see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
-                items:
+                  type: array
+                  x-kubernetes-list-type: set
+                tags:
+                  description: Tags is the monitor tags associated with your monitor
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                type:
+                  description: Type is the monitor type
                   type: string
-                type: array
-              tags:
-                description: Tags is the monitor tags associated with your monitor
-                items:
+              type: object
+            status:
+              description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+              properties:
+                conditions:
+                  description: Conditions Represents the latest available observations of a DatadogMonitor's current state.
+                  items:
+                    description: DatadogMonitorCondition describes the current state of a DatadogMonitor
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: Last time the condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of DatadogMonitor condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the monitor was created
+                  format: date-time
                   type: string
-                type: array
-              type:
-                description: Type is the monitor type
-                type: string
-            type: object
-          status:
-            description: DatadogMonitorStatus defines the observed state of DatadogMonitor
-            properties:
-              conditions:
-                description: Conditions Represents the latest available observations
-                  of a DatadogMonitor's current state.
-                items:
-                  description: DatadogMonitorCondition describes the current state
-                    of a DatadogMonitor
+                creator:
+                  description: Creator is the identify of the monitor creator
+                  type: string
+                currentHash:
+                  description: CurrentHash tracks the hash of the current DatadogMonitorSpec to know if the Spec has changed and needs an update
+                  type: string
+                downtimeStatus:
+                  description: DowntimeStatus defines whether the monitor is downtimed
                   properties:
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    lastUpdateTime:
-                      description: Last time the condition was updated.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A human readable message indicating details about
-                        the transition.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of DatadogMonitor condition
-                      type: string
-                  required:
-                  - status
-                  - type
+                    downtimeId:
+                      type: integer
+                    isDowntimed:
+                      type: boolean
                   type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              created:
-                description: Created is the time the monitor was created
-                format: date-time
-                type: string
-              creator:
-                description: Creator is the identify of the monitor creator
-                type: string
-              currentHash:
-                description: CurrentHash tracks the hash of the current DatadogMonitorSpec
-                  to know if the Spec has changed and needs an update
-                type: string
-              downtimeStatus:
-                description: DowntimeStatus defines whether the monitor is downtimed
-                properties:
-                  downtimeId:
-                    type: integer
-                  isDowntimed:
-                    type: boolean
-                type: object
-              id:
-                description: ID is the monitor ID generated in Datadog
-                type: integer
-              monitorLastForceSyncTime:
-                description: MonitorLastForceSyncTime is the last time the API monitor
-                  was last force synced with the DatadogMonitor resource
-                format: date-time
-                type: string
-              monitorState:
-                description: MonitorState is the overall state of monitor
-                type: string
-              monitorStateLastTransitionTime:
-                description: MonitorStateLastTransitionTime is the last time the monitor
-                  state changed
-                format: date-time
-                type: string
-              monitorStateLastUpdateTime:
-                description: MonitorStateLastUpdateTime is the last time the monitor
-                  state updated
-                format: date-time
-                type: string
-              primary:
-                description: Primary defines whether the monitor is managed by the
-                  Kubernetes custom resource (true) or outside Kubernetes (false)
-                type: boolean
-              syncStatus:
-                description: MonitorStateSyncStatus shows the health of syncing the
-                  monitor state to Datadog
-                type: string
-              triggeredState:
-                description: TriggeredState only includes details for monitor groups
-                  that are triggering
-                items:
-                  description: DatadogMonitorTriggeredState represents the details
-                    of a triggering DatadogMonitor The DatadogMonitor is triggering
-                    if one of its groups is in Alert, Warn, or No Data
-                  properties:
-                    lastTransitionTime:
-                      format: date-time
-                      type: string
-                    monitorGroup:
-                      description: MonitorGroup is the name of the triggering group
-                      type: string
-                    state:
-                      description: DatadogMonitorState represents the overall DatadogMonitor
-                        state
-                      type: string
-                  type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                id:
+                  description: ID is the monitor ID generated in Datadog
+                  type: integer
+                monitorLastForceSyncTime:
+                  description: MonitorLastForceSyncTime is the last time the API monitor was last force synced with the DatadogMonitor resource
+                  format: date-time
+                  type: string
+                monitorState:
+                  description: MonitorState is the overall state of monitor
+                  type: string
+                monitorStateLastTransitionTime:
+                  description: MonitorStateLastTransitionTime is the last time the monitor state changed
+                  format: date-time
+                  type: string
+                monitorStateLastUpdateTime:
+                  description: MonitorStateLastUpdateTime is the last time the monitor state updated
+                  format: date-time
+                  type: string
+                primary:
+                  description: Primary defines whether the monitor is managed by the Kubernetes custom resource (true) or outside Kubernetes (false)
+                  type: boolean
+                syncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
+                triggeredState:
+                  description: TriggeredState only includes details for monitor groups that are triggering
+                  items:
+                    description: DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      monitorGroup:
+                        description: MonitorGroup is the name of the triggering group
+                        type: string
+                      state:
+                        description: DatadogMonitorState represents the overall DatadogMonitor state
+                        type: string
+                    required:
+                      - monitorGroup
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - monitorGroup
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

Update CRDs from Operator 1.2.0 tag.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
