### PR TITLE
CRD update from 1.3.0

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+* Update CRDs from Datadog Operator v1.3.0 tag.
+
 ## 1.2.0
 * Update CRDs from Datadog Operator v1.2.0 tag.
 

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 1.2.0
+version: 1.3.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 
@@ -25,6 +25,7 @@ But the recommended Kubernetes versions are `1.16+`.
 | crds.datadogAgents | bool | `false` | Set to true to deploy the DatadogAgents CRD |
 | crds.datadogMetrics | bool | `false` | Set to true to deploy the DatadogMetrics CRD |
 | crds.datadogMonitors | bool | `false` | Set to true to deploy the DatadogMonitors CRD |
+| crds.datadogSLOs | bool | `false` | Set to true to deploy the DatadogSLO CRD |
 | fullnameOverride | string | `""` | Override the fully qualified app name |
 | migration.datadogAgents.conversionWebhook.enabled | bool | `false` |  |
 | migration.datadogAgents.conversionWebhook.name | string | `"datadog-operator-webhook-service"` |  |

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -6064,6 +6064,8 @@ spec:
                           type: object
                         originDetectionEnabled:
                           type: boolean
+                        tagCardinality:
+                          type: string
                         unixDomainSocketConfig:
                           properties:
                             enabled:
@@ -6119,6 +6121,8 @@ spec:
                         port:
                           format: int32
                           type: integer
+                        registerAPIService:
+                          type: boolean
                         useDatadogMetrics:
                           type: boolean
                         wpaController:
@@ -6275,6 +6279,11 @@ spec:
                               type: object
                           type: object
                       type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     prometheusScrape:
                       properties:
                         additionalConfigs:
@@ -6290,6 +6299,31 @@ spec:
                       properties:
                         enabled:
                           type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
                       type: object
                     tcpQueueLength:
                       properties:
@@ -7499,148 +7533,6 @@ spec:
                                 type: boolean
                               runAsUserName:
                                 type: string
-                            type: object
-                        type: object
-                      securityContextConstraints:
-                        properties:
-                          create:
-                            type: boolean
-                          customConfiguration:
-                            properties:
-                              allowHostDirVolumePlugin:
-                                type: boolean
-                              allowHostIPC:
-                                type: boolean
-                              allowHostNetwork:
-                                type: boolean
-                              allowHostPID:
-                                type: boolean
-                              allowHostPorts:
-                                type: boolean
-                              allowPrivilegedContainer:
-                                type: boolean
-                              allowedCapabilities:
-                                items:
-                                  type: string
-                                type: array
-                              allowedFlexVolumes:
-                                items:
-                                  properties:
-                                    driver:
-                                      type: string
-                                  type: object
-                                type: array
-                              apiVersion:
-                                type: string
-                              defaultAddCapabilities:
-                                items:
-                                  type: string
-                                type: array
-                              fsGroup:
-                                properties:
-                                  ranges:
-                                    items:
-                                      properties:
-                                        max:
-                                          format: int64
-                                          type: integer
-                                        min:
-                                          format: int64
-                                          type: integer
-                                      type: object
-                                    type: array
-                                  type:
-                                    type: string
-                                type: object
-                              groups:
-                                items:
-                                  type: string
-                                type: array
-                              kind:
-                                type: string
-                              metadata:
-                                type: object
-                              priority:
-                                format: int32
-                                type: integer
-                              readOnlyRootFilesystem:
-                                type: boolean
-                              requiredDropCapabilities:
-                                items:
-                                  type: string
-                                type: array
-                              runAsUser:
-                                properties:
-                                  type:
-                                    type: string
-                                  uid:
-                                    format: int64
-                                    type: integer
-                                  uidRangeMax:
-                                    format: int64
-                                    type: integer
-                                  uidRangeMin:
-                                    format: int64
-                                    type: integer
-                                type: object
-                              seLinuxContext:
-                                properties:
-                                  seLinuxOptions:
-                                    properties:
-                                      level:
-                                        type: string
-                                      role:
-                                        type: string
-                                      type:
-                                        type: string
-                                      user:
-                                        type: string
-                                    type: object
-                                  type:
-                                    type: string
-                                type: object
-                              seccompProfiles:
-                                items:
-                                  type: string
-                                type: array
-                              supplementalGroups:
-                                properties:
-                                  ranges:
-                                    items:
-                                      properties:
-                                        max:
-                                          format: int64
-                                          type: integer
-                                        min:
-                                          format: int64
-                                          type: integer
-                                      type: object
-                                    type: array
-                                  type:
-                                    type: string
-                                type: object
-                              users:
-                                items:
-                                  type: string
-                                type: array
-                              volumes:
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                              - allowHostDirVolumePlugin
-                              - allowHostIPC
-                              - allowHostNetwork
-                              - allowHostPID
-                              - allowHostPorts
-                              - allowPrivilegedContainer
-                              - allowedCapabilities
-                              - allowedFlexVolumes
-                              - defaultAddCapabilities
-                              - priority
-                              - readOnlyRootFilesystem
-                              - requiredDropCapabilities
-                              - volumes
                             type: object
                         type: object
                       serviceAccountName:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -6053,6 +6053,8 @@ spec:
                           type: object
                         originDetectionEnabled:
                           type: boolean
