### PR TITLE
Add `podLabels` value to allow setting labels that only appear on the pods managed by the deployment.

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.16.0
+
+* Add `podLabels` value to allow setting labels that only appear on the pods managed by the deployment.
+
 ## 0.15.31
 
 * Fix `env` indentation in Deployment template.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.31
+version: 0.16.0
 appVersion: 1.46.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.31](https://img.shields.io/badge/Version-0.15.31-informational?style=flat-square) ![AppVersion: 1.46.0](https://img.shields.io/badge/AppVersion-1.46.0-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![AppVersion: 1.46.0](https://img.shields.io/badge/AppVersion-1.46.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 
@@ -45,6 +45,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Synthetics Private Location on specific nodes |
 | podAnnotations | object | `{}` | Annotations to set to Datadog Synthetics Private Location PODs |
+| podLabels | object | `{}` | Labels to be placed on pods managed by the deployment |
 | podSecurityContext | object | `{}` | Security context to set to Datadog Synthetics Private Location PODs |
 | priorityClassName | string | `""` | Allows to specify PriorityClass for Datadog Synthetics Private Location PODs |
 | replicaCount | int | `1` | Number of instances of Datadog Synthetics Private Location |

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     {{- end }}
       labels:
         {{- include "synthetics-private-location.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{ if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy}}

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -52,6 +52,9 @@ extraVolumeMounts: []
 # podAnnotations -- Annotations to set to Datadog Synthetics Private Location PODs
 podAnnotations: {}
 
+# podLabels -- Labels to be placed on pods managed by the deployment
+podLabels: {}
+
 # podSecurityContext -- Security context to set to Datadog Synthetics Private Location PODs
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
#### What this PR does / why we need it:
Add `podLabels` value to allow setting labels that only appear on the pods managed by the deployment.
Need pod label for monitoring that value changes regularly with version upgrades. Cannot use `commonLabels` because they are used as match labels which are immutable.

#### Which issue this PR fixes
  - fixes #1357 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
