### PR TITLE
Fix: clusterchecks missing DD_TAGS environment variable and rbac.create=false

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.59.0
+* fix missing DD_TAGS on clusterchecks runner deployment
+* fix: clusterChecksRunner.rbac.create=false should not create rbac resources
+
 ## 3.58.0
 
 * Change configuration options for APM Instrumentation. Starting from Agent and Cluster-Agent version `7.51.0` APM Instrumentation needs to be configured using the following configuration options:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.58.0
+version: 3.59.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -156,6 +156,10 @@ spec:
           - name: DD_LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}
           {{- end }}
+          {{- if .Values.datadog.tags }}
+          - name: DD_TAGS
+            value: {{ tpl (.Values.datadog.tags | join " " | quote) . }}
+          {{- end }}
           - name: DD_EXTRA_CONFIG_PROVIDERS
             value: "clusterchecks"
           - name: DD_HEALTH_PORT

--- a/charts/datadog/templates/agent-clusterchecks-rbac.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq (include "should-enable-cluster-check-workers" .) "true") .Values.clusterChecksRunner.rbac.dedicated -}}
+{{- if and .Values.clusterChecksRunner.rbac.create (or (eq (include "should-enable-cluster-check-workers" .) "true") .Values.clusterChecksRunner.rbac.dedicated) -}}
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix 2 issues in cluster checks runner deployment
* missing `DD_TAGS` on clusterchecks runner deployment (fixes #831)
* `clusterChecksRunner.rbac.create=false` should not create rbac resources

#### Special notes for your reviewer:

issue 1: 
With `kubeStateMetricsCore.useClusterCheckRunners=true`, kubernetes_state metrics come from cluster check runner but it hasn't `DD_TAGS` environment variable to add global tag on theses metrics like explain in the [doc](https://docs.datadoghq.com/integrations/kubernetes_state_core/?tab=helm#node-level-tag-assignment)

issue 2:
With `clusterChecksRunner.rbac.create=false`, the helm chart still deployed cluster check runner rbac (ClusterRoleBinding and ServiceAccount)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