+                        tagCardinality:
+                          type: string
                         unixDomainSocketConfig:
                           properties:
                             enabled:
@@ -6108,6 +6110,8 @@ spec:
                         port:
                           format: int32
                           type: integer
+                        registerAPIService:
+                          type: boolean
                         useDatadogMetrics:
                           type: boolean
                         wpaController:
@@ -6264,6 +6268,11 @@ spec:
                               type: object
                           type: object
                       type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     prometheusScrape:
                       properties:
                         additionalConfigs:
@@ -6279,6 +6288,31 @@ spec:
                       properties:
                         enabled:
                           type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
                       type: object
                     tcpQueueLength:
                       properties:
@@ -7488,148 +7522,6 @@ spec:
                                 type: boolean
                               runAsUserName:
                                 type: string
-                            type: object
-                        type: object
-                      securityContextConstraints:
-                        properties:
-                          create:
-                            type: boolean
-                          customConfiguration:
-                            properties:
-                              allowHostDirVolumePlugin:
-                                type: boolean
-                              allowHostIPC:
-                                type: boolean
-                              allowHostNetwork:
-                                type: boolean
-                              allowHostPID:
-                                type: boolean
-                              allowHostPorts:
-                                type: boolean
-                              allowPrivilegedContainer:
-                                type: boolean
-                              allowedCapabilities:
-                                items:
-                                  type: string
-                                type: array
-                              allowedFlexVolumes:
-                                items:
-                                  properties:
-                                    driver:
-                                      type: string
-                                  type: object
-                                type: array
-                              apiVersion:
-                                type: string
-                              defaultAddCapabilities:
-                                items:
-                                  type: string
-                                type: array
-                              fsGroup:
-                                properties:
-                                  ranges:
-                                    items:
-                                      properties:
-                                        max:
-                                          format: int64
-                                          type: integer
-                                        min:
-                                          format: int64
-                                          type: integer
-                                      type: object
-                                    type: array
-                                  type:
-                                    type: string
-                                type: object
-                              groups:
-                                items:
-                                  type: string
-                                type: array
-                              kind:
-                                type: string
-                              metadata:
-                                type: object
-                              priority:
-                                format: int32
-                                type: integer
-                              readOnlyRootFilesystem:
-                                type: boolean
-                              requiredDropCapabilities:
-                                items:
-                                  type: string
-                                type: array
-                              runAsUser:
-                                properties:
-                                  type:
-                                    type: string
-                                  uid:
-                                    format: int64
-                                    type: integer
-                                  uidRangeMax:
-                                    format: int64
-                                    type: integer
-                                  uidRangeMin:
-                                    format: int64
-                                    type: integer
-                                type: object
-                              seLinuxContext:
-                                properties:
-                                  seLinuxOptions:
-                                    properties:
-                                      level:
-                                        type: string
-                                      role:
-                                        type: string
-                                      type:
-                                        type: string
-                                      user:
-                                        type: string
-                                    type: object
-                                  type:
-                                    type: string
-                                type: object
-                              seccompProfiles:
-                                items:
-                                  type: string
-                                type: array
-                              supplementalGroups:
-                                properties:
-                                  ranges:
-                                    items:
-                                      properties:
-                                        max:
-                                          format: int64
-                                          type: integer
-                                        min:
-                                          format: int64
-                                          type: integer
-                                      type: object
-                                    type: array
-                                  type:
-                                    type: string
-                                type: object
-                              users:
-                                items:
-                                  type: string
-                                type: array
-                              volumes:
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                              - allowHostDirVolumePlugin
-                              - allowHostIPC
-                              - allowHostNetwork
-                              - allowHostPID
-                              - allowHostPorts
-                              - allowPrivilegedContainer
-                              - allowedCapabilities
-                              - allowedFlexVolumes
-                              - defaultAddCapabilities
-                              - priority
-                              - readOnlyRootFilesystem
-                              - requiredDropCapabilities
-                              - volumes
                             type: object
                         type: object
                       serviceAccountName:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogslos_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogslos_v1.yaml
