### PR TITLE
[Synthetics] Allow specifying PriorityClass for pods

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.15.23
+
+* Add `priorityClassName` value to specify PriorityClass for pods.
+
 ## 0.15.22
 
 * Update private location image version to `1.43.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.22
+version: 0.15.23
 appVersion: 1.43.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.22](https://img.shields.io/badge/Version-0.15.22-informational?style=flat-square) ![AppVersion: 1.43.0](https://img.shields.io/badge/AppVersion-1.43.0-informational?style=flat-square)
+![Version: 0.15.23](https://img.shields.io/badge/Version-0.15.23-informational?style=flat-square) ![AppVersion: 1.43.0](https://img.shields.io/badge/AppVersion-1.43.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -46,6 +46,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | nodeSelector | object | `{}` | Allows to schedule Datadog Synthetics Private Location on specific nodes |
 | podAnnotations | object | `{}` | Annotations to set to Datadog Synthetics Private Location PODs |
 | podSecurityContext | object | `{}` | Security context to set to Datadog Synthetics Private Location PODs |
+| priorityClassName | string | `""` | Allows to specify PriorityClass for Datadog Synthetics Private Location PODs |
 | replicaCount | int | `1` | Number of instances of Datadog Synthetics Private Location |
 | resources | object | `{}` | Set resources requests/limits for Datadog Synthetics Private Location PODs |
 | securityContext | object | `{}` | Security context to set to the Datadog Synthetics Private Location container |

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       {{ if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy}}
       {{ end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -115,3 +115,7 @@ hostAliases: []
 # enableStatusProbes -- Enable both liveness and readiness probes (minimal private location image version required: 1.12.0)
 enableStatusProbes: false
   # Requires to be in sync with `enableStatusProbes` in the configuration of the private location worker
+
+
+# priorityClassName -- Allows to specify PriorityClass for Datadog Synthetics Private Location PODs
+priorityClassName: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows user to specify [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) they want to use for Private Location PODs. 
My use case is to guarantee that Private Location pods have higher priority than application pods during scheduling and can't be evicted by app pods in case of resource pressure on the k8s node.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
