### PR TITLE
[datadog-operator] update chart for 1.7.0

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.0
+
+* Update Datadog Operator version to 1.7.0.
+
 ## 1.7.1
 
 * Add `DD_TOOL_VERSION` to operator deployment.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 1.6.0
-digest: sha256:8ba0faa3eec8b7e0fab258789b0ddf16a106b725adb8548edd7fedbb862499f3
-generated: "2024-05-15T17:32:24.08231-04:00"
+  version: 1.7.0
+digest: sha256:30edb3c96a953b123604997bffdd2e4f52d2634d60b102c5fe7d532327c26c27
+generated: "2024-06-17T10:48:12.316395-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.7.1
-appVersion: 1.6.0
+version: 1.8.0
+appVersion: 1.7.0
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "=1.6.0"
+  version: "=1.7.0"
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 ## Values
 
@@ -11,6 +11,7 @@
 | apiKeyExistingSecret | string | `nil` | Use existing Secret which stores API key instead of creating a new one |
 | appKey | string | `nil` | Your Datadog APP key |
 | appKeyExistingSecret | string | `nil` | Use existing Secret which stores APP key instead of creating a new one |
+| clusterName | string | `nil` | Set a unique cluster name reporting from the Datadog Operator. |
 | collectOperatorMetrics | bool | `true` | Configures an openmetrics check to collect operator metrics |
 | containerSecurityContext | object | `{}` | A security context defines privileges and access control settings for a container. |
 | datadogAgent.enabled | bool | `true` | Enables Datadog Agent controller |
@@ -31,7 +32,7 @@
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.6.0"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.7.0"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |
@@ -44,6 +45,7 @@
 | podAnnotations | object | `{}` | Allows setting additional annotations for Datadog Operator PODs |
 | podLabels | object | `{}` | Allows setting additional labels for for Datadog Operator PODs |
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |
+| remoteConfiguration.enabled | bool | `false` | If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set. |
 | replicaCount | int | `1` | Number of instances of Datadog Operator |
 | resources | object | `{}` | Set resources requests/limits for Datadog Operator PODs |
 | secretBackend.arguments | string | `""` | Specifies the space-separated arguments passed to the command that implements the secret backend api |
@@ -122,7 +124,7 @@ You can update with the following:
 ```
 helm upgrade \
     datadog-operator datadog/datadog-operator \
-    --set image.tag=1.6.0 \
+    --set image.tag=1.7.0 \
     --set datadogCRDs.migration.datadogAgents.version=v2alpha1 \
     --set datadogCRDs.migration.datadogAgents.useCertManager=true \
     --set datadogCRDs.migration.datadogAgents.conversionWebhook.enabled=true

--- a/charts/datadog-operator/README.md.gotmpl
+++ b/charts/datadog-operator/README.md.gotmpl
@@ -68,7 +68,7 @@ You can update with the following:
 ```
 helm upgrade \
     datadog-operator datadog/datadog-operator \
-    --set image.tag=1.6.0 \
+    --set image.tag=1.7.0 \
     --set datadogCRDs.migration.datadogAgents.version=v2alpha1 \
     --set datadogCRDs.migration.datadogAgents.useCertManager=true \
     --set datadogCRDs.migration.datadogAgents.conversionWebhook.enabled=true

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -696,6 +696,12 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+    - ""
+  resources:
+    - pods/exec
+  verbs:
+    - create
 {{- if .Values.datadogAgentProfile.enabled }}
 - apiGroups:
   - ""

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
             - name: DD_TOOL_VERSION
               value: "helm"
             {{- end }}
+            {{- if .Values.clusterName }}
+            - name: DD_CLUSTER_NAME
+              value: {{ .Values.clusterName }}
+            {{- end }}
             {{- if or .Values.apiKey .Values.apiKeyExistingSecret }}
             - name: DD_API_KEY
               valueFrom:
@@ -124,6 +128,9 @@ spec:
           {{- end }}
           {{- if (semverCompare ">=1.3.0" .Values.image.tag) }}
             - "-datadogSLOEnabled={{ .Values.datadogSLO.enabled }}"
