### PR TITLE
feat(admission controller): add .injectConfig.injectContainerName setting

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.65.0
+
+* Add `clusterAgent.admissionController.injectConfig.injectContainerName` setting to enable injection of the container name along with the pod uid in `DD_ENTITY_ID`. Disabled by default
+
 ## 3.64.1
 
 * Add `datadog.securityAgent.runtime.useSecruntimeTrack` config to start sending CWS events directly to the new secruntime track (and to the new agent events explorer).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.64.1
+version: 3.65.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.64.1](https://img.shields.io/badge/Version-3.64.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.65.0](https://img.shields.io/badge/Version-3.65.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -556,6 +556,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.admissionController.containerRegistry | string | `nil` | Override the default registry for the admission controller. |
 | clusterAgent.admissionController.enabled | bool | `true` | Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods |
 | clusterAgent.admissionController.failurePolicy | string | `"Ignore"` | Set the failure policy for dynamic admission control.' |
+| clusterAgent.admissionController.injectConfig.injectContainerName | bool | `false` | Injects the container name along with the pod uid in `DD_ENTITY_ID` if it was not set manually. Default: false. (Requires Agent 7.54.0+). |
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |
 | clusterAgent.admissionController.port | int | `8000` | Set port of cluster-agent admission controller service |
 | clusterAgent.admissionController.remoteInstrumentation.enabled | bool | `false` | Enable polling and applying library injection using Remote Config. # This feature is in beta, and enables Remote Config in the Cluster Agent. It also requires Cluster Agent version 7.43+. # Enabling this feature grants the Cluster Agent the permissions to patch Deployment objects in the cluster. |

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -222,6 +222,10 @@ spec:
             {{- end }}
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
             value: {{ template "localService.name" . }}
+          {{- if .Values.clusterAgent.admissionController.injectConfig.injectContainerName }}
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_INJECT_CONTAINER_NAME
+            value: {{ .Values.clusterAgent.admissionController.injectConfig.injectContainerName | quote }}
+          {{- end }}
           {{- if .Values.providers.aks.enabled }}
           - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
             value: "true"

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1091,6 +1091,10 @@ clusterAgent:
     ## Setting to Fail will require the admission controller to be present and pods to be injected before they are allowed to run.
     failurePolicy: Ignore
 
+    injectConfig:
+      # clusterAgent.admissionController.injectConfig.injectContainerName -- Injects the container name along with the pod uid in `DD_ENTITY_ID` if it was not set manually. Default: false. (Requires Agent 7.54.0+).
+      injectContainerName: false
+
     # clusterAgent.admissionController.containerRegistry -- Override the default registry for the admission controller.
 
     ## The clusterAgent uses this configuration for apm.instrumentation, agentSidecar, and cwsInstrumentation, if


### PR DESCRIPTION
Adds the .injectConfig.injectContainerName setting for the Admission Controller.

This setting enables injection of the container name along with the pod uid in `DD_ENTITY_ID`.

#### What this PR does / why we need it:

This is needed to support this feature: https://github.com/DataDog/datadog-agent/pull/23447

#### Special notes for your reviewer:

With this manifest:
```
registry: public.ecr.aws/datadog
datadog:
  clusterName: wassim-minikube
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
    coreCheck: true
clusterAgent:
  image:
    tag: 7.54.0-rc.3
  admissionController:
    injectConfig:
      injectContainerName: true
```

You will see:
```
➜  helm k exec -it datadog-agent-cluster-agent-547446b8f9-nwbcx -- agent config | grep inject_container_name
Defaulted container "cluster-agent" out of: cluster-agent, init-volume (init)
    inject_container_name: true
```

With this manifest:
```
registry: public.ecr.aws/datadog
datadog:
  clusterName: wassim-minikube
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
    coreCheck: true
clusterAgent:
  image:
    tag: 7.54.0-rc.3-jmx
```

You will see:
```
➜  helm k exec -it datadog-agent-cluster-agent-5bfffdbf47-28qgj -- agent config | grep inject_container_name
Defaulted container "cluster-agent" out of: cluster-agent, init-volume (init)
    inject_container_name: false
```


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
