### PR TITLE
Skip Operator integ tests on PRs from forks

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -2,12 +2,10 @@ name: Go Test
 on:
   push:
     paths:
-      - '.github/workflows/go-test.yaml'
       - 'test/**'
       - 'charts/datadog-operator/**'
   pull_request:
     paths:
-      - '.github/workflows/go-test.yaml'
       - 'test/**'
       - 'charts/datadog-operator/**'
 env:
@@ -36,7 +34,7 @@ jobs:
         make unit-test
 
   integ-tests:
-    if: ${{github_event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{github.event.pull_request.head.repo.full_name == github.repository }}
     name: integ-tests
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -2,10 +2,12 @@ name: Go Test
 on:
   push:
     paths:
+      - '.github/workflows/go-test.yaml'
       - 'test/**'
       - 'charts/datadog-operator/**'
   pull_request:
     paths:
+      - '.github/workflows/go-test.yaml'
       - 'test/**'
       - 'charts/datadog-operator/**'
 env:
@@ -34,6 +36,7 @@ jobs:
         make unit-test
 
   integ-tests:
+    if: ${{github_event.pull_request.head.repo.full_name == github.repository }}
     name: integ-tests
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
#### What this PR does / why we need it:
Run Operator tests on `go-test.yaml` ci changes and skip integration tests on PRs from forks. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
