### PR TITLE
Fix envFrom indentation in synthetics-private-location

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.15.30
+
+* Fix `envFrom` indentation in Deployment template.
+
 ## 0.15.29
 
 * Update Kubernetes deployment template to set `DATADOG_WORKER_ENABLE_STATUS_PROBES` environment variable when `enableStatusProbes` value is defined.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.15.29
+version: 0.15.30
 appVersion: 1.46.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.15.29](https://img.shields.io/badge/Version-0.15.29-informational?style=flat-square) ![AppVersion: 1.46.0](https://img.shields.io/badge/AppVersion-1.46.0-informational?style=flat-square)
+![Version: 0.15.30](https://img.shields.io/badge/Version-0.15.30-informational?style=flat-square) ![AppVersion: 1.46.0](https://img.shields.io/badge/AppVersion-1.46.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
 

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if .Values.envFrom }}
           envFrom:
-      {{ toYaml .Values.envFrom | indent 12 }}
+      {{- toYaml .Values.envFrom | nindent 12 }}
       {{- end }}
       {{- if or (.Values.env) (.Values.enableStatusProbes) }}
           env:


### PR DESCRIPTION
#### What this PR does / why we need it:
0.15.29 breaks the indentation of `envFrom` in the `synthetics-private-location` deployment template. This adjusts the templating to use the same `{{-` and `nindent` that other variables use.

Tested locally by uncommenting the example `envFrom` in `values.yaml`:
Before this change:
`$ cd charts/synthetics-private-location`
`$ helm template .`
```
Error: YAML parse error on synthetics-private-location/templates/deployment.yaml: error converting YAML to JSON: yaml: line 41: did not find expected key

Use --debug flag to render out invalid YAML
```
After this change:
Valid yaml.


Tested with:
```
$ helm version
version.BuildInfo{Version:"v3.10.2", GitCommit:"50f003e5ee8704ec937a756c646870227d7c8b58", GitTreeState:"clean", GoVersion:"go1.19.3"}
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
- [X] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
