### PR TITLE
[observability-pipelines-worker] update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@ charts/datadog/templates/container-system-probe.yaml @DataDog/ebpf-platform @Dat
 charts/datadog/templates/system-probe-configmap.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/system-probe-init.yaml      @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/synthetics-private-location/                  @Datadog/synthetics
-charts/observability-pipelines-worker                @DataDog/observability-pipelines-worker
+charts/observability-pipelines-worker                @DataDog/observability-pipelines


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates codeowners for the Observability Pipelines chart.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
