### PR TITLE
Fix VolumeMounts for Agent container when sbom host is enabled

### DIFF
--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -174,6 +174,8 @@
     {{- if .Values.datadog.sbom.host.enabled }}
     - name: DD_SBOM_HOST_ENABLED
       value: "true"
+    - name: HOST_ROOT
+      value: /host/root
     {{- end }}
     {{- end }}
     {{- include "additional-env-entries" .Values.agents.containers.agent.env | indent 4 }}
@@ -212,6 +214,11 @@
       readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
+    {{- if .Values.datadog.sbom.host.enabled }}
+    - name: hostroot
+      mountPath: /host/root
+      readOnly: true
+    {{- end }}
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: false


### PR DESCRIPTION
#### What this PR does / why we need it:
When sbom host is enabled, the agent container fails with a 
When I set the necessary variables, the proper Volume to the daemonset, and VolumeMount for hostroot is set for the security-agent and system-probe container. This can be seen in the datadog helm template for those containers: [security-agent](https://github.com/DataDog/helm-charts/blob/c9fdd3f759303f0b5f27f8a633a1a92e5e4509ad/charts/datadog/templates/_container-security-agent.yaml#L100) and [system-probe](https://github.com/DataDog/helm-charts/blob/c9fdd3f759303f0b5f27f8a633a1a92e5e4509ad/charts/datadog/templates/_container-system-probe.yaml#L86).

```
datadog: 
  sbom:
    containerImage:
      enabled: true
    containerImageCollection:
      enabled: true
    host:
      enabled: true
  securityAgent:
    compliance:
      enabled: true
      host_benchmarks:
        enabled: true
    runtime:
      enabled: true
  serviceMonitoring:
    enabled: true
```

However there is nothing for the agent container, which needs the hostroot VolumeMount, otherwise the agent container crashes. To remedy this, I've added the following env vars, VolumeMount. But this results in a duplicate value for hostroot for the daemonset.

```
* spec.template.spec.containers[3].volumeMounts[24].mountPath: Invalid value: "/host/root": must be unique
* spec.template.spec.containers[4].volumeMounts[14].mountPath: Invalid value: "/host/root": must be unique
```

```
agents:
  containers:
    agent:
      env:
        - name: HOST_ROOT
          value: /host/root
  volumeMounts:
    - hostPath:
        path: /
      name: hostroot
```
Work around which is clunky involves having a separate volumeMount and volume just so I dont run into a duplicate volumemount on the security-agent and system-probe container.

```
agents:
  containers:
    agent:
      env:
        - name: HOST_ROOT
          value: /host/root2
  volumeMounts:
    - name: hostroot2
      mountPath: /host/root2
      readOnly: true
  volumes:
    - hostPath:
        path: /
      name: hostroot2
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
