### PR TITLE
[DO NOT MERGE] OPA-1840: add DD_OP_PCI_COMPLIANT environment variable

### DIFF
--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: "2.0.2"
+version: "2.0.3"
 description: Observability Pipelines Worker
 type: application
 keywords:

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
+![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 
@@ -76,85 +76,85 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` | Configure [affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). |
-| args | list | `["run"]` | Override default image arguments. |
-| autoscaling.behavior | object | `{}` | Configure separate scale-up and scale-down behaviors. |
-| autoscaling.enabled | bool | `false` | If **true**, create a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/). |
-| autoscaling.maxReplicas | int | `10` | Specify the maximum number of replicas. |
-| autoscaling.minReplicas | int | `1` | Specify the minimum number of replicas. |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` | Specify the target CPU utilization. |
-| autoscaling.targetMemoryUtilizationPercentage | int | `nil` | Specify the target memory utilization. |
-| command | list | `[]` | Override default image command. |
-| commonLabels | object | `{}` | Labels to apply to all resources. |
-| containerPorts | list | `[]` | Manually define ContainerPort array, overriding automated generation of ContainerPorts. |
-| datadog.apiKey | string | `nil` | Specify your Datadog API key. |
-| datadog.apiKeyExistingSecret | string | `""` | Specify a preexisting Secret that has your API key instead of creating a new one. The value must be stored under the `api-key`. |
-| datadog.dataDir | string | `"/var/lib/observability-pipelines-worker"` | The data directory for OPW to store runtime data in. |
-| datadog.pipelineId | string | `nil` | Specify your Datadog Observability Pipelines pipeline ID |
-| datadog.site | string | `"datadoghq.com"` | The [site](https://docs.datadoghq.com/getting_started/site/) of the Datadog intake to send data to. |
-| datadog.workerAPI.address | string | `"127.0.0.1:8686"` | Local address to bind the Worker's API to. |
-| datadog.workerAPI.enabled | bool | `false` | Whether to enable the Worker's API. |
-| datadog.workerAPI.playground | bool | `true` | Whether to enable the Worker's API GraphQL playground. |
-| dnsConfig | object | `{}` | Specify the [dnsConfig](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config). |
-| dnsPolicy | string | `"ClusterFirst"` | Specify the [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy). |
-| env | list | `[]` | Define environment variables. |
-| envFrom | list | `[]` | Define environment variables from ConfigMap or Secret data. |
-| extraContainers | list | `[]` | Specify extra Containers to be added. |
-| extraVolumeMounts | list | `[]` | Specify Additional VolumeMounts to use. |
-| extraVolumes | list | `[]` | Specify additional Volumes to use. |
-| fullnameOverride | string | `""` | Override the fully qualified app name. |
-| image.digest | string | `nil` | Specify the image digest to use; takes precedence over `image.tag`. |
-| image.name | string | `"observability-pipelines-worker"` | Specify the image name to use (relative to `image.repository`). |
-| image.pullPolicy | string | `"IfNotPresent"` | Specify the [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy). |
-| image.pullSecrets | list | `[]` | Specify the [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod). |
-| image.repository | string | `"gcr.io/datadoghq"` | Specify the image repository to use. |
-| image.tag | string | `"2.0.2"` | Specify the image tag to use. |
-| ingress.annotations | object | `{}` | Specify annotations for the Ingress. |
-| ingress.className | string | `""` | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18. |
-| ingress.enabled | bool | `false` | If **true**, create an Ingress resource. |
-| ingress.hosts | list | `[]` | Configure the hosts and paths for the Ingress. |
-| ingress.tls | list | `[]` | Configure TLS for the Ingress. |
-| initContainers | list | `[]` | Specify initContainers to be added. |
-| lifecycle | object | `{}` | Specify lifecycle hooks for Containers. |
-| livenessProbe | object | `{}` | Specify the livenessProbe [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes). |
-| nameOverride | string | `""` | Override the name of the app. |
-| nodeSelector | object | `{}` | Configure [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector). |
-| persistence.accessModes | list | `["ReadWriteOnce"]` | Specify the accessModes for PersistentVolumeClaims. |
-| persistence.enabled | bool | `false` | If **true**, create and use PersistentVolumeClaims. |
-| persistence.existingClaim | string | `""` | Name of an existing PersistentVolumeClaim to use. |
-| persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Specify the finalizers of PersistentVolumeClaims. |
-| persistence.selector | object | `{}` | Specify the selectors for PersistentVolumeClaims. |
-| persistence.size | string | `"10Gi"` | Specify the size of PersistentVolumeClaims. |
-| persistence.storageClassName | string | `nil` | Specify the storageClassName for PersistentVolumeClaims. |
-| podAnnotations | object | `{}` | Set annotations on Pods. |
-| podDisruptionBudget.enabled | bool | `false` | If **true**, create a [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/). |
-| podDisruptionBudget.maxUnavailable | int | `nil` | Specify the number of Pods that can be unavailable after an eviction. |
-| podDisruptionBudget.minAvailable | int | `1` | Specify the number of Pods that must still be available after an eviction. |
-| podHostNetwork | bool | `false` | Enable the hostNetwork option on Pods. |
-| podLabels | object | `{}` | Set labels on Pods. |
-| podManagementPolicy | string | `"OrderedReady"` | Specify the [podManagementPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies). |
-| podPriorityClassName | string | `""` | Set the [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass). |
-| podSecurityContext | object | `{}` | Allows you to overwrite the default [PodSecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
-| readinessProbe | object | `{}` | Specify the readinessProbe [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes). |
-| replicas | int | `1` | Specify the number of replicas to create. |
-| resources | object | `{}` | Specify resource requests and limits. |
-| securityContext | object | `{}` | Specify securityContext for Containers. |
-| service.annotations | object | `{}` | Specify annotations for the Service. |
-| service.enabled | bool | `true` | If **true**, create a Service resource. |
-| service.externalTrafficPolicy | string | `""` | Specify the [externalTrafficPolicy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip). |
-| service.ipFamilies | list | `[]` | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/). |
-| service.ipFamilyPolicy | string | `""` | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/). |
-| service.loadBalancerIP | string | `""` | Specify the [loadBalancerIP](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer). |
-| service.ports | array | `nil` | Manually set the ServicePort array, overriding automated generation of ServicePorts. |
-| service.topologyKeys | array | `nil` | Specify the [topologyKeys](https://kubernetes.io/docs/concepts/services-networking/service-topology/#using-service-topology). |
-| service.type | string | `"ClusterIP"` | Specify the type for the Service. |
-| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount, if `serviceAccount.create` is **true**. |
-| serviceAccount.create | bool | `true` | If **true**, create a ServiceAccount. |
-| serviceAccount.name | string | `"default"` | Specify a preexisting ServiceAccount to use if `serviceAccount.create` is **false**. |
-| serviceHeadless.enabled | bool | `true` | If **true**, create a "headless" Service resource. |
-| terminationGracePeriodSeconds | int | `60` | Override terminationGracePeriodSeconds. |
-| tolerations | list | `[]` | Configure [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). |
-| topologySpreadConstraints | list | `[]` | Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/). |
-| updateStrategy | object | `{}` | Customize the [updateStrategy](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/#StatefulSetSpec). |
+| Key                                           | Type   | Default                                     | Description                                                                                                                                                                                |
+| --------------------------------------------- | ------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| affinity                                      | object | `{}`                                        | Configure [affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).                                               |
+| args                                          | list   | `["run"]`                                   | Override default image arguments.                                                                                                                                                          |
+| autoscaling.behavior                          | object | `{}`                                        | Configure separate scale-up and scale-down behaviors.                                                                                                                                      |
+| autoscaling.enabled                           | bool   | `false`                                     | If **true**, create a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/).                                                               |
+| autoscaling.maxReplicas                       | int    | `10`                                        | Specify the maximum number of replicas.                                                                                                                                                    |
+| autoscaling.minReplicas                       | int    | `1`                                         | Specify the minimum number of replicas.                                                                                                                                                    |
+| autoscaling.targetCPUUtilizationPercentage    | int    | `80`                                        | Specify the target CPU utilization.                                                                                                                                                        |
+| autoscaling.targetMemoryUtilizationPercentage | int    | `nil`                                       | Specify the target memory utilization.                                                                                                                                                     |
+| command                                       | list   | `[]`                                        | Override default image command.                                                                                                                                                            |
+| commonLabels                                  | object | `{}`                                        | Labels to apply to all resources.                                                                                                                                                          |
+| containerPorts                                | list   | `[]`                                        | Manually define ContainerPort array, overriding automated generation of ContainerPorts.                                                                                                    |
+| datadog.apiKey                                | string | `nil`                                       | Specify your Datadog API key.                                                                                                                                                              |
+| datadog.apiKeyExistingSecret                  | string | `""`                                        | Specify a preexisting Secret that has your API key instead of creating a new one. The value must be stored under the `api-key`.                                                            |
+| datadog.dataDir                               | string | `"/var/lib/observability-pipelines-worker"` | The data directory for OPW to store runtime data in.                                                                                                                                       |
+| datadog.pipelineId                            | string | `nil`                                       | Specify your Datadog Observability Pipelines pipeline ID                                                                                                                                   |
+| datadog.site                                  | string | `"datadoghq.com"`                           | The [site](https://docs.datadoghq.com/getting_started/site/) of the Datadog intake to send data to.                                                                                        |
+| datadog.workerAPI.address                     | string | `"127.0.0.1:8686"`                          | Local address to bind the Worker's API to.                                                                                                                                                 |
+| datadog.workerAPI.enabled                     | bool   | `false`                                     | Whether to enable the Worker's API.                                                                                                                                                        |
+| datadog.workerAPI.playground                  | bool   | `true`                                      | Whether to enable the Worker's API GraphQL playground.                                                                                                                                     |
+| dnsConfig                                     | object | `{}`                                        | Specify the [dnsConfig](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config).                                                                          |
+| dnsPolicy                                     | string | `"ClusterFirst"`                            | Specify the [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).                                                                        |
+| env                                           | list   | `[]`                                        | Define environment variables.                                                                                                                                                              |
+| envFrom                                       | list   | `[]`                                        | Define environment variables from ConfigMap or Secret data.                                                                                                                                |
+| extraContainers                               | list   | `[]`                                        | Specify extra Containers to be added.                                                                                                                                                      |
+| extraVolumeMounts                             | list   | `[]`                                        | Specify Additional VolumeMounts to use.                                                                                                                                                    |
+| extraVolumes                                  | list   | `[]`                                        | Specify additional Volumes to use.                                                                                                                                                         |
+| fullnameOverride                              | string | `""`                                        | Override the fully qualified app name.                                                                                                                                                     |
+| image.digest                                  | string | `nil`                                       | Specify the image digest to use; takes precedence over `image.tag`.                                                                                                                        |
+| image.name                                    | string | `"observability-pipelines-worker"`          | Specify the image name to use (relative to `image.repository`).                                                                                                                            |
+| image.pullPolicy                              | string | `"IfNotPresent"`                            | Specify the [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy).                                                                                        |
+| image.pullSecrets                             | list   | `[]`                                        | Specify the [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).                                                               |
+| image.repository                              | string | `"gcr.io/datadoghq"`                        | Specify the image repository to use.                                                                                                                                                       |
+| image.tag                                     | string | `"2.0.2"`                                   | Specify the image tag to use.                                                                                                                                                              |
+| ingress.annotations                           | object | `{}`                                        | Specify annotations for the Ingress.                                                                                                                                                       |
+| ingress.className                             | string | `""`                                        | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18. |
+| ingress.enabled                               | bool   | `false`                                     | If **true**, create an Ingress resource.                                                                                                                                                   |
+| ingress.hosts                                 | list   | `[]`                                        | Configure the hosts and paths for the Ingress.                                                                                                                                             |
+| ingress.tls                                   | list   | `[]`                                        | Configure TLS for the Ingress.                                                                                                                                                             |
+| initContainers                                | list   | `[]`                                        | Specify initContainers to be added.                                                                                                                                                        |
+| lifecycle                                     | object | `{}`                                        | Specify lifecycle hooks for Containers.                                                                                                                                                    |
+| livenessProbe                                 | object | `{}`                                        | Specify the livenessProbe [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).                         |
+| nameOverride                                  | string | `""`                                        | Override the name of the app.                                                                                                                                                              |
+| nodeSelector                                  | object | `{}`                                        | Configure [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).                                                                           |
+| persistence.accessModes                       | list   | `["ReadWriteOnce"]`                         | Specify the accessModes for PersistentVolumeClaims.                                                                                                                                        |
+| persistence.enabled                           | bool   | `false`                                     | If **true**, create and use PersistentVolumeClaims.                                                                                                                                        |
+| persistence.existingClaim                     | string | `""`                                        | Name of an existing PersistentVolumeClaim to use.                                                                                                                                          |
+| persistence.finalizers                        | list   | `["kubernetes.io/pvc-protection"]`          | Specify the finalizers of PersistentVolumeClaims.                                                                                                                                          |
+| persistence.selector                          | object | `{}`                                        | Specify the selectors for PersistentVolumeClaims.                                                                                                                                          |
+| persistence.size                              | string | `"10Gi"`                                    | Specify the size of PersistentVolumeClaims.                                                                                                                                                |
+| persistence.storageClassName                  | string | `nil`                                       | Specify the storageClassName for PersistentVolumeClaims.                                                                                                                                   |
+| podAnnotations                                | object | `{}`                                        | Set annotations on Pods.                                                                                                                                                                   |
+| podDisruptionBudget.enabled                   | bool   | `false`                                     | If **true**, create a [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).                                                                              |
+| podDisruptionBudget.maxUnavailable            | int    | `nil`                                       | Specify the number of Pods that can be unavailable after an eviction.                                                                                                                      |
+| podDisruptionBudget.minAvailable              | int    | `1`                                         | Specify the number of Pods that must still be available after an eviction.                                                                                                                 |
+| podHostNetwork                                | bool   | `false`                                     | Enable the hostNetwork option on Pods.                                                                                                                                                     |
+| podLabels                                     | object | `{}`                                        | Set labels on Pods.                                                                                                                                                                        |
+| podManagementPolicy                           | string | `"OrderedReady"`                            | Specify the [podManagementPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies).                                                         |
+| podPriorityClassName                          | string | `""`                                        | Set the [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).                                                               |
+| podSecurityContext                            | object | `{}`                                        | Allows you to overwrite the default [PodSecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).                                                      |
+| readinessProbe                                | object | `{}`                                        | Specify the readinessProbe [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).                        |
+| replicas                                      | int    | `1`                                         | Specify the number of replicas to create.                                                                                                                                                  |
+| resources                                     | object | `{}`                                        | Specify resource requests and limits.                                                                                                                                                      |
+| securityContext                               | object | `{}`                                        | Specify securityContext for Containers.                                                                                                                                                    |
+| service.annotations                           | object | `{}`                                        | Specify annotations for the Service.                                                                                                                                                       |
+| service.enabled                               | bool   | `true`                                      | If **true**, create a Service resource.                                                                                                                                                    |
+| service.externalTrafficPolicy                 | string | `""`                                        | Specify the [externalTrafficPolicy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip).                           |
+| service.ipFamilies                            | list   | `[]`                                        | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).                                                                                     |
+| service.ipFamilyPolicy                        | string | `""`                                        | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).                                                                                     |
+| service.loadBalancerIP                        | string | `""`                                        | Specify the [loadBalancerIP](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer).                                                                               |
+| service.ports                                 | array  | `nil`                                       | Manually set the ServicePort array, overriding automated generation of ServicePorts.                                                                                                       |
+| service.topologyKeys                          | array  | `nil`                                       | Specify the [topologyKeys](https://kubernetes.io/docs/concepts/services-networking/service-topology/#using-service-topology).                                                              |
+| service.type                                  | string | `"ClusterIP"`                               | Specify the type for the Service.                                                                                                                                                          |
+| serviceAccount.annotations                    | object | `{}`                                        | Annotations to add to the ServiceAccount, if `serviceAccount.create` is **true**.                                                                                                          |
+| serviceAccount.create                         | bool   | `true`                                      | If **true**, create a ServiceAccount.                                                                                                                                                      |
+| serviceAccount.name                           | string | `"default"`                                 | Specify a preexisting ServiceAccount to use if `serviceAccount.create` is **false**.                                                                                                       |
+| serviceHeadless.enabled                       | bool   | `true`                                      | If **true**, create a "headless" Service resource.                                                                                                                                         |
+| terminationGracePeriodSeconds                 | int    | `60`                                        | Override terminationGracePeriodSeconds.                                                                                                                                                    |
+| tolerations                                   | list   | `[]`                                        | Configure [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).                                                                         |
+| topologySpreadConstraints                     | list   | `[]`                                        | Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).                                                             |
+| updateStrategy                                | object | `{}`                                        | Customize the [updateStrategy](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/#StatefulSetSpec).                                                   |

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -92,6 +92,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | datadog.apiKey | string | `nil` | Specify your Datadog API key. |
 | datadog.apiKeyExistingSecret | string | `""` | Specify a preexisting Secret that has your API key instead of creating a new one. The value must be stored under the `api-key`. |
 | datadog.dataDir | string | `"/var/lib/observability-pipelines-worker"` | The data directory for OPW to store runtime data in. |
+| datadog.pciCompliant | bool | `false` | Sets the DD_OP_PCI_COMPLIANT to true when enabled. |
 | datadog.pipelineId | string | `nil` | Specify your Datadog Observability Pipelines pipeline ID |
 | datadog.site | string | `"datadoghq.com"` | The [site](https://docs.datadoghq.com/getting_started/site/) of the Datadog intake to send data to. |
 | datadog.workerAPI.address | string | `"127.0.0.1:8686"` | Local address to bind the Worker's API to. |

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -76,85 +76,85 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Values
 
-| Key                                           | Type   | Default                                     | Description                                                                                                                                                                                |
-| --------------------------------------------- | ------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| affinity                                      | object | `{}`                                        | Configure [affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).                                               |
-| args                                          | list   | `["run"]`                                   | Override default image arguments.                                                                                                                                                          |
-| autoscaling.behavior                          | object | `{}`                                        | Configure separate scale-up and scale-down behaviors.                                                                                                                                      |
-| autoscaling.enabled                           | bool   | `false`                                     | If **true**, create a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/).                                                               |
-| autoscaling.maxReplicas                       | int    | `10`                                        | Specify the maximum number of replicas.                                                                                                                                                    |
-| autoscaling.minReplicas                       | int    | `1`                                         | Specify the minimum number of replicas.                                                                                                                                                    |
-| autoscaling.targetCPUUtilizationPercentage    | int    | `80`                                        | Specify the target CPU utilization.                                                                                                                                                        |
-| autoscaling.targetMemoryUtilizationPercentage | int    | `nil`                                       | Specify the target memory utilization.                                                                                                                                                     |
-| command                                       | list   | `[]`                                        | Override default image command.                                                                                                                                                            |
-| commonLabels                                  | object | `{}`                                        | Labels to apply to all resources.                                                                                                                                                          |
-| containerPorts                                | list   | `[]`                                        | Manually define ContainerPort array, overriding automated generation of ContainerPorts.                                                                                                    |
-| datadog.apiKey                                | string | `nil`                                       | Specify your Datadog API key.                                                                                                                                                              |
-| datadog.apiKeyExistingSecret                  | string | `""`                                        | Specify a preexisting Secret that has your API key instead of creating a new one. The value must be stored under the `api-key`.                                                            |
-| datadog.dataDir                               | string | `"/var/lib/observability-pipelines-worker"` | The data directory for OPW to store runtime data in.                                                                                                                                       |
-| datadog.pipelineId                            | string | `nil`                                       | Specify your Datadog Observability Pipelines pipeline ID                                                                                                                                   |
-| datadog.site                                  | string | `"datadoghq.com"`                           | The [site](https://docs.datadoghq.com/getting_started/site/) of the Datadog intake to send data to.                                                                                        |
-| datadog.workerAPI.address                     | string | `"127.0.0.1:8686"`                          | Local address to bind the Worker's API to.                                                                                                                                                 |
-| datadog.workerAPI.enabled                     | bool   | `false`                                     | Whether to enable the Worker's API.                                                                                                                                                        |
-| datadog.workerAPI.playground                  | bool   | `true`                                      | Whether to enable the Worker's API GraphQL playground.                                                                                                                                     |
-| dnsConfig                                     | object | `{}`                                        | Specify the [dnsConfig](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config).                                                                          |
-| dnsPolicy                                     | string | `"ClusterFirst"`                            | Specify the [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).                                                                        |
-| env                                           | list   | `[]`                                        | Define environment variables.                                                                                                                                                              |
-| envFrom                                       | list   | `[]`                                        | Define environment variables from ConfigMap or Secret data.                                                                                                                                |
-| extraContainers                               | list   | `[]`                                        | Specify extra Containers to be added.                                                                                                                                                      |
-| extraVolumeMounts                             | list   | `[]`                                        | Specify Additional VolumeMounts to use.                                                                                                                                                    |
-| extraVolumes                                  | list   | `[]`                                        | Specify additional Volumes to use.                                                                                                                                                         |
-| fullnameOverride                              | string | `""`                                        | Override the fully qualified app name.                                                                                                                                                     |
-| image.digest                                  | string | `nil`                                       | Specify the image digest to use; takes precedence over `image.tag`.                                                                                                                        |
-| image.name                                    | string | `"observability-pipelines-worker"`          | Specify the image name to use (relative to `image.repository`).                                                                                                                            |
-| image.pullPolicy                              | string | `"IfNotPresent"`                            | Specify the [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy).                                                                                        |
-| image.pullSecrets                             | list   | `[]`                                        | Specify the [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).                                                               |
-| image.repository                              | string | `"gcr.io/datadoghq"`                        | Specify the image repository to use.                                                                                                                                                       |
-| image.tag                                     | string | `"2.0.2"`                                   | Specify the image tag to use.                                                                                                                                                              |
-| ingress.annotations                           | object | `{}`                                        | Specify annotations for the Ingress.                                                                                                                                                       |
-| ingress.className                             | string | `""`                                        | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18. |
-| ingress.enabled                               | bool   | `false`                                     | If **true**, create an Ingress resource.                                                                                                                                                   |
-| ingress.hosts                                 | list   | `[]`                                        | Configure the hosts and paths for the Ingress.                                                                                                                                             |
-| ingress.tls                                   | list   | `[]`                                        | Configure TLS for the Ingress.                                                                                                                                                             |
-| initContainers                                | list   | `[]`                                        | Specify initContainers to be added.                                                                                                                                                        |
-| lifecycle                                     | object | `{}`                                        | Specify lifecycle hooks for Containers.                                                                                                                                                    |
-| livenessProbe                                 | object | `{}`                                        | Specify the livenessProbe [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).                         |
-| nameOverride                                  | string | `""`                                        | Override the name of the app.                                                                                                                                                              |
-| nodeSelector                                  | object | `{}`                                        | Configure [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).                                                                           |
-| persistence.accessModes                       | list   | `["ReadWriteOnce"]`                         | Specify the accessModes for PersistentVolumeClaims.                                                                                                                                        |
-| persistence.enabled                           | bool   | `false`                                     | If **true**, create and use PersistentVolumeClaims.                                                                                                                                        |
-| persistence.existingClaim                     | string | `""`                                        | Name of an existing PersistentVolumeClaim to use.                                                                                                                                          |
-| persistence.finalizers                        | list   | `["kubernetes.io/pvc-protection"]`          | Specify the finalizers of PersistentVolumeClaims.                                                                                                                                          |
-| persistence.selector                          | object | `{}`                                        | Specify the selectors for PersistentVolumeClaims.                                                                                                                                          |
-| persistence.size                              | string | `"10Gi"`                                    | Specify the size of PersistentVolumeClaims.                                                                                                                                                |
-| persistence.storageClassName                  | string | `nil`                                       | Specify the storageClassName for PersistentVolumeClaims.                                                                                                                                   |
-| podAnnotations                                | object | `{}`                                        | Set annotations on Pods.                                                                                                                                                                   |
-| podDisruptionBudget.enabled                   | bool   | `false`                                     | If **true**, create a [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).                                                                              |
-| podDisruptionBudget.maxUnavailable            | int    | `nil`                                       | Specify the number of Pods that can be unavailable after an eviction.                                                                                                                      |
-| podDisruptionBudget.minAvailable              | int    | `1`                                         | Specify the number of Pods that must still be available after an eviction.                                                                                                                 |
-| podHostNetwork                                | bool   | `false`                                     | Enable the hostNetwork option on Pods.                                                                                                                                                     |
-| podLabels                                     | object | `{}`                                        | Set labels on Pods.                                                                                                                                                                        |
-| podManagementPolicy                           | string | `"OrderedReady"`                            | Specify the [podManagementPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies).                                                         |
-| podPriorityClassName                          | string | `""`                                        | Set the [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).                                                               |
-| podSecurityContext                            | object | `{}`                                        | Allows you to overwrite the default [PodSecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).                                                      |
-| readinessProbe                                | object | `{}`                                        | Specify the readinessProbe [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).                        |
-| replicas                                      | int    | `1`                                         | Specify the number of replicas to create.                                                                                                                                                  |
-| resources                                     | object | `{}`                                        | Specify resource requests and limits.                                                                                                                                                      |
-| securityContext                               | object | `{}`                                        | Specify securityContext for Containers.                                                                                                                                                    |
-| service.annotations                           | object | `{}`                                        | Specify annotations for the Service.                                                                                                                                                       |
-| service.enabled                               | bool   | `true`                                      | If **true**, create a Service resource.                                                                                                                                                    |
-| service.externalTrafficPolicy                 | string | `""`                                        | Specify the [externalTrafficPolicy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip).                           |
-| service.ipFamilies                            | list   | `[]`                                        | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).                                                                                     |
-| service.ipFamilyPolicy                        | string | `""`                                        | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).                                                                                     |
-| service.loadBalancerIP                        | string | `""`                                        | Specify the [loadBalancerIP](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer).                                                                               |
-| service.ports                                 | array  | `nil`                                       | Manually set the ServicePort array, overriding automated generation of ServicePorts.                                                                                                       |
-| service.topologyKeys                          | array  | `nil`                                       | Specify the [topologyKeys](https://kubernetes.io/docs/concepts/services-networking/service-topology/#using-service-topology).                                                              |
-| service.type                                  | string | `"ClusterIP"`                               | Specify the type for the Service.                                                                                                                                                          |
-| serviceAccount.annotations                    | object | `{}`                                        | Annotations to add to the ServiceAccount, if `serviceAccount.create` is **true**.                                                                                                          |
-| serviceAccount.create                         | bool   | `true`                                      | If **true**, create a ServiceAccount.                                                                                                                                                      |
-| serviceAccount.name                           | string | `"default"`                                 | Specify a preexisting ServiceAccount to use if `serviceAccount.create` is **false**.                                                                                                       |
-| serviceHeadless.enabled                       | bool   | `true`                                      | If **true**, create a "headless" Service resource.                                                                                                                                         |
-| terminationGracePeriodSeconds                 | int    | `60`                                        | Override terminationGracePeriodSeconds.                                                                                                                                                    |
-| tolerations                                   | list   | `[]`                                        | Configure [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).                                                                         |
-| topologySpreadConstraints                     | list   | `[]`                                        | Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).                                                             |
-| updateStrategy                                | object | `{}`                                        | Customize the [updateStrategy](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/#StatefulSetSpec).                                                   |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Configure [affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). |
+| args | list | `["run"]` | Override default image arguments. |
+| autoscaling.behavior | object | `{}` | Configure separate scale-up and scale-down behaviors. |
+| autoscaling.enabled | bool | `false` | If **true**, create a [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/). |
+| autoscaling.maxReplicas | int | `10` | Specify the maximum number of replicas. |
+| autoscaling.minReplicas | int | `1` | Specify the minimum number of replicas. |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Specify the target CPU utilization. |
+| autoscaling.targetMemoryUtilizationPercentage | int | `nil` | Specify the target memory utilization. |
+| command | list | `[]` | Override default image command. |
+| commonLabels | object | `{}` | Labels to apply to all resources. |
+| containerPorts | list | `[]` | Manually define ContainerPort array, overriding automated generation of ContainerPorts. |
+| datadog.apiKey | string | `nil` | Specify your Datadog API key. |
+| datadog.apiKeyExistingSecret | string | `""` | Specify a preexisting Secret that has your API key instead of creating a new one. The value must be stored under the `api-key`. |
+| datadog.dataDir | string | `"/var/lib/observability-pipelines-worker"` | The data directory for OPW to store runtime data in. |
+| datadog.pipelineId | string | `nil` | Specify your Datadog Observability Pipelines pipeline ID |
+| datadog.site | string | `"datadoghq.com"` | The [site](https://docs.datadoghq.com/getting_started/site/) of the Datadog intake to send data to. |
+| datadog.workerAPI.address | string | `"127.0.0.1:8686"` | Local address to bind the Worker's API to. |
+| datadog.workerAPI.enabled | bool | `false` | Whether to enable the Worker's API. |
+| datadog.workerAPI.playground | bool | `true` | Whether to enable the Worker's API GraphQL playground. |
+| dnsConfig | object | `{}` | Specify the [dnsConfig](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config). |
+| dnsPolicy | string | `"ClusterFirst"` | Specify the [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy). |
+| env | list | `[]` | Define environment variables. |
+| envFrom | list | `[]` | Define environment variables from ConfigMap or Secret data. |
+| extraContainers | list | `[]` | Specify extra Containers to be added. |
+| extraVolumeMounts | list | `[]` | Specify Additional VolumeMounts to use. |
+| extraVolumes | list | `[]` | Specify additional Volumes to use. |
+| fullnameOverride | string | `""` | Override the fully qualified app name. |
+| image.digest | string | `nil` | Specify the image digest to use; takes precedence over `image.tag`. |
+| image.name | string | `"observability-pipelines-worker"` | Specify the image name to use (relative to `image.repository`). |
+| image.pullPolicy | string | `"IfNotPresent"` | Specify the [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy). |
+| image.pullSecrets | list | `[]` | Specify the [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod). |
+| image.repository | string | `"gcr.io/datadoghq"` | Specify the image repository to use. |
+| image.tag | string | `"2.0.2"` | Specify the image tag to use. |
+| ingress.annotations | object | `{}` | Specify annotations for the Ingress. |
+| ingress.className | string | `""` | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18. |
+| ingress.enabled | bool | `false` | If **true**, create an Ingress resource. |
+| ingress.hosts | list | `[]` | Configure the hosts and paths for the Ingress. |
+| ingress.tls | list | `[]` | Configure TLS for the Ingress. |
+| initContainers | list | `[]` | Specify initContainers to be added. |
+| lifecycle | object | `{}` | Specify lifecycle hooks for Containers. |
+| livenessProbe | object | `{}` | Specify the livenessProbe [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes). |
+| nameOverride | string | `""` | Override the name of the app. |
+| nodeSelector | object | `{}` | Configure [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector). |
+| persistence.accessModes | list | `["ReadWriteOnce"]` | Specify the accessModes for PersistentVolumeClaims. |
+| persistence.enabled | bool | `false` | If **true**, create and use PersistentVolumeClaims. |
+| persistence.existingClaim | string | `""` | Name of an existing PersistentVolumeClaim to use. |
+| persistence.finalizers | list | `["kubernetes.io/pvc-protection"]` | Specify the finalizers of PersistentVolumeClaims. |
+| persistence.selector | object | `{}` | Specify the selectors for PersistentVolumeClaims. |
+| persistence.size | string | `"10Gi"` | Specify the size of PersistentVolumeClaims. |
+| persistence.storageClassName | string | `nil` | Specify the storageClassName for PersistentVolumeClaims. |
+| podAnnotations | object | `{}` | Set annotations on Pods. |
+| podDisruptionBudget.enabled | bool | `false` | If **true**, create a [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/). |
+| podDisruptionBudget.maxUnavailable | int | `nil` | Specify the number of Pods that can be unavailable after an eviction. |
+| podDisruptionBudget.minAvailable | int | `1` | Specify the number of Pods that must still be available after an eviction. |
+| podHostNetwork | bool | `false` | Enable the hostNetwork option on Pods. |
+| podLabels | object | `{}` | Set labels on Pods. |
+| podManagementPolicy | string | `"OrderedReady"` | Specify the [podManagementPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies). |
+| podPriorityClassName | string | `""` | Set the [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass). |
+| podSecurityContext | object | `{}` | Allows you to overwrite the default [PodSecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
+| readinessProbe | object | `{}` | Specify the readinessProbe [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes). |
+| replicas | int | `1` | Specify the number of replicas to create. |
+| resources | object | `{}` | Specify resource requests and limits. |
+| securityContext | object | `{}` | Specify securityContext for Containers. |
+| service.annotations | object | `{}` | Specify annotations for the Service. |
+| service.enabled | bool | `true` | If **true**, create a Service resource. |
+| service.externalTrafficPolicy | string | `""` | Specify the [externalTrafficPolicy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip). |
+| service.ipFamilies | list | `[]` | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/). |
+| service.ipFamilyPolicy | string | `""` | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/). |
+| service.loadBalancerIP | string | `""` | Specify the [loadBalancerIP](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer). |
+| service.ports | array | `nil` | Manually set the ServicePort array, overriding automated generation of ServicePorts. |
+| service.topologyKeys | array | `nil` | Specify the [topologyKeys](https://kubernetes.io/docs/concepts/services-networking/service-topology/#using-service-topology). |
+| service.type | string | `"ClusterIP"` | Specify the type for the Service. |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount, if `serviceAccount.create` is **true**. |
+| serviceAccount.create | bool | `true` | If **true**, create a ServiceAccount. |
+| serviceAccount.name | string | `"default"` | Specify a preexisting ServiceAccount to use if `serviceAccount.create` is **false**. |
+| serviceHeadless.enabled | bool | `true` | If **true**, create a "headless" Service resource. |
+| terminationGracePeriodSeconds | int | `60` | Override terminationGracePeriodSeconds. |
+| tolerations | list | `[]` | Configure [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/). |
+| topologySpreadConstraints | list | `[]` | Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/). |
+| updateStrategy | object | `{}` | Customize the [updateStrategy](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/#StatefulSetSpec). |

--- a/charts/observability-pipelines-worker/templates/_pod.tpl
+++ b/charts/observability-pipelines-worker/templates/_pod.tpl
@@ -63,6 +63,10 @@ containers:
         value: {{ .Values.datadog.workerAPI.playground | quote }}
       - name: DD_OP_API_ADDRESS
         value: {{ .Values.datadog.workerAPI.address | quote }}
+      {{- if .Values.datadog.pciCompliant }}
+      - name: DD_OP_PCI_COMPLIANT
+        value: "true"
+      {{- end }}
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 6 }}
 {{- end }}

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -30,6 +30,8 @@ datadog:
   site: datadoghq.com
   # datadog.dataDir -- The data directory for OPW to store runtime data in.
   dataDir: "/var/lib/observability-pipelines-worker"
