### PR TITLE
support setting annotations on datadog-operator deployment

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.4
+
+* Add option to specify `deployment.annotations`.
+
 ## 1.8.3
 
 * Add `image.doNotCheckTag` option to permit skipping operator image tag compatibility.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.8.3
+version: 1.8.4
 appVersion: 1.7.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.8.3](https://img.shields.io/badge/Version-1.8.3-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 1.8.4](https://img.shields.io/badge/Version-1.8.4-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 ## Values
 
@@ -28,6 +28,7 @@
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
+| deployment.annotations | object | `{}` | Allows setting additional annotations for the deployment resource |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |
 | fullnameOverride | string | `""` |  |
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: {{ include "datadog-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
+{{- if .Values.deployment.annotations }}
+  annotations:
+{{ toYaml .Values.deployment.annotations | indent 4 }}
+{{- end }}
   labels:
 {{ include "datadog-operator.labels" . | indent 4 }}
 spec:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -94,6 +94,9 @@ remoteConfiguration:
   # remoteConfiguration.enabled -- If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set.
   enabled: false
 
+deployment:
+  # deployment.annotations -- Allows setting additional annotations for the deployment resource
+  annotations: {}
 rbac:
   # rbac.create -- Specifies whether the RBAC resources should be created
   create: true

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.8.3
+    helm.sh/chart: datadog-operator-1.8.4
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_with_certManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.8.3
+    helm.sh/chart: datadog-operator-1.8.4
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog-clusterchecks
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -36,8 +36,8 @@ spec:
         
       name: datadog-clusterchecks
       annotations:
-        checksum/clusteragent_token: 940bb7a00150569c15840feeeaa4ec5f054ab8a9c543fd9c717853ef86408928
-        checksum/install_info: f50ea8a79f0564dc664ff870e2b565a24e874dd107024252b8439ef2771dc70c
+        checksum/clusteragent_token: b6f86c2f5bedfdb5004c60faa7201e578be2b0be3818cd517e958f3b76a07ae3
+        checksum/install_info: 9a6b3a0afdc7e755915a24989677c6d492582d562fdd38a2270518ae18310357
     spec:
       serviceAccountName: datadog-cluster-checks
       automountServiceAccountToken: true
@@ -45,7 +45,7 @@ spec:
         []
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -57,7 +57,7 @@ spec:
         resources:
           {}
       - name: init-config
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -70,7 +70,7 @@ spec:
           {}
       containers:
       - name: agent
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         command: ["bash", "-c"]
         args:
           - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run

--- a/test/datadog/baseline/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -36,17 +36,17 @@ spec:
         
       name: datadog-cluster-agent
       annotations:
-        checksum/clusteragent_token: 41016e2dccdc8ec14bc77b12fa837798cf9b49d6ec33b982f38a9357bfcdb015
-        checksum/clusteragent-configmap: fc0dc6008f97f0f0bbf7ff0d570e8f2aa1fe695c1d6e2ca0d4d014040fbdb06e
-        checksum/api_key: d625c7eeff65b2ba930348cd0cccd7158d616f7e71f4befd49eb3734387f2388
+        checksum/clusteragent_token: 459abf22e9c0b7c33f45f92b6e33f2f95b1d7a196953d49defa4dbf5559716db
+        checksum/clusteragent-configmap: 1870b1d37dffa2a9ff20295dd22d1ce1a0c508d09e47e7143bea43fbf3e6939e
+        checksum/api_key: 28e63a1c4b64c11f42208b7a22e1a9cac1e2c837cea1ca56788b8b748b370e5c
         checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/install_info: f50ea8a79f0564dc664ff870e2b565a24e874dd107024252b8439ef2771dc70c
+        checksum/install_info: 9a6b3a0afdc7e755915a24989677c6d492582d562fdd38a2270518ae18310357
     spec:
       serviceAccountName: datadog-cluster-agent
       automountServiceAccountToken: true
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command:
           - cp
@@ -59,7 +59,7 @@ spec:
             mountPath: /opt/datadog-agent
       containers:
       - name: cluster-agent
-        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.55.1"
         imagePullPolicy: IfNotPresent
         resources:
           {}

--- a/test/datadog/baseline/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -36,17 +36,17 @@ spec:
         
       name: datadog-cluster-agent
       annotations:
-        checksum/clusteragent_token: e49cae63816f935069ef6f12fb6355438b1303e5e141b5a7141baacf2d5d819b
-        checksum/clusteragent-configmap: fc0dc6008f97f0f0bbf7ff0d570e8f2aa1fe695c1d6e2ca0d4d014040fbdb06e
-        checksum/api_key: d625c7eeff65b2ba930348cd0cccd7158d616f7e71f4befd49eb3734387f2388
+        checksum/clusteragent_token: b30c3fd9a0ddb5efc2ce81df6b5668148dda9e587e2877e60ab5a98176fe1fa5
+        checksum/clusteragent-configmap: 1870b1d37dffa2a9ff20295dd22d1ce1a0c508d09e47e7143bea43fbf3e6939e
+        checksum/api_key: 28e63a1c4b64c11f42208b7a22e1a9cac1e2c837cea1ca56788b8b748b370e5c
         checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/install_info: f50ea8a79f0564dc664ff870e2b565a24e874dd107024252b8439ef2771dc70c
+        checksum/install_info: 9a6b3a0afdc7e755915a24989677c6d492582d562fdd38a2270518ae18310357
     spec:
       serviceAccountName: datadog-cluster-agent
       automountServiceAccountToken: true
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command:
           - cp
@@ -59,7 +59,7 @@ spec:
             mountPath: /opt/datadog-agent
       containers:
       - name: cluster-agent
-        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.55.1"
         imagePullPolicy: IfNotPresent
         resources:
           {}

--- a/test/datadog/baseline/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -36,17 +36,17 @@ spec:
         
       name: datadog-cluster-agent
       annotations:
-        checksum/clusteragent_token: 7a0ca4e15723140df2c3fc4bf3aac52589061ce45538b1db674ddcc72273e0b4
-        checksum/clusteragent-configmap: fc0dc6008f97f0f0bbf7ff0d570e8f2aa1fe695c1d6e2ca0d4d014040fbdb06e
-        checksum/api_key: d625c7eeff65b2ba930348cd0cccd7158d616f7e71f4befd49eb3734387f2388
+        checksum/clusteragent_token: 9970ddeb0c78cac061f61440e3235abd3701e14f4e3e4adbd5bd8ccf7b171042
+        checksum/clusteragent-configmap: 1870b1d37dffa2a9ff20295dd22d1ce1a0c508d09e47e7143bea43fbf3e6939e
+        checksum/api_key: 28e63a1c4b64c11f42208b7a22e1a9cac1e2c837cea1ca56788b8b748b370e5c
         checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/install_info: f50ea8a79f0564dc664ff870e2b565a24e874dd107024252b8439ef2771dc70c
+        checksum/install_info: 9a6b3a0afdc7e755915a24989677c6d492582d562fdd38a2270518ae18310357
     spec:
       serviceAccountName: datadog-cluster-agent
       automountServiceAccountToken: true
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command:
           - cp
@@ -59,7 +59,7 @@ spec:
             mountPath: /opt/datadog-agent
       containers:
       - name: cluster-agent
-        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.55.1"
         imagePullPolicy: IfNotPresent
         resources:
           {}
@@ -119,7 +119,7 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
             value: agent
           - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-            value: 7.54.0
+            value: 7.55.1
           - name: DD_REMOTE_CONFIGURATION_ENABLED
             value: "false"
           - name: DD_CLUSTER_CHECKS_ENABLED

--- a/test/datadog/baseline/daemonset_default.yaml
+++ b/test/datadog/baseline/daemonset_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -30,8 +30,8 @@ spec:
         
       name: datadog
       annotations:
-        checksum/clusteragent_token: 287b49c857ea99e60a036ce189b6d1b59cb4a00baae0607a6b1b463ba2ea6613
-        checksum/install_info: f50ea8a79f0564dc664ff870e2b565a24e874dd107024252b8439ef2771dc70c
+        checksum/clusteragent_token: 179d0baafb25372e797d4253ad5e40a628e62ad44086dcb4401a466741784615
+        checksum/install_info: 9a6b3a0afdc7e755915a24989677c6d492582d562fdd38a2270518ae18310357
         checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
         checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
@@ -42,7 +42,7 @@ spec:
       hostPID: true
       containers:
       - name: agent
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["agent", "run"]
         
@@ -76,6 +76,11 @@ spec:
             value: "false"
           
           
+          
+          - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+            value: "true"
+          - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+            value: "false"
           - name: DD_LOG_LEVEL
             value: "INFO"
           - name: DD_DOGSTATSD_PORT
@@ -192,7 +197,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
       - name: trace-agent
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]  
         resources:
@@ -298,7 +303,7 @@ spec:
             port: 8126
           timeoutSeconds: 5
       - name: process-agent
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]  
         resources:
@@ -336,8 +341,11 @@ spec:
                   name: datadog-cluster-agent
                   key: token
           
+          
           - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
             value: "true"
+          - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+            value: "false"
           - name: DD_LOG_LEVEL
             value: "INFO"
           - name: DD_SYSTEM_PROBE_ENABLED
@@ -387,7 +395,7 @@ spec:
           
       - name: init-volume
         
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -400,7 +408,7 @@ spec:
           {}
       - name: init-config
         
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command:
           - bash

--- a/test/datadog/baseline/other_default.yaml
+++ b/test/datadog/baseline/other_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: datadog-clusterchecks
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -24,7 +24,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -41,13 +41,13 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "7"
     app: "datadog"
-    chart: "datadog-3.67.3"
+    chart: "datadog-3.68.0"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-checks
@@ -60,10 +60,10 @@ automountServiceAccountToken: true
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-3.67.3"
+    chart: "datadog-3.68.0"
     heritage: "Helm"
     release: "datadog"
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -79,7 +79,7 @@ metadata:
   name: datadog
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -92,14 +92,14 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "7"
 type: Opaque
 data:
-  token: "QUFveTdyd21RNU1ZUUhkTlJxSVRZSkJFdTdwdnVrVHQ="
+  token: "VEw0RnJvVnp3RkJUNXFtcDcwbGgySDNkV2d3VkNGbUs="
 ---
 # Source: datadog/templates/cluster-agent-confd-configmap.yaml
 apiVersion: v1
@@ -108,7 +108,7 @@ metadata:
   name: datadog-cluster-agent-confd
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -157,20 +157,20 @@ metadata:
   name: datadog-installinfo
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "7"
   annotations:
-    checksum/install_info: f50ea8a79f0564dc664ff870e2b565a24e874dd107024252b8439ef2771dc70c
+    checksum/install_info: 9a6b3a0afdc7e755915a24989677c6d492582d562fdd38a2270518ae18310357
 data:
   install_info: |
     ---
     install_method:
       tool: helm
       tool_version: Helm
-      installer_version: datadog-3.67.3
+      installer_version: datadog-3.68.0
 ---
 # Source: datadog/templates/kpi-telemetry-configmap.yaml
 apiVersion: v1
@@ -179,22 +179,22 @@ metadata:
   name: datadog-kpi-telemetry-configmap
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: "7"
 data:
   install_type: k8s_manual
-  install_id: "4e30aa1a-8ec7-4190-808c-beaa484cd1be"
-  install_time: "1720546349"
+  install_id: "50096d3c-dfdd-4dcd-b22a-b547b24cd97a"
+  install_time: "1721285287"
 ---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -409,7 +409,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -505,7 +505,7 @@ kind: ClusterRole
 metadata:
   name: datadog
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -553,7 +553,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -573,7 +573,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -593,7 +593,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -614,7 +614,7 @@ kind: ClusterRoleBinding
 metadata:
   name: datadog
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -633,7 +633,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -650,7 +650,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -672,7 +672,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -693,7 +693,7 @@ apiVersion: "rbac.authorization.k8s.io/v1"
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -716,7 +716,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -738,10 +738,10 @@ metadata:
   namespace: datadog-agent
   labels:
     app: "datadog"
-    chart: "datadog-3.67.3"
+    chart: "datadog-3.68.0"
     release: "datadog"
     heritage: "Helm"
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -764,10 +764,10 @@ metadata:
   namespace: datadog-agent
   labels:
     app: "datadog"
-    chart: "datadog-3.67.3"
+    chart: "datadog-3.68.0"
     release: "datadog"
     heritage: "Helm"
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -793,7 +793,7 @@ metadata:
   name: datadog
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -817,8 +817,8 @@ spec:
         
       name: datadog
       annotations:
-        checksum/clusteragent_token: 9ef97dddd1e5b1a58467f956443bb44b5cc254b773babc64f396c7084c983245
-        checksum/install_info: f50ea8a79f0564dc664ff870e2b565a24e874dd107024252b8439ef2771dc70c
+        checksum/clusteragent_token: e14d4eae995370df8bff980ef455f891a9e141e06368fe62958554c779d31766
+        checksum/install_info: 9a6b3a0afdc7e755915a24989677c6d492582d562fdd38a2270518ae18310357
         checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
         checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
@@ -829,7 +829,7 @@ spec:
       hostPID: true
       containers:
       - name: agent
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["agent", "run"]
         
@@ -863,6 +863,11 @@ spec:
             value: "false"
           
           
+          
+          - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+            value: "true"
+          - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+            value: "false"
           - name: DD_LOG_LEVEL
             value: "INFO"
           - name: DD_DOGSTATSD_PORT
@@ -980,7 +985,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
       - name: trace-agent
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]  
         resources:
