### PR TITLE
Fix CHANGELOG for 3.59.5

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 3.59.5
 
-* Add configuration option datadog.apm.instrumentation.skipKPITelemetry.
+* Set default `Agent` and `Cluster-Agent` version to `7.52.1`.
 
 ## 3.59.4
 


### PR DESCRIPTION
Adding back changelog message accidentally removed in pull #1328

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
