### PR TITLE
Added option to disable external metrics registration as an APIService

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.40.3
 
-* Add the option `clusterAgent.metricsProvider.register` to allow user to disable registering external-metrics server as an `APIService`
+* Add the option `clusterAgent.metricsProvider.registerAPIService` to allow user to disable registering external-metrics server as an `APIService`
 
 ## 3.40.2
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.40.3
+
+* Add the option `clusterAgent.metricsProvider.register` to allow user to disable registering external-metrics server as an `APIService`
+
 ## 3.40.2
 
 * Gate `PodSecurityPolicy` RBAC for k8s versions which no longer support this deprecated API.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 * Default `Agent` and `Cluster-Agent` to `7.48.1` version.
 
-
 ## 3.40.2
 
 * Gate `PodSecurityPolicy` RBAC for k8s versions which no longer support this deprecated API.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.40.3
+version: 3.40.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.40.2
+version: 3.40.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.40.2](https://img.shields.io/badge/Version-3.40.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.40.3](https://img.shields.io/badge/Version-3.40.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -520,6 +520,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.metricsProvider.createReaderRbac | bool | `true` | Create `external-metrics-reader` RBAC automatically (to allow HPA to read data from Cluster Agent) |
 | clusterAgent.metricsProvider.enabled | bool | `false` | Set this to true to enable Metrics Provider |
 | clusterAgent.metricsProvider.endpoint | string | `nil` | Override the external metrics provider endpoint. If not set, the cluster-agent defaults to `datadog.site` |
+| clusterAgent.metricsProvider.register | bool | `true` | Set this to false to disable external metrics registration as an APIService |
 | clusterAgent.metricsProvider.service.port | int | `8443` | Set port of cluster-agent metrics server service (Kubernetes >= 1.15) |
 | clusterAgent.metricsProvider.service.type | string | `"ClusterIP"` | Set type of cluster-agent metrics server service |
 | clusterAgent.metricsProvider.useDatadogMetrics | bool | `false` | Enable usage of DatadogMetric CRD to autoscale on arbitrary Datadog queries |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -520,7 +520,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.metricsProvider.createReaderRbac | bool | `true` | Create `external-metrics-reader` RBAC automatically (to allow HPA to read data from Cluster Agent) |
 | clusterAgent.metricsProvider.enabled | bool | `false` | Set this to true to enable Metrics Provider |
 | clusterAgent.metricsProvider.endpoint | string | `nil` | Override the external metrics provider endpoint. If not set, the cluster-agent defaults to `datadog.site` |
-| clusterAgent.metricsProvider.register | bool | `true` | Set this to false to disable external metrics registration as an APIService |
+| clusterAgent.metricsProvider.registerAPIService | bool | `true` |  |
 | clusterAgent.metricsProvider.service.port | int | `8443` | Set port of cluster-agent metrics server service (Kubernetes >= 1.15) |
 | clusterAgent.metricsProvider.service.type | string | `"ClusterIP"` | Set type of cluster-agent metrics server service |
 | clusterAgent.metricsProvider.useDatadogMetrics | bool | `false` | Enable usage of DatadogMetric CRD to autoscale on arbitrary Datadog queries |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.40.3](https://img.shields.io/badge/Version-3.40.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.40.4](https://img.shields.io/badge/Version-3.40.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -520,7 +520,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.metricsProvider.createReaderRbac | bool | `true` | Create `external-metrics-reader` RBAC automatically (to allow HPA to read data from Cluster Agent) |
 | clusterAgent.metricsProvider.enabled | bool | `false` | Set this to true to enable Metrics Provider |
 | clusterAgent.metricsProvider.endpoint | string | `nil` | Override the external metrics provider endpoint. If not set, the cluster-agent defaults to `datadog.site` |
-| clusterAgent.metricsProvider.registerAPIService | bool | `true` |  |
+| clusterAgent.metricsProvider.registerAPIService | bool | `true` | Set this to false to disable external metrics registration as an APIService |
 | clusterAgent.metricsProvider.service.port | int | `8443` | Set port of cluster-agent metrics server service (Kubernetes >= 1.15) |
 | clusterAgent.metricsProvider.service.type | string | `"ClusterIP"` | Set type of cluster-agent metrics server service |
 | clusterAgent.metricsProvider.useDatadogMetrics | bool | `false` | Enable usage of DatadogMetric CRD to autoscale on arbitrary Datadog queries |

--- a/charts/datadog/templates/agent-apiservice.yaml
+++ b/charts/datadog/templates/agent-apiservice.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterAgent.rbac.create (eq (include "should-deploy-cluster-agent" .) "true") .Values.clusterAgent.metricsProvider.enabled -}}
+{{- if and .Values.clusterAgent.rbac.create (eq (include "should-deploy-cluster-agent" .) "true") .Values.clusterAgent.metricsProvider.enabled .Values.clusterAgent.metricsProvider.register -}}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:

