### PR TITLE
[synthetics] Auto set env var when enableStatusProbes is true

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.15.28
+
+* Update Kubernetes deployment template to set `DATADOG_WORKER_ENABLE_STATUS_PROBES` environment variable when `enableStatusProbes` value is defined.
+
 ## 0.15.27
 
 * Update private location image version to `1.45.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.27
+version: 0.15.28
 appVersion: 1.45.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.27](https://img.shields.io/badge/Version-0.15.27-informational?style=flat-square) ![AppVersion: 1.45.0](https://img.shields.io/badge/AppVersion-1.45.0-informational?style=flat-square)
+![Version: 0.15.28](https://img.shields.io/badge/Version-0.15.28-informational?style=flat-square) ![AppVersion: 1.45.0](https://img.shields.io/badge/AppVersion-1.45.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -65,14 +65,20 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-{{- if .Values.envFrom }}
+      {{- if .Values.envFrom }}
           envFrom:
-{{ toYaml .Values.envFrom | indent 12 }}
-{{- end }}
-{{- if .Values.env }}
+      {{ toYaml .Values.envFrom | indent 12 }}
+      {{- end }}
+      {{- if or (.Values.env) (.Values.enableStatusProbes) }}
           env:
-{{ toYaml .Values.env | indent 12 }}
-{{- end }}
+      {{- if .Values.enableStatusProbes }}
+            - name: DATADOG_WORKER_ENABLE_STATUS_PROBES
+              value: {{ .Values.enableStatusProbes }}
+      {{- end }}
+      {{- if .Values.env }}
+      {{ toYaml .Values.env | indent 12 }}
+      {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR automatically sets the `enableStatusProbes=true` configuration of the Synthetics private location when the liveness and readiness probes are enabled in the Kubernetes deployment, by setting the `DATADOG_WORKER_ENABLE_STATUS_PROBES` env variable.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] ~For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)~
