### PR TITLE
[PROCS-3709] Add support to run process checks in core agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.67.5
+
+* Add support for `processAgent.runInCoreAgent` as an experimental feature.
+
 ## 3.67.4
 
 * Overwrite the securityContext for the `seccomp-setup` initContainer with `agents.containers.initContainers.securityContext`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.67.4
+version: 3.67.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -775,7 +775,7 @@ helm install <RELEASE_NAME> \
 | datadog.processAgent.enabled | bool | `true` | Set this to true to enable live process monitoring agent |
 | datadog.processAgent.processCollection | bool | `false` | Set this to true to enable process collection in process monitoring agent |
 | datadog.processAgent.processDiscovery | bool | `true` | Enables or disables autodiscovery of integrations |
-| datadog.processAgent.runInCoreAgent | bool | `false` | Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery. # This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation. # If Orchestrator Explorer, Network Performance Monitoring is not being used, processAgent.enabled should be set to false to remove the process-agent container. |
+| datadog.processAgent.runInCoreAgent | bool | `false` | Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery. # This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation. # If Network Performance Monitoring is not being used, processAgent.enabled should be set to false to remove the process-agent container. |
 | datadog.processAgent.stripProcessArguments | bool | `false` | Set this to scrub all arguments from collected processes |
 | datadog.prometheusScrape.additionalConfigs | list | `[]` | Allows adding advanced openmetrics check configurations with custom discovery rules. (Requires Agent version 7.27+) |
 | datadog.prometheusScrape.enabled | bool | `false` | Enable autodiscovering pods and services exposing prometheus metrics. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.67.4](https://img.shields.io/badge/Version-3.67.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.67.5](https://img.shields.io/badge/Version-3.67.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -775,6 +775,7 @@ helm install <RELEASE_NAME> \
 | datadog.processAgent.enabled | bool | `true` | Set this to true to enable live process monitoring agent |
 | datadog.processAgent.processCollection | bool | `false` | Set this to true to enable process collection in process monitoring agent |
 | datadog.processAgent.processDiscovery | bool | `true` | Enables or disables autodiscovery of integrations |
+| datadog.processAgent.runInCoreAgent | bool | `false` | Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery. This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation. If Orchestrator Explorer, Network Performance Monitoring is not being used, processAgent.enabled should be set to false to remove the process-agent container. |
 | datadog.processAgent.stripProcessArguments | bool | `false` | Set this to scrub all arguments from collected processes |
 | datadog.prometheusScrape.additionalConfigs | list | `[]` | Allows adding advanced openmetrics check configurations with custom discovery rules. (Requires Agent version 7.27+) |
 | datadog.prometheusScrape.enabled | bool | `false` | Enable autodiscovering pods and services exposing prometheus metrics. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -775,7 +775,7 @@ helm install <RELEASE_NAME> \
 | datadog.processAgent.enabled | bool | `true` | Set this to true to enable live process monitoring agent |
 | datadog.processAgent.processCollection | bool | `false` | Set this to true to enable process collection in process monitoring agent |
 | datadog.processAgent.processDiscovery | bool | `true` | Enables or disables autodiscovery of integrations |
-| datadog.processAgent.runInCoreAgent | bool | `false` | Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery. This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation. If Orchestrator Explorer, Network Performance Monitoring is not being used, processAgent.enabled should be set to false to remove the process-agent container. |
+| datadog.processAgent.runInCoreAgent | bool | `false` | Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery. # This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation. # If Orchestrator Explorer, Network Performance Monitoring is not being used, processAgent.enabled should be set to false to remove the process-agent container. |
 | datadog.processAgent.stripProcessArguments | bool | `false` | Set this to scrub all arguments from collected processes |
 | datadog.prometheusScrape.additionalConfigs | list | `[]` | Allows adding advanced openmetrics check configurations with custom discovery rules. (Requires Agent version 7.27+) |
 | datadog.prometheusScrape.enabled | bool | `false` | Enable autodiscovering pods and services exposing prometheus metrics. |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -58,9 +58,7 @@
   env:
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "fips-envvar" . | nindent 4 }}
-    {{- if .Values.datadog.processAgent.runInCoreAgent }}
     {{- include "processes-common-envs" . | nindent 4 }}
-    {{- end }}
     {{- if .Values.datadog.logLevel }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -58,7 +58,9 @@
   env:
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "fips-envvar" . | nindent 4 }}
+    {{- if .Values.datadog.processAgent.runInCoreAgent }}
     {{- include "processes-common-envs" . | nindent 4 }}
+    {{- end }}
     {{- if .Values.datadog.logLevel }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -58,6 +58,7 @@
   env:
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "fips-envvar" . | nindent 4 }}
+    {{- include "processes-common-envs" . | nindent 4 }}
     {{- if .Values.datadog.logLevel }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}
