### PR TITLE
Fixed indentation for agentSidecarInjection.selectors

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.66.1
+
+* Fixes indentation for `agentSidecarInjection.selectors`.
+  
 ## 3.66.0
 
 * Set default `Agent` and `Cluster-Agent` version to `7.54.0`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.66.0
+version: 3.66.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.66.0](https://img.shields.io/badge/Version-3.66.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.66.1](https://img.shields.io/badge/Version-3.66.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1133,7 +1133,7 @@ clusterAgent:
       # clusterAgent.admissionController.agentSidecarInjection.selectors -- Defines the pod selector for sidecar injection, currently only one rule is supported.
       selectors: []
         # - objectSelector:
-        #   matchLabels:
+        #     matchLabels:
         #       "podlabelKey1": podlabelValue1
         #       "podlabelKey2": podlabelValue2
         #   namespaceSelector:


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a missing indentation for clusterAgent.admissionController.agentSidecarInjection.selectors.matchLabels. 
WIthout the indentation, objectSelector resolved to null:
`DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_SELECTORS=[{"matchLabels":{"podlabelKey1": "podlabelValue1"},"objectSelector":null}]`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
