### PR TITLE
Add baseline tests for Agent chart

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@
 - [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
 - [ ] `CHANGELOG.md` has been updated
 - [ ] Variables are documented in the `README.md`
-- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
+- [ ] For `datadog-operator` or `datadog` chart or value changes update the test baselines (run: `make update-test-baselines`)

--- a/.github/workflows/go-test-agent.yaml
+++ b/.github/workflows/go-test-agent.yaml
@@ -1,0 +1,39 @@
+name: Go Test
+on:
+  push:
+    paths:
+      - 'test/datadog/**'
+      - 'charts/datadog/**'
+  pull_request:
+    paths:
+      - 'test/datadog/**'
+      - 'charts/datadog/**'
+env:
+  GO111MODULE: "on"
+  PROJECTNAME: "helm-charts"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.20
+      id: go
+    - name: Set up Helm
+      uses: azure/setup-helm@v3.5
+      with:
+        version: v3.10.1
+    - name: Add Datadog Helm repo
+      run: |
+        helm repo add Promotheus https://prometheus-community.github.io/helm-charts
+        helm repo add datadog https://helm.datadoghq.com
+        helm repo update
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+    - name: run Go tests
+      run: |
+        helm dependency update ./charts/datadog
+        helm dependency build ./charts/datadog
+        make unit-test
+

--- a/.github/workflows/go-test-operator.yaml
+++ b/.github/workflows/go-test-operator.yaml
@@ -2,11 +2,11 @@ name: Go Test
 on:
   push:
     paths:
-      - 'test/**'
+      - 'test/datadog-operator/**'
       - 'charts/datadog-operator/**'
   pull_request:
     paths:
-      - 'test/**'
+      - 'test/datadog-operator/**'
       - 'charts/datadog-operator/**'
 env:
   GO111MODULE: "on"
@@ -30,6 +30,7 @@ jobs:
       uses: actions/checkout@v1
     - name: run Go tests
       run: |
+        helm dependency update ./charts/datadog-operator
         helm dependency build ./charts/datadog-operator
         make unit-test
 

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -37,7 +37,7 @@ func RenderChart(t *testing.T, cmd HelmCommand) (string, error) {
 		ValuesFiles:    cmd.Values,
 	}
 
-	output, err := helm.RenderTemplateE(t, options, chartPath, cmd.ReleaseName, cmd.ShowOnly)
+	output, err := helm.RenderTemplateE(t, options, chartPath, cmd.ReleaseName, cmd.ShowOnly, "--debug")
 
 	return output, err
 }
@@ -78,6 +78,12 @@ func CreateSecretFromEnv(t *testing.T, kubectlOptions *k8s.KubectlOptions, apiKe
 		t.Log("Deleting secret")
 		k8s.RunKubectl(t, kubectlOptions, "delete", "secret", "datadog-secret")
 	}
