### PR TITLE
feat: support templated clusterName

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.56.0
+
+* Allow templating of `datadog.clusterName`.
+
 ## 3.55.0
 
 * Modify `datadog.dogstatsd.originDetection` to also support container tagging for origin detection enabled clients.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.55.0
+version: 3.56.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.55.0](https://img.shields.io/badge/Version-3.55.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.56.0](https://img.shields.io/badge/Version-3.56.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_components-common-env.yaml
+++ b/charts/datadog/templates/_components-common-env.yaml
@@ -16,7 +16,7 @@
 {{- if .Values.datadog.clusterName }}
 {{- template "check-cluster-name" . }}
 - name: DD_CLUSTER_NAME
-  value: {{ .Values.datadog.clusterName | quote }}
+  value: {{ tpl .Values.datadog.clusterName . | quote }}
 {{- end }}
 {{- if .Values.datadog.tags }}
 - name: DD_TAGS

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -67,11 +67,12 @@ true
 {{- end -}}
 
 {{- define "check-cluster-name" }}
-{{- $length := len .Values.datadog.clusterName -}}
+{{- $clusterName := tpl .Values.datadog.clusterName . -}}
+{{- $length := len $clusterName -}}
 {{- if (gt $length 80)}}
 {{- fail "Your `clusterName` isn’t valid it has to be below 81 chars." -}}
 {{- end}}
-{{- if not (regexMatch "^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$" .Values.datadog.clusterName) -}}
+{{- if not (regexMatch "^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$" $clusterName) -}}
 {{- fail "Your `clusterName` isn’t valid. It must be dot-separated tokens where a token start with a lowercase letter followed by lowercase letters, numbers, or hyphens, can only end with a with [a-z0-9] and has to be below 80 chars." -}}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -194,7 +194,7 @@ spec:
           {{- if .Values.datadog.clusterName }}
           {{- template "check-cluster-name" . }}
           - name: DD_CLUSTER_NAME
-            value: {{ .Values.datadog.clusterName | quote }}
+            value: {{ tpl .Values.datadog.clusterName . | quote }}
           {{- end }}
           {{- include "provider-env" . | nindent 10 }}
           {{- include "fips-envvar" . | nindent 10 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

We're deploying the chart using ArgoCD and ApplicationSets with a cluster generator. To avoid having to bake Datadog-specific logic into our wider ArgoCD Application generator, we need support for rendering `clusterName` as a template variable in order to generate an appropriate value from generic values.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
- [X] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