+          {{- end }}
+          {{- if (semverCompare ">=1.7.0" .Values.image.tag) }}
+            - "-remoteConfigEnabled={{ .Values.remoteConfiguration.enabled }}"
           {{- end }}
           ports:
             - name: metrics

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -16,6 +16,10 @@ apiKeyExistingSecret:  # <DATADOG_API_KEY_SECRET>
 # appKey -- Your Datadog APP key
 appKey:  # <DATADOG_APP_KEY>
 
+
+# clusterName -- Set a unique cluster name reporting from the Datadog Operator.
+clusterName:
+
 # site -- The site of the Datadog intake to send data to (documentation: https://docs.datadoghq.com/getting_started/site/)
 
 ## Set to 'datadoghq.com' to send data to the US1 site (default).
@@ -43,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.6.0
+  tag: 1.7.0
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
 # imagePullSecrets -- Datadog Operator repository pullSecret (ex: specify docker registry credentials)
@@ -84,6 +88,10 @@ datadogMonitor:
 datadogSLO:
   # datadogSLO.enabled -- Enables the Datadog SLO controller
   enabled: false
+remoteConfiguration:
+  # remoteConfiguration.enabled -- If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set.
+  enabled: false
+
 rbac:
   # rbac.create -- Specifies whether the RBAC resources should be created
   create: true

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -8,7 +8,7 @@ metadata:
   creationTimestamp: null
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-1.6.0'
+    helm.sh/chart: 'datadogCRDs-1.7.0'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -5875,12 +5875,190 @@ spec:
                       properties:
                         agentCommunicationMode:
                           type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
                         enabled:
                           type: boolean
                         failurePolicy:
                           type: string
                         mutateUnlabelled:
                           type: boolean
+                        registry:
+                          type: string
                         serviceName:
                           type: string
                         webhookName:
@@ -5923,6 +6101,24 @@ spec:
                               type: boolean
                             path:
                               type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
                           type: object
                       type: object
                     clusterChecks:
@@ -6610,6 +6806,11 @@ spec:
                     nodeLabelsAsTags:
                       additionalProperties:
                         type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     podAnnotationsAsTags:
                       additionalProperties:
@@ -8509,6 +8710,681 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            mutateUnlabelled:
+                              type: boolean
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
               type: object
           type: object
       served: true

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_with_certManager.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_with_certManager.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-1.6.0'
+    helm.sh/chart: 'datadogCRDs-1.7.0'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -5886,12 +5886,190 @@ spec:
                       properties:
                         agentCommunicationMode:
                           type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
                         enabled:
                           type: boolean
                         failurePolicy:
                           type: string
                         mutateUnlabelled:
                           type: boolean
+                        registry:
+                          type: string
                         serviceName:
                           type: string
                         webhookName:
@@ -5934,6 +6112,24 @@ spec:
                               type: boolean
                             path:
                               type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
                           type: object
                       type: object
                     clusterChecks:
@@ -6621,6 +6817,11 @@ spec:
                     nodeLabelsAsTags:
                       additionalProperties:
                         type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     podAnnotationsAsTags:
                       additionalProperties:
@@ -8520,6 +8721,681 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            mutateUnlabelled:
+                              type: boolean
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
               type: object
           type: object
       served: true

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.7.1
+    helm.sh/chart: datadog-operator-1.8.0
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.6.0"
+          image: "gcr.io/datadoghq/operator:1.7.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -58,6 +58,7 @@ spec:
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
             - "-datadogSLOEnabled=false"
+            - "-remoteConfigEnabled=false"
           ports:
             - name: metrics
               containerPort: 8383

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -46,6 +46,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DD_TOOL_VERSION
+              value: "helm"
           args:
             - "-supportExtendedDaemonset=false"
             - "-logEncoder=json"

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.7.1
+    helm.sh/chart: datadog-operator-1.8.0
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.6.0"
+    app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.6.0"
+          image: "gcr.io/datadoghq/operator:1.7.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -58,6 +58,7 @@ spec:
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
             - "-datadogSLOEnabled=false"
+            - "-remoteConfigEnabled=false"
           ports:
             - name: metrics
               containerPort: 8383

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -46,6 +46,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DD_TOOL_VERSION
+              value: "helm"
           args:
             - "-supportExtendedDaemonset=false"
             - "-logEncoder=json"

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -131,7 +131,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "gcr.io/datadoghq/operator:1.6.0", operatorContainer.Image)
+	assert.Equal(t, "gcr.io/datadoghq/operator:1.7.0", operatorContainer.Image)
 	assert.Contains(t, operatorContainer.Args, "-webhookEnabled=false")
 }
 

