### PR TITLE
Add option to enable namespace collection

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.62.1
+
+* Add `datadog.collectKubernetesNamespaces` config to enable collection of kubernetes namespace information
+
 ## 3.62.0
 
 * Add `datadog.asm` section to configure various features of the ASM Security Product. Disabled by default

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.62.0
+version: 3.62.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.62.0](https://img.shields.io/badge/Version-3.62.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.62.1](https://img.shields.io/badge/Version-3.62.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -686,6 +686,7 @@ helm install <RELEASE_NAME> \
 | datadog.clusterName | string | `nil` | Set a unique cluster name to allow scoping hosts and Cluster Checks easily |
 | datadog.clusterTagger.collectKubernetesTags | bool | `false` | Enables Kubernetes resources tags collection. |
 | datadog.collectEvents | bool | `true` | Enables this to start event collection from the kubernetes API |
+| datadog.collectKubernetesNamespaces | bool | false | Toggle if kubernetes namespace information should be collected. (Requires Agent/Cluster Agent 7.55.0+) |
 | datadog.confd | object | `{}` | Provide additional check configurations (static and Autodiscovery) |
 | datadog.containerExclude | string | `nil` | Exclude containers from Agent Autodiscovery, as a space-separated list |
 | datadog.containerExcludeLogs | string | `nil` | Exclude logs from Agent Autodiscovery, as a space-separated list |

--- a/charts/datadog/templates/_components-common-env.yaml
+++ b/charts/datadog/templates/_components-common-env.yaml
@@ -42,6 +42,10 @@
 - name: DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS
   value: '{{ toJson .Values.datadog.namespaceLabelsAsTags }}'
 {{- end }}
+{{- if .Values.datadog.collectKubernetesNamespaces }}
+- name: DD_KUBERNETES_NAMESPACE_COLLECTION_ENABLED
+  value: {{ .Values.datadog.kubelet.collectKubernetesNamespaces | quote }}
+{{- end }}
 - name: KUBERNETES
   value: "yes"
 {{- if .Values.datadog.site }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -249,6 +249,10 @@ datadog:
   #   env: environment
   #   <KUBERNETES_NAMESPACE_LABEL>: <DATADOG_TAG_KEY>
 
+  # datadog.collectKubernetesNamespaces -- Toggle if kubernetes namespace information should be collected. (Requires Agent/Cluster Agent 7.55.0+)
+  # @default -- false
+  collectKubernetesNamespaces: false
+
   # datadog.tags -- List of static tags to attach to every metric, event and service check collected by this Agent.
 
   ## Learn more about tagging: https://docs.datadoghq.com/tagging/


### PR DESCRIPTION
#### What this PR does / why we need it:

Add config for `collectKubernetesNamespaces` to enable namespace collection in workloadmeta. This config controls the changes introduced in https://github.com/DataDog/datadog-agent/pull/25279 (targeting `7.55.0`)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
