### PR TITLE
Support new registries for GKE Autopilot

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 3.50.1
+
+* Support automatic registry selection based on `datadog.site` on GKE Autopilot.
+
 ## 3.50.0
 
 * Set default `Agent` and `Cluster-Agent` version to `7.50.1`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.50.0
+version: 3.50.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.50.0](https://img.shields.io/badge/Version-3.50.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.50.1](https://img.shields.io/badge/Version-3.50.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -267,8 +267,6 @@ Return the proper registry based on datadog.site (requires .Values to be passed 
 {{- define "registry" -}}
 {{- if .registry -}}
 {{- .registry -}}
-{{- else if .providers.gke.autopilot -}}
-gcr.io/datadoghq
 {{- else if eq .datadog.site "datadoghq.eu" -}}
 eu.gcr.io/datadoghq
 {{- else if eq .datadog.site "ddog-gov.com" -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Follow-up to https://github.com/DataDog/helm-charts/pull/1258. New Datadog `allowlistedv2workloads` has been published which support the new registries. 

#### Which issue this PR fixes
  - fixes #1257

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
