### PR TITLE
Add option to use containerd snapshotter to generate SBOMs

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.50.5
+
+* Add option to use containerd snapshotter to generate SBOMs.
+
 ## 3.50.4
 
 * Mount host files for proper OS detection in SBOMs.
@@ -8,7 +12,7 @@
 
 * Set default `Agent` and `Cluster-Agent` version to `7.50.3`.
 
-# 3.50.2
+## 3.50.2
 
 * Support automatic registry selection based on `datadog.site` on GKE Autopilot.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.50.4
+version: 3.50.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -761,7 +761,7 @@ helm install <RELEASE_NAME> \
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. |
 | datadog.remoteConfiguration.enabled | bool | `true` | Set to true to enable remote configuration. Consider using remoteConfiguration.enabled instead |
 | datadog.sbom.containerImage.enabled | bool | `false` | Enable SBOM collection for container images |
-| datadog.sbom.containerImage.uncompressedLayersSupport | bool | `false` | Use container runtime snapshotter This should be set to true when using EKS, GKE or if containerd is configured to discard uncompressed layers. |
+| datadog.sbom.containerImage.uncompressedLayersSupport | bool | `false` | Use container runtime snapshotter This should be set to true when using EKS, GKE or if containerd is configured to discard uncompressed layers. This feature requires the SYS_ADMIN capability to be added to the Agent container. |
 | datadog.sbom.host.enabled | bool | `false` | Enable SBOM collection for host filesystems |
 | datadog.secretAnnotations | object | `{}` |  |
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.50.4](https://img.shields.io/badge/Version-3.50.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.50.5](https://img.shields.io/badge/Version-3.50.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -761,6 +761,7 @@ helm install <RELEASE_NAME> \
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. |
 | datadog.remoteConfiguration.enabled | bool | `true` | Set to true to enable remote configuration. Consider using remoteConfiguration.enabled instead |
 | datadog.sbom.containerImage.enabled | bool | `false` | Enable SBOM collection for container images |
+| datadog.sbom.containerImage.uncompressedLayersSupport | bool | `false` | Use container runtime snapshotter This should be set to true when using EKS, GKE or if containerd is configured to discard uncompressed layers. |
 | datadog.sbom.host.enabled | bool | `false` | Enable SBOM collection for host filesystems |
 | datadog.secretAnnotations | object | `{}` |  |
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -761,7 +761,7 @@ helm install <RELEASE_NAME> \
 | datadog.prometheusScrape.version | int | `2` | Version of the openmetrics check to schedule by default. |
 | datadog.remoteConfiguration.enabled | bool | `true` | Set to true to enable remote configuration. Consider using remoteConfiguration.enabled instead |
 | datadog.sbom.containerImage.enabled | bool | `false` | Enable SBOM collection for container images |
-| datadog.sbom.containerImage.uncompressedLayersSupport | bool | `false` | Use container runtime snapshotter This should be set to true when using EKS, GKE or if containerd is configured to discard uncompressed layers. This feature requires the SYS_ADMIN capability to be added to the Agent container. |
+| datadog.sbom.containerImage.uncompressedLayersSupport | bool | `false` | Use container runtime snapshotter This should be set to true when using EKS, GKE or if containerd is configured to discard uncompressed layers. This feature will cause the SYS_ADMIN capability to be added to the Agent container. |
 | datadog.sbom.host.enabled | bool | `false` | Enable SBOM collection for host filesystems |
 | datadog.secretAnnotations | object | `{}` |  |
 | datadog.secretBackend.arguments | string | `nil` | Configure the secret backend command arguments (space-separated strings). |

--- a/charts/datadog/ci/agent-sbom-snapshotter.yaml
+++ b/charts/datadog/ci/agent-sbom-snapshotter.yaml
@@ -1,0 +1,8 @@
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  site: datadoghq.eu
+  sbom:
+    containerImage:
+      enabled: true
+      uncompressedLayersSupport: true

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -3,7 +3,12 @@
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
   command: ["agent", "run"]
+{{- if .Values.datadog.sbom.containerImage.uncompressedLayersSupport -}}
+{{- $capabilities := dict "capabilities" (dict "add" (list "SYS_ADMIN")) }}
+{{ include "generate-security-context" (dict "securityContext" (merge $capabilities .Values.agents.containers.agent.securityContext) "targetSystem" "foobar" "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | indent 2 }}
+{{- else }}
 {{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.agent.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | indent 2 }}
+{{- end }}
   resources:
 {{ toYaml .Values.agents.containers.agent.resources | indent 4 }}
   ports:
@@ -171,6 +176,10 @@
     - name: DD_SBOM_CONTAINER_IMAGE_ENABLED
       value: "true"
     {{- end }}
+    {{- if .Values.datadog.sbom.containerImage.uncompressedLayersSupport }}
+    - name: DD_SBOM_CONTAINER_IMAGE_USE_MOUNT
+      value: "true"
+    {{- end }}
     {{- if .Values.datadog.sbom.host.enabled }}
     - name: DD_SBOM_HOST_ENABLED
       value: "true"
@@ -253,6 +262,11 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
     {{- end }}
+    {{- end }}
+    {{- if .Values.datadog.sbom.containerImage.uncompressedLayersSupport }}
+    - name: host-containerd-dir
+      mountPath: /host/var/lib/containerd
+      readOnly: true
     {{- end }}
     {{- if .Values.datadog.sbom.host.enabled }}
     - name: host-apk-dir

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -3,12 +3,7 @@
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
   command: ["agent", "run"]
-{{- if .Values.datadog.sbom.containerImage.uncompressedLayersSupport -}}
-{{- $capabilities := dict "capabilities" (dict "add" (list "SYS_ADMIN")) }}
-{{ include "generate-security-context" (dict "securityContext" (merge $capabilities .Values.agents.containers.agent.securityContext) "targetSystem" "foobar" "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | indent 2 }}
-{{- else }}
-{{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.agent.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | indent 2 }}
-{{- end }}
+{{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.agent.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version "sysAdmin" .Values.datadog.sbom.containerImage.uncompressedLayersSupport) | indent 2 }}
   resources:
 {{ toYaml .Values.agents.containers.agent.resources | indent 4 }}
   ports:

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -147,6 +147,11 @@
     path: /
   name: hostroot
 {{- end }}
+{{- if .Values.datadog.sbom.containerImage.uncompressedLayersSupport }}
+- hostPath:
+    path: /var/lib/containerd
+  name: host-containerd-dir
+{{- end }}
 {{- if .Values.datadog.sbom.host.enabled }}
 - hostPath:
     path: /var/lib/apk

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -755,7 +755,12 @@ securityContext:
   {{- end -}}
 {{- else }}
 securityContext:
+{{- if .sysAdmin }}
+{{- $capabilities := dict "capabilities" (dict "add" (list "SYS_ADMIN")) }}
+{{ toYaml (merge $capabilities .securityContext) | indent 2 }}
+{{- else }}
 {{ toYaml .securityContext | indent 2 }}
+{{- end -}}
 {{- if and .seccomp .kubeversion (semverCompare ">=1.19.0" .kubeversion) }}
   seccompProfile:
     {{- if hasPrefix "localhost/" .seccomp }}
@@ -770,6 +775,9 @@ securityContext:
     {{- end }}
 {{- end -}}
 {{- end -}}
+{{- else if .sysAdmin }}
+securityContext:
+{{ toYaml (dict "capabilities" (dict "add" (list "SYS_ADMIN"))) | indent 2 }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -58,6 +58,9 @@ spec:
         container.seccomp.security.alpha.kubernetes.io/system-probe: {{ .Values.datadog.systemProbe.seccomp }}
         {{- end }}
         {{- end }}
+        {{- if and .Values.agents.podSecurity.apparmor.enabled .Values.datadog.sbom.containerImage.uncompressedLayersSupport }}
+        container.apparmor.security.beta.kubernetes.io/agent: unconfined
+        {{- end }}
       {{- if .Values.agents.podAnnotations }}
 {{ tpl (toYaml .Values.agents.podAnnotations) . | indent 8 }}
       {{- end }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
       shareProcessNamespace: {{ .Values.agents.shareProcessNamespace }}
       {{- end }}
       {{- if .Values.datadog.securityContext -}}
-      {{ include "generate-security-context" (dict "securityContext" .Values.datadog.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | nindent 6 }}
+      {{ include "generate-security-context" (dict "securityContext" .Values.datadog.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version ) | nindent 6 }}
       {{- else if or .Values.agents.podSecurity.podSecurityPolicy.create .Values.agents.podSecurity.securityContextConstraints.create -}}
       {{- if .Values.agents.podSecurity.securityContext }}
       {{- if .Values.agents.podSecurity.securityContext.seLinuxOptions }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -709,6 +709,7 @@ datadog:
       # datadog.sbom.containerImage.uncompressedLayersSupport -- Use container runtime snapshotter
       # This should be set to true when using EKS, GKE or if containerd is configured to
       # discard uncompressed layers.
+      # This feature will cause the SYS_ADMIN capability to be added to the Agent container.
       uncompressedLayersSupport: false
 
     host:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -706,6 +706,11 @@ datadog:
       # datadog.sbom.containerImage.enabled -- Enable SBOM collection for container images
       enabled: false
 
+      # datadog.sbom.containerImage.uncompressedLayersSupport -- Use container runtime snapshotter
+      # This should be set to true when using EKS, GKE or if containerd is configured to
+      # discard uncompressed layers.
+      uncompressedLayersSupport: false
+
     host:
       # datadog.sbom.host.enabled -- Enable SBOM collection for host filesystems
       enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR set up container image scanning using the containerd snapshotter.
To do so, it bind mounts the containerd folder and adds the required
capability to mount container images. This is intended to be used when
facing the `discard_uncompress_layers` issue with containerd.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
