### PR TITLE
Mention that public contribution commits need to be signed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,9 @@ We aim to follow high quality standards, thus your PR must follow some rules:
 - Make sure your changes are compatible (or protected) with older Kubernetes version (CI will validate this down to 1.14)
 - Make sure you updated documentation (after bumping `Chart.yaml`) by running `.github/helm-docs.sh`
 
+Additionally, your commits need to be signed and marked as verified by Github. See [About commit signature verification
+](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
+
 Our team will then happily review and merge contributions!
 
 ## Go Tests


### PR DESCRIPTION
The policy on the base branch of this repository requires all commits to be signed and verified by Github:
![image](https://github.com/DataDog/helm-charts/assets/44869593/3d34a871-a5ad-4d62-b0b7-34526273e679)

This PR adds a mention for contributors to sign their commits so that their contributions can be accepted.