### PR TITLE
Parameter to enable SLO controller: rebase and sign

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.1
+
+* Add configuration for Operator flag `datadogSLOEnabled` : this parameter is used to enable the Datadog SLO Controller. It is disabled by default.
+
+## 1.4.0
+
+* Update Datadog Operator version to 1.3.0.
+
 ## 1.3.0
 
 * Add configuration to mount volumes (`volumes` and `volumeMounts`) in the container. Empty by default.
@@ -38,7 +46,7 @@
 
 ## 1.0.6
 
-* Fix conversionWebhook.enabled parameter to correctly set user-configured value when enabling the conversion webhook. 
+* Fix conversionWebhook.enabled parameter to correctly set user-configured value when enabling the conversion webhook.
 
 ## 1.0.5
 

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.3.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 ## Values
 
@@ -24,6 +24,7 @@
 | datadogCRDs.migration.datadogAgents.useCertManager | bool | `false` |  |
 | datadogCRDs.migration.datadogAgents.version | string | `"v2alpha1"` |  |
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
+| datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |
 | fullnameOverride | string | `""` |  |

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -499,6 +499,38 @@ rules:
   - list
   - watch
 - apiGroups:
+    - datadoghq.com
+  resources:
+    - datadogslos
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - datadoghq.com
+  resources:
+    - datadogslos/finalizers
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - datadoghq.com
+  resources:
+    - datadogslos/status
+  verbs:
+    - get
+    - patch
+    - update
+- apiGroups:
   - external.metrics.k8s.io
   resources:
   - '*'

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -112,6 +112,9 @@ spec:
           {{- if (semverCompare ">=1.0.0-rc.13" .Values.image.tag) }}
             - "-datadogAgentEnabled={{ .Values.datadogAgent.enabled }}"
           {{- end }}
+          {{- if (semverCompare ">=1.3.0" .Values.image.tag) }}
+            - "-datadogSLOEnabled={{ .Values.datadogSLO.enabled }}"
+          {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -73,6 +73,9 @@ datadogAgent:
 datadogMonitor:
   # datadogMonitor.enabled -- Enables the Datadog Monitor controller
   enabled: false
+datadogSLO:
+  # datadogSLO.enabled -- Enables the Datadog SLO controller
+  enabled: false
 rbac:
   # rbac.create -- Specifies whether the RBAC resources should be created
   create: true

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.4.0
+    helm.sh/chart: datadog-operator-1.4.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/managed-by: Helm
@@ -55,6 +55,7 @@ spec:
             - "-webhookEnabled=false"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
           ports:
             - name: metrics
               containerPort: 8383

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.4.0
+    helm.sh/chart: datadog-operator-1.4.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/managed-by: Helm
@@ -55,6 +55,7 @@ spec:
             - "-webhookEnabled=true"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
           ports:
             - name: metrics
               containerPort: 8383


### PR DESCRIPTION
#### What this PR does / why we need it:
SLO controller has been released in datadog-operator 1.3.0 and we need a flag to enable it.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
