### PR TITLE
[CWS] Configuration options for enabling CWSInstrumentation in the `cluster-agent`

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.0
+
+* Add configuration to grand to the operator the necessary RBAC for the CWS Instrumentation admission controller feature in the Cluster-Agent to work.
+
 ## 2.3.0
 
 * Update Datadog Operator version to 1.10.0.

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.0
 
-* Add configuration to grand to the operator the necessary RBAC for the CWS Instrumentation admission controller feature in the Cluster-Agent to work.
+* Add configuration to grant the necessary RBAC to the operator for the CWS Instrumentation Admission Controller feature in the Cluster-Agent.
 
 ## 2.3.0
 

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.3.0
+version: 2.4.0
 appVersion: 1.10.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,11 +1,12 @@
 # Datadog Operator
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| addCWSInstrumentationRBAC | bool | `false` | Defines if the operator should be deployed with the RBAC required for the cluster-agent CWSInstrumentation feature. |
 | affinity | object | `{}` | Allows to specify affinity for Datadog Operator PODs |
 | apiKey | string | `nil` | Your Datadog API key |
 | apiKeyExistingSecret | string | `nil` | Use existing Secret which stores API key instead of creating a new one |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -6,14 +6,13 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| addCWSInstrumentationRBAC | bool | `false` | Defines if the operator should be deployed with the RBAC required for the cluster-agent CWSInstrumentation feature. |
 | affinity | object | `{}` | Allows to specify affinity for Datadog Operator PODs |
 | apiKey | string | `nil` | Your Datadog API key |
 | apiKeyExistingSecret | string | `nil` | Use existing Secret which stores API key instead of creating a new one |
 | appKey | string | `nil` | Your Datadog APP key |
 | appKeyExistingSecret | string | `nil` | Use existing Secret which stores APP key instead of creating a new one |
 | clusterName | string | `nil` | Set a unique cluster name reporting from the Datadog Operator. |
-| clusterRole | object | `{"allowReadAllResources":false}` | Set specific configuration for the cluster role |
+| clusterRole | object | `{"allowCreatePodsExec":false,"allowReadAllResources":false}` | Set specific configuration for the cluster role |
 | collectOperatorMetrics | bool | `true` | Configures an openmetrics check to collect operator metrics |
 | containerSecurityContext | object | `{}` | A security context defines privileges and access control settings for a container. |
 | datadogAgent.enabled | bool | `true` | Enables Datadog Agent controller |

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -803,7 +803,7 @@ rules:
   - list
   - watch
 {{- end }}
-{{- if .Values.addCWSInstrumentationRBAC }}
+{{- if .Values.clusterRole.allowCreatePodsExec }}
 - apiGroups: [""]
   resources: ["pods/exec"]
   verbs: ["create"]

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -803,4 +803,9 @@ rules:
   - list
   - watch
 {{- end }}
+{{- if .Values.addCWSInstrumentationRBAC }}
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
 {{- end }}
+{{- end -}}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -197,6 +197,5 @@ clusterRole:
   # If collecting CRDs in the Kubernetes Explorer this is required
   allowReadAllResources: false
 
-# addCWSInstrumentationRBAC -- Defines if the operator should be deployed with the RBAC required for the cluster-agent
-# CWSInstrumentation feature.
-addCWSInstrumentationRBAC: false
+  # allowCreatePodsExec is required for `remote_copy` mode of the CWS Instrumentation feature.
+  allowCreatePodsExec: false

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -196,3 +196,7 @@ clusterRole:
   # allowReadAllResources is required to allow the operator to view all custom resources.
   # If collecting CRDs in the Kubernetes Explorer this is required
   allowReadAllResources: false
+
+# addCWSInstrumentationRBAC -- Defines if the operator should be deployed with the RBAC required for the cluster-agent
+# CWSInstrumentation feature.
+addCWSInstrumentationRBAC: false

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.82.0
+
+* Add `pods/exec` RBAC to the `Cluster-Agent` when needed and inject the service account name of the `Cluster-Agent` as environment variable.
+
 ## 3.81.2
 
 * Fix ci values.yaml files name to be taken into account by the ci job.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.81.2
