### PR TITLE
Mount host package manager database when host SBOM is enabled

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.49.8
+
+* Mount host package manager database when host SBOM is enabled.
+
 ## 3.49.7
 
 Fix NOTES warning for APM Instrumentation
@@ -10,7 +14,7 @@ Get rid of the old GODEBUG=x509ignoreCN=0 hack that is not effective anymore in 
 
 ## 3.49.5
 
-Fix registry selection with GKE Autopilot until new registries are allowed.
+* Fix registry selection with GKE Autopilot until new registries are allowed.
 
 ## 3.49.4
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.49.7
+version: 3.49.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.49.7](https://img.shields.io/badge/Version-3.49.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.49.8](https://img.shields.io/badge/Version-3.49.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -175,7 +175,7 @@
     - name: DD_SBOM_HOST_ENABLED
       value: "true"
     - name: HOST_ROOT
-      value: /host/root
+      value: /host
     {{- end }}
     {{- end }}
     {{- include "additional-env-entries" .Values.agents.containers.agent.env | indent 4 }}
@@ -255,8 +255,14 @@
     {{- end }}
     {{- end }}
     {{- if .Values.datadog.sbom.host.enabled }}
-    - name: hostroot
-      mountPath: /host/root
+    - name: host-apk-dir
+      mountPath: /host/var/lib/apk
+      readOnly: true
+    - name: host-dpkg-dir
+      mountPath: /host/var/lib/dpkg
+      readOnly: true
+    - name: host-rpm-dir
+      mountPath: /host/var/lib/rpm
       readOnly: true
     {{- end }}
     {{- end }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -174,6 +174,8 @@
     {{- if .Values.datadog.sbom.host.enabled }}
     - name: DD_SBOM_HOST_ENABLED
       value: "true"
+    - name: HOST_ROOT
+      value: /host/root
     {{- end }}
     {{- end }}
     {{- include "additional-env-entries" .Values.agents.containers.agent.env | indent 4 }}
@@ -251,6 +253,11 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
     {{- end }}
+    {{- end }}
+    {{- if .Values.datadog.sbom.host.enabled }}
+    - name: hostroot
+      mountPath: /host/root
+      readOnly: true
     {{- end }}
     {{- end }}
     {{- if eq .Values.targetSystem "windows" }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -141,7 +141,7 @@
     path: /etc/passwd
   name: passwd
 {{- end }}
-{{- if or (and (eq (include "should-enable-system-probe" .) "true") .Values.datadog.serviceMonitoring.enabled) (and (eq (include "should-enable-security-agent" .) "true") .Values.datadog.securityAgent.compliance.enabled) }}
+{{- if or (and (eq (include "should-enable-system-probe" .) "true") .Values.datadog.serviceMonitoring.enabled) (and (eq (include "should-enable-security-agent" .) "true") .Values.datadog.securityAgent.compliance.enabled) .Values.datadog.sbom.host.enabled }}
 - hostPath:
     path: /
   name: hostroot

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -9,13 +9,12 @@
 - hostPath:
     path: /sys/fs/cgroup
   name: cgroups
-{{- if and (not .Values.providers.gke.autopilot) (or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath) }}
+{{- if and (not .Values.providers.gke.autopilot) (or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath .Values.datadog.sbom.host.enabled) }}
 - hostPath:
     path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   name: os-release-file
 {{- end }}
-{{- if eq (include "should-enable-system-probe" .) "true" }}
-{{- if .Values.datadog.systemProbe.enableDefaultOsReleasePaths }}
+{{- if or (and (eq (include "should-enable-system-probe" .) "true") .Values.datadog.systemProbe.enableDefaultOsReleasePaths) .Values.datadog.sbom.host.enabled }}
 - hostPath:
     path: /etc/redhat-release
   name: etc-redhat-release
@@ -25,7 +24,6 @@
 - hostPath:
     path: /etc/lsb-release
   name: etc-lsb-release
-{{- end }}
 {{- end -}}
 {{- if eq (include "should-enable-fips" . ) "true" }}
 {{ include "linux-container-fips-proxy-cfg-volume" . }}
@@ -141,10 +139,21 @@
     path: /etc/passwd
   name: passwd
 {{- end }}
-{{- if or (and (eq (include "should-enable-system-probe" .) "true") .Values.datadog.serviceMonitoring.enabled) (and (eq (include "should-enable-security-agent" .) "true") .Values.datadog.securityAgent.compliance.enabled) .Values.datadog.sbom.host.enabled }}
+{{- if or (and (eq (include "should-enable-system-probe" .) "true") .Values.datadog.serviceMonitoring.enabled) (and (eq (include "should-enable-security-agent" .) "true") .Values.datadog.securityAgent.compliance.enabled) }}
 - hostPath:
     path: /
   name: hostroot
+{{- end }}
+{{- if .Values.datadog.sbom.host.enabled }}
+- hostPath:
+    path: /var/lib/apk
+  name: host-apk-dir
+- hostPath:
+    path: /var/lib/dpkg
+  name: host-dpkg-dir
+- hostPath:
+    path: /var/lib/rpm
+  name: host-rpm-dir
 {{- end }}
 {{- if eq  (include "should-enable-security-agent" .) "true" }}
 {{- if .Values.datadog.securityAgent.compliance.enabled }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This fixes a bug a customer has been facing when enabling host SBOM (`datadog.sbom.host.enabled`)
When the feature is enabled, the agent needs to have access to the package manager databases of the host.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