--- a/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog-clusterchecks
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -36,8 +36,8 @@ spec:
         
       name: datadog-clusterchecks
       annotations:
-        checksum/clusteragent_token: 61c40a6cf60e0eedd46df38594b28a4a091044fcc50a168f84f1837c7b14b0b8
-        checksum/install_info: f2cb33b54b5eb5df4f4e7285e408f6d4ee343c8a98a644780e18ab457ac4207f
+        checksum/clusteragent_token: 3459e971a8ca6563795d449c569bef1d0cb8d8038bb60cc2ca805b61c2f2db26
+        checksum/install_info: 4b7ec9616456fc79cafc6e8f64bda4671d2b86f7e48196ab808e5edc4d2e42b8
     spec:
       serviceAccountName: datadog-cluster-checks
       automountServiceAccountToken: true
@@ -45,7 +45,7 @@ spec:
         []
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -57,7 +57,7 @@ spec:
         resources:
           {}
       - name: init-config
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -70,7 +70,7 @@ spec:
           {}
       containers:
       - name: agent
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         command: ["bash", "-c"]
         args:
           - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run

--- a/test/datadog/baseline/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -36,17 +36,17 @@ spec:
         
       name: datadog-cluster-agent
       annotations:
-        checksum/clusteragent_token: dc8cfc926a5573098750522941a404659c7f1eb96ba650f7ff981da66403a9cd
-        checksum/clusteragent-configmap: caf999fa78367514b2b4ed07b750164036342f54a91dd4ed386dc79ee1441a4c
-        checksum/api_key: cc9f65a108b01735ce1b5508397b1a84f2dee1679fabd5a3dcfbc8822c3e8301
+        checksum/clusteragent_token: 4122a08135d1943b564119d27d6f9815b3323c3646663257d7dd24962e6df266
+        checksum/clusteragent-configmap: 80a9c13662500ea03119b6b8dda56d052531ff50d984e940ea12154216366835
+        checksum/api_key: 2ef8b628066c8d58e91d72385732a044c160dd44704d385170e2b045d98e05f7
         checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/install_info: f2cb33b54b5eb5df4f4e7285e408f6d4ee343c8a98a644780e18ab457ac4207f
+        checksum/install_info: 4b7ec9616456fc79cafc6e8f64bda4671d2b86f7e48196ab808e5edc4d2e42b8
     spec:
       serviceAccountName: datadog-cluster-agent
       automountServiceAccountToken: true
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/cluster-agent:7.53.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command:
           - cp
@@ -59,7 +59,7 @@ spec:
             mountPath: /opt/datadog-agent
       containers:
       - name: cluster-agent
-        image: "gcr.io/datadoghq/cluster-agent:7.53.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
         imagePullPolicy: IfNotPresent
         resources:
           {}

--- a/test/datadog/baseline/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -36,17 +36,17 @@ spec:
         
       name: datadog-cluster-agent
       annotations:
-        checksum/clusteragent_token: cceac6b866c30b95baaca15e9d16c3bbaf6d074f7b624a4fc82254008f3fdab4
-        checksum/clusteragent-configmap: caf999fa78367514b2b4ed07b750164036342f54a91dd4ed386dc79ee1441a4c
-        checksum/api_key: cc9f65a108b01735ce1b5508397b1a84f2dee1679fabd5a3dcfbc8822c3e8301
+        checksum/clusteragent_token: 3866496aa7bdfa37da999d8aee1996caa9abfa70b312ecd5438a3b03134b1ec6
+        checksum/clusteragent-configmap: 80a9c13662500ea03119b6b8dda56d052531ff50d984e940ea12154216366835
+        checksum/api_key: 2ef8b628066c8d58e91d72385732a044c160dd44704d385170e2b045d98e05f7
         checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/install_info: f2cb33b54b5eb5df4f4e7285e408f6d4ee343c8a98a644780e18ab457ac4207f
+        checksum/install_info: 4b7ec9616456fc79cafc6e8f64bda4671d2b86f7e48196ab808e5edc4d2e42b8
     spec:
       serviceAccountName: datadog-cluster-agent
       automountServiceAccountToken: true
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/cluster-agent:7.53.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command:
           - cp