@@ -1,0 +1,205 @@
+{{- if and .Values.crds.datadogSLOs (semverCompare ">1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: datadogslos.datadoghq.com
+  labels:
+    helm.sh/chart: '{{ include "datadog-crds.chart" . }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "datadog-crds.name" . }}'
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: Description is a user-defined description of the service level objective. Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective. Included in service level objective responses if it is not empty. Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: Query is the query for a metric-based SLO. Required if type is metric. Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: 'Tags is a list of tags to associate with your service level objective. This can help you categorize and filter service level objectives in the service level objectives page of the UI. Note: it''s not currently possible to filter by these tags when querying via the API.'
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: CurrentHash tracks the hash of the current DatadogSLOSpec to know if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -59,3 +59,4 @@ download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogagents data
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogagents datadogAgents v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogmonitors datadogMonitors v1beta1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogmonitors datadogMonitors v1
+download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogslos datadogSLOs v1

--- a/charts/datadog-crds/values.yaml
+++ b/charts/datadog-crds/values.yaml
@@ -9,6 +9,8 @@ crds:
   datadogAgents: false
   # crds.datadogMonitors -- Set to true to deploy the DatadogMonitors CRD
   datadogMonitors: false
+  # crds.datadogSLOs -- Set to true to deploy the DatadogSLO CRD
+  datadogSLOs: false
 
 migration:
   datadogAgents:

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -6038,6 +6038,8 @@ spec:
                           type: object
                         originDetectionEnabled:
                           type: boolean
+                        tagCardinality:
+                          type: string
                         unixDomainSocketConfig:
                           properties:
                             enabled:
@@ -6093,6 +6095,8 @@ spec:
                         port:
                           format: int32
                           type: integer
+                        registerAPIService:
+                          type: boolean
                         useDatadogMetrics:
                           type: boolean
                         wpaController:
@@ -6249,6 +6253,11 @@ spec:
                               type: object
                           type: object
                       type: object
+                    processDiscovery:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     prometheusScrape:
                       properties:
                         additionalConfigs:
@@ -6264,6 +6273,31 @@ spec:
                       properties:
                         enabled:
                           type: boolean
+                      type: object
+                    sbom:
+                      properties:
+                        containerImage:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
+                        enabled:
+                          type: boolean
+                        host:
+                          properties:
+                            analyzers:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                          type: object
                       type: object
                     tcpQueueLength:
                       properties:
@@ -7473,148 +7507,6 @@ spec:
                                 type: boolean
                               runAsUserName:
                                 type: string
-                            type: object
-                        type: object
-                      securityContextConstraints:
-                        properties:
-                          create:
-                            type: boolean
-                          customConfiguration:
-                            properties:
-                              allowHostDirVolumePlugin:
-                                type: boolean
-                              allowHostIPC:
-                                type: boolean
-                              allowHostNetwork:
-                                type: boolean
-                              allowHostPID:
-                                type: boolean
-                              allowHostPorts:
-                                type: boolean
-                              allowPrivilegedContainer:
-                                type: boolean
-                              allowedCapabilities:
-                                items:
-                                  type: string
-                                type: array
-                              allowedFlexVolumes:
-                                items:
-                                  properties:
-                                    driver:
-                                      type: string
-                                  type: object
-                                type: array
-                              apiVersion:
-                                type: string
-                              defaultAddCapabilities:
-                                items:
-                                  type: string
-                                type: array
-                              fsGroup:
-                                properties:
-                                  ranges:
-                                    items:
-                                      properties:
-                                        max:
-                                          format: int64
-                                          type: integer
-                                        min:
-                                          format: int64
-                                          type: integer
-                                      type: object
-                                    type: array
-                                  type:
-                                    type: string
-                                type: object
-                              groups:
-                                items:
-                                  type: string
-                                type: array
-                              kind:
-                                type: string
-                              metadata:
-                                type: object
-                              priority:
-                                format: int32
-                                type: integer
-                              readOnlyRootFilesystem:
-                                type: boolean
-                              requiredDropCapabilities:
-                                items:
-                                  type: string
-                                type: array
-                              runAsUser:
-                                properties:
-                                  type:
-                                    type: string
-                                  uid:
-                                    format: int64
-                                    type: integer
-                                  uidRangeMax:
-                                    format: int64
-                                    type: integer
-                                  uidRangeMin:
-                                    format: int64
-                                    type: integer
-                                type: object
-                              seLinuxContext:
-                                properties:
-                                  seLinuxOptions:
-                                    properties:
-                                      level:
-                                        type: string
-                                      role:
-                                        type: string
-                                      type:
-                                        type: string
-                                      user:
-                                        type: string
-                                    type: object
-                                  type:
-                                    type: string
-                                type: object
-                              seccompProfiles:
-                                items:
-                                  type: string
-                                type: array
-                              supplementalGroups:
-                                properties:
-                                  ranges:
-                                    items:
-                                      properties:
-                                        max:
-                                          format: int64
-                                          type: integer
-                                        min:
-                                          format: int64
-                                          type: integer
-                                      type: object
-                                    type: array
-                                  type:
-                                    type: string
-                                type: object
-                              users:
-                                items:
-                                  type: string
-                                type: array
-                              volumes:
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                              - allowHostDirVolumePlugin
-                              - allowHostIPC
-                              - allowHostNetwork
-                              - allowHostPID
-                              - allowHostPorts
-                              - allowPrivilegedContainer
-                              - allowedCapabilities
-                              - allowedFlexVolumes
-                              - defaultAddCapabilities
-                              - priority
-                              - readOnlyRootFilesystem
-                              - requiredDropCapabilities
-                              - volumes
                             type: object
                         type: object
                       serviceAccountName:

--- a/crds/datadoghq.com_datadogslos.yaml
+++ b/crds/datadoghq.com_datadogslos.yaml
@@ -1,0 +1,198 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: datadogslos.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+      - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllerOptions:
+                  description: ControllerOptions are the optional parameters in the DatadogSLO controller
+                  properties:
+                    disableRequiredTags:
+                      description: DisableRequiredTags disables the automatic addition of required tags to SLOs.
+                      type: boolean
+                  type: object
+                description:
+                  description: Description is a user-defined description of the service level objective. Always included in service level objective responses (but may be null). Optional in create/update requests.
+                  type: string
+                groups:
+                  description: Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective. Included in service level objective responses if it is not empty. Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                monitorIDs:
+                  description: MonitorIDs is a list of monitor IDs that defines the scope of a monitor service level objective. Required if type is monitor.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                  x-kubernetes-list-type: set
+                name:
+                  description: Name is the name of the service level objective.
+                  type: string
+                query:
+                  description: Query is the query for a metric-based SLO. Required if type is metric. Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                  properties:
+                    denominator:
+                      description: Denominator is a Datadog metric query for total (valid) events.
+                      type: string
+                    numerator:
+                      description: Numerator is a Datadog metric query for good events.
+                      type: string
+                  required:
+                    - denominator
+                    - numerator
+                  type: object
+                tags:
+                  description: 'Tags is a list of tags to associate with your service level objective. This can help you categorize and filter service level objectives in the service level objectives page of the UI. Note: it''s not currently possible to filter by these tags when querying via the API.'
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                targetThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: TargetThreshold is the target threshold such that when the service level indicator is above this threshold over the given timeframe, the objective is being met.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                timeframe:
+                  description: The SLO time window options.
+                  type: string
+                type:
+                  description: Type is the type of the service level objective.
+                  type: string
+                warningThreshold:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: WarningThreshold is a optional warning threshold such that when the service level indicator is below this value for the given threshold, but above the target threshold, the objective appears in a "warning" state. This value must be greater than the target threshold.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              required:
+                - name
+                - targetThreshold
+                - timeframe
+                - type
+              type: object
+            status:
+              description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogSLO.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the SLO was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the SLO creator.
+                  type: string
+                currentHash:
+                  description: CurrentHash tracks the hash of the current DatadogSLOSpec to know if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the SLO ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API SLO was last force synced with the DatadogSLO resource.
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the SLO state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
#### What this PR does / why we need it:
Update CRDs for Operator 1.3.0 release. 


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
