### PR TITLE
Add CODEOWNER for process agent template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,13 +6,14 @@
 *.md             @DataDog/documentation @DataDog/container-helm-chart-maintainers
 
 # Charts
-charts/datadog-crds                                  @DataDog/container-ecosystems
-charts/datadog-operator                              @DataDog/container-ecosystems
-charts/extended-daemon-set                           @DataDog/container-ecosystems
-charts/datadog                                       @DataDog/container-helm-chart-maintainers
-charts/datadog/templates/container-system-probe.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
-charts/datadog/templates/system-probe-configmap.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
-charts/datadog/templates/system-probe-init.yaml      @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
-charts/synthetics-private-location/                  @Datadog/synthetics
-charts/observability-pipelines-worker                @DataDog/observability-pipelines
-charts/datadog/templates/_container-trace-agent.yaml @DataDog/agent-apm @DataDog/container-helm-chart-maintainers
+charts/datadog-crds                                    @DataDog/container-ecosystems
+charts/datadog-operator                                @DataDog/container-ecosystems
+charts/extended-daemon-set                             @DataDog/container-ecosystems
+charts/datadog                                         @DataDog/container-helm-chart-maintainers
+charts/datadog/templates/_container-process-agent.yaml @DataDog/processes @DataDog/container-helm-chart-maintainers
+charts/datadog/templates/_container-system-probe.yaml  @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
+charts/datadog/templates/_container-trace-agent.yaml   @DataDog/agent-apm @DataDog/container-helm-chart-maintainers
+charts/datadog/templates/_system-probe-init.yaml       @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
+charts/datadog/templates/system-probe-configmap.yaml   @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
+charts/synthetics-private-location/                    @Datadog/synthetics
+charts/observability-pipelines-worker                  @DataDog/observability-pipelines


### PR DESCRIPTION
#### What this PR does / why we need it:

Add @DataDog/processes as a code owner for the process agent template `_container-process-agent.yaml`

This ensures the Processes team is aware of PRs that affect the process agent.

Note: This PR also reorders the files alphabetically and fixes the system-probe filenames.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
