### PR TITLE
Allow setting container registry used by cluster agent admission controller for library injection

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.58.1
+
+* Add `clusterAgent.admissionController.autoInstrumentationContainerRegistry` option for cluster-agent to specify registry used by Admission Controller for library injection (by setting `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY` environment variable).
+
 ## 3.58.0
 
 * Change configuration options for APM Instrumentation. Starting from Agent and Cluster-Agent version `7.51.0` APM Instrumentation needs to be configured using the following configuration options:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.58.0
+version: 3.58.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.58.0](https://img.shields.io/badge/Version-3.58.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.58.1](https://img.shields.io/badge/Version-3.58.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -544,6 +544,7 @@ helm install <RELEASE_NAME> \
 | agents.volumeMounts | list | `[]` | Specify additional volumes to mount in all containers of the agent pod |
 | agents.volumes | list | `[]` | Specify additional volumes to mount in the dd-agent container |
 | clusterAgent.additionalLabels | object | `{}` | Adds labels to the Cluster Agent deployment and pods |
+| clusterAgent.admissionController.autoInstrumentationContainerRegistry | string | `"gcr.io/datadoghq"` | registry used by the Admission Controller for the initContainer that injects instrumentation libraries |
 | clusterAgent.admissionController.configMode | string | `nil` | The kind of configuration to be injected, it can be "hostip", "service", or "socket". |
 | clusterAgent.admissionController.enabled | bool | `true` | Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods |
 | clusterAgent.admissionController.failurePolicy | string | `"Ignore"` | Set the failure policy for dynamic admission control.' |

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -220,6 +220,8 @@ spec:
             {{- else }}
             value: {{ .Values.clusterAgent.admissionController.configMode | quote }}
             {{- end }}
+          - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY
+            value: {{ .Values.clusterAgent.admissionController.autoInstrumentationContainerRegistry }}
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
             value: {{ template "localService.name" . }}
           {{- if .Values.providers.aks.enabled }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1057,6 +1057,9 @@ clusterAgent:
       ## This feature is in beta, and enables Remote Config in the Cluster Agent. It also requires Cluster Agent version 7.43+.
       ## Enabling this feature grants the Cluster Agent the permissions to patch Deployment objects in the cluster.
       enabled: false
+    
+    # clusterAgent.admissionController.autoInstrumentationContainerRegistry -- registry used by the Admission Controller for the initContainer that injects instrumentation libraries
+    autoInstrumentationContainerRegistry: "gcr.io/datadoghq" # "gcr.io/datadoghq", "docker.io/datadog" or "public.ecr.aws/datadog"
 
     # clusterAgent.admissionController.port -- Set port of cluster-agent admission controller service
     port: 8000


### PR DESCRIPTION
#### What this PR does / why we need it:

I was reviewing the [Admission Controller documentation regarding library injection](https://docs.datadoghq.com/tracing/trace_collection/library_injection_local/?tab=kubernetes#container-registries) for application instrumentation and came across this warning:

> Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from GCR or ECR. For instructions, see [Changing your container registry](https://docs.datadoghq.com/agent/guide/changing_container_registry).

I checked the helm chart and it doesn't provide an option for doing this. This PR adds an option to the helm values (`clusterAgent.admissionController.autoInstrumentationContainerRegistry`) so that the environment variable `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY` can be set in the datadog cluster-agent.

This PR solves this issue: https://github.com/DataDog/helm-charts/issues/1078

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
