### PR TITLE
[APM Onboarding] Fix NOTES for APM Instrumentation

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.49.6
+
+Fix NOTES warning for APM Instrumentation
+
 ## 3.49.5
 
 Fix registry selection with GKE Autopilot until new registries are allowed.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.49.5
+version: 3.49.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.49.5](https://img.shields.io/badge/Version-3.49.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.49.6](https://img.shields.io/badge/Version-3.49.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -125,13 +125,13 @@ Trace Agent liveness probe port ({{ $liveness.port }}) is different from the con
 The Datadog Agent is listening on port {{ $apmPort }} for APM service.
 {{- end }}
 
-{{- if and .Values.datadog.apm.instrumentation.enabled_namespaces .Values.datadog.apm.instrumentation.disabled_namespaces }}
+{{- if and .Values.datadog.apm.instrumentation.enabledNamespaces .Values.datadog.apm.instrumentation.disabledNamespaces }}
 
 ###################################################################################
 ####               ERROR: APM Single Step Instrumentation misconfiguration     ####
 ###################################################################################
 
-{{- fail "The options `datadog.apm.instrumentation.enabled_namespaces` and `datadog.apm.instrumentation.disabled_namespaces` cannot be set together." }}
+{{- fail "The options `datadog.apm.instrumentation.enabledNamespaces` and `datadog.apm.instrumentation.disabledNamespaces` cannot be set together." }}
 
 {{- end }}
 
@@ -161,28 +161,28 @@ The Datadog Agent is listening on port {{ $apmPort }} for APM service.
 ####               WARNING: Configuration notice             ####
 #################################################################
 
-You are using datadog.apm.instrumentation.enabled_namespaces but you disabled the cluster agent. This configuration is unsupported and Kubernetes resource monitoring has been turned off.
+You are using datadog.apm.instrumentation.enabledNamespaces but you disabled the cluster agent. This configuration is unsupported and Kubernetes resource monitoring has been turned off.
 To enable it please set clusterAgent.enabled to 'true'.
 {{- end }}
 
-{{- if and .Values.datadog.apm.instrumentation.enabled .Values.datadog.apm.instrumentation.enabled_namespaces }}
+{{- if and .Values.datadog.apm.instrumentation.enabled .Values.datadog.apm.instrumentation.enabledNamespaces }}
 
 #################################################################
 ####               WARNING: Configuration notice             ####
 #################################################################
 
-The options `datadog.apm.instrumentation.enabled` and `datadog.apm.instrumentation.enabled_namespaces` are set together.
+The options `datadog.apm.instrumentation.enabled` and `datadog.apm.instrumentation.enabledNamespaces` are set together.
 APM Single Step Instrumentation will be enabled in the whole cluster.
 
 {{- end }}
 
-{{- if and .Values.datadog.apm.instrumentation.disabled_namespaces (not .Values.datadog.apm.instrumentation.enabled) }}
+{{- if and .Values.datadog.apm.instrumentation.disabledNamespaces (not .Values.datadog.apm.instrumentation.enabled) }}
 
 #################################################################
 ####               WARNING: Configuration notice             ####
 #################################################################
 
-The option `datadog.apm.instrumentation.disabled_namespaces` is set while `datadog.apm.instrumentation.enabled` is disabled.
+The option `datadog.apm.instrumentation.disabledNamespaces` is set while `datadog.apm.instrumentation.enabled` is disabled.
 APM Single Step Instrumentation will be disabled in the whole cluster.
 
 {{- end }}


### PR DESCRIPTION
NOTES template has a bug of using snake case formatted Single Step Instrumentation configuration instead of camel case.

With this fix, configuration like
```
  apm:
    enabled: false
    socketEnabled: true
    instrumentation:
      enabled: true
      disabledNamespaces:
      - default
      enabledNamespaces:
      - datadog
      - rc-tests
      libVersions: []
```
will result in the error
```
➜  helm-charts git:(liliya.belaus/fix-ssi-notes) helm install dd2 ./charts/datadog --dry-run --debug -n datadog -f ~/values-test-cluster.yaml
install.go:200: [debug] Original chart version: ""
install.go:217: [debug] CHART PATH: /Users/liliya.belaus/dd/helm-charts/charts/datadog

coalesce.go:220: warning: cannot overwrite table with non table for datadog.datadog.apm.instrumentation.libVersions (map[])
coalesce.go:220: warning: cannot overwrite table with non table for datadog.datadog.apm.instrumentation.libVersions (map[])
Error: INSTALLATION FAILED: execution error at (datadog/templates/NOTES.txt:134:4): The options `datadog.apm.instrumentation.enabledNamespaces` and `datadog.apm.instrumentation.disabledNamespaces` cannot be set together.
helm.go:84: [debug] execution error at (datadog/templates/NOTES.txt:134:4): The options `datadog.apm.instrumentation.enabledNamespaces` and `datadog.apm.instrumentation.disabledNamespaces` cannot be set together.
INSTALLATION FAILED
main.newInstallCmd.func2
	helm.sh/helm/v3/cmd/helm/install.go:147
github.com/spf13/cobra.(*Command).execute
	github.com/spf13/cobra@v1.6.1/command.go:916
github.com/spf13/cobra.(*Command).ExecuteC
	github.com/spf13/cobra@v1.6.1/command.go:1044
github.com/spf13/cobra.(*Command).Execute
	github.com/spf13/cobra@v1.6.1/command.go:968
main.main
	helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
	runtime/proc.go:250
runtime.goexit
	runtime/asm_arm64.s:1172
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
