### PR TITLE
add agent-apm as co-owner of _container-trace-agent.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,4 @@ charts/datadog/templates/system-probe-configmap.yaml @DataDog/ebpf-platform @Dat
 charts/datadog/templates/system-probe-init.yaml      @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/synthetics-private-location/                  @Datadog/synthetics
 charts/observability-pipelines-worker                @DataDog/observability-pipelines
+charts/datadog/templates/_container-trace-agent.yaml @DataDog/agent-apm @DataDog/container-helm-chart-maintainers


### PR DESCRIPTION
#### What this PR does / why we need it:

Add agent-apm as co-owner of _container-trace-agent.yaml. The main purpose is to allow the apm agent team to be notified when changes in the trace agent container are made.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
