### PR TITLE
Update helm chart to allow automultline extra patterns to be configured

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Datadog changelog
 
 ## 3.29.3
-* Makes automultiline extra patterns configurable in the main chart *
+* Makes automultiline extra patterns configurable in the main chart.
 
 ## 3.29.2
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 3.29.3
+* Makes automultiline extra patterns configurable in the main chart *
+
 ## 3.29.2
 
 * Default `Agent` and `Cluster-Agent` to `7.44.1` version.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Datadog changelog
 
 ## 3.29.3
-* Makes automultiline extra patterns configurable in the main chart.
+* Makes `DD_LOGS_CONFIG_AUTO_MULTI_LINE_EXTRA_PATTERNS` configurable in the main chart.
 
 ## 3.29.2
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.29.2
+version: 3.29.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -106,8 +106,10 @@
       value: {{ .Values.datadog.logs.containerCollectUsingFiles | quote }}
     - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
       value: {{ .Values.datadog.logs.autoMultiLineDetection | quote }}
+    {{- if .Values.datadog.logs.autoMultiLineExtraPatterns }}
     - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_EXTRA_PATTERNS
       value: {{ .Values.datadog.logs.autoMultiLineExtraPatterns | quote }}
+    {{- end }}
     - name: DD_HEALTH_PORT
     {{- $healthPort := .Values.agents.containers.agent.healthPort }}
       value: {{ $healthPort | quote }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -106,6 +106,8 @@
       value: {{ .Values.datadog.logs.containerCollectUsingFiles | quote }}
     - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
       value: {{ .Values.datadog.logs.autoMultiLineDetection | quote }}
+    - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_EXTRA_PATTERNS
+      value: {{ .Values.datadog.logs.autoMultiLineExtraPatterns | quote }}
     - name: DD_HEALTH_PORT
     {{- $healthPort := .Values.agents.containers.agent.healthPort }}
       value: {{ $healthPort | quote }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -410,6 +410,9 @@ datadog:
     ## ref: https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile#automatic-multi-line-aggregation
     autoMultiLineDetection: false
 
+    ## ref: https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile#automatic-multi-line-aggregation
+    autoMultiLineExtraLines: 
+
   ## Enable apm agent and provide custom configs
   apm:
     # datadog.apm.socketEnabled -- Enable APM over Socket (Unix Socket or windows named pipe)

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -411,7 +411,8 @@ datadog:
     autoMultiLineDetection: false
 
     ## ref: https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile#automatic-multi-line-aggregation
-    autoMultiLineExtraLines: 
+    ## sample line matches timestamp of [2024-01-31 10:10:10]. Configure it with a comma separated string for multiple values.
+    autoMultiLineExtraLines: #\\[\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}\\]'
 
   ## Enable apm agent and provide custom configs
   apm:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR makes `DD_LOGS_CONFIG_AUTO_MULTI_LINE_EXTRA_PATTERNS` configurable in Helm. We, technical post sales/solutions, frequently into this question and it always has to have a work around configured to allow a standard value added to thelm. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
