### PR TITLE
change /etc/passwd/ hostpath volume for EKS Bottlerocket OS environments

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.59.7
+
+* Change the `etc/passwd/` `hostPath` volume to include `type: File` for cases where the process agent crashes in EKS Bottlerocket OS environments.
+
 ## 3.59.6
 
 * Add configuration option datadog.apm.instrumentation.skipKPITelemetry.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.59.6
+version: 3.59.7
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.59.6](https://img.shields.io/badge/Version-3.59.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.59.7](https://img.shields.io/badge/Version-3.59.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -140,6 +140,7 @@
 {{- if or .Values.datadog.processAgent.enabled (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true") }}
 - hostPath:
     path: /etc/passwd
+    type: File
   name: passwd
 {{- end }}
 {{- if or (and (eq (include "should-enable-system-probe" .) "true") .Values.datadog.serviceMonitoring.enabled) (and (eq (include "should-enable-security-agent" .) "true") .Values.datadog.securityAgent.compliance.enabled) }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds the following to the `/etc/passwd` hostPath volume with `type: File` to avoid the process-agent from crashing in EKS Bottlerocket environments

#### Which issue this PR fixes
Cases where the process-agent throws the following error in EKS Bottlerocket:
"Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/etc/passwd" to rootfs at "/etc/passwd": mount /etc/passwd:/etc/passwd (via /proc/self/fd/6), flags: 0x5001, data: context="system_u:object_r:data_t:s0:c405,c705": not a directory: unknown"

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
