### PR TITLE
feat: add support for log format configuration

### DIFF
--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -62,6 +62,10 @@
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}
     {{- end }}
+    {{- if eq .Values.datadog.logFormat "json" }}
+    - name: DD_LOG_FORMAT_JSON
+      value: "true"
+    {{- end }}
     {{- if .Values.datadog.dogstatsd.port }}
     - name: DD_DOGSTATSD_PORT
       value: {{ .Values.datadog.dogstatsd.port | quote }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -40,6 +40,10 @@
     {{- end }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.processAgent.logLevel | default .Values.datadog.logLevel | quote }}
+    {{- if eq .Values.datadog.logFormat "json" }}
+    - name: DD_LOG_FORMAT_JSON
+      value: "true"
+    {{- end }}
     - name: DD_SYSTEM_PROBE_ENABLED
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}
     {{- if .Values.datadog.networkMonitoring.enabled }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -36,6 +36,10 @@
     {{- include "fips-envvar" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.traceAgent.logLevel | default .Values.datadog.logLevel | quote }}
+    {{- if eq .Values.datadog.logFormat "json" }}
+    - name: DD_LOG_FORMAT_JSON
+      value: "true"
+    {{- end }}
     - name: DD_APM_ENABLED
       value: "true"
     - name: DD_APM_NON_LOCAL_TRAFFIC

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -278,6 +278,10 @@ spec:
           - name: DD_LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}
           {{- end }}
+          {{- if eq .Values.datadog.logFormat "json" }}
+          - name: DD_LOG_FORMAT_JSON
+            value: "true"
+          {{- end }}
           - name: DD_LEADER_ELECTION
             value: {{ .Values.datadog.leaderElection | quote}}
           - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -123,6 +123,9 @@ datadog:
   # datadog.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, off
   logLevel: INFO
 
+  # datadog.logFormat -- Set logging format to text (default) or JSON
+  logFormat: text
+
   # datadog.kubeStateMetricsEnabled -- If true, deploys the kube-state-metrics deployment
 
   ## ref: https://github.com/kubernetes/kube-state-metrics/tree/kube-state-metrics-helm-chart-2.13.2/charts/kube-state-metrics


### PR DESCRIPTION
#### What this PR does / why we need it:
Sets the `DD_LOG_FORMAT_JSON` env variable to make the agents log messages in the JSON format.
This is controlled with the new variable `datadog.logFormat` (options are `text` (default) and `json`).

#### Checklist
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
