### PR TITLE
fix(datadog-operator): fix PodDisruptionBudget creation issue when setting replicaCount via --set

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.2
+* Fix that an error occurs when specifying replicaCount using `--set`
+
 ## 1.2.1
 
 * Minor spelling corrections in the `datadog-operator` chart.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.2.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/pod_disruption_budget.yaml
+++ b/charts/datadog-operator/templates/pod_disruption_budget.yaml
@@ -1,4 +1,4 @@
-{{- if gt .Values.replicaCount 1.0 -}}
+{{- if gt (int .Values.replicaCount) 1 -}}
 apiVersion: {{ template "policy.poddisruptionbudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.2.0
+    helm.sh/chart: datadog-operator-1.2.2
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.2.0"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.2.0
+    helm.sh/chart: datadog-operator-1.2.2
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.2.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix an issue where when trying to helm install using `--set replicaCount=x`, a typecast issue occurred and the install failed.

```
helm install datadog-operator datadog/datadog-operator --set installCRDs=true --set replicaCount=2
Error: INSTALLATION FAILED: template: datadog-operator/templates/pod_disruption_budget.yaml:1:7: executing "datadog-operator/templates/pod_disruption_budget.yaml" at <gt .Values.replicaCount 1.0>: error calling gt: incompatible types for comparison
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