@@ -248,6 +249,11 @@
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
+    {{- if .Values.datadog.processAgent.runInCoreAgent }}
+    - name: passwd
+      mountPath: /etc/passwd
+      readOnly: true
+    {{- end }}
     {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
     - name: pointerdir
       mountPath: /opt/datadog-agent/run

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -28,16 +28,7 @@
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
     {{- include "fips-envvar" . | nindent 4 }}
-    {{- if .Values.datadog.processAgent.processCollection }}
-    - name: DD_PROCESS_AGENT_ENABLED
-      value: "true"
-    {{- end }}
-    - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
-      value: {{ .Values.datadog.processAgent.processDiscovery | quote }}
-    {{- if .Values.datadog.processAgent.stripProcessArguments }}
-    - name: DD_STRIP_PROCESS_ARGS
-      value: "true"
-    {{- end }}
+    {{- include "processes-common-envs" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.processAgent.logLevel | default .Values.datadog.logLevel | quote }}
     - name: DD_SYSTEM_PROBE_ENABLED

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -137,7 +137,7 @@
   name: btf-path
 {{- end }}
 {{- end }}
-{{- if or .Values.datadog.processAgent.enabled (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true") }}
+{{- if or .Values.datadog.processAgent.enabled .Values.datadog.processAgent.runInCoreAgent (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true") }}
 - hostPath:
     path: /etc/passwd
   name: passwd

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -913,5 +913,3 @@ Create RBACs for custom resources
     false
   {{- end -}}
 {{- end -}}
-
-

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -913,3 +913,5 @@ Create RBACs for custom resources
     false
   {{- end -}}
 {{- end -}}
+
+

--- a/charts/datadog/templates/_processes-common-env.yaml
+++ b/charts/datadog/templates/_processes-common-env.yaml
@@ -1,4 +1,3 @@
-
 # Defines set of environment variables for Processes-related checks.
 {{- define "processes-common-envs" -}}
 {{- if .Values.datadog.processAgent.processCollection }}

--- a/charts/datadog/templates/_processes-common-env.yaml
+++ b/charts/datadog/templates/_processes-common-env.yaml
@@ -1,0 +1,18 @@
+
+# Defines set of environment variables for Processes-related checks.
+{{- define "processes-common-envs" -}}
+{{- if .Values.datadog.processAgent.processCollection }}
+- name: DD_PROCESS_AGENT_ENABLED
+  value: "true"
+{{- end }}
+- name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+  value: {{ .Values.datadog.processAgent.processDiscovery | quote }}
+{{- if .Values.datadog.processAgent.stripProcessArguments }}
+- name: DD_STRIP_PROCESS_ARGS
+  value: "true"
+{{- end }}
+{{- if eq .Values.targetSystem "linux" }}
+- name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+  value: {{ .Values.datadog.processAgent.runInCoreAgent | quote }}
+{{- end }}  
+{{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -625,8 +625,8 @@ datadog:
     processDiscovery: true
 
     # datadog.processAgent.runInCoreAgent -- Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery.
-    # This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation.
-    # If Orchestrator Explorer, Network Performance Monitoring is not being used, processAgent.enabled should be set to false to remove the process-agent container.
+    ## This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation.
+    ## If Orchestrator Explorer, Network Performance Monitoring is not being used, processAgent.enabled should be set to false to remove the process-agent container.
     runInCoreAgent: false
 
   # datadog.osReleasePath -- Specify the path to your os-release file

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -624,6 +624,11 @@ datadog:
     # datadog.processAgent.processDiscovery -- Enables or disables autodiscovery of integrations
     processDiscovery: true
 
+    # datadog.processAgent.runInCoreAgent -- Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery.
+    # This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation.
+    # If Orchestrator Explorer, Network Performance Monitoring is not being used, processAgent.enabled should be set to false to remove the process-agent container.
+    runInCoreAgent: false
+
   # datadog.osReleasePath -- Specify the path to your os-release file
   osReleasePath: /etc/os-release
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -626,7 +626,7 @@ datadog:
 
     # datadog.processAgent.runInCoreAgent -- Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery.
     ## This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation.
-    ## If Orchestrator Explorer, Network Performance Monitoring is not being used, processAgent.enabled should be set to false to remove the process-agent container.
+    ## If Network Performance Monitoring is not being used, processAgent.enabled should be set to false to remove the process-agent container.
     runInCoreAgent: false
 
   # datadog.osReleasePath -- Specify the path to your os-release file


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds initial support for running Processes-related checks in the core agent instead of the process-agent. This is documented as an experimental feature. 

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
There is a possible misconfiguration: If `processAgent.enabled=true` and the process checks are moved to core agent without other running checks on the core agent, the process agent container enters crash loop. We advise in the documentation to set `processAgent.enabled=false` in that case.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
