### PR TITLE
[synthetics-private-location] Support dnsPolicy configuration

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.15.20
+
+* Support `dnsPolicy` configuration.
+
 ## 0.15.19
 
 * Update private location image version to `1.41.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.19
+version: 0.15.20
 appVersion: 1.41.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.19](https://img.shields.io/badge/Version-0.15.19-informational?style=flat-square) ![AppVersion: 1.41.0](https://img.shields.io/badge/AppVersion-1.41.0-informational?style=flat-square)
+![Version: 0.15.20](https://img.shields.io/badge/Version-0.15.20-informational?style=flat-square) ![AppVersion: 1.41.0](https://img.shields.io/badge/AppVersion-1.41.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -30,6 +30,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | configConfigMap | string | `""` | Config Map that stores the configuration of the private location worker for the deployment |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
 | configSecret | string | `""` | Secret that stores the configuration of the private location worker for the deployment |
+| dnsPolicy | string | `"ClusterFirst"` | DNS Policy to set to the Datadog Synthetics Private Location PODs |
 | enableStatusProbes | bool | `false` | Enable both liveness and readiness probes (minimal private location image version required: 1.12.0) |
 | env | list | `[]` | Set environment variables |
 | envFrom | list | `[]` | Set environment variables from configMaps and/or secrets |

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         {{- include "synthetics-private-location.selectorLabels" . | nindent 8 }}
     spec:
+      {{ if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy}}
+      {{ end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -17,6 +17,9 @@ image:
   # image.tag -- Define the Datadog Synthetics Private Location version to use
   tag: 1.41.0
 
+# dnsPolicy -- DNS Policy to set to the Datadog Synthetics Private Location PODs
+dnsPolicy: ClusterFirst
+
 # imagePullSecrets -- Datadog Synthetics Private Location repository pullSecret (ex: specify docker registry credentials)
 imagePullSecrets: []
 # nameOverride -- Override name of app


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for `dnsPolicy` configuration in the synthetics private location helm chart.

#### Which issue this PR fixes

  - fixes [#1121](https://github.com/DataDog/helm-charts/issues/1121)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
