### PR TITLE
[Bug fix] Use correct KPI configmap in Cluster and Trace Agents

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Datadog changelog
 
+## 3.51.2
+
+* Use correct kpi-telemetry-configmap in Cluster Agent and Trace Agent.
+
 ## 3.51.1
 
-* Parametrize the name of kpi-telemetry-configmap
+* Parametrize the name of kpi-telemetry-configmap.
 
 ## 3.51.0
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.51.1
+version: 3.51.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.51.1](https://img.shields.io/badge/Version-3.51.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.51.2](https://img.shields.io/badge/Version-3.51.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -53,17 +53,17 @@
     - name: DD_INSTRUMENTATION_INSTALL_TIME
       valueFrom:
         configMapKeyRef:
-          name: {{ .Release.Name }}-kpi-telemetry-configmap
+          name: {{ template "datadog.fullname" . }}-kpi-telemetry-configmap
           key: install_time
     - name: DD_INSTRUMENTATION_INSTALL_ID
       valueFrom:
         configMapKeyRef:
-          name: {{ .Release.Name }}-kpi-telemetry-configmap
+          name: {{ template "datadog.fullname" . }}-kpi-telemetry-configmap
           key: install_id
     - name: DD_INSTRUMENTATION_INSTALL_TYPE
       valueFrom:
         configMapKeyRef:
-          name: {{ .Release.Name }}-kpi-telemetry-configmap
+          name: {{ template "datadog.fullname" . }}-kpi-telemetry-configmap
           key: install_type
     {{- include "additional-env-entries" .Values.agents.containers.traceAgent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.traceAgent.envDict | indent 4 }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -331,17 +331,17 @@ spec:
           - name: DD_INSTRUMENTATION_INSTALL_TIME
             valueFrom:
               configMapKeyRef:
-                name: {{ .Release.Name }}-kpi-telemetry-configmap
+                name: {{ template "datadog.fullname" . }}-kpi-telemetry-configmap
                 key: install_time
           - name: DD_INSTRUMENTATION_INSTALL_ID
             valueFrom:
               configMapKeyRef:
-                name: {{ .Release.Name }}-kpi-telemetry-configmap
+                name: {{ template "datadog.fullname" . }}-kpi-telemetry-configmap
                 key: install_id
           - name: DD_INSTRUMENTATION_INSTALL_TYPE
             valueFrom:
               configMapKeyRef:
-                name: {{ .Release.Name }}-kpi-telemetry-configmap
+                name: {{ template "datadog.fullname" . }}-kpi-telemetry-configmap
                 key: install_type
           {{- include "fips-envvar" . | nindent 10 }}
           {{- include "additional-env-entries" .Values.clusterAgent.env | indent 10 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Previous bug fix PR changed the configmap name, but not its usage. Updating used configmaps in Cluster and Trace agents.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