+  # datadog.pciCompliant -- Sets the DD_OP_PCI_COMPLIANT to true when enabled.
+  pciCompliant: false
   workerAPI:
     # datadog.workerAPI.enabled -- Whether to enable the Worker's API.
     enabled: false
@@ -80,7 +82,8 @@ autoscaling:
   # autoscaling.targetMemoryUtilizationPercentage -- (int) Specify the target memory utilization.
   targetMemoryUtilizationPercentage:
   # autoscaling.behavior -- Configure separate scale-up and scale-down behaviors.
-  behavior: {}
+  behavior:
+    {}
     # scaleDown:
     #   stabilizationWindowSeconds: 300
 
@@ -149,7 +152,8 @@ envFrom: []
 containerPorts: []
 
 # resources -- Specify resource requests and limits.
-resources: {}
+resources:
+  {}
   # requests:
   #   cpu: 200m
   #   memory: 256Mi
@@ -158,7 +162,8 @@ resources: {}
   #   memory: 256Mi
 
 # lifecycle -- Specify lifecycle hooks for Containers.
-lifecycle: {}
+lifecycle:
+  {}
   # preStop:
   #   exec:
   #     command:
@@ -232,7 +237,8 @@ ingress:
   # requires Kubernetes >= 1.18.
   className: ""
   # ingress.annotations -- Specify annotations for the Ingress.
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # ingress.hosts -- Configure the hosts and paths for the Ingress.


### PR DESCRIPTION
#### What this PR does / why we need it:

We need to be able to add the PCI empliance environment variable through the `datadog.pciCompliant` parameter defined in https://datadoghq.atlassian.net/browse/OPA-1840.

#### Which issue this PR fixes

Fixes https://datadoghq.atlassian.net/browse/OPA-1841

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
