### PR TITLE
add(tooling): Add disktype label on kind nodes

### DIFF
--- a/.github/kind_config.yaml
+++ b/.github/kind_config.yaml
@@ -2,5 +2,11 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  labels:
+    disktype: ssd
 - role: worker
+  labels:
+    disktype: ssd
 - role: worker
+  labels:
+    disktype: ssd


### PR DESCRIPTION

#### What this PR does / why we need it:

the goal is to ease the CI migration from `kubeval` to `kubeconform` introduced by the PR #1199


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
