### PR TITLE
feat: datadog-operator add volumes and volumeMounts

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+## 1.3.0
+
+* Add configuration to mount volumes (`volumes` and `volumeMounts`) in the container. Empty by default.
+
 ## 1.2.2
+
 * Fix that an error occurs when specifying replicaCount using `--set`
 
 ## 1.2.1

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.2.2
+version: 1.3.0
 appVersion: 1.2.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 ## Values
 
@@ -50,6 +50,8 @@
 | site | string | `nil` | The site of the Datadog intake to send data to (documentation: https://docs.datadoghq.com/getting_started/site/) |
 | supportExtendedDaemonset | string | `"false"` | If true, supports using ExtendedDaemonSet CRD |
 | tolerations | list | `[]` | Allows to schedule Datadog Operator on tainted nodes |
+| volumeMounts | list | `[]` | Specify additional volumes to mount in the container |
+| volumes | list | `[]` | Specify additional volumes to mount in the container |
 | watchNamespaces | list | `[]` | Restricts the Operator to watch its managed resources on specific namespaces |
 
 ## How to configure which namespaces are watched by the Operator.

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -128,11 +128,14 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled  }}
           volumeMounts:
+          {{- if .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled  }}
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: cert
             readOnly: true
+          {{- end }}
+          {{- if .Values.volumeMounts }}
+          {{- toYaml .Values.volumeMounts | nindent 10 }}
           {{- end }}
           {{- if .Values.containerSecurityContext }}
           securityContext:
@@ -150,10 +153,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled  }}
       volumes:
+      {{- if .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled  }}
       - name: cert
         secret:
           defaultMode: 420
           secretName: {{ .Release.Name }}-webhook-server-cert
-    {{- end }}
+      {{- end }}
+      {{- if .Values.volumes }}
+      {{- toYaml .Values.volumes | nindent 6 }}
+      {{- end }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -144,3 +144,15 @@ watchNamespaces: []
 
 # containerSecurityContext -- A security context defines privileges and access control settings for a container.
 containerSecurityContext: {}
+
+# volumes -- Specify additional volumes to mount in the container
+volumes: []
+#   - hostPath:
+#       path: <HOST_PATH>
+#     name: <VOLUME_NAME>
+
+# volumeMounts -- Specify additional volumes to mount in the container
+volumeMounts: []
+#   - name: <VOLUME_NAME>
+#     mountPath: <CONTAINER_PATH>
+#     readOnly: true

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.2.2
+    helm.sh/chart: datadog-operator-1.3.0
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.2.0"
     app.kubernetes.io/managed-by: Helm
@@ -66,3 +66,5 @@ spec:
             periodSeconds: 10
           resources:
             {}
+          volumeMounts:
+      volumes:

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.2.2
+    helm.sh/chart: datadog-operator-1.3.0
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.2.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:

SecretProviderClass can be used to pull a secret from a cloud provider (ie. AWS Secrets Manager) and create the associated Kubernetes Secret. For this to work, we need to mount the SecretProviderClass in the container. Secret will be pulled when the container start.

This PR add configuration for `volumes` and `volumeMounts` so that we can pass a SecretProviderClass to the container.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)