@@ -1086,7 +1091,7 @@ spec:
             port: 8126
           timeoutSeconds: 5
       - name: process-agent
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]  
         resources:
@@ -1124,8 +1129,11 @@ spec:
                   name: datadog-cluster-agent
                   key: token
           
+          
           - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
             value: "true"
+          - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+            value: "false"
           - name: DD_LOG_LEVEL
             value: "INFO"
           - name: DD_SYSTEM_PROBE_ENABLED
@@ -1175,7 +1183,7 @@ spec:
           
       - name: init-volume
         
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -1188,7 +1196,7 @@ spec:
           {}
       - name: init-config
         
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command:
           - bash
@@ -1293,7 +1301,7 @@ metadata:
   name: datadog-clusterchecks
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -1323,8 +1331,8 @@ spec:
         
       name: datadog-clusterchecks
       annotations:
-        checksum/clusteragent_token: 34e2ad428259e9338b0aba3854c49fe82fca0bf62a56104652c011f6381d5140
-        checksum/install_info: f50ea8a79f0564dc664ff870e2b565a24e874dd107024252b8439ef2771dc70c
+        checksum/clusteragent_token: 6236d64c33330168fac8f433ce53e171946653cfee9bbedc10708f4bffd12237
+        checksum/install_info: 9a6b3a0afdc7e755915a24989677c6d492582d562fdd38a2270518ae18310357
     spec:
       serviceAccountName: datadog-cluster-checks
       automountServiceAccountToken: true