@@ -59,7 +59,7 @@ spec:
             mountPath: /opt/datadog-agent
       containers:
       - name: cluster-agent
-        image: "gcr.io/datadoghq/cluster-agent:7.53.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
         imagePullPolicy: IfNotPresent
         resources:
           {}

--- a/test/datadog/baseline/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -36,17 +36,17 @@ spec:
         
       name: datadog-cluster-agent
       annotations:
-        checksum/clusteragent_token: 39e098085201de3706d0276d95382f9dd9114f7fb62f45501163ceedb1660144
-        checksum/clusteragent-configmap: caf999fa78367514b2b4ed07b750164036342f54a91dd4ed386dc79ee1441a4c
-        checksum/api_key: cc9f65a108b01735ce1b5508397b1a84f2dee1679fabd5a3dcfbc8822c3e8301
+        checksum/clusteragent_token: da0754a7afd92073e09fdd53304b8a3f73d07f26c41f56de654dae7863400d33
+        checksum/clusteragent-configmap: 80a9c13662500ea03119b6b8dda56d052531ff50d984e940ea12154216366835
+        checksum/api_key: 2ef8b628066c8d58e91d72385732a044c160dd44704d385170e2b045d98e05f7
         checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/install_info: f2cb33b54b5eb5df4f4e7285e408f6d4ee343c8a98a644780e18ab457ac4207f
+        checksum/install_info: 4b7ec9616456fc79cafc6e8f64bda4671d2b86f7e48196ab808e5edc4d2e42b8
     spec:
       serviceAccountName: datadog-cluster-agent
       automountServiceAccountToken: true
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/cluster-agent:7.53.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command:
           - cp
@@ -59,7 +59,7 @@ spec:
             mountPath: /opt/datadog-agent
       containers:
       - name: cluster-agent
-        image: "gcr.io/datadoghq/cluster-agent:7.53.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -119,7 +119,7 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
             value: agent
           - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-            value: 7.53.0
+            value: 7.54.0
           - name: DD_REMOTE_CONFIGURATION_ENABLED
             value: "false"
           - name: DD_CLUSTER_CHECKS_ENABLED

--- a/test/datadog/baseline/daemonset_default.yaml
+++ b/test/datadog/baseline/daemonset_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -30,8 +30,8 @@ spec:
         
       name: datadog
       annotations:
-        checksum/clusteragent_token: a35e0fc3c9cc5d2684bce9d9cc6a3c694647a2ab9e7135057afd317d893a8771
-        checksum/install_info: f2cb33b54b5eb5df4f4e7285e408f6d4ee343c8a98a644780e18ab457ac4207f
+        checksum/clusteragent_token: 6f8939afb1a8bca4c40c75a43a7e0b7995b0832814af2ba85a32bd891f20d0c6
+        checksum/install_info: 4b7ec9616456fc79cafc6e8f64bda4671d2b86f7e48196ab808e5edc4d2e42b8
         checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
         checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
@@ -42,7 +42,7 @@ spec:
       hostPID: true
       containers:
       - name: agent
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["agent", "run"]
         
@@ -182,7 +182,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
       - name: trace-agent
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]  
         resources:
@@ -288,7 +288,7 @@ spec:
             port: 8126
           timeoutSeconds: 5
       - name: process-agent
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]  
         resources:
@@ -335,9 +335,7 @@ spec:
           - name: DD_DOGSTATSD_SOCKET
             value: "/var/run/datadog/dsd.socket"
           - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-            value: "true"
-          - name: DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED
-            value: "false"        
+            value: "true"        
         volumeMounts:
           - name: config
             mountPath: /etc/datadog-agent
@@ -379,7 +377,7 @@ spec:
           
       - name: init-volume
         
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -392,7 +390,7 @@ spec:
           {}
       - name: init-config
         
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command:
           - bash

--- a/test/datadog/baseline/other_default.yaml
+++ b/test/datadog/baseline/other_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog-clusterchecks
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -24,7 +24,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -41,13 +41,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "7"
     app: "datadog"
