### PR TITLE
[synthetics] Add comments to clarify the usage of configSecret for public PL chart

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.15.24
+
+* Clarify the usage of `configSecret`
+
 ## 0.15.23
 
 * Add `priorityClassName` value to specify PriorityClass for pods.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.23
+version: 0.15.24
 appVersion: 1.43.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -29,7 +29,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | commonLabels | object | `{}` | Labels to apply to all resources |
 | configConfigMap | string | `""` | Config Map that stores the configuration of the private location worker for the deployment |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
-| configSecret | string | `""` | Secret that stores the configuration of the private location worker for the deployment |
+| configSecret | string | `""` | Name of the secret that stores the configuration of the private location worker for the deployment. Only if you want to manage the secret outside of the Helm chart as using `configFile` will create a secret. The `data` inside the secret needs to have the key `synthetics-check-runner.json`. |
 | dnsPolicy | string | `"ClusterFirst"` | DNS Policy to set to the Datadog Synthetics Private Location PODs |
 | enableStatusProbes | bool | `false` | Enable both liveness and readiness probes (minimal private location image version required: 1.12.0) |
 | env | list | `[]` | Set environment variables |

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.23](https://img.shields.io/badge/Version-0.15.23-informational?style=flat-square) ![AppVersion: 1.43.0](https://img.shields.io/badge/AppVersion-1.43.0-informational?style=flat-square)
+![Version: 0.15.24](https://img.shields.io/badge/Version-0.15.24-informational?style=flat-square) ![AppVersion: 1.43.0](https://img.shields.io/badge/AppVersion-1.43.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -29,7 +29,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | commonLabels | object | `{}` | Labels to apply to all resources |
 | configConfigMap | string | `""` | Config Map that stores the configuration of the private location worker for the deployment |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |
-| configSecret | string | `""` | Name of the secret that stores the configuration of the private location worker for the deployment. Only if you want to manage the secret outside of the Helm chart as using `configFile` will create a secret. The `data` inside the secret needs to have the key `synthetics-check-runner.json`. |
+| configSecret | string | `""` | Name of the secret that stores the configuration of the private location worker for the deployment. Use it only if you want to manage the secret outside of the Helm chart as using `configFile` will create a secret. The `data` inside the secret needs to have the key `synthetics-check-runner.json`. |
 | dnsPolicy | string | `"ClusterFirst"` | DNS Policy to set to the Datadog Synthetics Private Location PODs |
 | enableStatusProbes | bool | `false` | Enable both liveness and readiness probes (minimal private location image version required: 1.12.0) |
 | env | list | `[]` | Set environment variables |

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -91,7 +91,7 @@ configFile: "{}"
 # configConfigMap -- Config Map that stores the configuration of the private location worker for the deployment
 configConfigMap: ""
 
-# configSecret -- Secret that stores the configuration of the private location worker for the deployment
+# configSecret -- Name of the secret that stores the configuration of the private location worker for the deployment. Use it only if you want to manage the secret outside of the Helm chart as using `configFile` will create a secret. The `data` inside the secret needs to have the key `synthetics-check-runner.json`.
 configSecret: ""
 
 # envFrom -- Set environment variables from configMaps and/or secrets


### PR DESCRIPTION
This PR clarifies the usage of `configSecret` in the `synthetics-private-location` chart.

It is only used if you want to manage the secret holding the configuration outside of the Helm chart, and it needs to have a given format (key name needs to be `synthetics-check-runner.json`).