@@ -1332,7 +1340,7 @@ spec:
         []
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -1344,7 +1352,7 @@ spec:
         resources:
           {}
       - name: init-config
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command: ["bash", "-c"]
         args:
@@ -1357,7 +1365,7 @@ spec:
           {}
       containers:
       - name: agent
-        image: "gcr.io/datadoghq/agent:7.54.0"
+        image: "gcr.io/datadoghq/agent:7.55.1"
         command: ["bash", "-c"]
         args:
           - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run
@@ -1484,7 +1492,7 @@ metadata:
   name: datadog-cluster-agent
   namespace: datadog-agent
   labels:
-    helm.sh/chart: 'datadog-3.67.3'
+    helm.sh/chart: 'datadog-3.68.0'
     app.kubernetes.io/name: "datadog"
     app.kubernetes.io/instance: "datadog"
     app.kubernetes.io/managed-by: Helm
@@ -1514,15 +1522,15 @@ spec:
         
       name: datadog-cluster-agent
       annotations:
-        checksum/clusteragent_token: f4606476ef366e0c3fab79dde5c5c9bd3970824b6e48d4dd61dce484d892a491
-        checksum/clusteragent-configmap: 3e05961e3055e7f00a5c6765d16eb843b13277b0201f232957d2fb832d7a2f64
-        checksum/install_info: f50ea8a79f0564dc664ff870e2b565a24e874dd107024252b8439ef2771dc70c
+        checksum/clusteragent_token: 982e3679f4d216c771b4be67a945049a92c86c024fc7fe3b3715ea293b599ccd
+        checksum/clusteragent-configmap: da78943b0a2b4039c8db933c5af5009ba72516f8625b14b5815a83e4080f38ac
+        checksum/install_info: 9a6b3a0afdc7e755915a24989677c6d492582d562fdd38a2270518ae18310357
     spec:
       serviceAccountName: datadog-cluster-agent
       automountServiceAccountToken: true
       initContainers:
       - name: init-volume
