### PR TITLE
[datadog] Change admissionController.configMode resolution path

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.59.5
+
+* Change resolution path for `datadog.admissionController.configMode`
+
 ## 3.59.4
 
 * Add language detection enable option for `APM` instrumentation.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.59.4
+version: 3.59.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.59.4](https://img.shields.io/badge/Version-3.59.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.59.5](https://img.shields.io/badge/Version-3.59.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -211,10 +211,10 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE
             {{- if .Values.clusterAgent.admissionController.configMode }}
             value: {{ .Values.clusterAgent.admissionController.configMode }}
-            {{- else if eq (include "trace-agent-use-uds" .) "true" }}
-            value: socket
             {{- else if or (eq (include "trace-agent-use-tcp-port" .) "true") ( .Values.providers.gke.autopilot )}}
             value: hostip
+            {{- else if eq (include "trace-agent-use-uds" .) "true" }}
+            value: socket
             {{- else if or (not .Values.datadog.apm.enabled ) (and (eq (include "trace-agent-use-tcp-port" .) "true") (eq (include "trace-agent-use-uds" .) "true")) }}
             value: socket
             {{- else }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1046,8 +1046,8 @@ clusterAgent:
     # clusterAgent.admissionController.configMode -- The kind of configuration to be injected, it can be "hostip", "service", or "socket".
 
     ## If clusterAgent.admissionController.configMode is not set:
-    ##   * and datadog.apm.socketEnabled is true, the Admission Controller uses socket.
     ##   * and datadog.apm.portEnabled is true, the Admission Controller uses hostip.
+    ##   * and datadog.apm.socketEnabled is true, the Admission Controller uses socket.
     ##   * Otherwise, the Admission Controller defaults to hostip.
     ## Note: "service" mode relies on the internal traffic service to target the agent running on the local node (requires Kubernetes v1.22+).
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/#configure-apm-and-dogstatsd-communication-mode


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
  - fixes https://github.com/DataDog/datadog-agent/issues/16710

#### Special notes for your reviewer:
This will fix this issue: https://github.com/DataDog/datadog-agent/issues/16710
Current resolution path is described as:
```
    ## If clusterAgent.admissionController.configMode is not set:
    ##   * and datadog.apm.socketEnabled is true, the Admission Controller uses socket.
    ##   * and datadog.apm.portEnabled is true, the Admission Controller uses hostip.
    ##   * Otherwise, the Admission Controller defaults to hostip.
```
Comparing this with the chart version [3.22.0](https://github.com/DataDog/helm-charts/blob/5436c0c0bf262b6a62af5d51fa57aafeace7bd2a/charts/datadog/values.yaml#L940) this includes considerable change in the logic. Previously if `clusterAgent.admissionController.configMode` was not set, we would not have `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE` environment variable preset in the pod spec, which was defaulting then to `hostip`, despite the `datadog.apm.socketEnabled` was by default set to `true` in the `values.yaml`. Some implementations were not setting `clusterAgent.admissionController.configMode: hostip` explicitly, while `datadog.apm.portEnabled: true` was set, so they relied on the default implementation. This change in logic was not documented clearly, so people get into rabbit hole as trying to open port 8000 on the security groups, with deployments getting broken as they relied on the admission controller to mutate template. I am proposing opinionated change of the logic, which might mitigate this issue, especially during migrations. The logic would resolve in the following order:
```
    ## If clusterAgent.admissionController.configMode is not set:
    ##   * and datadog.apm.portEnabled is true, the Admission Controller uses hostip.
    ##   * and datadog.apm.socketEnabled is true, the Admission Controller uses socket.
    ##   * Otherwise, the Admission Controller defaults to hostip.
```
As you might see, I have changed just the order of resolution to comply with the settings that were present in versions 3.21.0 and before.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated