### PR TITLE
[release] Add `CR_SKIP_EXISTING` flag to release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,3 +27,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_SKIP_EXISTING: true # Ignore chart changes when version was not updated (documentation)


### PR DESCRIPTION


#### What this PR does / why we need it:

If a chart was updated but the version was not bumped (example documentation, changelog), the [release job will fail for all charts](https://github.com/DataDog/helm-charts/actions/runs/8702337157/job/23964331154) with:
```
Error: error creating GitHub release datadog-3.59.6: POST https://api.github.com/repos/DataDog/helm-charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
```

This PR adds the `CR_SKIP_EXISTING` flag to the release to ignore this issue.

#### Which issue this PR fixes

  - fixes datadog/synthetics-private-location 0.16.1 release: https://github.com/DataDog/helm-charts/pull/1372#issuecomment-2062057411



#### Checklist

- ~~Chart Version bumped~~
- ~~Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)~~
- ~~`CHANGELOG.md` has been updated~~
-  ~~Variables are documented in the `README.md`~~
- ~~For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)~~
