### PR TITLE
Disable mutations on Datadog resources pods

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.57.3
+
+* Exclude agent, cluster agent and agent clusterchecks pods from injection from the admission controller.
+
 ## 3.57.2
 
 * Add `networkpolicies` default permission for the cluster agent.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.57.2
+version: 3.57.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.57.2](https://img.shields.io/badge/Version-3.57.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.57.3](https://img.shields.io/badge/Version-3.57.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       labels:
 {{ include "datadog.template-labels" . | indent 8 }}
         app.kubernetes.io/component: clusterchecks-agent
+        admission.datadoghq.com/enabled: "false"
         app: {{ template "datadog.fullname" . }}-clusterchecks
         {{- if .Values.clusterChecksRunner.additionalLabels }}
 {{ toYaml .Values.clusterChecksRunner.additionalLabels | indent 8 }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: cluster-agent
-    admission.datadoghq.com/enabled: "false"
     {{- if .Values.clusterAgent.additionalLabels }}
 {{ toYaml .Values.clusterAgent.additionalLabels | indent 4 }}
     {{- end }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: cluster-agent
+    admission.datadoghq.com/enabled: "false"
     {{- if .Values.clusterAgent.additionalLabels }}
 {{ toYaml .Values.clusterAgent.additionalLabels | indent 4 }}
     {{- end }}
@@ -38,6 +39,7 @@ spec:
       labels:
 {{ include "datadog.template-labels" . | indent 8 }}
         app.kubernetes.io/component: cluster-agent
+        admission.datadoghq.com/enabled: "false"
         app: {{ template "datadog.fullname" . }}-cluster-agent
         {{- if .Values.clusterAgent.podLabels }}
 {{ toYaml .Values.clusterAgent.podLabels | indent 8 }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
 {{ include "datadog.template-labels" . | indent 8 }}
         app.kubernetes.io/component: agent
+        admission.datadoghq.com/enabled: "false"
         app: {{ template "datadog.fullname" . }}
         {{- if .Values.agents.podLabels }}
 {{ toYaml .Values.agents.podLabels | indent 8 }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: agent
-    admission.datadoghq.com/enabled: "false"
     {{- if .Values.agents.additionalLabels }}
 {{ toYaml .Values.agents.additionalLabels | indent 4 }}
     {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Exclude the agent, cluster agent and clusterchecks pods from any kind of mutation performed by the Admission Controller. With this change Admission Controllers will not inject configs, tags or tracing libraries into DD resources.

Agent pod for latest helm-chart:
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
    checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
    checksum/clusteragent_token: 03184415b2e1becb4249a9453d54f35f031f89ed107c895018bf4ec611d9265e
    checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
    checksum/install_info: 53a0b6d31a0130a55703ac799b2ab18fdaed9e338e6d27bf12695bb42b598cb4
  creationTimestamp: "2024-02-22T16:23:29Z"
  generateName: dd2-datadog-
  labels:
    app: dd2-datadog
    app.kubernetes.io/component: agent
    app.kubernetes.io/instance: dd2
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: dd2-datadog
    controller-revision-hash: 76f596d679
    pod-template-generation: "1"
  name: dd2-datadog-56z92
  namespace: default
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: DaemonSet
    name: dd2-datadog
    uid: 62e74eb9-7170-4bb2-a7da-f1118d8fefac
  resourceVersion: "250590100"
  uid: bf578731-e008-4879-852c-60318d3a069d
...
```

Agent pod with PR's change:
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
    checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
    checksum/clusteragent_token: f80d582aa8960692c0c36b44a445c3fab290bcedf3eff324ee7b2700d8181699
    checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
    checksum/install_info: ba661cfd1e600203476c7247bad81157e5bc70aaa7f91e6cdd6be6a469cd0093
  creationTimestamp: "2024-02-22T18:38:41Z"
  generateName: dd2-datadog-
  labels:
    admission.datadoghq.com/enabled: "false"
    app: dd2-datadog
    app.kubernetes.io/component: agent
    app.kubernetes.io/instance: dd2
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: dd2-datadog
    controller-revision-hash: bd85b9c86
    pod-template-generation: "1"
  name: dd2-datadog-6hvj6
  namespace: default
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: DaemonSet
    name: dd2-datadog
    uid: 011344d2-58f0-4da9-b9e5-71fcdfd6e691
  resourceVersion: "250664017"
  uid: 870f46c9-946c-4a5a-9a4a-0b868511801d
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
