### PR TITLE
[CONTP-257] add namespaceAnnotationsAsTags to helm chart

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.66.1
+
+* Add 'datadog.namespaceAnnotationsAsTags' to assign namespace annotations as tags on pod entities in the tagger.
+
 ## 3.66.0
 
 * Set default `Agent` and `Cluster-Agent` version to `7.54.0`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.66.0
+version: 3.66.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.66.0](https://img.shields.io/badge/Version-3.66.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.66.1](https://img.shields.io/badge/Version-3.66.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -748,6 +748,7 @@ helm install <RELEASE_NAME> \
 | datadog.logs.containerCollectAll | bool | `false` | Enable this to allow log collection for all containers |
 | datadog.logs.containerCollectUsingFiles | bool | `true` | Collect logs from files in /var/log/pods instead of using container runtime API |
 | datadog.logs.enabled | bool | `false` | Enables this to activate Datadog Agent log collection |
+| datadog.namespaceAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Namespace Annotations to Datadog Tags |
 | datadog.namespaceLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Namespace Labels to Datadog Tags |
 | datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
 | datadog.networkPolicy.cilium.dnsSelector | object | kube-dns in namespace kube-system | Cilium selector of the DNS server entity |

--- a/charts/datadog/templates/_components-common-env.yaml
+++ b/charts/datadog/templates/_components-common-env.yaml
@@ -42,6 +42,10 @@
 - name: DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS
   value: '{{ toJson .Values.datadog.namespaceLabelsAsTags }}'
 {{- end }}
+{{- if .Values.datadog.namespaceAnnotationsAsTags }}
+- name: DD_KUBERNETES_NAMESPACE_ANNOTATIONS_AS_TAGS
+  value: '{{ toJson .Values.datadog.namespaceAnnotationsAsTags }}'
+{{- end }}
 - name: KUBERNETES
   value: "yes"
 {{- if .Values.datadog.site }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -249,6 +249,11 @@ datadog:
   #   env: environment
   #   <KUBERNETES_NAMESPACE_LABEL>: <DATADOG_TAG_KEY>
 
+  # datadog.namespaceAnnotationsAsTags -- Provide a mapping of Kubernetes Namespace Annotations to Datadog Tags
+  namespaceAnnotationsAsTags: {}
+  #   env: environment
+  #   <KUBERNETES_NAMESPACE_ANNOTATIONS>: <DATADOG_TAG_KEY>
+
   originDetectionUnified:
     # datadog.originDetectionUnified.enabled -- Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+).
     enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
[CONTP-257](https://datadoghq.atlassian.net/browse/CONTP-257)
Expose namespaceAnnotationsAsTags option
We recently added support for “kubernetes namespace annotations as tags” option: https://github.com/DataDog/datadog-agent/pull/25585 
However, it’s not exposed in the public helm chart.
We already have a setting for “kubernetes namespace labels as tags” (`datadog.namespaceLabelsAsTags`) so we should also have one for the annotations to avoid having to configure this using ENVs.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Chart Version bumped
- [ x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x ] `CHANGELOG.md` has been updated
- [x ] Variables are documented in the `README.md`


[CONTP-257]: https://datadoghq.atlassian.net/browse/CONTP-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