### PR TITLE
[datadog-operator] add flag for introspection

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.1
+
+* Add configuration for Operator flag `introspectionEnabled`: this parameter is used to enable the Introspection. It is disabled by default.
+
 ## 1.5.0
 
 * Update Datadog Operator version to 1.4.0.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.5.0
+version: 1.5.1
 appVersion: 1.4.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 ## Values
 
@@ -33,6 +33,7 @@
 | image.tag | string | `"1.4.0"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
+| introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |
 | logLevel | string | `"info"` | Set Datadog Operator log level (debug, info, error, panic, fatal) |
 | maximumGoroutines | string | `nil` | Override default goroutines threshold for the health check failure. |
 | metricsPort | int | `8383` | Port used for OpenMetrics endpoint |

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -108,6 +108,9 @@ spec:
           {{- if and .Values.maximumGoroutines (semverCompare ">=1.0.0-rc.13" .Values.image.tag) }}
             - "-maximumGoroutines={{ .Values.maximumGoroutines }}"
           {{- end }}
+          {{- if (semverCompare ">=1.4.0" .Values.image.tag) }}
+            - "-introspectionEnabled={{ .Values.introspection.enabled }}"
+          {{- end }}
             - "-datadogMonitorEnabled={{ .Values.datadogMonitor.enabled }}"
           {{- if (semverCompare ">=1.0.0-rc.13" .Values.image.tag) }}
             - "-datadogAgentEnabled={{ .Values.datadogAgent.enabled }}"

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -56,6 +56,11 @@ fullnameOverride: ""
 logLevel: "info"
 # maximumGoroutines -- Override default goroutines threshold for the health check failure.
 maximumGoroutines:
+
+
+introspection:
+# introspection.enabled -- If true, enables introspection feature (beta). Requires v1.4.0+
+  enabled: false
 # supportExtendedDaemonset -- If true, supports using ExtendedDaemonSet CRD
 supportExtendedDaemonset: "false"
 # operatorMetricsEnabled -- Enable forwarding of Datadog Operator metrics and events to Datadog.

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.5.0
+    helm.sh/chart: datadog-operator-1.5.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
@@ -53,6 +53,7 @@ spec:
             - "-loglevel=info"
             - "-operatorMetricsEnabled=true"
             - "-webhookEnabled=false"
+            - "-introspectionEnabled=false"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
             - "-datadogSLOEnabled=false"

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.5.0
+    helm.sh/chart: datadog-operator-1.5.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.4.0"
     app.kubernetes.io/managed-by: Helm
@@ -53,6 +53,7 @@ spec:
             - "-loglevel=info"
             - "-operatorMetricsEnabled=true"
             - "-webhookEnabled=true"
+            - "-introspectionEnabled=false"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
             - "-datadogSLOEnabled=false"


### PR DESCRIPTION
#### What this PR does / why we need it:

Add option to enable introspection following the release of Operator 1.4.0

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
- [X] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