+}
+
+func ReadFile(t *testing.T, filepath string) string {
+	fileContent, err := os.ReadFile(filepath)
+	require.NoError(t, err, "can't load manifest from file", "path", filepath)
+	return string(fileContent)
 }
 
 func LoadFromFile[T any](t *testing.T, filepath string, destObj *T) string {

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.2.0
+    helm.sh/chart: datadog-operator-1.2.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.2.0
+    helm.sh/chart: datadog-operator-1.2.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
@@ -1,0 +1,180 @@
+---
+# Source: datadog/templates/agent-clusterchecks-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-clusterchecks
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+    app.kubernetes.io/component: clusterchecks-agent
+    
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: datadog-clusterchecks
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "datadog"
+        app.kubernetes.io/instance: "datadog"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: clusterchecks-agent
+        app: datadog-clusterchecks
+        
+      name: datadog-clusterchecks
+      annotations:
+        checksum/clusteragent_token: b755904b1ad5a36cbb95300b58bab32f6581a93a1ea57fda3150881736113f05
+        checksum/install_info: e25591d3c3d4f1ffd34b44799840d82a96fd1bdf4875b5bdba29f1cde44f600b
+    spec:
+      serviceAccountName: datadog-cluster-checks
+      automountServiceAccountToken: true
+      imagePullSecrets:
+        []
+      initContainers:
+      - name: init-volume
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+          - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+          - name: config
+            mountPath: /opt/datadog-agent
+            readOnly: false # Need RW for writing agent config files
+        resources:
+          {}
+      - name: init-config
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+          - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+        volumeMounts:
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: false # Need RW for writing datadog.yaml config file
+        resources:
+          {}
+      containers:
+      - name: agent
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        command: ["bash", "-c"]
+        args:
+          - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_LOG_LEVEL
+            value: "INFO"
+          - name: DD_EXTRA_CONFIG_PROVIDERS
+            value: "clusterchecks"
+          - name: DD_HEALTH_PORT
+            value: "5557"
+          # Cluster checks (cluster-agent communication)
+          - name: DD_CLUSTER_AGENT_ENABLED
+            value: "true"
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: datadog-cluster-agent
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                  name: datadog-cluster-agent
+                  key: token
+          # Safely run alongside the daemonset
+          - name: DD_ENABLE_METADATA_COLLECTION
+            value: "false"
+          # Expose CLC stats
+          - name: DD_CLC_RUNNER_ENABLED
+            value: "true"
+          - name: DD_CLC_RUNNER_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: DD_CLC_RUNNER_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          # Remove unused features
+          - name: DD_USE_DOGSTATSD
+            value: "false"
+          - name: DD_PROCESS_AGENT_ENABLED
+            value: "false"
+          - name: DD_LOGS_ENABLED
+            value: "false"
+          - name: DD_APM_ENABLED
+            value: "false"
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "false"
+          - name: DD_HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          
+                              
+        resources:
+          {}
+        volumeMounts:
+          - name: installinfo
+            subPath: install_info
+            mountPath: /etc/datadog-agent/install_info
+            readOnly: true
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: false # Need RW for config path
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /live
+            port: 5557
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /ready
+            port: 5557
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+      volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-installinfo
+        - name: config
+          emptyDir: {}
+      affinity:
+        # Prefer scheduling the runners on different nodes if possible
+        # for better checks stability in case of node failure.
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: datadog-clusterchecks
+              topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/test/datadog/baseline/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default.yaml
@@ -1,0 +1,222 @@
+---
+# Source: datadog/templates/cluster-agent-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-cluster-agent
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+    app.kubernetes.io/component: cluster-agent
+    
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: datadog-cluster-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "datadog"
+        app.kubernetes.io/instance: "datadog"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: cluster-agent
+        app: datadog-cluster-agent
+        
+      name: datadog-cluster-agent
+      annotations:
+        checksum/clusteragent_token: eb2c5f44cc4b867bb29e6a68a2f08f15b033e462a3ae203821227f85acc5ef23
+        checksum/clusteragent-configmap: 6b71b588ddba327b5d0f8960314102c0f9b18701cbe6ee2732c070c57fb384be
+        checksum/api_key: 14cd30736bf4c9ec0c03305908ee5835c033075eb380dc497860aa54d55d3e52
+        checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/install_info: e25591d3c3d4f1ffd34b44799840d82a96fd1bdf4875b5bdba29f1cde44f600b
+    spec:
+      serviceAccountName: datadog-cluster-agent
+      automountServiceAccountToken: true
+      initContainers:
+      - name: init-volume
+        image: "gcr.io/datadoghq/cluster-agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command:
+          - bash
+          - -c
+        args:
+          - |
+            chmod -R 744 /etc/datadog-agent;
+            cp -r /etc/datadog-agent /opt
+        volumeMounts:
+          - name: config
+            mountPath: /opt/datadog-agent
+      containers:
+      - name: cluster-agent
+        image: "gcr.io/datadoghq/cluster-agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        resources:
+          {}
+        ports:
+        - containerPort: 5005
+          name: agentport
+          protocol: TCP
+        - containerPort: 5000
+          name: agentmetrics
+          protocol: TCP
+        - containerPort: 8000
+          name: datadog-webhook
+          protocol: TCP
+        env:
+          - name: DD_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: DD_HEALTH_PORT
+            value: "5556"
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog"
+                key: api-key
+                optional: true
+          
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_ADMISSION_CONTROLLER_ENABLED
+            value: "true"
+          - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
+            value: "datadog-webhook"
+          - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
+            value: "false"
+          - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
+            value: datadog-cluster-agent-admission-controller
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE
+            value: socket
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
+            value: datadog
+          - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
+            value: "Ignore"
+          - name: DD_ADMISSION_CONTROLLER_PORT
+            value: "8000"
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "false"
+          - name: DD_CLUSTER_CHECKS_ENABLED
+            value: "true"
+          - name: DD_EXTRA_CONFIG_PROVIDERS
+            value: "kube_endpoints kube_services"
+          - name: DD_EXTRA_LISTENERS
+            value: "kube_endpoints kube_services"
+          - name: DD_LOG_LEVEL
+            value: "INFO"
+          - name: DD_LEADER_ELECTION
+            value: "true"
+          - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+            value: "configmap"
+          - name: DD_LEADER_LEASE_NAME
+            value: datadog-leader-election
+          - name: DD_CLUSTER_AGENT_TOKEN_NAME
+            value: datadogtoken
+          - name: DD_COLLECT_KUBERNETES_EVENTS
+            value: "true"
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: datadog-cluster-agent
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: datadog-cluster-agent
+                key: token
+          - name: DD_CLUSTER_AGENT_COLLECT_KUBERNETES_TAGS
+            value: "false"
+          - name: DD_KUBE_RESOURCES_NAMESPACE
+            value: datadog-agent
+          - name: CHART_RELEASE_NAME
+            value: "datadog"
+          - name: AGENT_DAEMONSET
+            value: datadog
+          - name: CLUSTER_AGENT_DEPLOYMENT
+            value: datadog-cluster-agent
+          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            value: "true"
+          - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
+            value: "true"
+                              
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /live
+            port: 5556
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /ready
+            port: 5556
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        volumeMounts:
+          - name: datadogrun
+            mountPath: /opt/datadog-agent/run
+            readOnly: false
+          - name: varlog
+            mountPath: /var/log/datadog
+            readOnly: false
+          - name: tmpdir
+            mountPath: /tmp
+            readOnly: false
+          - name: installinfo
+            subPath: install_info
+            mountPath: /etc/datadog-agent/install_info
+            readOnly: true
+          - name: confd
+            mountPath: /conf.d
+            readOnly: true
+          - name: config
+            mountPath: /etc/datadog-agent
+      volumes:
+        - name: datadogrun
+          emptyDir: {}
+        - name: varlog
+          emptyDir: {}
+        - name: tmpdir
+          emptyDir: {}
+        - name: installinfo
+          configMap:
+            name: datadog-installinfo
+        - name: confd
+          configMap:
+            name: datadog-cluster-agent-confd
+            items:
+            - key: kubernetes_state_core.yaml.default
+              path: kubernetes_state_core.yaml.default
+        - name: config
+          emptyDir: {}
+      affinity:
+        # Prefer scheduling the cluster agents on different nodes
+        # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: datadog-cluster-agent
+              topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/test/datadog/baseline/daemonset_default.yaml
+++ b/test/datadog/baseline/daemonset_default.yaml
@@ -1,0 +1,459 @@
+---
+# Source: datadog/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: datadog
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+    app.kubernetes.io/component: agent
+    
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: datadog
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "datadog"
+        app.kubernetes.io/instance: "datadog"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: agent
+        app: datadog
+        
+      name: datadog
+      annotations:
+        checksum/clusteragent_token: 7b9874ae13094ab787a81ff6442602a305537f4755f1c965987469efdff35e26
+        checksum/install_info: e25591d3c3d4f1ffd34b44799840d82a96fd1bdf4875b5bdba29f1cde44f600b
+        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
+        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+    spec:
+      
+      securityContext:
+        runAsUser: 0
+      hostPID: true
+      containers:
+      - name: agent
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["agent", "run"]
+        
+        resources:
+          {}
+        ports:
+        - containerPort: 8125
+          name: dogstatsdport
+          protocol: UDP
+        env:
+          # Needs to be removed when Agent N-2 is built with Golang 1.17
+          - name: GODEBUG
+            value: x509ignoreCN=0
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "true"
+          - name: DD_AUTH_TOKEN_FILE_PATH
+            value: /etc/datadog-agent/auth/token
+          
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          
+          
+          - name: DD_LOG_LEVEL
+            value: "INFO"
+          - name: DD_DOGSTATSD_PORT
+            value: "8125"
+          - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+            value: "true"
+          - name: DD_DOGSTATSD_TAG_CARDINALITY
+            value: "low"
+          - name: DD_CLUSTER_AGENT_ENABLED
+            value: "true"
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: datadog-cluster-agent
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                  name: datadog-cluster-agent
+                  key: token
+          - name: DD_APM_ENABLED
+            value: "false"
+          - name: DD_LOGS_ENABLED
+            value: "false"
+          - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+            value: "false"
+          - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+            value: "true"
+          - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
+            value: "false"
+          - name: DD_HEALTH_PORT
+            value: "5555"
+          - name: DD_DOGSTATSD_SOCKET
+            value: "/var/run/datadog/dsd.socket"
+          - name: DD_EXTRA_CONFIG_PROVIDERS
+            value: "clusterchecks endpointschecks"
+          - name: DD_IGNORE_AUTOCONF
+            value: "kubernetes_state"
+          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            value: "true"
+          - name: DD_EXPVAR_PORT
+            value: "6000"
+          - name: DD_COMPLIANCE_CONFIG_ENABLED
+            value: "false"        
+        volumeMounts:
+          - name: logdatadog
+            mountPath: /var/log/datadog
+            readOnly: false # Need RW to write logs
+          - name: installinfo
+            subPath: install_info
+            mountPath: /etc/datadog-agent/install_info
+            readOnly: true
+          - name: tmpdir
+            mountPath: /tmp
+            readOnly: false # Need RW to write to /tmp directory
+          
+          - name: os-release-file
+            mountPath: /host/etc/os-release
+            readOnly: true
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: false # Need RW to mount to config path
+          - name: auth-token
+            mountPath: /etc/datadog-agent/auth
+            readOnly: false # Need RW to write auth token
+          
+          - name: runtimesocketdir
+            mountPath: /host/var/run
+            mountPropagation: None
+            readOnly: true
+          
+          - name: dsdsocket
+            mountPath: /var/run/datadog
+            readOnly: false
+          - name: procdir
+            mountPath: /host/proc
+            mountPropagation: None
+            readOnly: true
+          - name: cgroups
+            mountPath: /host/sys/fs/cgroup
+            mountPropagation: None
+            readOnly: true
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /live
+            port: 5555
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /ready
+            port: 5555
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+      - name: trace-agent
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]  
+        resources:
+          {}
+        ports:
+        - containerPort: 8126
+          name: traceport
+          protocol: TCP
+        env:
+          # Needs to be removed when Agent N-2 is built with Golang 1.17
+          - name: GODEBUG
+            value: x509ignoreCN=0
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "true"
+          - name: DD_AUTH_TOKEN_FILE_PATH
+            value: /etc/datadog-agent/auth/token
+          
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          
+          - name: DD_CLUSTER_AGENT_ENABLED
+            value: "true"
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: datadog-cluster-agent
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                  name: datadog-cluster-agent
+                  key: token
+          
+          - name: DD_LOG_LEVEL
+            value: "INFO"
+          - name: DD_APM_ENABLED
+            value: "true"
+          - name: DD_APM_NON_LOCAL_TRAFFIC
+            value: "true"
+          - name: DD_APM_RECEIVER_PORT
+            value: "8126"
+          - name: DD_APM_RECEIVER_SOCKET
+            value: "/var/run/datadog/apm.socket"
+          - name: DD_DOGSTATSD_SOCKET
+            value: "/var/run/datadog/dsd.socket"        
+        volumeMounts:
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: true
+          - name: logdatadog
+            mountPath: /var/log/datadog
+            readOnly: false # Need RW to write logs
+          - name: auth-token
+            mountPath: /etc/datadog-agent/auth
+            readOnly: true
+          - name: procdir
+            mountPath: /host/proc
+            mountPropagation: None
+            readOnly: true
+          - name: cgroups
+            mountPath: /host/sys/fs/cgroup
+            mountPropagation: None
+            readOnly: true
+          - name: tmpdir
+            mountPath: /tmp
+            readOnly: false # Need RW for tmp directory
+          - name: dsdsocket
+            mountPath: /var/run/datadog
+            readOnly: false # Need RW for UDS DSD socket
+          
+          - name: runtimesocketdir
+            mountPath: /host/var/run
+            mountPropagation: None
+            readOnly: true
+          
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          tcpSocket:
+            port: 8126
+          timeoutSeconds: 5
+      - name: process-agent
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]  
+        resources:
+          {}
+        env:
+          # Needs to be removed when Agent N-2 is built with Golang 1.17
+          - name: GODEBUG
+            value: x509ignoreCN=0
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "true"
+          - name: DD_AUTH_TOKEN_FILE_PATH
+            value: /etc/datadog-agent/auth/token
+          
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          
+          - name: DD_CLUSTER_AGENT_ENABLED
+            value: "true"
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: datadog-cluster-agent
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                  name: datadog-cluster-agent
+                  key: token
+          
+          - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+            value: "true"
+          - name: DD_LOG_LEVEL
+            value: "INFO"
+          - name: DD_SYSTEM_PROBE_ENABLED
+            value: "false"
+          - name: DD_DOGSTATSD_SOCKET
+            value: "/var/run/datadog/dsd.socket"
+          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            value: "true"        
+        volumeMounts:
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: true
+          - name: logdatadog
+            mountPath: /var/log/datadog
+            readOnly: false # Need RW to write logs
+          - name: auth-token
+            mountPath: /etc/datadog-agent/auth
+            readOnly: true
+          - name: dsdsocket
+            mountPath: /var/run/datadog
+            readOnly: false # Need RW for UDS DSD socket
+          - name: tmpdir
+            mountPath: /tmp
+            readOnly: false # Need RW to write to tmp directory
+          
+          - name: os-release-file
+            mountPath: /host/etc/os-release
+            readOnly: true
+          
+          - name: runtimesocketdir
+            mountPath: /host/var/run
+            mountPropagation: None
+            readOnly: true
+          
+          - name: cgroups
+            mountPath: /host/sys/fs/cgroup
+            mountPropagation: None
+            readOnly: true
+          - name: passwd
+            mountPath: /etc/passwd
+            readOnly: true
+          - name: procdir
+            mountPath: /host/proc
+            mountPropagation: None
+            readOnly: true
+      initContainers:
+          
+      - name: init-volume
+        
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+          - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+          - name: config
+            mountPath: /opt/datadog-agent
+            readOnly: false # Need RW for config path
+        resources:
+          {}
+      - name: init-config
+        
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command:
+          - bash
+          - -c
+        args:
+          - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+        volumeMounts:
+          - name: logdatadog
+            mountPath: /var/log/datadog
+            readOnly: false # Need RW to write logs
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: false # Need RW for config path
+          - name: procdir
+            mountPath: /host/proc
+            mountPropagation: None
+            readOnly: true
+          
+          - name: runtimesocketdir
+            mountPath: /host/var/run
+            mountPropagation: None
+            readOnly: true
+        env:
+          # Needs to be removed when Agent N-2 is built with Golang 1.17
+          - name: GODEBUG
+            value: x509ignoreCN=0
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "true"
+          - name: DD_AUTH_TOKEN_FILE_PATH
+            value: /etc/datadog-agent/auth/token
+          
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          
+        resources:
+          {}
+      volumes:
+      - name: auth-token
+        emptyDir: {}
+      - name: installinfo
+        configMap:
+          name: datadog-installinfo
+      - name: config
+        emptyDir: {}
+        
+      - name: logdatadog
+        emptyDir: {}
+      - name: tmpdir
+        emptyDir: {}
+      - hostPath:
+          path: /proc
+        name: procdir
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroups
+      - hostPath:
+          path: /etc/os-release
+        name: os-release-file
+      - hostPath:
+          path: /var/run/datadog/
+          type: DirectoryOrCreate
+        name: dsdsocket
+      - hostPath:
+          path: /var/run/datadog/
+          type: DirectoryOrCreate
+        name: apmsocket
+      - name: s6-run
+        emptyDir: {}
+      - hostPath:
+          path: /etc/passwd
+        name: passwd
+      - hostPath:
+          path: /var/run
+        name: runtimesocketdir
+      tolerations:
+      affinity:
+        {}
+      serviceAccountName: "datadog"
+      automountServiceAccountToken: true
+      nodeSelector:
+        kubernetes.io/os: linux
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/test/datadog/baseline/other_default.yaml
+++ b/test/datadog/baseline/other_default.yaml
@@ -1,0 +1,1618 @@
+---
+# Source: datadog/templates/agent-clusterchecks-pdb.yaml
+apiVersion: "policy/v1"
+kind: PodDisruptionBudget
+metadata:
+  name: datadog-clusterchecks
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: datadog-clusterchecks
+---
+# Source: datadog/templates/cluster-agent-pdb.yaml
+apiVersion: "policy/v1"
+kind: PodDisruptionBudget
+metadata:
+  name: datadog-cluster-agent
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: datadog-cluster-agent
+---
+# Source: datadog/templates/agent-clusterchecks-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+    app: "datadog"
+    chart: "datadog-3.40.2"
+    heritage: "Helm"
+    release: "datadog"
+  name: datadog-cluster-checks
+  namespace: datadog-agent
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  labels:
+    app: "datadog"
+    chart: "datadog-3.40.2"
+    heritage: "Helm"
+    release: "datadog"
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent
+  namespace: datadog-agent
+---
+# Source: datadog/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: datadog
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7" # end range $role := .Values.datadog.secretBackend.roles
+---
+# Source: datadog/templates/secret-cluster-agent-token.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-cluster-agent
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+type: Opaque
+data:
+  token: "bnZJdVBrQzQ4VjkxQ2haMHRRTEI2YkdFVjRCMEViRmQ="
+---
+# Source: datadog/templates/cluster-agent-confd-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-cluster-agent-confd
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  annotations:
+    checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+data:
+  kubernetes_state_core.yaml.default: |-
+    cluster_check: true
+    init_config:
+    instances:
+      - collectors:
+        - secrets
+        - configmaps
+        - nodes
+        - pods
+        - services
+        - resourcequotas
+        - replicationcontrollers
+        - limitranges
+        - persistentvolumeclaims
+        - persistentvolumes
+        - namespaces
+        - endpoints
+        - daemonsets
+        - deployments
+        - replicasets
+        - statefulsets
+        - cronjobs
+        - jobs
+        - horizontalpodautoscalers
+        - poddisruptionbudgets
+        - storageclasses
+        - volumeattachments
+        - ingresses
+        skip_leader_election: true
+        labels_as_tags:
+          {}
+        annotations_as_tags:
+          {}
+---
+# Source: datadog/templates/install_info-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-installinfo
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  annotations:
+    checksum/install_info: e25591d3c3d4f1ffd34b44799840d82a96fd1bdf4875b5bdba29f1cde44f600b
+data:
+  install_info: |
+    ---
+    install_method:
+      tool: helm
+      tool_version: Helm
+      installer_version: datadog-3.40.2
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  - nodes
+  - namespaces
+  - componentstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups: ["quota.openshift.io"]
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - "autoscaling"
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - datadogtoken  # Kubernetes event collection state
+  - datadogtoken  # Kept for backward compatibility with agent <7.37.0
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - datadog-leader-election  # Leader election token
+  - datadog-leader-election  # Kept for backward compatibility with agent <7.37.0
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  resourceNames:
+  - datadog-leader-election  # Leader election token
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:  # To create the leader election token and hpa events
+  - ""
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - create
+- nonResourceURLs:
+  - "/version"
+  - "/healthz"
+  verbs:
+  - get
+- apiGroups:  # to get the kube-system namespace UID and generate a cluster ID
+  - ""
+  resources:
+  - namespaces
+  resourceNames:
+  - "kube-system"
+  verbs:
+  - get
+- apiGroups:  # To create the cluster-id configmap
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - "datadog-cluster-id"
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  - persistentvolumeclaims
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  - statefulsets
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - list
+    - get
+    - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  resourceNames:
+    - "datadog-webhook"
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs: ["create"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["get"]
+- apiGroups: ["apps"]
+  resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
+  verbs: ["get"]
+- apiGroups:
+  - "security.openshift.io"
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - datadog-cluster-agent
+  - hostnetwork
+---
+# Source: datadog/templates/kube-state-metrics-core-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  name: datadog-ksm-core
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  - events
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - list
+    - watch
+---
+# Source: datadog/templates/rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRole
+metadata:
+  name: datadog
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  - "/metrics/slis"
+  verbs:
+  - get
+- apiGroups:  # Kubelet connectivity
+  - ""
+  resources:
+  - nodes/metrics
+  - nodes/spec
+  - nodes/proxy
+  - nodes/stats
+  verbs:
+  - get
+- apiGroups:  # leader election check
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+- apiGroups:
+  - "security.openshift.io"
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - datadog
+  - hostaccess
+  - privileged
+- apiGroups:  # leader election check
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+---
+# Source: datadog/templates/agent-clusterchecks-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-checks
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-checks
+    namespace: datadog-agent
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+# Source: datadog/templates/kube-state-metrics-core-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  name: datadog-ksm-core
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-ksm-core
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-checks
+    namespace: datadog-agent
+---
+# Source: datadog/templates/rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRoleBinding
+metadata:
+  name: datadog
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog
+subjects:
+  - kind: ServiceAccount
+    name: datadog
+    namespace: datadog-agent
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: Role
+metadata:
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-main
+  namespace: datadog-agent
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "update", "create"]
+---
+# Source: datadog/templates/dca-helm-values-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: Role
+metadata:
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  name: datadog-dca-flare
+  namespace: datadog-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: RoleBinding
+metadata:
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  name: "datadog-cluster-agent-main"
+  namespace: datadog-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: datadog-cluster-agent-main
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+# Source: datadog/templates/dca-helm-values-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: RoleBinding
+metadata:
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+  name: datadog-dca-flare
+  namespace: datadog-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: datadog-dca-flare
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-cluster-agent
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+spec:
+  type: ClusterIP
+  selector:
+    app: datadog-cluster-agent
+  ports:
+  - port: 5005
+    name: agentport
+    protocol: TCP
+---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-cluster-agent-admission-controller
+  namespace: datadog-agent
+  labels:
+    app: "datadog"
+    chart: "datadog-3.40.2"
+    release: "datadog"
+    heritage: "Helm"
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+spec:
+  selector:
+    app: datadog-cluster-agent
+  ports:
+  - port: 443
+    targetPort: 8000
+    name: datadog-webhook
+    protocol: TCP
+---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: datadog
+  namespace: datadog-agent
+  labels:
+    app: "datadog"
+    chart: "datadog-3.40.2"
+    release: "datadog"
+    heritage: "Helm"
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+spec:
+  selector:
+    app: datadog
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsdport
+  internalTrafficPolicy: Local
+---
+# Source: datadog/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: datadog
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+    app.kubernetes.io/component: agent
+    
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: datadog
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "datadog"
+        app.kubernetes.io/instance: "datadog"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: agent
+        app: datadog
+        
+      name: datadog
+      annotations:
+        checksum/clusteragent_token: 769ab4bd0f605d091f1fba9afd850e87bd14231ff459f861c1f6680cb45be8ca
+        checksum/install_info: e25591d3c3d4f1ffd34b44799840d82a96fd1bdf4875b5bdba29f1cde44f600b
+        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
+        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+    spec:
+      
+      securityContext:
+        runAsUser: 0
+      hostPID: true
+      containers:
+      - name: agent
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["agent", "run"]
+        
+        resources:
+          {}
+        ports:
+        - containerPort: 8125
+          name: dogstatsdport
+          protocol: UDP
+        env:
+          # Needs to be removed when Agent N-2 is built with Golang 1.17
+          - name: GODEBUG
+            value: x509ignoreCN=0
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "true"
+          - name: DD_AUTH_TOKEN_FILE_PATH
+            value: /etc/datadog-agent/auth/token
+          
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          
+          
+          - name: DD_LOG_LEVEL
+            value: "INFO"
+          - name: DD_DOGSTATSD_PORT
+            value: "8125"
+          - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+            value: "true"
+          - name: DD_DOGSTATSD_TAG_CARDINALITY
+            value: "low"
+          - name: DD_CLUSTER_AGENT_ENABLED
+            value: "true"
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: datadog-cluster-agent
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                  name: datadog-cluster-agent
+                  key: token
+          - name: DD_APM_ENABLED
+            value: "false"
+          - name: DD_LOGS_ENABLED
+            value: "false"
+          - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+            value: "false"
+          - name: DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE
+            value: "true"
+          - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
+            value: "false"
+          - name: DD_HEALTH_PORT
+            value: "5555"
+          - name: DD_DOGSTATSD_SOCKET
+            value: "/var/run/datadog/dsd.socket"
+          - name: DD_EXTRA_CONFIG_PROVIDERS
+            value: "endpointschecks"
+          
+          - name: DD_IGNORE_AUTOCONF
+            value: "kubernetes_state"
+          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            value: "true"
+          - name: DD_EXPVAR_PORT
+            value: "6000"
+          - name: DD_COMPLIANCE_CONFIG_ENABLED
+            value: "false"        
+        volumeMounts:
+          - name: logdatadog
+            mountPath: /var/log/datadog
+            readOnly: false # Need RW to write logs
+          - name: installinfo
+            subPath: install_info
+            mountPath: /etc/datadog-agent/install_info
+            readOnly: true
+          - name: tmpdir
+            mountPath: /tmp
+            readOnly: false # Need RW to write to /tmp directory
+          
+          - name: os-release-file
+            mountPath: /host/etc/os-release
+            readOnly: true
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: false # Need RW to mount to config path
+          - name: auth-token
+            mountPath: /etc/datadog-agent/auth
+            readOnly: false # Need RW to write auth token
+          
+          - name: runtimesocketdir
+            mountPath: /host/var/run
+            mountPropagation: None
+            readOnly: true
+          
+          - name: dsdsocket
+            mountPath: /var/run/datadog
+            readOnly: false
+          - name: procdir
+            mountPath: /host/proc
+            mountPropagation: None
+            readOnly: true
+          - name: cgroups
+            mountPath: /host/sys/fs/cgroup
+            mountPropagation: None
+            readOnly: true
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /live
+            port: 5555
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /ready
+            port: 5555
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+      - name: trace-agent
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]  
+        resources:
+          {}
+        ports:
+        - containerPort: 8126
+          name: traceport
+          protocol: TCP
+        env:
+          # Needs to be removed when Agent N-2 is built with Golang 1.17
+          - name: GODEBUG
+            value: x509ignoreCN=0
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "true"
+          - name: DD_AUTH_TOKEN_FILE_PATH
+            value: /etc/datadog-agent/auth/token
+          
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          
+          - name: DD_CLUSTER_AGENT_ENABLED
+            value: "true"
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: datadog-cluster-agent
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                  name: datadog-cluster-agent
+                  key: token
+          
+          - name: DD_LOG_LEVEL
+            value: "INFO"
+          - name: DD_APM_ENABLED
+            value: "true"
+          - name: DD_APM_NON_LOCAL_TRAFFIC
+            value: "true"
+          - name: DD_APM_RECEIVER_PORT
+            value: "8126"
+          - name: DD_APM_RECEIVER_SOCKET
+            value: "/var/run/datadog/apm.socket"
+          - name: DD_DOGSTATSD_SOCKET
+            value: "/var/run/datadog/dsd.socket"        
+        volumeMounts:
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: true
+          - name: logdatadog
+            mountPath: /var/log/datadog
+            readOnly: false # Need RW to write logs
+          - name: auth-token
+            mountPath: /etc/datadog-agent/auth
+            readOnly: true
+          - name: procdir
+            mountPath: /host/proc
+            mountPropagation: None
+            readOnly: true
+          - name: cgroups
+            mountPath: /host/sys/fs/cgroup
+            mountPropagation: None
+            readOnly: true
+          - name: tmpdir
+            mountPath: /tmp
+            readOnly: false # Need RW for tmp directory
+          - name: dsdsocket
+            mountPath: /var/run/datadog
+            readOnly: false # Need RW for UDS DSD socket
+          
+          - name: runtimesocketdir
+            mountPath: /host/var/run
+            mountPropagation: None
+            readOnly: true
+          
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          tcpSocket:
+            port: 8126
+          timeoutSeconds: 5
+      - name: process-agent
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]  
+        resources:
+          {}
+        env:
+          # Needs to be removed when Agent N-2 is built with Golang 1.17
+          - name: GODEBUG
+            value: x509ignoreCN=0
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "true"
+          - name: DD_AUTH_TOKEN_FILE_PATH
+            value: /etc/datadog-agent/auth/token
+          
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          
+          - name: DD_CLUSTER_AGENT_ENABLED
+            value: "true"
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: datadog-cluster-agent
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                  name: datadog-cluster-agent
+                  key: token
+          
+          - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+            value: "true"
+          - name: DD_LOG_LEVEL
+            value: "INFO"
+          - name: DD_SYSTEM_PROBE_ENABLED
+            value: "false"
+          - name: DD_DOGSTATSD_SOCKET
+            value: "/var/run/datadog/dsd.socket"
+          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            value: "true"        
+        volumeMounts:
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: true
+          - name: logdatadog
+            mountPath: /var/log/datadog
+            readOnly: false # Need RW to write logs
+          - name: auth-token
+            mountPath: /etc/datadog-agent/auth
+            readOnly: true
+          - name: dsdsocket
+            mountPath: /var/run/datadog
+            readOnly: false # Need RW for UDS DSD socket
+          - name: tmpdir
+            mountPath: /tmp
+            readOnly: false # Need RW to write to tmp directory
+          
+          - name: os-release-file
+            mountPath: /host/etc/os-release
+            readOnly: true
+          
+          - name: runtimesocketdir
+            mountPath: /host/var/run
+            mountPropagation: None
+            readOnly: true
+          
+          - name: cgroups
+            mountPath: /host/sys/fs/cgroup
+            mountPropagation: None
+            readOnly: true
+          - name: passwd
+            mountPath: /etc/passwd
+            readOnly: true
+          - name: procdir
+            mountPath: /host/proc
+            mountPropagation: None
+            readOnly: true
+      initContainers:
+          
+      - name: init-volume
+        
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+          - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+          - name: config
+            mountPath: /opt/datadog-agent
+            readOnly: false # Need RW for config path
+        resources:
+          {}
+      - name: init-config
+        
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command:
+          - bash
+          - -c
+        args:
+          - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+        volumeMounts:
+          - name: logdatadog
+            mountPath: /var/log/datadog
+            readOnly: false # Need RW to write logs
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: false # Need RW for config path
+          - name: procdir
+            mountPath: /host/proc
+            mountPropagation: None
+            readOnly: true
+          
+          - name: runtimesocketdir
+            mountPath: /host/var/run
+            mountPropagation: None
+            readOnly: true
+        env:
+          # Needs to be removed when Agent N-2 is built with Golang 1.17
+          - name: GODEBUG
+            value: x509ignoreCN=0
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "true"
+          - name: DD_AUTH_TOKEN_FILE_PATH
+            value: /etc/datadog-agent/auth/token
+          
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          
+        resources:
+          {}
+      volumes:
+      - name: auth-token
+        emptyDir: {}
+      - name: installinfo
+        configMap:
+          name: datadog-installinfo
+      - name: config
+        emptyDir: {}
+        
+      - name: logdatadog
+        emptyDir: {}
+      - name: tmpdir
+        emptyDir: {}
+      - hostPath:
+          path: /proc
+        name: procdir
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroups
+      - hostPath:
+          path: /etc/os-release
+        name: os-release-file
+      - hostPath:
+          path: /var/run/datadog/
+          type: DirectoryOrCreate
+        name: dsdsocket
+      - hostPath:
+          path: /var/run/datadog/
+          type: DirectoryOrCreate
+        name: apmsocket
+      - name: s6-run
+        emptyDir: {}
+      - hostPath:
+          path: /etc/passwd
+        name: passwd
+      - hostPath:
+          path: /var/run
+        name: runtimesocketdir
+      tolerations:
+      affinity:
+        {}
+      serviceAccountName: "datadog"
+      automountServiceAccountToken: true
+      nodeSelector:
+        kubernetes.io/os: linux
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+---
+# Source: datadog/templates/agent-clusterchecks-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-clusterchecks
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+    app.kubernetes.io/component: clusterchecks-agent
+    
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: datadog-clusterchecks
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "datadog"
+        app.kubernetes.io/instance: "datadog"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: clusterchecks-agent
+        app: datadog-clusterchecks
+        
+      name: datadog-clusterchecks
+      annotations:
+        checksum/clusteragent_token: e9b4a9e362c5002ec4d78f57144f63b00d70c984a4626b8f2d76fade63d9430f
+        checksum/install_info: e25591d3c3d4f1ffd34b44799840d82a96fd1bdf4875b5bdba29f1cde44f600b
+    spec:
+      serviceAccountName: datadog-cluster-checks
+      automountServiceAccountToken: true
+      imagePullSecrets:
+        []
+      initContainers:
+      - name: init-volume
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+          - cp -r /etc/datadog-agent /opt
+        volumeMounts:
+          - name: config
+            mountPath: /opt/datadog-agent
+            readOnly: false # Need RW for writing agent config files
+        resources:
+          {}
+      - name: init-config
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c"]
+        args:
+          - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+        volumeMounts:
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: false # Need RW for writing datadog.yaml config file
+        resources:
+          {}
+      containers:
+      - name: agent
+        image: "gcr.io/datadoghq/agent:7.48.0"
+        command: ["bash", "-c"]
+        args:
+          - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_LOG_LEVEL
+            value: "INFO"
+          - name: DD_EXTRA_CONFIG_PROVIDERS
+            value: "clusterchecks"
+          - name: DD_HEALTH_PORT
+            value: "5557"
+          # Cluster checks (cluster-agent communication)
+          - name: DD_CLUSTER_AGENT_ENABLED
+            value: "true"
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: datadog-cluster-agent
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                  name: datadog-cluster-agent
+                  key: token
+          # Safely run alongside the daemonset
+          - name: DD_ENABLE_METADATA_COLLECTION
+            value: "false"
+          # Expose CLC stats
+          - name: DD_CLC_RUNNER_ENABLED
+            value: "true"
+          - name: DD_CLC_RUNNER_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: DD_CLC_RUNNER_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          # Remove unused features
+          - name: DD_USE_DOGSTATSD
+            value: "false"
+          - name: DD_PROCESS_AGENT_ENABLED
+            value: "false"
+          - name: DD_LOGS_ENABLED
+            value: "false"
+          - name: DD_APM_ENABLED
+            value: "false"
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "false"
+          - name: DD_HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          
+                              
+        resources:
+          {}
+        volumeMounts:
+          - name: installinfo
+            subPath: install_info
+            mountPath: /etc/datadog-agent/install_info
+            readOnly: true
+          - name: config
+            mountPath: /etc/datadog-agent
+            readOnly: false # Need RW for config path
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /live
+            port: 5557
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /ready
+            port: 5557
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+      volumes:
+        - name: installinfo
+          configMap:
+            name: datadog-installinfo
+        - name: config
+          emptyDir: {}
+      affinity:
+        # Prefer scheduling the runners on different nodes if possible
+        # for better checks stability in case of node failure.
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: datadog-clusterchecks
+              topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: datadog/templates/cluster-agent-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datadog-cluster-agent
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: 'datadog-3.40.2'
+    app.kubernetes.io/name: "datadog"
+    app.kubernetes.io/instance: "datadog"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "7"
+    app.kubernetes.io/component: cluster-agent
+    
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: datadog-cluster-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "datadog"
+        app.kubernetes.io/instance: "datadog"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: cluster-agent
+        app: datadog-cluster-agent
+        
+      name: datadog-cluster-agent
+      annotations:
+        checksum/clusteragent_token: 436ae44047269e2270051295a4ca0173f6cdac28c84c7d093a4e9c2c753aa048
+        checksum/clusteragent-configmap: 37ece2fae5e132daa96a3ab45752ac9e00cb166d690b43a4371c904831d30dc9
+        checksum/install_info: e25591d3c3d4f1ffd34b44799840d82a96fd1bdf4875b5bdba29f1cde44f600b
+    spec:
+      serviceAccountName: datadog-cluster-agent
+      automountServiceAccountToken: true
+      initContainers:
+      - name: init-volume
+        image: "gcr.io/datadoghq/cluster-agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        command:
+          - bash
+          - -c
+        args:
+          - |
+            chmod -R 744 /etc/datadog-agent;
+            cp -r /etc/datadog-agent /opt
+        volumeMounts:
+          - name: config
+            mountPath: /opt/datadog-agent
+      containers:
+      - name: cluster-agent
+        image: "gcr.io/datadoghq/cluster-agent:7.48.0"
+        imagePullPolicy: IfNotPresent
+        resources:
+          {}
+        ports:
+        - containerPort: 5005
+          name: agentport
+          protocol: TCP
+        - containerPort: 5000
+          name: agentmetrics
+          protocol: TCP
+        - containerPort: 8000
+          name: datadog-webhook
+          protocol: TCP
+        env:
+          - name: DD_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: DD_HEALTH_PORT
+            value: "5556"
+          - name: DD_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "datadog-secret"
+                key: api-key
+                optional: true
+          
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_ADMISSION_CONTROLLER_ENABLED
+            value: "true"
+          - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
+            value: "datadog-webhook"
+          - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
+            value: "false"
+          - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
+            value: datadog-cluster-agent-admission-controller
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE
+            value: socket
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
+            value: datadog
+          - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
+            value: "Ignore"
+          - name: DD_ADMISSION_CONTROLLER_PORT
+            value: "8000"
+          - name: DD_REMOTE_CONFIGURATION_ENABLED
+            value: "false"
+          - name: DD_CLUSTER_CHECKS_ENABLED
+            value: "true"
+          - name: DD_EXTRA_CONFIG_PROVIDERS
+            value: "kube_endpoints kube_services"
+          - name: DD_EXTRA_LISTENERS
+            value: "kube_endpoints kube_services"
+          - name: DD_LOG_LEVEL
+            value: "INFO"
+          - name: DD_LEADER_ELECTION
+            value: "true"
+          - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+            value: "configmap"
+          - name: DD_LEADER_LEASE_DURATION
+            value: "15"
+          - name: DD_LEADER_LEASE_NAME
+            value: datadog-leader-election
+          - name: DD_CLUSTER_AGENT_TOKEN_NAME
+            value: datadogtoken
+          - name: DD_COLLECT_KUBERNETES_EVENTS
+            value: "true"
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: datadog-cluster-agent
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: datadog-cluster-agent
+                key: token
+          - name: DD_CLUSTER_AGENT_COLLECT_KUBERNETES_TAGS
+            value: "false"
+          - name: DD_KUBE_RESOURCES_NAMESPACE
+            value: datadog-agent
+          - name: CHART_RELEASE_NAME
+            value: "datadog"
+          - name: AGENT_DAEMONSET
+            value: datadog
+          - name: CLUSTER_AGENT_DEPLOYMENT
+            value: datadog-cluster-agent
+          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            value: "true"
+          - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
+            value: "true"
+                              
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /live
+            port: 5556
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /ready
+            port: 5556
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        volumeMounts:
+          - name: datadogrun
+            mountPath: /opt/datadog-agent/run
+            readOnly: false
+          - name: varlog
+            mountPath: /var/log/datadog
+            readOnly: false
+          - name: tmpdir
+            mountPath: /tmp
+            readOnly: false
+          - name: installinfo
+            subPath: install_info
+            mountPath: /etc/datadog-agent/install_info
+            readOnly: true
+          - name: confd
+            mountPath: /conf.d
+            readOnly: true
+          - name: config
+            mountPath: /etc/datadog-agent
+      volumes:
+        - name: datadogrun
+          emptyDir: {}
+        - name: varlog
+          emptyDir: {}
+        - name: tmpdir
+          emptyDir: {}
+        - name: installinfo
+          configMap:
+            name: datadog-installinfo
+        - name: confd
+          configMap:
+            name: datadog-cluster-agent-confd
+            items:
+            - key: kubernetes_state_core.yaml.default
+              path: kubernetes_state_core.yaml.default
+        - name: config
+          emptyDir: {}
+      affinity:
+        # Prefer scheduling the cluster agents on different nodes
+        # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: datadog-cluster-agent
+              topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/test/datadog/baseline_test.go
+++ b/test/datadog/baseline_test.go
@@ -1,0 +1,167 @@
+package datadog
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/helm-charts/test/common"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func Test_baseline_manifests(t *testing.T) {
+	tests := []struct {
+		name                 string
+		command              common.HelmCommand
+		baselineManifestPath string
+		assertions           func(t *testing.T, baselineManifestPath, manifest string)
+	}{
+		{
+			name: "Daemonset default",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret": "datadog-secret",
+					"datadog.appKeyExistingSecret": "datadog-secret",
+				},
+			},
+			baselineManifestPath: "./baseline/daemonset_default.yaml",
+			assertions:           verifyDaemonset,
+		},
+		{
+			name: "DCA Deployment default",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/cluster-agent-deployment.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides:   map[string]string{},
+			},
+			baselineManifestPath: "./baseline/cluster-agent-deployment_default.yaml",
+			assertions:           verifyDeployment,
+		},
+		{
+			name: "CLC Deployment default",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/agent-clusterchecks-deployment.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":                        "datadog-secret",
+					"datadog.appKeyExistingSecret":                        "datadog-secret",
+					"datadog.kubeStateMetricsCore.useClusterCheckRunners": "true",
+					"datadog.clusterChecks.enabled":                       "true",
+					"clusterChecksRunner.enabled":                         "true",
+				}},
+			baselineManifestPath: "./baseline/agent-clusterchecks-deployment_default.yaml",
+			assertions:           verifyDeployment,
+		},
+		{
+			name: "Other resources, skips Deployment, DaemonSet, Secret; creates PDBs",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":                        "datadog-secret",
+					"datadog.appKeyExistingSecret":                        "datadog-secret",
+					"datadog.kubeStateMetricsCore.useClusterCheckRunners": "true",
+					"datadog.clusterChecks.enabled":                       "true",
+					"clusterChecksRunner.enabled":                         "true",
+					// Create PDB for DCA and CLC
+					"clusterAgent.createPodDisruptionBudget":        "true",
+					"clusterChecksRunner.createPodDisruptionBudget": "true",
+				}},
+			baselineManifestPath: "./baseline/other_default.yaml",
+			assertions:           verifyUntypedResources,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := common.RenderChart(t, tt.command)
+			assert.Nil(t, err, "couldn't render template")
+			t.Log("update baselines", common.UpdateBaselines)
+			if common.UpdateBaselines {
+				common.WriteToFile(t, tt.baselineManifestPath, manifest)
+			}
+			tt.assertions(t, tt.baselineManifestPath, manifest)
+		})
+	}
+}
+
+func verifyDaemonset(t *testing.T, baselineManifestPath, manifest string) {
+	verifyBaseline(t, baselineManifestPath, manifest, appsv1.DaemonSet{}, appsv1.DaemonSet{})
+}
+
+func verifyDeployment(t *testing.T, baselineManifestPath, manifest string) {
+	verifyBaseline(t, baselineManifestPath, manifest, appsv1.Deployment{}, appsv1.Deployment{})
+}
+
+func verifyBaseline[T any](t *testing.T, baselineManifestPath, manifest string, baseline, actual T) {
+	common.Unmarshal(t, manifest, &actual)
+	common.LoadFromFile(t, baselineManifestPath, &baseline)
+
+	// Exclude
+	// - "helm.sh/chart" label
+	// - checksum annotations
+	// - Image
+	// to avoid frequent baseline update and CI failures.
+	ops := make(cmp.Options, 0)
+	ops = append(ops, cmpopts.IgnoreMapEntries(func(k, v string) bool {
+		return k == "helm.sh/chart" || k == "checksum/clusteragent_token" || strings.Contains(k, "checksum") || k == "Image"
+	}))
+	ops = append(ops, cmpopts.IgnoreFields(corev1.Container{}, "Image"))
+
+	assert.True(t, cmp.Equal(baseline, actual, ops), cmp.Diff(baseline, actual))
+}
+
+func verifyUntypedResources(t *testing.T, baselineManifestPath, actual string) {
+	baselineManifest := common.ReadFile(t, baselineManifestPath)
+
+	rB := bufio.NewReader(strings.NewReader(baselineManifest))
+	baselineReader := yaml.NewYAMLReader(rB)
+	rA := bufio.NewReader(strings.NewReader(actual))
+	expectedReader := yaml.NewYAMLReader(rA)
+
+	for {
+		baselineResource, errB := baselineReader.Read()
+		actualResource, errA := expectedReader.Read()
+		if errB == io.EOF || errA == io.EOF {
+			break
+		}
+		require.NoError(t, errB, "couldn't read resource from manifest", baselineManifest)
+		require.NoError(t, errA, "couldn't read resource from manifest", actual)
+
+		// unmarshal as map since this can be any resource
+		var expected, actual map[string]interface{}
+		yaml.Unmarshal(baselineResource, &expected)
+		yaml.Unmarshal(actualResource, &actual)
+
+		assert.Equal(t, expected["kind"], actual["kind"])
+		kind := expected["kind"]
+		if kind == "Deployment" || kind == "DaemonSet" || kind == "Secret" {
+			continue
+		}
+
+		ops := make(cmp.Options, 0)
+		ops = append(ops, cmpopts.IgnoreMapEntries(func(k, v string) bool {
+			// skip these as these change freqently
+			return k == "helm.sh/chart" || k == "token" || strings.Contains(k, "checksum")
+		}))
+
+		assert.True(t, cmp.Equal(expected, actual, ops), cmp.Diff(expected, actual))
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adding 'baseline' tests for `datadog` chart covering default cases.

Why?
- Render chart with default settings to catch typos.
- Include the resources diff in the PR when baseline changes.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
