### PR TITLE
Disable language detection reporting by default

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.59.2
+
+* Disable language detection reporting by default in Cluster Agent with Agent 7.52+.
+
 ## 3.59.1
 
 * Add support for configuring Agent sidecar injection using Admission Controller.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.59.1
+version: 3.59.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.59.1](https://img.shields.io/badge/Version-3.59.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.59.2](https://img.shields.io/badge/Version-3.59.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_components-common-env.yaml
+++ b/charts/datadog/templates/_components-common-env.yaml
@@ -1,6 +1,9 @@
 # The purpose of this template is to define a minimal set of environment
 # variables shared between components: agent, cluster-agent
 {{- define "components-common-env" -}}
+# Workaround for issue in `7.52.0` default activating language detection
+- name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+  value: "false"
 {{- if .Values.datadog.secretBackend.command }}
 - name: DD_SECRET_BACKEND_COMMAND
   value: {{ .Values.datadog.secretBackend.command | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Disable by default language detection reporting with Agent 7.52.0.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
