### PR TITLE
[AIT-8952] Generate DD_INSTRUMENTATION_INSTALL_TIME and DD_INSTRUMENTATION_INSTALL_ID

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.50.0
 
+Add env variables to support APM Telemetry KPIs to Tracer Agent
+
+## 3.50.0
+
 Add env variables to support APM Telemetry KPIs
 
 ## 3.49.7

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.51.0
 
-* Add env variables to support APM Telemetry KPIs
+* Add `DD_INSTRUMENTATION_INSTALL_TIME`, `DD_INSTRUMENTATION_INSTALL_ID`, `DD_INSTRUMENTATION_INSTALL_TYPE` env variables to the Trace and Cluster agents to support APM Telemetry KPIs.
 
 ## 3.50.5
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.51.0
 
-* Add env variables to support APM Telemetry KPIs to Tracer Agent
+* Add env variables to support APM Telemetry KPIs
 
 # 3.50.2
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.50.0
+
+Add env variables to support APM Telemetry KPIs
+
 ## 3.49.5
 
 Fix registry selection with GKE Autopilot until new registries are allowed.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.50.0
+## 3.50.1
 
 Add env variables to support APM Telemetry KPIs to Tracer Agent
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,10 +1,6 @@
 apiVersion: v1
 name: datadog
-<<<<<<< HEAD
 version: 3.51.0
-=======
-version: 3.50.5
->>>>>>> origin/main
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.50.0
+version: 3.50.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.49.5
+version: 3.50.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,10 +1,6 @@
 # Datadog
 
