### PR TITLE
Add helm chart installation for OTel Agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.69.0
+
+* Add support OTel Agent container. OTel Agent is Datadog's distribution of OTel collector. 
+
 ## 3.68.2
 * Fix datadog.containerLifecycle.enabled conditional statement to accept flase value
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.68.2
+version: 3.69.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.68.2](https://img.shields.io/badge/Version-3.68.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.69.0](https://img.shields.io/badge/Version-3.69.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -471,6 +471,12 @@ helm install <RELEASE_NAME> \
 | agents.containers.initContainers.resources | object | `{}` | Resource requests and limits for the init containers |
 | agents.containers.initContainers.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the init containers. |
 | agents.containers.initContainers.volumeMounts | list | `[]` | Specify additional volumes to mount for the init containers |
+| agents.containers.otelAgent.env | list | `[]` | Additional environment variables for the trace-agent container |
+| agents.containers.otelAgent.envDict | object | `{}` | Set environment variables specific to trace-agent defined in a dict |
+| agents.containers.otelAgent.envFrom | list | `[]` | Set environment variables specific to trace-agent from configMaps and/or secrets |
+| agents.containers.otelAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
+| agents.containers.otelAgent.resources | object | `{}` | Resource requests and limits for the trace-agent container |
+| agents.containers.otelAgent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the trace-agent container. |
 | agents.containers.processAgent.env | list | `[]` | Additional environment variables for the process-agent container |
 | agents.containers.processAgent.envDict | object | `{}` | Set environment variables specific to process-agent defined in a dict |
 | agents.containers.processAgent.envFrom | list | `[]` | Set environment variables specific to process-agent from configMaps and/or secrets |
@@ -763,6 +769,9 @@ helm install <RELEASE_NAME> \
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
 | datadog.originDetectionUnified.enabled | bool | `false` | Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+). |
 | datadog.osReleasePath | string | `"/etc/os-release"` | Specify the path to your os-release file |
+| datadog.otelCollector.config | object | `{}` | OTel collector configuration |
+| datadog.otelCollector.enabled | bool | `false` | Enable the OTel Collector |
+| datadog.otelCollector.ports | list | `[{"containerPort":"4317","name":"otel-grpc"},{"containerPort":"4318","name":"otel-http"}]` | Ports that OTel Collector is listening |
 | datadog.otlp.logs.enabled | bool | `false` | Enable logs support in the OTLP ingest endpoint |
 | datadog.otlp.receiver.protocols.grpc.enabled | bool | `false` | Enable the OTLP/gRPC endpoint |
 | datadog.otlp.receiver.protocols.grpc.endpoint | string | `"0.0.0.0:4317"` | OTLP/gRPC endpoint |

--- a/charts/datadog/ci/agent-otel-collector-no-config-values.yaml
+++ b/charts/datadog/ci/agent-otel-collector-no-config-values.yaml
@@ -1,0 +1,16 @@
+targetSystem: "linux"
+agents:
+  image:
+    repository: datadog/agent-dev
+    tag: nightly-ot-beta-main
+    doNotCheckTag: true
+  containers:
+    agent:
+      env:
+        - name: DD_HOSTNAME
+          value: "datadog"
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  otelCollector:
+    enabled: true

--- a/charts/datadog/ci/agent-otel-collector-ports-values.yaml
+++ b/charts/datadog/ci/agent-otel-collector-ports-values.yaml
@@ -1,0 +1,41 @@
+targetSystem: "linux"
+agents:
+  image:
+    repository: datadog/agent-dev
+    tag: nightly-ot-beta-main
+    doNotCheckTag: true
+  containers:
+    agent:
+      env:
+        - name: DD_HOSTNAME
+          value: "datadog"
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  otelCollector:
+    enabled: true
+    ports:
+      - containerPort: "5317"
+        hostPort: "5317"
+        name: "otel-grpc"
+    config: |
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: "localhost:5317"
+      exporters:
+        datadog:
+          api:
+            key: "00000000000000000000000000000000"
+      service:
+        pipelines:
+          traces:
+            receivers: [otlp]
+            exporters: [datadog]
+          metrics:
+            receivers: [otlp]
+            exporters: [datadog]
+          logs:
+            receivers: [otlp]
+            exporters: [datadog]