-        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.55.1"
         imagePullPolicy: IfNotPresent
         command:
           - cp
@@ -1535,7 +1543,7 @@ spec:
             mountPath: /opt/datadog-agent
       containers:
       - name: cluster-agent
-        image: "gcr.io/datadoghq/cluster-agent:7.54.0"
+        image: "gcr.io/datadoghq/cluster-agent:7.55.1"
         imagePullPolicy: IfNotPresent
         resources:
           {}

--- a/test/datadog/dca_AC_sidecar_test.go
+++ b/test/datadog/dca_AC_sidecar_test.go
@@ -91,7 +91,7 @@ func verifyDeploymentFargateMinimal(t *testing.T, manifest string) {
 	// Default will be set by DCA
 	assert.Empty(t, acConfigEnv[DDSidecarRegistry])
 	assert.Equal(t, "agent", acConfigEnv[DDSidecarImageName])
-	assert.Equal(t, "7.54.0", acConfigEnv[DDSidecarImageTag])
+	assert.Equal(t, "7.55.1", acConfigEnv[DDSidecarImageTag])
 	assert.Empty(t, acConfigEnv[DDSidecarSelectors])
 	assert.Empty(t, acConfigEnv[DDSidecarProfiles])
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

In our deployment of datadog-operator we want to utilize https://github.com/stakater/Reloader to automatically restart (a.k.a. perform a fresh rollout) the deployment of the operator when secrets (e.g. api-key, app-key) change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
