### PR TITLE
fix(datadog-agent): Properly set DD_APM_ENABLED in the core agent container

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Datadog changelog
 
+## 3.53.3
+
+* Set `DD_APM_ENABLED` value in the core agent container to properly report its value.
+
 ## 3.53.2
 
-* Exclude agent pod from labels injection from the admission controller 
+* Exclude agent pod from labels injection from the admission controller
 
 ## 3.53.1
 
@@ -82,7 +86,7 @@ Get rid of the old GODEBUG=x509ignoreCN=0 hack that is not effective anymore in 
 
 ## 3.49.2
 
-* Fix check for APM Instrumentation when apm.intrumentation.disabledNamespaces is set 
+* Fix check for APM Instrumentation when apm.intrumentation.disabledNamespaces is set
 
 ## 3.49.1
 
@@ -139,7 +143,7 @@ Get rid of the old GODEBUG=x509ignoreCN=0 hack that is not effective anymore in 
 
 ## 3.42.1
 
-* Bump FIPS proxy OpenSSL version to 3.0.12 
+* Bump FIPS proxy OpenSSL version to 3.0.12
 
 ## 3.42.0
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.53.2
+version: 3.53.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.53.2](https://img.shields.io/badge/Version-3.53.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.53.3](https://img.shields.io/badge/Version-3.53.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -101,7 +101,7 @@
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
     {{- end }}
     - name: DD_APM_ENABLED
-      value: "false"
+      value: {{ include "should-enable-trace-agent" . | quote }}
     - name: DD_LOGS_ENABLED
       value: {{  (default false (or .Values.datadog.logs.enabled .Values.datadog.logsEnabled)) | quote}}
     - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL


### PR DESCRIPTION
#### What this PR does / why we need it:
The `DD_APM_ENABLED` value has always been hardcoded to `false` in the core agent container, leading to situations where APM is indeed enabled and the value of `apm.enabled` is set to false in the core agent and true in the trace agent. This hasn't been an issue until we started reporting the agent configuration to the backend, and to display it in the UI. The agent configuration is reported from the core agent, meaning that customers will see `apm.enabled: false` in the UI even if the trace agent exists.

Here we fix this by setting DD_APM_ENABLED to true in the core agent if the trace agent exists.

#### Special notes for your reviewer:
This has been reported in Zendesk

#### Checklist
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
