### PR TITLE
Add support for mounting host journald persistent dir

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.54.0
+
+* Add support for mounting host journald persistent and runtime directories to the agent - `datadog.journaldMount`
+
 ## 3.53.0
 
 * Add `otlp.logs.enabled` option to datadog agent to set the `DD_OTLP_CONFIG_LOGS_ENABLED` env variable.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.53.0
+version: 3.54.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.53.0](https://img.shields.io/badge/Version-3.53.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.54.0](https://img.shields.io/badge/Version-3.54.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -705,6 +705,7 @@ helm install <RELEASE_NAME> \
 | datadog.helmCheck.valuesAsTags | object | `{}` | Collects Helm values from a release and uses them as tags (Requires Agent and Cluster Agent 7.40.0+). This requires datadog.HelmCheck.enabled to be set to true |
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.ignoreAutoConfig | list | `[]` | List of integration to ignore auto_conf.yaml. |
+| datadog.journaldMount | object | `{"enabled":false,"persistentDir":"/var/log/journal"}` | Mount the host journald persistent directory to the agent # Requires datadog.logs.enabled to be set to true, targetSystem to be "linux" to have any effect |
 | datadog.kubeStateMetricsCore.annotationsAsTags | object | `{}` | Extra annotations to collect from resources and to turn into datadog tag. |
 | datadog.kubeStateMetricsCore.collectApiServicesMetrics | bool | `false` | Enable watching apiservices objects and collecting their corresponding metrics kubernetes_state.apiservice.* (Requires Cluster Agent 7.45.0+) |
 | datadog.kubeStateMetricsCore.collectConfigMaps | bool | `true` | Enable watching configmap objects and collecting their corresponding metrics kubernetes_state.configmap.* |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -209,6 +209,7 @@
       mountPath: {{ template "datadog.confPath" . }}/auth
       readOnly: false # Need RW to write auth token
     {{- end }}
+    {{- include "container-journald-volumemounts" . | nindent 4 }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if and .Values.agents.useConfigMap (eq .Values.targetSystem "linux")}}

--- a/charts/datadog/templates/_container-journald-volumemounts.yaml
+++ b/charts/datadog/templates/_container-journald-volumemounts.yaml
@@ -1,0 +1,12 @@
+{{- define "container-journald-volumemounts" -}}
+{{- if .Values.datadog.logs.enabled }}
+{{- if .Values.datadog.journaldMount.enabled }}
+{{- if eq .Values.targetSystem "linux" }}
+- name: journaldpersistentpath
+  mountPath: {{ .Values.datadog.journaldMount.persistentDir }}
+  mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+  readOnly: true
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -195,6 +195,11 @@
     path: /var/lib/docker/containers
   name: logdockercontainerpath
 {{- end }}
+{{- if .Values.datadog.journaldMount.enabled }}
+- hostPath:
+    path: {{ .Values.datadog.journaldMount.persistentDir }}
+  name: journaldpersistentpath
+{{- end }}
 {{- end }}
 {{- if .Values.datadog.containerRuntimeSupport.enabled }}
 - hostPath:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -93,6 +93,12 @@ datadog:
   ## ref: https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
   hostVolumeMountPropagation: None
 
+  # datadog.journaldMount -- Mount the host journald persistent directory to the agent
+  ## Requires datadog.logs.enabled to be set to true, targetSystem to be "linux" to have any effect
+  journaldMount:
+    enabled: false
+    persistentDir: /var/log/journal
+
   # datadog.clusterName -- Set a unique cluster name to allow scoping hosts and Cluster Checks easily
 
   ## The name must be unique and must be dot-separated tokens with the following restrictions:


### PR DESCRIPTION
Enables journald log source to used from DaemonSet

#### What this PR does / why we need it:

The `journald` log source is not currently usable in context of a DaemonSet agent running on a k8s node. This PR adds support for mounting the host journald persistent dir into the container so that journald logs from the host can be read and submitted by the agent.

#### Which issue this PR fixes
* possibly related: #472 

#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
