### PR TITLE
Fix host OS detection for SBOMs

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.50.4
+
+* Mount host files for proper OS detection in SBOMs.
+
 ## 3.50.3
 
 * Set default `Agent` and `Cluster-Agent` version to `7.50.3`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.50.3
+version: 3.50.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.50.3](https://img.shields.io/badge/Version-3.50.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.50.4](https://img.shields.io/badge/Version-3.50.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -264,6 +264,26 @@
     - name: host-rpm-dir
       mountPath: /host/var/lib/rpm
       readOnly: true
+    {{- if ne .Values.datadog.osReleasePath "/etc/redhat-release" }}
+    - name: etc-redhat-release
+      mountPath: /host/etc/redhat-release
+      readOnly: true
+    {{- end }}
+    {{- if ne .Values.datadog.osReleasePath "/etc/fedora-release" }}
+    - name: etc-fedora-release
+      mountPath: /host/etc/fedora-release
+      readOnly: true
+    {{- end }}
+    {{- if ne .Values.datadog.osReleasePath "/etc/lsb-release" }}
+    - name: etc-lsb-release
+      mountPath: /host/etc/lsb-release
+      readOnly: true
+    {{- end }}
+    {{- if ne .Values.datadog.osReleasePath "/etc/system-release" }}
+    - name: etc-system-release
+      mountPath: /host/etc/system-release
+      readOnly: true
+    {{- end }}
     {{- end }}
     {{- end }}
     {{- if eq .Values.targetSystem "windows" }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -24,6 +24,9 @@
 - hostPath:
     path: /etc/lsb-release
   name: etc-lsb-release
+- hostPath:
+    path: /etc/system-release
+  name: etc-system-release
 {{- end -}}
 {{- if eq (include "should-enable-fips" . ) "true" }}
 {{ include "linux-container-fips-proxy-cfg-volume" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds additional bind mounts of system files for proper OS detection when generating SBOM for the host. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
