### PR TITLE
Add Kubernetes 1.30 to Operator integ test

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -49,6 +49,7 @@ jobs:
           - v1.27.3
           - v1.28.7
           - v1.29.2
+          - v1.30.0
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
#### What this PR does / why we need it:

Run Operator integ test on Kubernetes 1.30

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