--- a/charts/datadog/ci/agent-otel-collector-values.yaml
+++ b/charts/datadog/ci/agent-otel-collector-values.yaml
@@ -1,0 +1,34 @@
+targetSystem: "linux"
+agents:
+  image:
+    repository: datadog/agent-dev
+    tag: nightly-ot-beta-main
+    doNotCheckTag: true
+  containers:
+    agent:
+      env:
+        - name: DD_HOSTNAME
+          value: "datadog"
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  otelCollector:
+    enabled: true
+    config: |
+      receivers:
+        otlp:
+      exporters:
+        datadog:
+          api:
+            key: "00000000000000000000000000000000"
+      service:
+        pipelines:
+          traces:
+            receivers: [otlp]
+            exporters: [datadog]
+          metrics:
+            receivers: [otlp]
+            exporters: [datadog]
+          logs:
+            receivers: [otlp]
+            exporters: [datadog]

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -580,3 +580,12 @@ You are using the datadog.securityAgent.compliance.xccdf.enabled parameter which
 This version still supports both but the support of the old name will be dropped in the next major version of our Helm chart.
 More information about this change: https://github.com/DataDog/helm-charts/pull/1161
 {{- end }}
+
+
+{{- if and (eq (include "should-enable-otel-agent" .) "true") .Values.providers.gke.autopilot }}
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+OTel collector is not supported on GKE Autopilot.
+{{- fail "The OTel collector cannot be run on GKE Autopilot." }}
+{{- end }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -59,6 +59,7 @@
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "fips-envvar" . | nindent 4 }}
     {{- include "processes-common-envs" . | nindent 4 }}
+
     {{- if .Values.datadog.logLevel }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}
@@ -180,6 +181,7 @@
     - name: DD_SBOM_CONTAINER_IMAGE_USE_MOUNT
       value: "true"
     {{- end }}
+
     {{- if .Values.datadog.sbom.host.enabled }}
     - name: DD_SBOM_HOST_ENABLED
       value: "true"
@@ -190,6 +192,10 @@
     {{- if .Values.datadog.kubelet.coreCheckEnabled }}
     - name: DD_KUBELET_CORE_CHECK_ENABLED
       value: {{ .Values.datadog.kubelet.coreCheckEnabled | quote }}