-    chart: "datadog-3.64.1"
+    chart: "datadog-3.66.0"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-checks
@@ -60,10 +60,10 @@ automountServiceAccountToken: true
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-3.64.1"
+    chart: "datadog-3.66.0"
     heritage: "Helm"
     release: "datadog"
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -79,7 +79,7 @@ metadata:
   name: datadog
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -92,14 +92,14 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "7"
 type: Opaque
 data:
-  token: "N0JMTWlPaUoxMXlIMEhKbnVqTEVGUlJndTZ6NnMzTFY="
+  token: "QWc0RHFMaWI0bEtnQUV6bmRJZXFoNUVqNXZqVUhSWlU="
 ---
 # Source: datadog/templates/cluster-agent-confd-configmap.yaml
 apiVersion: v1
@@ -108,7 +108,7 @@ metadata:
   name: datadog-cluster-agent-confd
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -157,20 +157,20 @@ metadata:
   name: datadog-installinfo
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "7"
   annotations:
-    checksum/install_info: f2cb33b54b5eb5df4f4e7285e408f6d4ee343c8a98a644780e18ab457ac4207f
+    checksum/install_info: 4b7ec9616456fc79cafc6e8f64bda4671d2b86f7e48196ab808e5edc4d2e42b8
 data:
   install_info: |
     ---
     install_method:
       tool: helm
       tool_version: Helm
-      installer_version: datadog-3.64.1
+      installer_version: datadog-3.66.0
 ---
 # Source: datadog/templates/kpi-telemetry-configmap.yaml
 apiVersion: v1
@@ -179,22 +179,22 @@ metadata:
   name: datadog-kpi-telemetry-configmap
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "7"
 data:
   install_type: k8s_manual
-  install_id: "ecae0a5b-f319-413d-80bd-00aa24bddb11"
-  install_time: "1715810654"
+  install_id: "3120a1cd-f8ce-4480-a24e-c28ed115ee41"
+  install_time: "1718641163"
 ---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -210,6 +210,7 @@ rules:
   - nodes
   - namespaces
   - componentstatuses
+  - limitranges
   verbs:
   - get
   - list
@@ -352,6 +353,14 @@ rules:
   - get
   - watch
 - apiGroups:
+  - "storage.k8s.io"
+  resources:
+  - storageclasses
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
   - autoscaling.k8s.io
   resources:
   - verticalpodautoscalers
@@ -400,7 +409,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -496,7 +505,7 @@ kind: ClusterRole
 metadata:
   name: datadog
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -544,7 +553,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -564,7 +573,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -584,7 +593,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -605,7 +614,7 @@ kind: ClusterRoleBinding
 metadata:
   name: datadog
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -624,7 +633,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -641,7 +650,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -663,7 +672,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -684,7 +693,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -707,7 +716,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -729,10 +738,10 @@ metadata:
   namespace: datadog-agent
   labels:
     app: "datadog"
-    chart: "datadog-3.64.1"
+    chart: "datadog-3.66.0"
     release: "datadog"
     heritage: "Helm"
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -755,10 +764,10 @@ metadata:
   namespace: datadog-agent
   labels:
     app: "datadog"
-    chart: "datadog-3.64.1"
+    chart: "datadog-3.66.0"
     release: "datadog"
     heritage: "Helm"
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -784,7 +793,7 @@ metadata:
   name: datadog
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -808,8 +817,8 @@ spec:
         
       name: datadog
       annotations:
-        checksum/clusteragent_token: d03a9a5065f8962a08c54a40fe16a847c62d369a3b53fb0d8eab43464ceb2f71
-        checksum/install_info: f2cb33b54b5eb5df4f4e7285e408f6d4ee343c8a98a644780e18ab457ac4207f
+        checksum/clusteragent_token: e12e2eb2a4be1f1b8a29859f60fc96c130a9a5948f151b31dc43aeb993333ba3
+        checksum/install_info: 4b7ec9616456fc79cafc6e8f64bda4671d2b86f7e48196ab808e5edc4d2e42b8
         checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
         checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
@@ -820,7 +829,7 @@ spec:
       hostPID: true
       containers:
       - name: agent
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["agent", "run"]
         
@@ -961,7 +970,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
       - name: trace-agent
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]  
         resources:
@@ -1067,7 +1076,7 @@ spec:
             port: 8126
           timeoutSeconds: 5
       - name: process-agent
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]  
         resources:
