### PR TITLE
[APMON-284] Add support of APM Single Step Instrumentation in helm

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.40.3
+
+* Add `datadog.apm.instrumentation` sections to configure APM Single Step Instrumentation
+
 ## 3.40.2
 
 * Gate `PodSecurityPolicy` RBAC for k8s versions which no longer support this deprecated API.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.40.2
+version: 3.40.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,10 +1,6 @@
 apiVersion: v1
 name: datadog
-<<<<<<< HEAD
 version: 3.48.0
-=======
-version: 3.47.1
->>>>>>> origin/main
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.46.0
+version: 3.47.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,10 +1,6 @@
 # Datadog
 
-<<<<<<< HEAD
 ![Version: 3.48.0](https://img.shields.io/badge/Version-3.48.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
-=======
-![Version: 3.47.1](https://img.shields.io/badge/Version-3.47.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
->>>>>>> origin/main
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.40.2](https://img.shields.io/badge/Version-3.40.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.40.3](https://img.shields.io/badge/Version-3.40.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -226,6 +226,64 @@ datadog:
   # (...)
   apm:
     socketEnabled: false
+```
+
+### Enabling APM Single Step Instrumentation
+
+APM tracing libraries and configurations can be automatically injected in your application pods in the whole cluster or specific namespaces using Single Step Instrumentation.
+
+Update your `datadog-values.yaml` file with the following configration to enable Single Step Instrumentation in the whole cluster:
+
+```yaml
+datadog:
+  # (...)
+  apm:
+    instrumentation:
+      enabled: true
+```
+
+Single Step Instrumentation can be disabled in specific namespaces using configuration option `disabledNamespaces`:
+
+```yaml
+datadog:
+  # (...)
+  apm:
+    instrumentation:
+      enabled: true
+      disabledNamespaces:
+        - namespaceA
+        - namespaceB
+```
+
+Single Step Instrumentation can be enabled in specific namespaces using configuration option `enabledNamespaces`:
+
+```yaml
+datadog:
+  # (...)
+  apm:
+    instrumentation:
+      enabled: false
+      enabledNamespaces:
+        - namespaceC
+```
+
+To confiure the version of Tracing library that Single Step Instrumentation will instrument applications with, set the configuration `libVersions`:
+
+```yaml
+datadog:
+  # (...)
+  apm:
+    instrumentation:
+      enabled: false
+      libVersions: 
+        java: v1.18.0
+        python: v1.20.0
+```
+
+then upgrade your Datadog Helm chart:
+
+```bash
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
 ```
 
 ### Enabling Log Collection
@@ -593,6 +651,10 @@ helm install <RELEASE_NAME> \
 | datadog.apiKeyExistingSecret | string | `nil` | Use existing Secret which stores API key instead of creating a new one. The value should be set with the `api-key` key inside the secret. |
 | datadog.apm.enabled | bool | `false` | Enable this to enable APM and tracing, on port 8126 DEPRECATED. Use datadog.apm.portEnabled instead |
 | datadog.apm.hostSocketPath | string | `"/var/run/datadog/"` | Host path to the trace-agent socket |
+| datadog.apm.instrumentation.disabledNamespaces | list | `[]` | Disable injecting the Datadog APM libraries into pods in specific namespaces |
+| datadog.apm.instrumentation.enabled | bool | `false` | Enable injecting the Datadog APM libraries into all pods in the cluster (beta). |
+| datadog.apm.instrumentation.enabledNamespaces | list | `[]` | Enable injecting the Datadog APM libraries into pods in specific namespaces |
+| datadog.apm.instrumentation.libVersions | object | `{}` | Disable injecting the Datadog APM libraries into pods in specific namespaces |
 | datadog.apm.port | int | `8126` | Override the trace Agent port |
 | datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (port 8126 by default) |
 | datadog.apm.socketEnabled | bool | `true` | Enable APM over Socket (Unix Socket or windows named pipe) |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -596,7 +596,7 @@ helm install <RELEASE_NAME> \
 | datadog.apm.instrumentation.disabledNamespaces | list | `[]` | Disable injecting the Datadog APM libraries into pods in specific namespaces |
 | datadog.apm.instrumentation.enabled | bool | `false` | Enable injecting the Datadog APM libraries into all pods in the cluster (beta). |
 | datadog.apm.instrumentation.enabledNamespaces | list | `[]` | Enable injecting the Datadog APM libraries into pods in specific namespaces |
-| datadog.apm.instrumentation.libVersions | object | `{}` | Inject specific version of tracing libraries with Single Step Instrumentation  |
+| datadog.apm.instrumentation.libVersions | object | `{}` | Inject specific version of tracing libraries with Single Step Instrumentation |
 | datadog.apm.port | int | `8126` | Override the trace Agent port |
 | datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (port 8126 by default) |
 | datadog.apm.socketEnabled | bool | `true` | Enable APM over Socket (Unix Socket or windows named pipe) |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -228,64 +228,6 @@ datadog:
     socketEnabled: false
 ```
 
-### Enabling APM Single Step Instrumentation
-
-APM tracing libraries and configurations can be automatically injected in your application pods in the whole cluster or specific namespaces using Single Step Instrumentation.
-
-Update your `datadog-values.yaml` file with the following configration to enable Single Step Instrumentation in the whole cluster:
-
-```yaml
-datadog:
-  # (...)
-  apm:
-    instrumentation:
-      enabled: true
-```
-
-Single Step Instrumentation can be disabled in specific namespaces using configuration option `disabledNamespaces`:
-
-```yaml
-datadog:
-  # (...)
-  apm:
-    instrumentation:
-      enabled: true
-      disabledNamespaces:
-        - namespaceA
-        - namespaceB
-```
-
-Single Step Instrumentation can be enabled in specific namespaces using configuration option `enabledNamespaces`:
-
-```yaml
-datadog:
-  # (...)
-  apm:
-    instrumentation:
-      enabled: false
-      enabledNamespaces:
-        - namespaceC
-```
-
-To confiure the version of Tracing library that Single Step Instrumentation will instrument applications with, set the configuration `libVersions`:
-
-```yaml
-datadog:
-  # (...)
-  apm:
-    instrumentation:
-      enabled: false
-      libVersions: 
-        java: v1.18.0
-        python: v1.20.0
-```
-
-then upgrade your Datadog Helm chart:
-
-```bash
-helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
-```
-
 ### Enabling Log Collection
 
 Update your `datadog-values.yaml` file with the following log collection configuration:
@@ -654,7 +596,7 @@ helm install <RELEASE_NAME> \
 | datadog.apm.instrumentation.disabledNamespaces | list | `[]` | Disable injecting the Datadog APM libraries into pods in specific namespaces |
 | datadog.apm.instrumentation.enabled | bool | `false` | Enable injecting the Datadog APM libraries into all pods in the cluster (beta). |
 | datadog.apm.instrumentation.enabledNamespaces | list | `[]` | Enable injecting the Datadog APM libraries into pods in specific namespaces |
-| datadog.apm.instrumentation.libVersions | object | `{}` | Disable injecting the Datadog APM libraries into pods in specific namespaces |
+| datadog.apm.instrumentation.libVersions | object | `{}` | Inject specific version of tracing libraries with Single Step Instrumentation  |
 | datadog.apm.port | int | `8126` | Override the trace Agent port |
 | datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (port 8126 by default) |
 | datadog.apm.socketEnabled | bool | `true` | Enable APM over Socket (Unix Socket or windows named pipe) |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -275,7 +275,7 @@ datadog:
   apm:
     instrumentation:
       enabled: false
-      libVersions: 
+      libVersions:
         java: v1.18.0
         python: v1.20.0
 ```
@@ -652,10 +652,10 @@ helm install <RELEASE_NAME> \
 | datadog.apiKeyExistingSecret | string | `nil` | Use existing Secret which stores API key instead of creating a new one. The value should be set with the `api-key` key inside the secret. |
 | datadog.apm.enabled | bool | `false` | Enable this to enable APM and tracing, on port 8126 DEPRECATED. Use datadog.apm.portEnabled instead |
 | datadog.apm.hostSocketPath | string | `"/var/run/datadog/"` | Host path to the trace-agent socket |
-| datadog.apm.instrumentation.disabledNamespaces | list | `[]` | Disable injecting the Datadog APM libraries into pods in specific namespaces. # This feature is in beta, and requires Cluster Agent version 7.49+. # |
-| datadog.apm.instrumentation.enabled | bool | `false` | Enable injecting the Datadog APM libraries into all pods in the cluster (beta). # This feature is in beta, and requires Cluster Agent version 7.49+. # |
-| datadog.apm.instrumentation.enabledNamespaces | list | `[]` | Enable injecting the Datadog APM libraries into pods in specific namespaces. # This feature is in beta, and requires Cluster Agent version 7.49+. # |
-| datadog.apm.instrumentation.libVersions | object | `{}` | Inject specific version of tracing libraries with Single Step Instrumentation. # This feature is in beta, and requires Cluster Agent version 7.49+. # |
+| datadog.apm.instrumentation.disabledNamespaces | list | `[]` | Disable injecting the Datadog APM libraries into pods in specific namespaces (beta). |
+| datadog.apm.instrumentation.enabled | bool | `false` | Enable injecting the Datadog APM libraries into all pods in the cluster (beta). |
+| datadog.apm.instrumentation.enabledNamespaces | list | `[]` | Enable injecting the Datadog APM libraries into pods in specific namespaces (beta). |
+| datadog.apm.instrumentation.libVersions | object | `{}` | Inject specific version of tracing libraries with Single Step Instrumentation (beta). |
 | datadog.apm.port | int | `8126` | Override the trace Agent port |
 | datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (port 8126 by default) |
 | datadog.apm.socketEnabled | bool | `true` | Enable APM over Socket (Unix Socket or windows named pipe) |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.46.0](https://img.shields.io/badge/Version-3.46.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.47.0](https://img.shields.io/badge/Version-3.47.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md.gotmpl
+++ b/charts/datadog/README.md.gotmpl
@@ -224,6 +224,64 @@ datadog:
     socketEnabled: false
 ```
 
+### Enabling APM Single Step Instrumentation (beta)
+
+APM tracing libraries and configurations can be automatically injected in your application pods in the whole cluster or specific namespaces using Single Step Instrumentation.
+
+Update your `datadog-values.yaml` file with the following configration to enable Single Step Instrumentation in the whole cluster:
+
+```yaml
+datadog:
+  # (...)
+  apm:
+    instrumentation:
+      enabled: true
+```
+
+Single Step Instrumentation can be disabled in specific namespaces using configuration option `disabledNamespaces`:
+
+```yaml
+datadog:
+  # (...)
+  apm:
+    instrumentation:
+      enabled: true
+      disabledNamespaces:
+        - namespaceA
+        - namespaceB
+```
+
+Single Step Instrumentation can be enabled in specific namespaces using configuration option `enabledNamespaces`:
+
+```yaml
+datadog:
+  # (...)
+  apm:
+    instrumentation:
+      enabled: false
+      enabledNamespaces:
+        - namespaceC
+```
+
+To confiure the version of Tracing library that Single Step Instrumentation will instrument applications with, set the configuration `libVersions`:
+
+```yaml
+datadog:
+  # (...)
+  apm:
+    instrumentation:
+      enabled: false
+      libVersions:
+        java: v1.18.0
+        python: v1.20.0
+```
+
+then upgrade your Datadog Helm chart:
+
+```bash
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
+```
+
 ### Enabling Log Collection
 
 Update your `datadog-values.yaml` file with the following log collection configuration:

--- a/charts/datadog/ci/apm-single-step-instrumentation-admission-controller-values.yaml
+++ b/charts/datadog/ci/apm-single-step-instrumentation-admission-controller-values.yaml
@@ -1,0 +1,10 @@
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  apm:
+    instrumentation:
+      enabled: true
+clusterAgent:
+  enabled: true
+  admissionController:
+    enabled: true

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -131,7 +131,7 @@ The Datadog Agent is listening on port {{ $apmPort }} for APM service.
 ####               ERROR: APM Single Step Instrumentation misconfiguration     ####
 ###################################################################################
 
-The options `datadog.apm.instrumentation.enabled_namespaces` and `datadog.apm.instrumentation.disabled_namespaces` cannot be set together.
+{{- fail "The options `datadog.apm.instrumentation.enabled_namespaces` and `datadog.apm.instrumentation.disabled_namespaces` cannot be set together." }}
 
 {{- end }}
 
@@ -141,8 +141,19 @@ The options `datadog.apm.instrumentation.enabled_namespaces` and `datadog.apm.in
 ####               WARNING: Configuration notice             ####
 #################################################################
 
-You are using datadog.apm.instrumentation.enabled but you disabled the cluster agent. This configuration is unsupported and Kubernetes resource monitoring has been turned off.
-To enable it please set clusterAgent.enabled to 'true'.
+{{- fail "You are using datadog.apm.instrumentation.enabled but you disabled the cluster agent. This configuration is unsupported and Kubernetes resource monitoring has been turned off.
+To enable it please set clusterAgent.enabled to 'true'." }}
+
+{{- end }}
+
+{{- if and .Values.datadog.apm.instrumentation.enabled (not .Values.clusterAgent.admissionController.enabled)}}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+{{- fail "You are using datadog.apm.instrumentation.enabled but you disabled the admission controller. This configuration is unsupported. To enable it please set clusterAgent.admissionController.enabled to 'true'." }}
+
 {{- end }}
 
 {{- if and .Values.datadog.apm.instrumentation.enabled_namespaces (eq (include "cluster-agent-enabled" .) "false")}}

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -125,6 +125,59 @@ Trace Agent liveness probe port ({{ $liveness.port }}) is different from the con
 The Datadog Agent is listening on port {{ $apmPort }} for APM service.
 {{- end }}
 
+{{- if and .Values.datadog.apm.instrumentation.enabled_namespaces .Values.datadog.apm.instrumentation.disabled_namespaces }}
+
+###################################################################################
+####               ERROR: APM Single Step Instrumentation misconfiguration     ####
+###################################################################################
+
+The options `datadog.apm.instrumentation.enabled_namespaces` and `datadog.apm.instrumentation.disabled_namespaces` cannot be set together.
+
+{{- end }}
+
+{{- if and .Values.datadog.apm.instrumentation.enabled (eq (include "cluster-agent-enabled" .) "false")}}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+You are using datadog.apm.instrumentation.enabled but you disabled the cluster agent. This configuration is unsupported and Kubernetes resource monitoring has been turned off.
+To enable it please set clusterAgent.enabled to 'true'.
+{{- end }}
+
+{{- if and .Values.datadog.apm.instrumentation.enabled_namespaces (eq (include "cluster-agent-enabled" .) "false")}}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+You are using datadog.apm.instrumentation.enabled_namespaces but you disabled the cluster agent. This configuration is unsupported and Kubernetes resource monitoring has been turned off.
+To enable it please set clusterAgent.enabled to 'true'.
+{{- end }}
+
+{{- if and .Values.datadog.apm.instrumentation.enabled .Values.datadog.apm.instrumentation.enabled_namespaces }}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+The options `datadog.apm.instrumentation.enabled` and `datadog.apm.instrumentation.enabled_namespaces` are set together.
+APM Single Step Instrumentation will be enabled in the whole cluster.
+
+{{- end }}
+
+{{- if and .Values.datadog.apm.instrumentation.disabled_namespaces (eq .Values.datadog.apm.instrumentation.enabled "false") }}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+The option `datadog.apm.instrumentation.enabled_namespaces` is set while `datadog.apm.instrumentation.enabled` is disabled.
+APM Single Step Instrumentation will be disabled in the whole cluster.
+
+{{- end }}
+
+
 {{- if .Values.datadog.apm.enabled }}
 
 #################################################################

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -141,8 +141,7 @@ The Datadog Agent is listening on port {{ $apmPort }} for APM service.
 ####               WARNING: Configuration notice             ####
 #################################################################
 
-{{- fail "You are using datadog.apm.instrumentation.enabled but you disabled the cluster agent. This configuration is unsupported and Kubernetes resource monitoring has been turned off.
-To enable it please set clusterAgent.enabled to 'true'." }}
+{{- fail "You are using datadog.apm.instrumentation.enabled but you disabled the cluster agent. This configuration is unsupported and Kubernetes resource monitoring has been turned off. To enable it please set clusterAgent.enabled to 'true'." }}
 
 {{- end }}
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -229,6 +229,22 @@ spec:
           {{- end }}
           - name: DD_REMOTE_CONFIGURATION_ENABLED
             value: {{ include "clusterAgent-remoteConfiguration-enabled" . | quote }}
+          {{- if .Values.datadog.apm.instrumentation.enabled }}
+          - name: DD_APM_INSTRUMENTATION_ENABLED
+            value: "true"
+          {{- end }}
+          {{- if .Values.datadog.apm.instrumentation.enabled_namespaces }}
+          - name: DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES
+            value: {{ .Values.datadog.apm.instrumentation.enabled_namespaces }}
+          {{- end }}
+          {{- if .Values.datadog.apm.instrumentation.disabled_namespaces }}
+          - name: DD_APM_INSTRUMENTATION_DISABLED_NAMESPACES
+            value: {{ .Values.datadog.apm.instrumentation.disabled_namespaces }}
+          {{- end }}
+          {{- if .Values.datadog.apm.instrumentation.lib_versions }}
+          - name: DD_APM_INSTRUMENTATION_LIB_VERSIONS
+            value: {{ .Values.datadog.apm.instrumentation.lib_versions }}
+          {{- end }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED
             value: {{ .Values.datadog.clusterChecks.enabled | quote }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -233,17 +233,17 @@ spec:
           - name: DD_APM_INSTRUMENTATION_ENABLED
             value: "true"
           {{- end }}
-          {{- if .Values.datadog.apm.instrumentation.enabled_namespaces }}
+          {{- if .Values.datadog.apm.instrumentation.enabledNamespaces }}
           - name: DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES
-            value: {{ .Values.datadog.apm.instrumentation.enabled_namespaces }}
+            value: {{ .Values.datadog.apm.instrumentation.enabledNamespaces | toJson | quote }}
           {{- end }}
-          {{- if .Values.datadog.apm.instrumentation.disabled_namespaces }}
+          {{- if .Values.datadog.apm.instrumentation.disabledNamespaces }}
           - name: DD_APM_INSTRUMENTATION_DISABLED_NAMESPACES
-            value: {{ .Values.datadog.apm.instrumentation.disabled_namespaces }}
+            value: {{ .Values.datadog.apm.instrumentation.disabledNamespaces | toJson | quote }}
           {{- end }}
-          {{- if .Values.datadog.apm.instrumentation.lib_versions }}
+          {{- if .Values.datadog.apm.instrumentation.libVersions }}
           - name: DD_APM_INSTRUMENTATION_LIB_VERSIONS
-            value: {{ .Values.datadog.apm.instrumentation.lib_versions }}
+            value: {{ .Values.datadog.apm.instrumentation.libVersions | toJson | quote }}
           {{- end }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -473,7 +473,7 @@ datadog:
       # datadog.apm.instrumentation.disabledNamespaces -- Disable injecting the Datadog APM libraries into pods in specific namespaces
       disabledNamespaces: []
 
-      # datadog.apm.instrumentation.libVersions -- Disable injecting the Datadog APM libraries into pods in specific namespaces
+      # datadog.apm.instrumentation.libVersions -- Inject specific version of tracing libraries with Single Step Instrumentation 
       libVersions: {}
 
   ## OTLP ingest related configuration

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -467,14 +467,14 @@ datadog:
       # datadog.apm.instrumentation.enabled -- Enable injecting the Datadog APM libraries into all pods in the cluster (beta).
       enabled: false
 
-      # datadog.apm.instrumentation.enabled_namespaces -- Enable injecting the Datadog APM libraries into pods in specific namespaces
-      enabled_namespaces: []
+      # datadog.apm.instrumentation.enabledNamespaces -- Enable injecting the Datadog APM libraries into pods in specific namespaces
+      enabledNamespaces: []
 
-      # datadog.apm.instrumentation.disabled_namespaces -- Disable injecting the Datadog APM libraries into pods in specific namespaces
-      disabled_namespaces: []
+      # datadog.apm.instrumentation.disabledNamespaces -- Disable injecting the Datadog APM libraries into pods in specific namespaces
+      disabledNamespaces: []
 
-      # datadog.apm.instrumentation.lib_versions -- Disable injecting the Datadog APM libraries into pods in specific namespaces
-      lib_versions: {}
+      # datadog.apm.instrumentation.libVersions -- Disable injecting the Datadog APM libraries into pods in specific namespaces
+      libVersions: {}
 
   ## OTLP ingest related configuration
   otlp:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -461,6 +461,21 @@ datadog:
     # datadog.apm.hostSocketPath -- Host path to the trace-agent socket
     hostSocketPath: /var/run/datadog/
 
+    # APM Single Step Instrumentation
+    # This feature is in beta. It requires Cluster Agent 7.49+.
+    instrumentation:
+      # datadog.apm.instrumentation.enabled -- Enable injecting the Datadog APM libraries into all pods in the cluster (beta).
+      enabled: false
+
+      # datadog.apm.instrumentation.enabled_namespaces -- Enable injecting the Datadog APM libraries into pods in specific namespaces
+      enabled_namespaces: []
+
+      # datadog.apm.instrumentation.disabled_namespaces -- Disable injecting the Datadog APM libraries into pods in specific namespaces
+      disabled_namespaces: []
+
+      # datadog.apm.instrumentation.lib_versions -- Disable injecting the Datadog APM libraries into pods in specific namespaces
+      lib_versions: {}
+
   ## OTLP ingest related configuration
   otlp:
     receiver:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -473,7 +473,7 @@ datadog:
       # datadog.apm.instrumentation.disabledNamespaces -- Disable injecting the Datadog APM libraries into pods in specific namespaces
       disabledNamespaces: []
 
-      # datadog.apm.instrumentation.libVersions -- Inject specific version of tracing libraries with Single Step Instrumentation 
+      # datadog.apm.instrumentation.libVersions -- Inject specific version of tracing libraries with Single Step Instrumentation
       libVersions: {}
 
   ## OTLP ingest related configuration


### PR DESCRIPTION
#### What this PR does / why we need it:
Starting from release 7.49.x, cluster agent supports Single Step Instrumentation. This change allows configuring Single Step Instrumentation during agent installation with Helm.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
