### PR TITLE
fix(tooling): add config file path in helm/kind-action

### DIFF
--- a/.github/kind_config.yaml
+++ b/.github/kind_config.yaml
@@ -1,12 +1,10 @@
+---
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-- role: control-plane
-  labels:
-    disktype: ssd
-- role: worker
-  labels:
-    disktype: ssd
-- role: worker
-  labels:
-    disktype: ssd
+  - role: control-plane
+    labels:
+      disktype: ssd
+  - role: worker
+    labels:
+      disktype: ssd

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,7 @@ jobs:
   install-chart:
     name: install-chart
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     needs:
       - lint-chart
       - kubeval-chart
@@ -124,6 +125,7 @@ jobs:
         uses: helm/kind-action@v1.5.0
         with:
           node_image: kindest/node:${{ matrix.k8s }}
+          config: .github/kind_config.yaml
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7


### PR DESCRIPTION
#### What this PR does / why we need it:

In previous PR #1316 I added `node` labels in the kind cluster config. But this config was not used in the CI test...

This PR add the config path to the `helm/kind-action` configuration. Also this PR fix the yaml linter.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