+    {{- end }}
+    {{- if eq (include "should-enable-otel-agent" .) "true" }}
+    - name: DD_OTELCOLLECTOR_ENABLED
+      value: "true"
     {{- end }}
     {{- include "additional-env-entries" .Values.agents.containers.agent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.agent.envDict | indent 4 }}

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -1,0 +1,81 @@
+{{- define "container-otel-agent" -}}
+- name: otel-agent
+  image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
+  imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
+  {{- if eq .Values.targetSystem "linux" }}
+  command: ["otel-agent", "--config={{ template "datadog.otelconfPath" . }}/otel-config.yaml"]
+  {{- end -}}
+  {{- if eq .Values.targetSystem "windows" }}
+  command: ["otel-agent", "-foreground", "-config={{ template "datadog.otelconfPath" . }}/datadog.yaml"]
+  {{- end -}}
+{{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.otelAgent.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | indent 2 }}
+  resources:
+{{ toYaml .Values.agents.containers.otelAgent.resources | indent 4 }}
+  ports:
+    {{- range .Values.datadog.otelCollector.ports }}
+      - containerPort: {{ .containerPort }}
+        {{- if .hostPort }}
+        hostPort: {{ .hostPort }}
+        {{- end }}
+        protocol: TCP
+        name: {{ .name }}
+    {{- end }}
+{{- if or .Values.datadog.envFrom .Values.agents.containers.otelAgent.envFrom }}
+  envFrom:
+{{- if .Values.datadog.envFrom }}
+{{ .Values.datadog.envFrom | toYaml | indent 4 }}
+{{- end }}
+{{- if .Values.agents.containers.otelAgent.envFrom }}
+{{ .Values.agents.containers.otelAgent.envFrom | toYaml | indent 4 }}
+{{- end }}
+{{- end }}
+  env:
+    {{- include "containers-common-env" . | nindent 4 }}
+    {{- include "containers-cluster-agent-env" . | nindent 4 }}
+    {{- include "fips-envvar" . | nindent 4 }}
+    - name: DD_LOG_LEVEL
+      value: {{ .Values.agents.containers.otelAgent.logLevel | default .Values.datadog.logLevel | quote }}
+    {{- include "additional-env-entries" .Values.agents.containers.otelAgent.env | indent 4 }}
+    {{- include "additional-env-dict-entries" .Values.agents.containers.otelAgent.envDict | indent 4 }}
+  volumeMounts:
+    - name: config
+      mountPath: {{ template "datadog.confPath" . }}
+      readOnly: true
+    - name: logdatadog
+      mountPath: {{ template "datadog.logDirectoryPath" . }}
+      readOnly: false # Need RW to write logs
+    {{- if (not .Values.providers.gke.autopilot) }}
+    - name: auth-token
+      mountPath: {{ template "datadog.confPath" . }}/auth
+      readOnly: true
+    {{- end }}
+    - name: otelconfig
+      mountPath: {{ template "datadog.otelconfPath" . }}
+      readOnly: true
+    {{- if eq .Values.targetSystem "linux" }}
+    {{- if not .Values.providers.gke.autopilot }}
+    - name: procdir
+      mountPath: /host/proc
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
+    - name: cgroups
+      mountPath: /host/sys/fs/cgroup
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
+    {{- end }}
+    - name: tmpdir
+      mountPath: /tmp
+      readOnly: false # Need RW for tmp directory
+    - name: dsdsocket
+      mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
+      readOnly: true
+    {{- end }}
+    {{- include "container-crisocket-volumemounts" . | nindent 4 }}
+    {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
+    {{- if .Values.datadog.kubelet.hostCAPath }}
+{{ include "datadog.kubelet.volumeMount" . | indent 4 }}
+    {{- end }}
+{{- if .Values.agents.volumeMounts }}
+{{ toYaml .Values.agents.volumeMounts | indent 4 }}
+{{- end }}
+{{- end -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -107,6 +107,19 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Return true if the OTelAgent needs to be deployed
+*/}}
+{{- define "should-enable-otel-agent" -}}
+{{- if and .Values.datadog.otelCollector.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+
+
+{{/*
 Return secret name to be used based on provided values.
 */}}
 {{- define "datadog.apiSecretName" -}}
@@ -200,6 +213,18 @@ Return agent config path
 {{- define "datadog.confPath" -}}
 {{- if eq .Values.targetSystem "linux" -}}
 /etc/datadog-agent
+{{- end -}}
+{{- if eq .Values.targetSystem "windows" -}}
+C:/ProgramData/Datadog
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return agent config path
+*/}}
+{{- define "datadog.otelconfPath" -}}
+{{- if eq .Values.targetSystem "linux" -}}
+/etc/otel-agent
 {{- end -}}
 {{- if eq .Values.targetSystem "windows" -}}
 C:/ProgramData/Datadog
@@ -568,6 +593,10 @@ datadog-agent-fips-config
 {{- else -}}
 {{ template "datadog.fullname" . }}-fips-config
 {{- end -}}
+{{- end -}}
+
+{{- define "agents-install-otel-configmap-name" -}}
+{{ template "datadog.fullname" . }}-otel-config
 {{- end -}}
 
 {{/*
@@ -941,4 +970,14 @@ Create RBACs for custom resources
   {{- else -}}
     {{- include "process-checks-enabled" . -}}
   {{- end -}}
+{{- end -}}
+
+
+{{- define "get-port-number-from-name" -}}
+{{- $portName := .portName -}}
+{{- range .ports -}}
+  {{- if eq .name $portName -}}
+    {{ .containerPort }}
+  {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/datadog/templates/_otel_agent_config.yaml
+++ b/charts/datadog/templates/_otel_agent_config.yaml
@@ -1,0 +1,55 @@
+{{- define "otel-agent-config-configmap-content" -}}
+otel-config.yaml: {{- if .Values.datadog.otelCollector.config }} {{ toYaml .Values.datadog.otelCollector.config | indent 4 }}
+  {{- else }} |
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: "otelcol"
+              scrape_interval: 10s
+              static_configs:
+                - targets: ["0.0.0.0:8888"]
+      otlp:
+        protocols:
+          grpc:
+             endpoint: 0.0.0.0:{{ include "get-port-number-from-name" (dict "ports" .Values.datadog.otelCollector.ports "portName" "otel-grpc") }}
+          http:
+             endpoint: 0.0.0.0:{{ include "get-port-number-from-name" (dict "ports" .Values.datadog.otelCollector.ports "portName" "otel-http") }}
+    exporters:
+      debug:
+        verbosity: detailed
+      datadog:
+        api:
+          key: ${env:DD_API_KEY}
+    processors:
+      infraattributes:
+        cardinality: 2
+      batch:
+        timeout: 10s
+    connectors:
+      datadog/connector:
+        traces:
+          compute_top_level_by_span_kind: true
+          peer_tags_aggregation: true
+          compute_stats_by_span_kind: true
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [datadog/connector]
+        traces/otlp:
+          receivers: [otlp]
+          processors: [infraattributes, batch]
+          exporters: [datadog]
+        metrics:
+          receivers: [otlp, datadog/connector, prometheus]
+          processors: [infraattributes, batch]
+          exporters: [datadog]
+        logs:
+          receivers: [otlp]
+          processors: [infraattributes, batch]
+          exporters: [datadog]
+{{- end -}}
+{{- end -}}
+

--- a/charts/datadog/templates/agent-services.yaml
+++ b/charts/datadog/templates/agent-services.yaml
@@ -100,5 +100,13 @@ spec:
       targetPort: {{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
       name: otlphttpport
  {{- end }}
+{{- if eq (include "should-enable-otel-agent" .) "true" }}
+{{- range .Values.datadog.otelCollector.ports }}
+    - protocol: TCP
+      port: {{ .containerPort }}
+      targetPort: {{ .containerPort }}
+      name: {{ .name }}
+{{- end }}
+{{- end }}
   internalTrafficPolicy: Local
 {{ end }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -48,6 +48,9 @@ spec:
         checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}
         checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
         checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
+        {{- if eq (include "should-enable-otel-agent" .) "true" }}
+        checksum/otel-config: {{ include "otel-agent-config-configmap-content" . | sha256sum }}
+        {{- end }}
         {{- if .Values.agents.customAgentConfig }}
         checksum/agent-config: {{ tpl (toYaml .Values.agents.customAgentConfig) . | sha256sum }}
         {{- end }}
@@ -128,6 +131,9 @@ spec:
         {{- if eq  (include "should-enable-security-agent" .) "true" }}
           {{- include "container-security-agent" . | nindent 6 }}
         {{- end }}
+        {{- if eq (include "should-enable-otel-agent" .) "true" }}
+          {{- include "container-otel-agent" . | nindent 6 }}
+        {{- end }}
       initContainers:
         {{- if eq .Values.targetSystem "windows" }}
           {{ include "containers-init-windows" . | nindent 6 }}
@@ -163,6 +169,14 @@ spec:
       {{- end }}
       {{- if eq .Values.targetSystem "linux" }}
         {{ include "daemonset-volumes-linux" . | nindent 6 }}
+      {{- end }}
+      {{- if eq (include "should-enable-otel-agent" .) "true" }}
+      - name: otelconfig
+        configMap:
+          name: {{ include "agents-install-otel-configmap-name" . }}
+          items:
+          - key: otel-config.yaml
+            path: otel-config.yaml
       {{- end }}
 {{- if .Values.agents.volumes }}
 {{ toYaml .Values.agents.volumes | indent 6 }}

--- a/charts/datadog/templates/otel-configmap.yaml
+++ b/charts/datadog/templates/otel-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if eq (include "should-enable-otel-agent" .) "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agents-install-otel-configmap-name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "datadog.labels" . | nindent 4 }}
+  annotations:
+    checksum/otel-config: {{ printf "%s-%s" .Chart.Name .Chart.Version | sha256sum }}
+data: {{ include "otel-agent-config-configmap-content" . | nindent 2 }}
+{{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -520,6 +520,21 @@ datadog:
       # datadog.asm.iast.enabled -- Enable Application Security Management Interactive Application Security Testing by injecting `DD_IAST_ENABLED=true` environment variable to all pods in the cluster
       enabled: false
 
+  ## OTel collector related configuration
+  otelCollector:
+    # datadog.otelCollector.enabled -- Enable the OTel Collector
+    enabled: false
+    # datadog.otelCollector.ports -- Ports that OTel Collector is listening
+    ports:
+
+        # Default GRPC port of OTLP receiver
+      - containerPort: "4317"
+        name: otel-grpc
+        # Default HTTP port of OTLP receiver
+      - containerPort: "4318"
+        name: otel-http
+    # datadog.otelCollector.config -- OTel collector configuration
+    config: {}
   ## OTLP ingest related configuration
   otlp:
     receiver:
@@ -1648,6 +1663,35 @@ agents:
       # agents.containers.processAgent.ports -- Allows to specify extra ports (hostPorts for instance) for this container
       ports: []
 
+    otelAgent:
+      # agents.containers.otelAgent.env -- Additional environment variables for the trace-agent container
+      env: []
+
+      # agents.containers.otelAgent.envFrom -- Set environment variables specific to trace-agent from configMaps and/or secrets
+      envFrom: []
+      #   - configMapRef:
+      #       name: <CONFIGMAP_NAME>
+      #   - secretRef:
+      #       name: <SECRET_NAME>
+
+      # agents.containers.otelAgent.envDict -- Set environment variables specific to trace-agent defined in a dict
+      envDict: {}
+      #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
+
+      # agents.containers.otelAgent.resources -- Resource requests and limits for the trace-agent container
+      resources: {}
+      #  requests:
+      #    cpu: 100m
+      #    memory: 200Mi
+      #  limits:
+      #    cpu: 100m
+      #    memory: 200Mi
+
+      # agents.containers.otelAgent.securityContext -- Allows you to overwrite the default container SecurityContext for the trace-agent container.
+      securityContext: {}
+
+      # agents.containers.otelAgent.ports -- Allows to specify extra ports (hostPorts for instance) for this container
+      ports: []
     traceAgent:
       # agents.containers.traceAgent.env -- Additional environment variables for the trace-agent container
       env: []

--- a/examples/datadog/agent_otel_collector.yaml
+++ b/examples/datadog/agent_otel_collector.yaml
@@ -1,0 +1,29 @@
+agents:
+  image:
+    repository: datadog/agent-dev
+    tag: nightly-ot-beta-main
+    doNotCheckTag: true
+  containers:
+    agent:
+      env:
+        - name: DD_HOSTNAME
+          value: "my-hostname"
+datadog:
+  apiKey: $DD_API_KEY
+  otelCollector:
+    enabled: true
+  logs:
+    enabled: true
+    containerCollectAll: true
+  orchestratorExplorer:
+    enabled: true
+  processAgent:
+    enabled: true
+    processCollection: true
+  networkMonitoring:
+    enabled: true
+  apm:
+    portEnabled: true
+    peer_tags_aggregation: true
+    compute_stats_by_span_kind: true
+    peer_service_aggregation: true

--- a/examples/datadog/otel_collector_config.yaml
+++ b/examples/datadog/otel_collector_config.yaml
@@ -1,0 +1,58 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "otel-agent"
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["0.0.0.0:8888"]
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  debug:
+    verbosity: detailed
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+processors:
+  infraattributes:
+    cardinality: 2
+  probabilistic_sampler:
+    hash_seed: 22
+    sampling_percentage: 15.3
+  batch:
+    timeout: 10s
+connectors:
+  datadog/connector:
+    traces:
+      compute_top_level_by_span_kind: true
+      peer_tags_aggregation: true
+      compute_stats_by_span_kind: true
+extensions:
+  health_check:
+service:
+  extensions: [health_check]
+  telemetry:
+    logs:
+      level: debug
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog/connector]
+    traces/sampled:
+      receivers: [otlp]
+      processors: [probabilistic_sampler, infraattributes, batch]
+      exporters: [datadog]
+    metrics:
+      receivers: [otlp, datadog/connector, prometheus]
+      processors: [infraattributes, batch]
+      exporters: [datadog]
+    logs:
+      receivers: [otlp]
+      processors: [infraattributes, batch]
+      exporters: [datadog]


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds OTel Agent container  . OTel Agent is a Datadog's OpenTelemetry's collector distro that runs along with Agent. 

The PR add example collector configuration and corresponding agent configuration. 

To test the changes use the below helm command 

```
helm install my ./charts/datadog --set-file datadog.otelCollector.config=examples/datadog/otel_collector_config.yaml -f examples/datadog/agent_otel_collector.yaml  --set datadog.apiKey=${DD_API_KEY}              
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