+version: 3.82.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.81.2](https://img.shields.io/badge/Version-3.81.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.82.0](https://img.shields.io/badge/Version-3.82.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -571,6 +571,8 @@ helm install <RELEASE_NAME> \
 | clusterAgent.admissionController.agentSidecarInjection.selectors | list | `[]` | Defines the pod selector for sidecar injection, currently only one rule is supported. |
 | clusterAgent.admissionController.configMode | string | `nil` | The kind of configuration to be injected, it can be "hostip", "service", or "socket". |
 | clusterAgent.admissionController.containerRegistry | string | `nil` | Override the default registry for the admission controller. |
+| clusterAgent.admissionController.cwsInstrumentation.enabled | bool | `false` | Enable the CWS Instrumentation admission controller endpoint. |
+| clusterAgent.admissionController.cwsInstrumentation.mode | string | `"remote_copy"` | Mode defines how the CWS Instrumentation should behave. Options are "remote_copy" or "init_container" |
 | clusterAgent.admissionController.enabled | bool | `true` | Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods |
 | clusterAgent.admissionController.failurePolicy | string | `"Ignore"` | Set the failure policy for dynamic admission control.' |
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -160,6 +160,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: DD_CLUSTER_AGENT_SERVICE_ACCOUNT_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
           - name: DD_HEALTH_PORT
           {{- $healthPort := .Values.clusterAgent.healthPort }}
             value: {{ $healthPort | quote }}
@@ -247,6 +251,12 @@ spec:
             value: {{ .Values.clusterAgent.admissionController.containerRegistry | quote }}
           {{- else }}
             value: {{ include "registry" .Values | quote }}
+          {{- end }}
+          {{- if .Values.clusterAgent.admissionController.cwsInstrumentation.enabled }}
+          - name: DD_ADMISSION_CONTROLLER_CWS_INSTRUMENTATION_ENABLED
+            value: "true"
+          - name: DD_ADMISSION_CONTROLLER_CWS_INSTRUMENTATION_MODE
+            value: {{ .Values.clusterAgent.admissionController.cwsInstrumentation.mode | quote }}
           {{- end }}
           {{ include "ac-agent-sidecar-env" . | nindent 10 }}
           - name: DD_REMOTE_CONFIGURATION_ENABLED

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -262,6 +262,11 @@ rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
   verbs: ["get"]
+{{- if and .Values.clusterAgent.admissionController.cwsInstrumentation.enabled (eq .Values.clusterAgent.admissionController.cwsInstrumentation.mode "remote_copy") }}
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+{{- end }}
 {{- end }}
 {{- if eq  (include "should-enable-security-agent" .) "true" }}
 {{- if .Values.datadog.securityAgent.compliance.enabled }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1201,6 +1201,14 @@ clusterAgent:
     # clusterAgent.admissionController.port -- Set port of cluster-agent admission controller service
     port: 8000
 
+    cwsInstrumentation:
+      # clusterAgent.admissionController.cwsInstrumentation.enabled -- Enable the CWS Instrumentation admission controller endpoint.
+      enabled: false
+
+      # clusterAgent.admissionController.cwsInstrumentation.mode -- Mode defines how the CWS Instrumentation should behave.
+      # Options are "remote_copy" or "init_container"
+      mode: remote_copy
+
     agentSidecarInjection:
       # clusterAgent.admissionController.agentSidecarInjection.enabled -- Enables Datadog Agent sidecar injection.
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds the `pods/exec` RBAC to the `datadog-operator` and the `cluster-agent` deployments, when the "CWS Instrumentation" feature is enabled. It also injects the `cluster-agent` service account name as an environment of the `cluster-agent` deployment in the `datadog` chart (so that in both deployment methods the service account name is properly injected - see https://github.com/DataDog/datadog-operator/pull/1146)

#### Which issue this PR fixes

This PR is the helm chart counter part of [this](https://github.com/DataDog/datadog-operator/pull/1146) `datadog-operator` PR. It is necessary to allow the "CWS Instrumentation" feature to be enabled in `remote_copy` mode.

This PR fixes [this issue](https://github.com/DataDog/helm-charts/issues/1613).

#### Special notes for your reviewer:

Follow the steps in [the datadog-operator PR](https://github.com/DataDog/datadog-operator/pull/1146) to test this change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
