### PR TITLE
[EDS] Add rbac for the leader election lease

### DIFF
--- a/charts/extended-daemon-set/CHANGELOG.md
+++ b/charts/extended-daemon-set/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2
+
+* Add RBAC for the leader election lease.
+
 ## 0.3.1
 
 * Migrate from `kubeval` to `kubeconform` for ci chart validation.

--- a/charts/extended-daemon-set/Chart.yaml
+++ b/charts/extended-daemon-set/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.8.0
 description: Extended Daemonset Controller
 name: extendeddaemonset
-version: v0.3.1
+version: v0.3.2
 keywords:
   - monitoring
   - alerting

--- a/charts/extended-daemon-set/README.md
+++ b/charts/extended-daemon-set/README.md
@@ -1,6 +1,6 @@
 # Extended DaemonSet
 
-![Version: v0.3.1](https://img.shields.io/badge/Version-v0.3.1-informational?style=flat-square) ![AppVersion: v0.8.0](https://img.shields.io/badge/AppVersion-v0.8.0-informational?style=flat-square)
+![Version: v0.3.2](https://img.shields.io/badge/Version-v0.3.2-informational?style=flat-square) ![AppVersion: v0.8.0](https://img.shields.io/badge/AppVersion-v0.8.0-informational?style=flat-square)
 
 This chart installs the Extended DaemonSet (EDS). It aims to provide a new implementation of the Kubernetes DaemonSet resource with key features:
 - Canary Deployment: Deploy a new DaemonSet version with only a few nodes.

--- a/charts/extended-daemon-set/templates/role.yaml
+++ b/charts/extended-daemon-set/templates/role.yaml
@@ -35,6 +35,22 @@ rules:
   - get
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - extendeddaemonset-lock
+  verbs:
+  - update
+  - get
+  - watch
+- apiGroups:
     - ""
   resources:
     - podtemplates


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixing this:
```
{"level":"ERROR","ts":"2024-07-03T11:52:48Z","logger":"klog","msg":"error retrieving resource lock datadog-agent-operator/extendeddaemonset-lock: leases.coordination.k8s.io \"extendeddaemonset-lock\" is forbidden: User \"system:serviceaccount:datadog-agent-operator:extendeddaemonset\" cannot get resource \"leases\" in API group \"coordination.k8s.io\" in the namespace \"datadog-agent-operator\"\n"}
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
