### PR TITLE
update datadog-crds for operator 1.4.0

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+* Update CRDs from Datadog Operator v1.4.0 tag.
+
 ## 1.3.1
 * Migrate from `kubeval` to `kubeconform` for ci chart validation.
 

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 1.3.1
+version: 1.4.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -6351,6 +6351,8 @@ spec:
                       type: object
                     clusterName:
                       type: string
+                    containerStrategy:
+                      type: string
                     credentials:
                       properties:
                         apiKey:
@@ -6378,6 +6380,8 @@ spec:
                       type: object
                     criSocketPath:
                       type: string
+                    disableNonResourceRules:
+                      type: boolean
                     dockerSocketPath:
                       type: string
                     endpoint:
@@ -8277,6 +8281,44 @@ spec:
                     - ready
                     - upToDate
                   type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
                 clusterAgent:
                   properties:
                     availableReplicas:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -6340,6 +6340,8 @@ spec:
                       type: object
                     clusterName:
                       type: string
+                    containerStrategy:
+                      type: string
                     credentials:
                       properties:
                         apiKey:
@@ -6367,6 +6369,8 @@ spec:
                       type: object
                     criSocketPath:
                       type: string
+                    disableNonResourceRules:
+                      type: boolean
                     dockerSocketPath:
                       type: string
                     endpoint:
@@ -8266,6 +8270,44 @@ spec:
                     - ready
                     - upToDate
                   type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
                 clusterAgent:
                   properties:
                     availableReplicas:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -98,6 +98,9 @@ spec:
                       description: The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.
                       format: int64
                       type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
                     notifyAudit:
                       description: A Boolean indicating whether tagged users are notified on changes to this monitor.
                       type: boolean

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1beta1.yaml
@@ -98,6 +98,9 @@ spec:
                   description: The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.
                   format: int64
                   type: integer
+                notificationPresetName:
+                  description: An enum that toggles the display of additional content sent in the monitor notification.
+                  type: string
                 notifyAudit:
                   description: A Boolean indicating whether tagged users are notified on changes to this monitor.
                   type: boolean

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -6325,6 +6325,8 @@ spec:
                       type: object
                     clusterName:
                       type: string
+                    containerStrategy:
+                      type: string
                     credentials:
                       properties:
                         apiKey:
@@ -6352,6 +6354,8 @@ spec:
                       type: object
                     criSocketPath:
                       type: string
+                    disableNonResourceRules:
+                      type: boolean
                     dockerSocketPath:
                       type: string
                     endpoint:
@@ -8251,6 +8255,44 @@ spec:
                     - ready
                     - upToDate
                   type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
                 clusterAgent:
                   properties:
                     availableReplicas:

--- a/crds/datadoghq.com_datadogmonitors.yaml
+++ b/crds/datadoghq.com_datadogmonitors.yaml
@@ -92,6 +92,9 @@ spec:
                       description: The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.
                       format: int64
                       type: integer
+                    notificationPresetName:
+                      description: An enum that toggles the display of additional content sent in the monitor notification.
+                      type: string
                     notifyAudit:
                       description: A Boolean indicating whether tagged users are notified on changes to this monitor.
                       type: boolean


### PR DESCRIPTION
#### What this PR does / why we need it:

Update datadog-crds following release of Datadog Operator 1.4.0

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
