### PR TITLE
Modify tool version in operator chart

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.1
+
+* Configure tool version.
+
 ## 1.8.0
 
 * Update Datadog Operator version to 1.7.0.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.8.0
+version: 1.8.1
 appVersion: 1.7.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
                   fieldPath: metadata.name
             {{- if (semverCompare ">=1.7.0-0" .Values.image.tag) }}
             - name: DD_TOOL_VERSION
-              value: "helm"
+              value: {{ .Values.toolVersion | default "helm" }}
             {{- end }}
             {{- if .Values.clusterName }}
             - name: DD_CLUSTER_NAME

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.8.0
+    helm.sh/chart: datadog-operator-1.8.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: DD_TOOL_VERSION
-              value: "helm"
+              value: helm
           args:
             - "-supportExtendedDaemonset=false"
             - "-logEncoder=json"

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.8.0
+    helm.sh/chart: datadog-operator-1.8.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: DD_TOOL_VERSION
-              value: "helm"
+              value: helm
           args:
             - "-supportExtendedDaemonset=false"
             - "-logEncoder=json"


### PR DESCRIPTION
#### What this PR does / why we need it:

Modifies the tool version set in the operator helm chart. While the value should not need to be changed by the end user, we need to be able to modify it in our chart wrappers.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