-<<<<<<< HEAD
 ![Version: 3.51.0](https://img.shields.io/badge/Version-3.51.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
-=======
-![Version: 3.50.5](https://img.shields.io/badge/Version-3.50.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
->>>>>>> origin/main
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.49.5](https://img.shields.io/badge/Version-3.49.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.50.0](https://img.shields.io/badge/Version-3.50.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.50.0](https://img.shields.io/badge/Version-3.50.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.50.1](https://img.shields.io/badge/Version-3.50.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -34,6 +34,7 @@
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
     {{- include "fips-envvar" . | nindent 4 }}
+    {{- include "kpi-envvar" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.traceAgent.logLevel | default .Values.datadog.logLevel | quote }}
     - name: DD_APM_ENABLED

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -53,17 +53,17 @@
     - name: DD_INSTRUMENTATION_INSTALL_TIME
       valueFrom:
         configMapKeyRef:
-          name: kpi-telemetry-configmap
+          name: {{ .Release.Name }}-kpi-telemetry-configmap
           key: install_time
     - name: DD_INSTRUMENTATION_INSTALL_ID
       valueFrom:
         configMapKeyRef:
-          name: kpi-telemetry-configmap
+          name: {{ .Release.Name }}-kpi-telemetry-configmap
           key: install_id
     - name: DD_INSTRUMENTATION_INSTALL_TYPE
       valueFrom:
         configMapKeyRef:
-          name: kpi-telemetry-configmap
+          name: {{ .Release.Name }}-kpi-telemetry-configmap
           key: install_type
     {{- include "additional-env-entries" .Values.agents.containers.traceAgent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.traceAgent.envDict | indent 4 }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -34,7 +34,6 @@
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
     {{- include "fips-envvar" . | nindent 4 }}
-    {{- include "kpi-envvar" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.traceAgent.logLevel | default .Values.datadog.logLevel | quote }}
     - name: DD_APM_ENABLED
@@ -51,6 +50,21 @@
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
     {{- end }}
+    - name: DD_INSTRUMENTATION_INSTALL_TIME
+      valueFrom:
+        configMapKeyRef:
+          name: kpi-telemetry-configmap
+          key: install_time
+    - name: DD_INSTRUMENTATION_INSTALL_ID
+      valueFrom:
+        configMapKeyRef:
+          name: kpi-telemetry-configmap
+          key: install_id
+    - name: DD_INSTRUMENTATION_INSTALL_TYPE
+      valueFrom:
+        configMapKeyRef:
+          name: kpi-telemetry-configmap
+          key: install_type
     {{- include "additional-env-entries" .Values.agents.containers.traceAgent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.traceAgent.envDict | indent 4 }}
   volumeMounts:

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -158,4 +158,6 @@ Return a list of env-vars if the cluster-agent is enabled
   value: {{ now | unixEpoch | quote }}
 - name: DD_INSTRUMENTATION_INSTALL_ID
   value: {{ uuidv4 | quote }}
+- name: DD_INSTRUMENTATION_INSTALL_TYPE
+  value: placeholder
 {{- end -}}

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -151,3 +151,11 @@ Return a list of env-vars if the cluster-agent is enabled
         key: token
 {{- end }}
 {{- end -}}
+
+
+{{- define "kpi-envvar" -}}
+- name: DD_INSTRUMENTATION_INSTALL_TIME
+  value: {{ now | unixEpoch | quote }}
+- name: DD_INSTRUMENTATION_INSTALL_ID
+  value: {{ uuidv4 | quote }}
+{{- end -}}

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -151,4 +151,3 @@ Return a list of env-vars if the cluster-agent is enabled
         key: token
 {{- end }}
 {{- end -}}
-

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -152,12 +152,3 @@ Return a list of env-vars if the cluster-agent is enabled
 {{- end }}
 {{- end -}}
 
-
-{{- define "kpi-envvar" -}}
-- name: DD_INSTRUMENTATION_INSTALL_TIME
-  value: {{ now | unixEpoch | quote }}
-- name: DD_INSTRUMENTATION_INSTALL_ID
-  value: {{ uuidv4 | quote }}
-- name: DD_INSTRUMENTATION_INSTALL_TYPE
-  value: placeholder
-{{- end -}}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -328,8 +328,22 @@ spec:
             value: {{ .Values.datadog.prometheusScrape.version | quote }}
           {{- end }}
           {{- end }}
+          - name: DD_INSTRUMENTATION_INSTALL_TIME
+            valueFrom:
+              configMapKeyRef:
+                name: kpi-telemetry-configmap
+                key: install_time
+          - name: DD_INSTRUMENTATION_INSTALL_ID
+            valueFrom:
+              configMapKeyRef:
+                name: kpi-telemetry-configmap
+                key: install_id
+          - name: DD_INSTRUMENTATION_INSTALL_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: kpi-telemetry-configmap
+                key: install_type
           {{- include "fips-envvar" . | nindent 10 }}
-          {{- include "kpi-envvar" . | nindent 10 }}
           {{- include "additional-env-entries" .Values.clusterAgent.env | indent 10 }}
           {{- include "additional-env-dict-entries" .Values.clusterAgent.envDict | indent 10 }}
         livenessProbe:

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -252,10 +252,6 @@ spec:
           - name: DD_APM_INSTRUMENTATION_LIB_VERSIONS
             value: {{ .Values.datadog.apm.instrumentation.libVersions | toJson | quote }}
           {{- end }}
-          - name: DD_INSTRUMENTATION_INSTALL_TIME
-            value: {{ now | unixEpoch | quote }}
-          - name: DD_INSTRUMENTATION_INSTALL_ID
-            value: {{ uuidv4 | b64enc | quote }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED
             value: {{ .Values.datadog.clusterChecks.enabled | quote }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -329,6 +329,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- include "fips-envvar" . | nindent 10 }}
+          {{- include "kpi-envvar" . | nindent 10 }}
           {{- include "additional-env-entries" .Values.clusterAgent.env | indent 10 }}
           {{- include "additional-env-dict-entries" .Values.clusterAgent.envDict | indent 10 }}
         livenessProbe:

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -331,17 +331,17 @@ spec:
           - name: DD_INSTRUMENTATION_INSTALL_TIME
             valueFrom:
               configMapKeyRef:
-                name: kpi-telemetry-configmap
+                name: {{ .Release.Name }}-kpi-telemetry-configmap
                 key: install_time
           - name: DD_INSTRUMENTATION_INSTALL_ID
             valueFrom:
               configMapKeyRef:
-                name: kpi-telemetry-configmap
+                name: {{ .Release.Name }}-kpi-telemetry-configmap
                 key: install_id
           - name: DD_INSTRUMENTATION_INSTALL_TYPE
             valueFrom:
               configMapKeyRef:
-                name: kpi-telemetry-configmap
+                name: {{ .Release.Name }}-kpi-telemetry-configmap
                 key: install_type
           {{- include "fips-envvar" . | nindent 10 }}
           {{- include "additional-env-entries" .Values.clusterAgent.env | indent 10 }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -252,6 +252,10 @@ spec:
           - name: DD_APM_INSTRUMENTATION_LIB_VERSIONS
             value: {{ .Values.datadog.apm.instrumentation.libVersions | toJson | quote }}
           {{- end }}
+          - name: DD_INSTRUMENTATION_INSTALL_TIME
+            value: {{ now | unixEpoch | quote }}
+          - name: DD_INSTRUMENTATION_INSTALL_ID
+            value: {{ uuidv4 | b64enc | quote }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED
             value: {{ .Values.datadog.clusterChecks.enabled | quote }}

--- a/charts/datadog/templates/kpi-telemetry-configmap.yaml
+++ b/charts/datadog/templates/kpi-telemetry-configmap.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kpi-telemetry-configmap
+  name: {{ .Release.Name }}-kpi-telemetry-configmap
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}
 data:
   install_id: {{ uuidv4 | quote }}
-  install_type: unknown
+  install_type: k8s_manual
   install_time: {{ now | unixEpoch | quote }}

--- a/charts/datadog/templates/kpi-telemetry-configmap.yaml
+++ b/charts/datadog/templates/kpi-telemetry-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kpi-telemetry-configmap
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "datadog.labels" . | indent 4 }}
+data:
+  install_id: {{ uuidv4 | quote }}
+  install_type: unknown
+  install_time: {{ now | unixEpoch | quote }}


### PR DESCRIPTION
Generates DD_INSTRUMENTATION_INSTALL_TIME and DD_INSTRUMENTATION_INSTALL_ID on installation of Cluster Agent. These env variables are used to power [APM time-to-value KPI](https://docs.google.com/document/d/14vsrCbnAKnXmJAkacX9I6jKPGKmxsq0PKUb3dfiZpWE/edit#heading=h.8d3o7vtyu1y1)

https://datadoghq.atlassian.net/browse/AIT-8952

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
