### PR TITLE
Run e2e tests during mergequeue for `datadog` chart

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,10 @@
 stages:
   - e2e
 
+variables:
+  RUN_E2E_TEST:
+    description: "set RUN_E2E_TEST to 'true' if you want to trigger the e2e test on your pipeline."
+
 e2e:
   stage: e2e
   rules:
@@ -20,8 +24,9 @@ e2e:
           - test/**/*
         compare_to: "refs/heads/main"
       when: always
-    - if: $CI_COMMIT_BRANCH != "main"
+    - if: $RUN_E2E_TEST == "true"
       when: manual
+    - when: never
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:95dca87f269a
   tags: ["arch:amd64"]
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,11 +5,18 @@ e2e:
   stage: e2e
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
+      changes:
+        paths:
+          - charts/datadog/*.yaml
+          - test/**/*
+        compare_to: "refs/heads/main"
+      when: always
+    - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
       when: never
     - if: $CI_COMMIT_BRANCH == "main"
       changes:
         paths:
-          - charts/**/*.yaml
+          - charts/datadog/**
           - test/**/*
         compare_to: "refs/heads/main"
       when: always


### PR DESCRIPTION
#### What this PR does / why we need it:

* Run e2e tests during mergequeue only for `datadog` chart 
* Don't run e2e tests for any other charts change on `main`: for now e2e tests is only testing the `datadog` chart.
* Keep the possibility to run e2e test manually on other branch.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
