### PR TITLE
[CONTINT-4304] Add `useApiServerCache` to KSM core check

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.67.0
+
+* Add `datadog.kubeStateMetricsCore.useApiServerCache` to enable the use of the API server cache 
+in the Kube State Metrics Core check.
+
 ## 3.66.0
 
 * Set default `Agent` and `Cluster-Agent` version to `7.54.0`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.66.0
+version: 3.67.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.66.0](https://img.shields.io/badge/Version-3.66.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.67.0](https://img.shields.io/badge/Version-3.67.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -729,6 +729,7 @@ helm install <RELEASE_NAME> \
 | datadog.kubeStateMetricsCore.ignoreLegacyKSMCheck | bool | `true` | Disable the auto-configuration of legacy kubernetes_state check (taken into account only when datadog.kubeStateMetricsCore.enabled is true) |
 | datadog.kubeStateMetricsCore.labelsAsTags | object | `{}` | Extra labels to collect from resources and to turn into datadog tag. |
 | datadog.kubeStateMetricsCore.rbac.create | bool | `true` | If true, create & use RBAC resources |
+| datadog.kubeStateMetricsCore.useApiServerCache | bool | `false` | Enable the use of the Kubernetes API server cache for the kubernetes_state_core check. (Requires Cluster Agent 7.56+) |
 | datadog.kubeStateMetricsCore.useClusterCheckRunners | bool | `false` | For large clusters where the Kubernetes State Metrics Check Core needs to be distributed on dedicated workers. |
 | datadog.kubeStateMetricsEnabled | bool | `false` | If true, deploys the kube-state-metrics deployment |
 | datadog.kubeStateMetricsNetworkPolicy.create | bool | `false` | If true, create a NetworkPolicy for kube state metrics |

--- a/charts/datadog/templates/_kubernetes_state_core_config.yaml
+++ b/charts/datadog/templates/_kubernetes_state_core_config.yaml
@@ -42,6 +42,7 @@ kubernetes_state_core.yaml.default: |-
       - storageclasses
       - volumeattachments
       - ingresses
+      use_api_server_cache: {{ .Values.datadog.kubeStateMetricsCore.useApiServerCache }}
 {{- if .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners }}
       skip_leader_election: true
 {{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -143,6 +143,11 @@ datadog:
     # datadog.kubeStateMetricsCore.rbac.create -- If true, create & use RBAC resources
       create: true
 
+    # datadog.kubeStateMetricsCore.useApiServerCache -- Enable the use of the Kubernetes API server cache for the kubernetes_state_core check. (Requires Cluster Agent 7.56+)
+
+    ## Configuring this field will change the default kubernetes_state_core check configuration to run the kubernetes_state_core check.
+    useApiServerCache: false
+
     # datadog.kubeStateMetricsCore.ignoreLegacyKSMCheck -- Disable the auto-configuration of legacy kubernetes_state check (taken into account only when datadog.kubeStateMetricsCore.enabled is true)
 
     ## Disabling this field is not recommended as it results in enabling both checks, it can be useful though during the migration phase.


### PR DESCRIPTION
#### What this PR does / why we need it:

This option adds an option to set the new param added by https://github.com/DataDog/datadog-agent/pull/26371

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
