### PR TITLE
update latest image in datadog-operator chart to 1.4.0

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.0
+
+* Update Datadog Operator version to 1.4.0.
+
 ## 1.4.2
 
 * Migrate from `kubeval` to `kubeconform` for ci chart validation.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 1.3.0
-digest: sha256:c0d897e7b5648db215c1c051fed5a3d431fadb1d92784ed0eb5b0f0f6574821e
-generated: "2023-12-11T14:56:49.631017-05:00"
+  version: 1.4.0
+digest: sha256:051b894b6d03a9a78919a1549b891592cb1aa82e59386c237b93241bdba7054c
+generated: "2024-02-15T15:04:10.736131-05:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.4.2
-appVersion: 1.3.0
+version: 1.5.0
+appVersion: 1.4.0
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "=1.3.0"
+  version: "=1.4.0"
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 ## Values
 
@@ -30,7 +30,7 @@
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.3.0"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.4.0"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | logLevel | string | `"info"` | Set Datadog Operator log level (debug, info, error, panic, fatal) |
@@ -120,7 +120,7 @@ You can update with the following:
 ```
 helm upgrade \
     datadog-operator datadog/datadog-operator \
-    --set image.tag=1.3.0 \
+    --set image.tag=1.4.0 \
     --set datadogCRDs.migration.datadogAgents.version=v2alpha1 \
     --set datadogCRDs.migration.datadogAgents.useCertManager=true \
     --set datadogCRDs.migration.datadogAgents.conversionWebhook.enabled=true

--- a/charts/datadog-operator/README.md.gotmpl
+++ b/charts/datadog-operator/README.md.gotmpl
@@ -68,7 +68,7 @@ You can update with the following:
 ```
 helm upgrade \
     datadog-operator datadog/datadog-operator \
-    --set image.tag=1.3.0 \
+    --set image.tag=1.4.0 \
     --set datadogCRDs.migration.datadogAgents.version=v2alpha1 \
     --set datadogCRDs.migration.datadogAgents.useCertManager=true \
     --set datadogCRDs.migration.datadogAgents.conversionWebhook.enabled=true

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -43,7 +43,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.3.0
+  tag: 1.4.0
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
 # imagePullSecrets -- Datadog Operator repository pullSecret (ex: specify docker registry credentials)

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -8,7 +8,7 @@ metadata:
   creationTimestamp: null
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-1.3.0'
+    helm.sh/chart: 'datadogCRDs-1.4.0'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -6330,6 +6330,8 @@ spec:
                       type: object
                     clusterName:
                       type: string
+                    containerStrategy:
+                      type: string
                     credentials:
                       properties:
                         apiKey:
@@ -6357,6 +6359,8 @@ spec:
                       type: object
                     criSocketPath:
                       type: string
+                    disableNonResourceRules:
+                      type: boolean
                     dockerSocketPath:
                       type: string
                     endpoint:
@@ -8256,6 +8260,44 @@ spec:
                     - ready
                     - upToDate
                   type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
                 clusterAgent:
                   properties:
                     availableReplicas:

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_with_certManager.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_with_certManager.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-1.3.0'
+    helm.sh/chart: 'datadogCRDs-1.4.0'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -6341,6 +6341,8 @@ spec:
                       type: object
                     clusterName:
                       type: string
+                    containerStrategy:
+                      type: string
                     credentials:
                       properties:
                         apiKey:
@@ -6368,6 +6370,8 @@ spec:
                       type: object
                     criSocketPath:
                       type: string
+                    disableNonResourceRules:
+                      type: boolean
                     dockerSocketPath:
                       type: string
                     endpoint:
@@ -8267,6 +8271,44 @@ spec:
                     - ready
                     - upToDate
                   type: object
+                agentList:
+                  items:
+                    properties:
+                      available:
+                        format: int32
+                        type: integer
+                      current:
+                        format: int32
+                        type: integer
+                      currentHash:
+                        type: string
+                      daemonsetName:
+                        type: string
+                      desired:
+                        format: int32
+                        type: integer
+                      lastUpdate:
+                        format: date-time
+                        type: string
+                      ready:
+                        format: int32
+                        type: integer
+                      state:
+                        type: string
+                      status:
+                        type: string
+                      upToDate:
+                        format: int32
+                        type: integer
+                    required:
+                      - available
+                      - current
+                      - desired
+                      - ready
+                      - upToDate
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
                 clusterAgent:
                   properties:
                     availableReplicas:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.4.1
+    helm.sh/chart: datadog-operator-1.5.0
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.3.0"
+          image: "gcr.io/datadoghq/operator:1.4.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.4.1
+    helm.sh/chart: datadog-operator-1.5.0
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.3.0"
+          image: "gcr.io/datadoghq/operator:1.4.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -130,7 +130,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "gcr.io/datadoghq/operator:1.3.0", operatorContainer.Image)
+	assert.Equal(t, "gcr.io/datadoghq/operator:1.4.0", operatorContainer.Image)
 	assert.Contains(t, operatorContainer.Args, "-webhookEnabled=false")
 }
 

--- a/test/integ/operator_integ_test.go
+++ b/test/integ/operator_integ_test.go
@@ -118,7 +118,7 @@ func verifyOperator(t *testing.T, kubectlOptions *k8s.KubectlOptions) {
 }
 
 func verifyAgent(t *testing.T, kubectlOptions *k8s.KubectlOptions) {
-	verifyNumPodsForSelector(t, kubectlOptions, 2, "agent.datadoghq.com/component=agent")
+	verifyNumPodsForSelector(t, kubectlOptions, 1, "agent.datadoghq.com/component=agent")
 	verifyNumPodsForSelector(t, kubectlOptions, 1, "agent.datadoghq.com/component=cluster-agent")
 	verifyNumPodsForSelector(t, kubectlOptions, 1, "agent.datadoghq.com/component=cluster-checks-runner")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Update latest image reference for Datadog Operator to 1.4.0

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
- [X] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
