### PR TITLE
Unify Dogstatsd configuration between all containers

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.50.0
+
+* Align DogStatsD configuration across all Agent containers.
+
 ## 3.49.9
 
 * Update `fips.image.tag` to `1.0.1`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.49.9
+version: 3.50.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -62,26 +62,6 @@
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}
     {{- end }}
-    {{- if .Values.datadog.dogstatsd.port }}
-    - name: DD_DOGSTATSD_PORT
-      value: {{ .Values.datadog.dogstatsd.port | quote }}
-    {{- end }}
-    {{- if .Values.datadog.dogstatsd.nonLocalTraffic }}
-    - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
-      value: {{ .Values.datadog.dogstatsd.nonLocalTraffic | quote }}
-    {{- end }}
-    {{- if .Values.datadog.dogstatsd.originDetection }}
-    - name: DD_DOGSTATSD_ORIGIN_DETECTION
-      value: {{ .Values.datadog.dogstatsd.originDetection | quote }}
-    {{- end }}
-    {{- if .Values.datadog.dogstatsd.tagCardinality }}
-    - name: DD_DOGSTATSD_TAG_CARDINALITY
-      value: {{ .Values.datadog.dogstatsd.tagCardinality | quote }}
-    {{- end }}
-    {{- if .Values.datadog.dogstatsd.tags }}
-    - name: DD_DOGSTATSD_TAGS
-      value: {{ tpl (.Values.datadog.dogstatsd.tags | join " " | quote) . }}
-    {{- end }}
     {{- if eq (include "cluster-agent-enabled" .) "false" }}
     {{- if .Values.datadog.leaderElection }}
     - name: DD_LEADER_ELECTION
@@ -113,10 +93,6 @@
     - name: DD_HEALTH_PORT
     {{- $healthPort := .Values.agents.containers.agent.healthPort }}
       value: {{ $healthPort | quote }}
-    {{- if eq .Values.targetSystem "linux" }}
-    - name: DD_DOGSTATSD_SOCKET
-      value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
-    {{- end }}
     {{- if and (eq (include "cluster-agent-enabled" .) "true") .Values.datadog.clusterChecks.enabled }}
     {{- if or (and (not .Values.existingClusterAgent.join) .Values.clusterChecksRunner.enabled) (and .Values.existingClusterAgent.join (not .Values.existingClusterAgent.clusterchecksEnabled)) }}
     - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -46,10 +46,6 @@
     - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}
     {{- end }}
-    {{- if eq .Values.targetSystem "linux" }}
-    - name: DD_DOGSTATSD_SOCKET
-      value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
-    {{- end }}
     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
       value: {{ (include "should-enable-k8s-resource-monitoring" .) | quote }}
     {{- include "additional-env-entries" .Values.agents.containers.processAgent.env | indent 4 }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -51,10 +51,6 @@
     - name: DD_RUNTIME_SECURITY_CONFIG_SOCKET
       value: /var/run/sysprobe/runtime-security.sock
     {{- end }}
-    {{- if eq .Values.targetSystem "linux" }}
-    - name: DD_DOGSTATSD_SOCKET
-      value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
-    {{- end }}
     {{- include "additional-env-entries" .Values.agents.containers.securityAgent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.securityAgent.envDict | indent 4 }}
   volumeMounts:

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -46,10 +46,6 @@
     - name: DD_APM_RECEIVER_SOCKET
       value: {{ .Values.datadog.apm.socketPath | quote }}
     {{- end }}
-    {{- if eq .Values.targetSystem "linux" }}
-    - name: DD_DOGSTATSD_SOCKET
-      value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
-    {{- end }}
     {{- include "additional-env-entries" .Values.agents.containers.traceAgent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.traceAgent.envDict | indent 4 }}
   volumeMounts:

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -1,5 +1,6 @@
 # The purpose of this template is to define a minimal set of environment
 # variables required to operate dedicated containers in the daemonset
+
 {{- define "containers-common-env" -}}
 - name: DD_API_KEY
   valueFrom:
@@ -150,4 +151,32 @@ Return a list of env-vars if the cluster-agent is enabled
         name: {{ .Values.existingClusterAgent.tokenSecretName | quote }}
         key: token
 {{- end }}
+
+# Dogstatsd configuration
+
+{{- if .Values.datadog.dogstatsd.tags }}
+- name: DD_DOGSTATSD_TAGS
+  value: {{ tpl (.Values.datadog.dogstatsd.tags | join " " | quote) . }}
+{{- end }}
+{{- if .Values.datadog.dogstatsd.port }}
+- name: DD_DOGSTATSD_PORT
+  value: {{ .Values.datadog.dogstatsd.port | quote }}
+{{- end }}
+{{- if .Values.datadog.dogstatsd.nonLocalTraffic }}
+- name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+  value: {{ .Values.datadog.dogstatsd.nonLocalTraffic | quote }}
+{{- end }}
+{{- if .Values.datadog.dogstatsd.originDetection }}
+- name: DD_DOGSTATSD_ORIGIN_DETECTION
+  value: {{ .Values.datadog.dogstatsd.originDetection | quote }}
+{{- end }}
+{{- if .Values.datadog.dogstatsd.tagCardinality }}
+- name: DD_DOGSTATSD_TAG_CARDINALITY
+  value: {{ .Values.datadog.dogstatsd.tagCardinality | quote }}
+{{- end }}
+{{- if eq .Values.targetSystem "linux" }}
+- name: DD_DOGSTATSD_SOCKET
+  value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
+{{- end }}
+
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR unify the configuration for all agents across the different containers. This PR first focus on Dogstatsd settings.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
