### PR TITLE
Separate `DD_CONTAINER_INCLUDE/EXCLUDE` for agent/cluster agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.45.0
+
+* Separate values for `DD_CONTAINER_INCLUDE` and `DD_CONTAINER_EXCLUDE` in `Agent` and `Cluster-Agent`
+  Note: this requires agent/cluster agent version 7.50.0+
+
 ## 3.44.1
 
 * Fix local agent Kubernetes service to include APM traceport

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.40.0
 
+* Separate values for `DD_CONTAINER_INCLUDE` and `DD_CONTAINER_EXCLUDE` in `Agent` and `Cluster-Agent`
+
+## 3.40.0
+
 * Default `Agent` and `Cluster-Agent` to `7.48.0` version.
 
 ## 3.39.3

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.40.0
+## 3.40.1
 
 * Separate values for `DD_CONTAINER_INCLUDE` and `DD_CONTAINER_EXCLUDE` in `Agent` and `Cluster-Agent`
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.44.1
+version: 3.45.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.40.0
+version: 3.40.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.40.0](https://img.shields.io/badge/Version-3.40.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.40.1](https://img.shields.io/badge/Version-3.40.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -496,6 +496,8 @@ helm install <RELEASE_NAME> \
 | clusterAgent.affinity | object | `{}` | Allow the Cluster Agent Deployment to schedule using affinity rules |
 | clusterAgent.command | list | `[]` | Command to run in the Cluster Agent container as entrypoint |
 | clusterAgent.confd | object | `{}` | Provide additional cluster check configurations. Each key will become a file in /conf.d. |
+| clusterAgent.containerExclude | string | `nil` | Exclude containers from the Cluster Agent Autodiscovery, as a space-separated list |
+| clusterAgent.containerInclude | string | `nil` | Include containers in the Cluster Agent Autodiscovery, as a space-separated list.  If a container matches an include rule, it’s always included in the Autodiscovery |
 | clusterAgent.containers.clusterAgent.securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true}` | Specify securityContext on the cluster-agent container. |
 | clusterAgent.containers.initContainers.securityContext | object | `{}` |  |
 | clusterAgent.createPodDisruptionBudget | bool | `false` | Create pod disruption budget for Cluster Agent deployments |
@@ -607,7 +609,7 @@ helm install <RELEASE_NAME> \
 | datadog.clusterTagger.collectKubernetesTags | bool | `false` | Enables Kubernetes resources tags collection. |
 | datadog.collectEvents | bool | `true` | Enables this to start event collection from the kubernetes API |
 | datadog.confd | object | `{}` | Provide additional check configurations (static and Autodiscovery) |
-| datadog.containerExclude | string | `nil` | Exclude containers from the Agent Autodiscovery, as a space-sepatered list |
+| datadog.containerExclude | string | `nil` | Exclude containers from the Agent Autodiscovery, as a space-separated list |
 | datadog.containerExcludeLogs | string | `nil` | Exclude logs from the Agent Autodiscovery, as a space-separated list |
 | datadog.containerExcludeMetrics | string | `nil` | Exclude metrics from the Agent Autodiscovery, as a space-separated list |
 | datadog.containerInclude | string | `nil` | Include containers in the Agent Autodiscovery, as a space-separated list.  If a container matches an include rule, it’s always included in the Autodiscovery |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -497,8 +497,8 @@ helm install <RELEASE_NAME> \
 | clusterAgent.affinity | object | `{}` | Allow the Cluster Agent Deployment to schedule using affinity rules |
 | clusterAgent.command | list | `[]` | Command to run in the Cluster Agent container as entrypoint |
 | clusterAgent.confd | object | `{}` | Provide additional cluster check configurations. Each key will become a file in /conf.d. |
-| clusterAgent.containerExclude | string | `nil` | Exclude containers from the Cluster Agent Autodiscovery, as a space-separated list |
-| clusterAgent.containerInclude | string | `nil` | Include containers in the Cluster Agent Autodiscovery, as a space-separated list.  If a container matches an include rule, it’s always included in the Autodiscovery |
+| clusterAgent.containerExclude | string | `nil` | Exclude containers from the Cluster Agent Autodiscovery, as a space-separated list. (Requires Agent/Cluster Agent 7.50.0+) |
+| clusterAgent.containerInclude | string | `nil` | Include containers in the Cluster Agent Autodiscovery, as a space-separated list.  If a container matches an include rule, it’s always included in the Autodiscovery. (Requires Agent/Cluster Agent 7.50.0+) |
 | clusterAgent.containers.clusterAgent.securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true}` | Specify securityContext on the cluster-agent container. |
 | clusterAgent.containers.initContainers.securityContext | object | `{}` |  |
 | clusterAgent.createPodDisruptionBudget | bool | `false` | Create pod disruption budget for Cluster Agent deployments |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.44.1](https://img.shields.io/badge/Version-3.44.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.45.0](https://img.shields.io/badge/Version-3.45.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_components-common-env.yaml
+++ b/charts/datadog/templates/_components-common-env.yaml
@@ -48,14 +48,6 @@
 - name: DD_DD_URL
   value: {{ .Values.datadog.dd_url | quote }}
 {{- end }}
-{{- if .Values.datadog.containerInclude }}
-- name: DD_CONTAINER_INCLUDE
-  value: {{ .Values.datadog.containerInclude | quote }}
-{{- end }}
-{{- if .Values.datadog.containerExclude }}
-- name: DD_CONTAINER_EXCLUDE
-  value: {{ .Values.datadog.containerExclude | quote }}
-{{- end }}
 {{- if not .Values.datadog.excludePauseContainer }}
 - name: DD_EXCLUDE_PAUSE_CONTAINER
   value: "false"

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -48,6 +48,14 @@
 - name: DD_AC_EXCLUDE
   value: {{ .Values.datadog.acExclude | quote }}
 {{- end }}
+{{- if .Values.datadog.containerInclude }}
+- name: DD_CONTAINER_INCLUDE
+  value: {{ .Values.datadog.containerInclude | quote }}
+{{- end }}
+{{- if .Values.datadog.containerExclude }}
+- name: DD_CONTAINER_EXCLUDE
+  value: {{ .Values.datadog.containerExclude | quote }}
+{{- end }}
 {{- if .Values.datadog.containerIncludeMetrics }}
 - name: DD_CONTAINER_INCLUDE_METRICS
   value: {{ .Values.datadog.containerIncludeMetrics | quote }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -188,13 +188,13 @@ spec:
           - name: DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT
             value: {{ .Values.clusterAgent.metricsProvider.endpoint | quote }}
           {{- end }}
-          {{- if .Values.clusterAgent.datadog.containerInclude }}
+          {{- if .Values.clusterAgent.containerInclude }}
           - name: DD_CONTAINER_INCLUDE
-            value: {{ .Values.clusterAgent.datadog.containerInclude | quote }}
+            value: {{ .Values.clusterAgent.containerInclude | quote }}
           {{- end }}
-          {{- if .Values.clusterAgent.datadog.containerExclude }}
+          {{- if .Values.clusterAgent.containerExclude }}
           - name: DD_CONTAINER_EXCLUDE
-            value: {{ .Values.clusterAgent.datadog.containerExclude | quote }}
+            value: {{ .Values.clusterAgent.containerExclude | quote }}
           {{- end }}
           - name: DD_EXTERNAL_METRICS_AGGREGATOR
             value: {{ .Values.clusterAgent.metricsProvider.aggregator | quote }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -188,6 +188,14 @@ spec:
           - name: DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT
             value: {{ .Values.clusterAgent.metricsProvider.endpoint | quote }}
           {{- end }}
+          {{- if .Values.clusterAgent.datadog.containerInclude }}
+          - name: DD_CONTAINER_INCLUDE
+            value: {{ .Values.clusterAgent.datadog.containerInclude | quote }}
+          {{- end }}
+          {{- if .Values.clusterAgent.datadog.containerExclude }}
+          - name: DD_CONTAINER_EXCLUDE
+            value: {{ .Values.clusterAgent.datadog.containerExclude | quote }}
+          {{- end }}
           - name: DD_EXTERNAL_METRICS_AGGREGATOR
             value: {{ .Values.clusterAgent.metricsProvider.aggregator | quote }}
           {{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1158,7 +1158,7 @@ clusterAgent:
   # clusterAgent.additionalLabels -- Adds labels to the Cluster Agent deployment and pods
   additionalLabels: {}
     # key: "value"
-  
+
   # clusterAgent.containerExclude -- Exclude containers from the Cluster Agent
   # Autodiscovery, as a space-separated list
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1178,14 +1178,14 @@ clusterAgent:
     # key: "value"
 
   # clusterAgent.containerExclude -- Exclude containers from the Cluster Agent
-  # Autodiscovery, as a space-separated list
+  # Autodiscovery, as a space-separated list. (Requires Agent/Cluster Agent 7.50.0+)
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
   containerExclude:  # "image:datadog/agent"
 
   # clusterAgent.containerInclude -- Include containers in the Cluster Agent Autodiscovery,
   # as a space-separated list.  If a container matches an include rule, it’s
-  # always included in the Autodiscovery
+  # always included in the Autodiscovery. (Requires Agent/Cluster Agent 7.50.0+)
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#include-containers
   containerInclude:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -791,7 +791,7 @@ datadog:
   #  - kubernetes_state
 
   # datadog.containerExclude -- Exclude containers from the Agent
-  # Autodiscovery, as a space-sepatered list
+  # Autodiscovery, as a space-separated list
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
   containerExclude:  # "image:datadog/agent"
@@ -1158,6 +1158,19 @@ clusterAgent:
   # clusterAgent.additionalLabels -- Adds labels to the Cluster Agent deployment and pods
   additionalLabels: {}
     # key: "value"
+  
+  # clusterAgent.containerExclude -- Exclude containers from the Cluster Agent
+  # Autodiscovery, as a space-separated list
+
+  ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
+  containerExclude:  # "image:datadog/agent"
+
+  # clusterAgent.containerInclude -- Include containers in the Cluster Agent Autodiscovery,
+  # as a space-separated list.  If a container matches an include rule, it’s
+  # always included in the Autodiscovery
+
+  ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#include-containers
+  containerInclude:
 
 ## This section lets you configure the agents deployed by this chart to connect to a Cluster Agent
 ## deployed independently


### PR DESCRIPTION
#### What this PR does / why we need it:
As a part of the changes made in https://github.com/DataDog/datadog-agent/pull/19788 to support filtering of metrics emitted by service/endpoint checks, the values for `DD_CONTAINER_INCLUDE` and `DD_CONTAINER_EXCLUDE` had to be separated between the agent and the cluster agent. 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
