### PR TITLE
[APM instrumentation] Use boolean comparison directly in NOTES template

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.49.3
+
+* Fix NOTES warning for APM Instrumentation when apm.intrumentation.disabledNamespaces is set
+
 ## 3.49.2
 
 * Fix check for APM Instrumentation when apm.intrumentation.disabledNamespaces is set 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.49.2
+version: 3.49.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.49.2](https://img.shields.io/badge/Version-3.49.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.49.3](https://img.shields.io/badge/Version-3.49.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -176,7 +176,7 @@ APM Single Step Instrumentation will be enabled in the whole cluster.
 
 {{- end }}
 
-{{- if and .Values.datadog.apm.instrumentation.disabled_namespaces (eq .Values.datadog.apm.instrumentation.enabled "false") }}
+{{- if and .Values.datadog.apm.instrumentation.disabled_namespaces (not .Values.datadog.apm.instrumentation.enabled) }}
 
 #################################################################
 ####               WARNING: Configuration notice             ####


### PR DESCRIPTION
#### What this PR does / why we need it:
* Uses boolean comparison as `datadog.apm.instrumentation.enabled` is a boolean instead of relying on `eq` type conversion : this prevents the Agent installation when `datadog.apm.instrumentation.disabled_namespaces` is set

#### Which issue this PR fixes
* https://github.com/DataDog/helm-charts/issues/1249

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