--- a/charts/datadog/templates/agent-apiservice.yaml
+++ b/charts/datadog/templates/agent-apiservice.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterAgent.rbac.create (eq (include "should-deploy-cluster-agent" .) "true") .Values.clusterAgent.metricsProvider.enabled .Values.clusterAgent.metricsProvider.register -}}
+{{- if and .Values.clusterAgent.rbac.create (eq (include "should-deploy-cluster-agent" .) "true") .Values.clusterAgent.metricsProvider.enabled .Values.clusterAgent.metricsProvider.registerAPIService -}}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:

--- a/charts/datadog/templates/hpa-external-metrics-rbac.yaml
+++ b/charts/datadog/templates/hpa-external-metrics-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (include "should-deploy-cluster-agent" .) "true") .Values.clusterAgent.rbac.create .Values.clusterAgent.metricsProvider.enabled .Values.clusterAgent.metricsProvider.register .Values.clusterAgent.metricsProvider.createReaderRbac -}}
+{{- if and (eq (include "should-deploy-cluster-agent" .) "true") .Values.clusterAgent.rbac.create .Values.clusterAgent.metricsProvider.enabled .Values.clusterAgent.metricsProvider.registerAPIService .Values.clusterAgent.metricsProvider.createReaderRbac -}}
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:

--- a/charts/datadog/templates/hpa-external-metrics-rbac.yaml
+++ b/charts/datadog/templates/hpa-external-metrics-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (include "should-deploy-cluster-agent" .) "true") .Values.clusterAgent.rbac.create .Values.clusterAgent.metricsProvider.enabled .Values.clusterAgent.metricsProvider.createReaderRbac -}}
+{{- if and (eq (include "should-deploy-cluster-agent" .) "true") .Values.clusterAgent.rbac.create .Values.clusterAgent.metricsProvider.enabled .Values.clusterAgent.metricsProvider.register .Values.clusterAgent.metricsProvider.createReaderRbac -}}
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -925,6 +925,9 @@ clusterAgent:
   metricsProvider:
     # clusterAgent.metricsProvider.enabled -- Set this to true to enable Metrics Provider
     enabled: false
+    
+    # clusterAgent.metricsProvider.register -- Set this to false to disable external metrics registration as an APIService
+    register: true
 
     # clusterAgent.metricsProvider.wpaController -- Enable informer and controller of the watermark pod autoscaler
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -925,9 +925,9 @@ clusterAgent:
   metricsProvider:
     # clusterAgent.metricsProvider.enabled -- Set this to true to enable Metrics Provider
     enabled: false
-    
+
     # clusterAgent.metricsProvider.register -- Set this to false to disable external metrics registration as an APIService
-    register: true
+    registerAPIService: true
 
     # clusterAgent.metricsProvider.wpaController -- Enable informer and controller of the watermark pod autoscaler
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -926,7 +926,7 @@ clusterAgent:
     # clusterAgent.metricsProvider.enabled -- Set this to true to enable Metrics Provider
     enabled: false
 
-    # clusterAgent.metricsProvider.register -- Set this to false to disable external metrics registration as an APIService
+    # clusterAgent.metricsProvider.registerAPIService -- Set this to false to disable external metrics registration as an APIService
     registerAPIService: true
 
     # clusterAgent.metricsProvider.wpaController -- Enable informer and controller of the watermark pod autoscaler


### PR DESCRIPTION
#### What this PR does / why we need it:

External metrics server is started by the datadog agent when `clusterAgent.metricsProvider.enabled` is set to `true`. It is also registered by the helm chart in the kube api server as an APIService and an rbac is created to support it. 

This PR allows the user to enable creating an external metrics server while still disabling registering the external metrics server as an APIService. 

It does so by adding the option `clusterAgent.metricsProvider.registerAPIService` to allow user to disable registering external-metrics server as an `APIService`

This allows the user to use other external-metrics providers (such as KEDA) in the cluster, but also use the datadog cluster-agent as a metrics proxy to datadog. 

### Notes for reviewer:
- `clusterAgent.metricsProvider.registerAPIService` is defaulted to `true` in `values.yaml` for backward compatibility. By default we register the endpoint if someone enable external metrics server.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
