### PR TITLE
[datadog-crds] update CRDs following datadog operator 1.7.0 release

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.0
+* Update CRDs from Datadog Operator v1.7.0 tag.
+
 ## 1.6.0
 * Update CRDs from Datadog Operator v1.6.0 tag.
 

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 1.6.0
+version: 1.7.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
@@ -24,7 +24,17 @@ spec:
     singular: datadogagentprofile
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .status.valid
+          name: valid
+          type: string
+        - jsonPath: .status.applied
+          name: applied
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: DatadogAgentProfile is the Schema for the datadogagentprofiles API
@@ -105,6 +115,67 @@ spec:
               type: object
             status:
               description: DatadogAgentProfileStatus defines the observed state of DatadogAgentProfile
+              properties:
+                applied:
+                  description: Applied shows whether the DatadogAgentProfile conflicts with an existing DatadogAgentProfile.
+                  type: string
+                conditions:
+                  description: Conditions represents the latest available observations of a DatadogAgentProfile's current state.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                currentHash:
+                  description: CurrentHash is the stored hash of the DatadogAgentProfile.
+                  type: string
+                lastUpdate:
+                  description: LastUpdate is the last time the status was updated.
+                  format: date-time
+                  type: string
+                valid:
+                  description: Valid shows if the DatadogAgentProfile has a valid config spec.
+                  type: string
               type: object
           type: object
       served: true

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1beta1.yaml
@@ -14,6 +14,16 @@ metadata:
     app.kubernetes.io/name: '{{ include "datadog-crds.name" . }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'
 spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.valid
+      name: valid
+      type: string
+    - JSONPath: .status.applied
+      name: applied
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
   group: datadoghq.com
   names:
     kind: DatadogAgentProfile
@@ -105,6 +115,67 @@ spec:
           type: object
         status:
           description: DatadogAgentProfileStatus defines the observed state of DatadogAgentProfile
+          properties:
+            applied:
+              description: Applied shows whether the DatadogAgentProfile conflicts with an existing DatadogAgentProfile.
+              type: string
+            conditions:
+              description: Conditions represents the latest available observations of a DatadogAgentProfile's current state.
+              items:
+                description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                properties:
+                  lastTransitionTime:
+                    description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: message is a human readable message indicating details about the transition. This may be an empty string.
+                    maxLength: 32768
+                    type: string
+                  observedGeneration:
+                    description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  reason:
+                    description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                    maxLength: 1024
+                    minLength: 1
+                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    type: string
+                  status:
+                    description: status of the condition, one of True, False, Unknown.
+                    enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type: string
+                  type:
+                    description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                    maxLength: 316
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    type: string
+                required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+                - type
+              x-kubernetes-list-type: map
+            currentHash:
+              description: CurrentHash is the stored hash of the DatadogAgentProfile.
+              type: string
+            lastUpdate:
+              description: LastUpdate is the last time the status was updated.
+              format: date-time
+              type: string
+            valid:
+              description: Valid shows if the DatadogAgentProfile has a valid config spec.
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -5896,12 +5896,190 @@ spec:
                       properties:
                         agentCommunicationMode:
                           type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
                         enabled:
                           type: boolean
                         failurePolicy:
                           type: string
                         mutateUnlabelled:
                           type: boolean
+                        registry:
+                          type: string
                         serviceName:
                           type: string
                         webhookName:
@@ -5944,6 +6122,24 @@ spec:
                               type: boolean
                             path:
                               type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
                           type: object
                       type: object
                     clusterChecks:
@@ -6631,6 +6827,11 @@ spec:
                     nodeLabelsAsTags:
                       additionalProperties:
                         type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     podAnnotationsAsTags:
                       additionalProperties:
@@ -8530,15 +8731,685 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            mutateUnlabelled:
+                              type: boolean
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
               type: object
           type: object
-      {{- if eq .Values.migration.datadogAgents.version "v2alpha1" }}
       served: true
       storage: true
-      {{- else }}
-      served: true
-      storage: false
-      {{- end }}
       subresources:
         status: {}
 status:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1beta1.yaml
@@ -5885,12 +5885,190 @@ spec:
                       properties:
                         agentCommunicationMode:
                           type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
                         enabled:
                           type: boolean
                         failurePolicy:
                           type: string
                         mutateUnlabelled:
                           type: boolean
+                        registry:
+                          type: string
                         serviceName:
                           type: string
                         webhookName:
@@ -5933,6 +6111,24 @@ spec:
                               type: boolean
                             path:
                               type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
                           type: object
                       type: object
                     clusterChecks:
@@ -6620,6 +6816,11 @@ spec:
                     nodeLabelsAsTags:
                       additionalProperties:
                         type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     podAnnotationsAsTags:
                       additionalProperties:
@@ -8519,15 +8720,685 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            mutateUnlabelled:
+                              type: boolean
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
               type: object
           type: object
-      {{- if eq .Values.migration.datadogAgents.version "v2alpha1" }}
       served: true
       storage: true
-      {{- else }}
-      served: true
-      storage: false
-      {{- end }}
 status:
   acceptedNames:
     kind: ""

--- a/crds/datadoghq.com_datadogagentprofiles.yaml
+++ b/crds/datadoghq.com_datadogagentprofiles.yaml
@@ -18,7 +18,17 @@ spec:
     singular: datadogagentprofile
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .status.valid
+          name: valid
+          type: string
+        - jsonPath: .status.applied
+          name: applied
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: DatadogAgentProfile is the Schema for the datadogagentprofiles API
@@ -99,6 +109,67 @@ spec:
               type: object
             status:
               description: DatadogAgentProfileStatus defines the observed state of DatadogAgentProfile
+              properties:
+                applied:
+                  description: Applied shows whether the DatadogAgentProfile conflicts with an existing DatadogAgentProfile.
+                  type: string
+                conditions:
+                  description: Conditions represents the latest available observations of a DatadogAgentProfile's current state.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                currentHash:
+                  description: CurrentHash is the stored hash of the DatadogAgentProfile.
+                  type: string
+                lastUpdate:
+                  description: LastUpdate is the last time the status was updated.
+                  format: date-time
+                  type: string
+                valid:
+                  description: Valid shows if the DatadogAgentProfile has a valid config spec.
+                  type: string
               type: object
           type: object
       served: true

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -5870,12 +5870,190 @@ spec:
                       properties:
                         agentCommunicationMode:
                           type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
                         enabled:
                           type: boolean
                         failurePolicy:
                           type: string
                         mutateUnlabelled:
                           type: boolean
+                        registry:
+                          type: string
                         serviceName:
                           type: string
                         webhookName:
@@ -5918,6 +6096,24 @@ spec:
                               type: boolean
                             path:
                               type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
                           type: object
                       type: object
                     clusterChecks:
@@ -6605,6 +6801,11 @@ spec:
                     nodeLabelsAsTags:
                       additionalProperties:
                         type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     podAnnotationsAsTags:
                       additionalProperties:
@@ -8504,6 +8705,681 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            mutateUnlabelled:
+                              type: boolean
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
               type: object
           type: object
       served: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Update CRDs following release of Datadog Operator 1.7.0

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
- ~[ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)~