@@ -1114,9 +1123,7 @@ spec:
           - name: DD_DOGSTATSD_SOCKET
             value: "/var/run/datadog/dsd.socket"
           - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-            value: "true"
-          - name: DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED
-            value: "false"        
+            value: "true"        
         volumeMounts:
           - name: config
             mountPath: /etc/datadog-agent
@@ -1158,7 +1165,7 @@ spec:
           
       - name: init-volume
         
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -1171,7 +1178,7 @@ spec:
           {}
       - name: init-config
         
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command:
           - bash
@@ -1276,7 +1283,7 @@ metadata:
   name: datadog-clusterchecks
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -1306,8 +1313,8 @@ spec:
         
       name: datadog-clusterchecks
       annotations:
-        checksum/clusteragent_token: 831a63691a28bf46d9ee882d24ed86a390771d63d365e38f2c1de87a255b1189
-        checksum/install_info: f2cb33b54b5eb5df4f4e7285e408f6d4ee343c8a98a644780e18ab457ac4207f
+        checksum/clusteragent_token: 0a20b03220af60fbb374c64b77fea29760e35efce754ee9f67534c48259a378a
+        checksum/install_info: 4b7ec9616456fc79cafc6e8f64bda4671d2b86f7e48196ab808e5edc4d2e42b8
     spec:
       serviceAccountName: datadog-cluster-checks
       automountServiceAccountToken: true
@@ -1315,7 +1322,7 @@ spec:
         []
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -1327,7 +1334,7 @@ spec:
         resources:
           {}
       - name: init-config
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -1340,7 +1347,7 @@ spec:
           {}
       containers:
       - name: agent
-        image: "gcr.io/datadoghq/agent:7.53.0"
+        image: "gcr.io/datadoghq/agent:7.54.0"
         command: ["bash", "-c"]
         args:
           - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run
@@ -1457,7 +1464,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.64.1'
+    helm.sh/chart: 'datadog-3.66.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -1487,15 +1494,15 @@ spec:
         
       name: datadog-cluster-agent
       annotations:
-        checksum/clusteragent_token: bc65ea20059b7c744324b8d5d2847a197f1a57c3696a6ced7096ab67434c6e3b
-        checksum/clusteragent-configmap: e83039fde82075a0a0be813cf361ac8a4d8a726f6fba902b4a407fb172eab591
-        checksum/install_info: f2cb33b54b5eb5df4f4e7285e408f6d4ee343c8a98a644780e18ab457ac4207f
+        checksum/clusteragent_token: f89f726a8377f719975f1938011cad0013d557f9eda2b2c366a8f173d1481541
+        checksum/clusteragent-configmap: 55c5054d57dfce4e0394edaea52e4a1812a89b51feeace892f9ca30f98785450
+        checksum/install_info: 4b7ec9616456fc79cafc6e8f64bda4671d2b86f7e48196ab808e5edc4d2e42b8
     spec:
       serviceAccountName: datadog-cluster-agent
       automountServiceAccountToken: true
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/cluster-agent:7.53.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
         imagePullPolicy: IfNotPresent
         command:
           - cp
@@ -1508,7 +1515,7 @@ spec:
             mountPath: /opt/datadog-agent
       containers:
       - name: cluster-agent
-        image: "gcr.io/datadoghq/cluster-agent:7.53.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
         imagePullPolicy: IfNotPresent
         resources:
           {}

--- a/test/datadog/dca_AC_sidecar_test.go
+++ b/test/datadog/dca_AC_sidecar_test.go
@@ -91,7 +91,7 @@ func verifyDeploymentFargateMinimal(t *testing.T, manifest string) {
 	// Default will be set by DCA
 	assert.Empty(t, acConfigEnv[DDSidecarRegistry])
 	assert.Equal(t, "agent", acConfigEnv[DDSidecarImageName])
-	assert.Equal(t, "7.53.0", acConfigEnv[DDSidecarImageTag])
+	assert.Equal(t, "7.54.0", acConfigEnv[DDSidecarImageTag])
 	assert.Empty(t, acConfigEnv[DDSidecarSelectors])
 	assert.Empty(t, acConfigEnv[DDSidecarProfiles])
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Update Datadog Operator chart following the 1.7.0 release
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
- [X] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
