### PR TITLE
[doc] Update Private Location documentation link

### DIFF
--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![AppVersion: 1.47.0](https://img.shields.io/badge/AppVersion-1.47.0-informational?style=flat-square)
 
-[Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
+[Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations/?tab=helmchart).
 
 ## How to use Datadog Helm repository
 

--- a/charts/synthetics-private-location/README.md.gotmpl
+++ b/charts/synthetics-private-location/README.md.gotmpl
@@ -2,7 +2,7 @@
 
 {{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
 
-[Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations).
+[Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations/?tab=helmchart).
 
 ## How to use Datadog Helm repository
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Small PR to trigger the [release pipeline](https://github.com/DataDog/helm-charts/blob/main/.github/workflows/release.yaml) to properly publish the latest Private Location version after the fix: https://github.com/DataDog/helm-charts/pull/1378


> [!CAUTION]
> We skip updating the charts as the previous release failed and we want to retry it https://github.com/DataDog/helm-charts/pull/1372


#### Checklist

- ~~Chart Version bumped~~
- ~~Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)~~
- ~~`CHANGELOG.md` has been updated~~
-  ~~Variables are documented in the `README.md`~~
- ~~For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)~~
