### PR TITLE
feat(origin-detection): add unified setting

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.64.0
+
+* Add `datadog.originDetectionUnified.enabled` setting to enable unified origin detection for container tagging. Disabled by default
+
 ## 3.63.0
 
 * Set kubelet core check to be enabled by default

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.63.0
+version: 3.64.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.63.0](https://img.shields.io/badge/Version-3.63.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.64.0](https://img.shields.io/badge/Version-3.64.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -757,6 +757,7 @@ helm install <RELEASE_NAME> \
 | datadog.orchestratorExplorer.container_scrubbing | object | `{"enabled":true}` | Enable the scrubbing of containers in the kubernetes resource YAML for sensitive information |
 | datadog.orchestratorExplorer.customResources | list | `[]` | Defines custom resources for the orchestrator explorer to collect |
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
+| datadog.originDetectionUnified.enabled | bool | `false` | Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+). |
 | datadog.osReleasePath | string | `"/etc/os-release"` | Specify the path to your os-release file |
 | datadog.otlp.logs.enabled | bool | `false` | Enable logs support in the OTLP ingest endpoint |
 | datadog.otlp.receiver.protocols.grpc.enabled | bool | `false` | Enable the OTLP/gRPC endpoint |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -76,6 +76,10 @@
     - name: DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT
       value: {{ .Values.datadog.dogstatsd.originDetection | quote }}
     {{- end }}
+    {{- if .Values.datadog.originDetectionUnified.enabled }}
+    - name: DD_ORIGIN_DETECTION_UNIFIED
+      value: {{ .Values.datadog.originDetectionUnified.enabled | quote }}
+    {{- end }}
     {{- if .Values.datadog.dogstatsd.tagCardinality }}
     - name: DD_DOGSTATSD_TAG_CARDINALITY
       value: {{ .Values.datadog.dogstatsd.tagCardinality | quote }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -249,6 +249,10 @@ datadog:
   #   env: environment
   #   <KUBERNETES_NAMESPACE_LABEL>: <DATADOG_TAG_KEY>
 
+  originDetectionUnified:
+    # datadog.originDetectionUnified.enabled -- Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+).
+    enabled: false
+
   # datadog.tags -- List of static tags to attach to every metric, event and service check collected by this Agent.
 
   ## Learn more about tagging: https://docs.datadoghq.com/tagging/


### PR DESCRIPTION
#### What this PR does / why we need it:

Add a new Global setting for the Origin Detection Unified setting of the Agent. This setting is a global one as it control Origin Detection behaviour for multiple Operator features (APM and DogStatsD).

#### Special notes for your reviewer:

Using the following chart:
```
➜  helm cat enabled.yaml
registry: public.ecr.aws/datadog
datadog:
  clusterName: wassim-minikube
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  originDetectionUnified:
    enabled: true
  kubelet:
    tlsVerify: false
    coreCheck: true
agents:
  image:
    tag: 7.54.0-rc.3-jmx
  env:
  - name: DD_TELEMETRY_ENABLED
    value: true
```

You should see:
```
➜  helm k exec -it datadog-agent-56tr4 -- agent config | grep unified
Defaulted container "agent" out of: agent, trace-agent, process-agent, init-volume (init), init-config (init)
origin_detection_unified: true
```

Using the following chart:
```
➜  helm cat enabled.yaml
registry: public.ecr.aws/datadog
datadog:
  clusterName: wassim-minikube
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
    coreCheck: true
agents:
  image:
    tag: 7.54.0-rc.3-jmx
  env:
  - name: DD_TELEMETRY_ENABLED
    value: true
```

You should see:
```
➜  helm k exec -it datadog-agent-jrsk5 -- agent config | grep unified
Defaulted container "agent" out of: agent, trace-agent, process-agent, init-volume (init), init-config (init)
origin_detection_unified: false
```

#### Checklist

- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
