### PR TITLE
allow configuration of the security context of the security agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.69.0
+
+* Allow configuration of the security context of the security agent, as is already the case for other agents.
+
 ## 3.68.0
 
 * Set default `Agent` and `Cluster-Agent` version to `7.55.1`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.68.0
+version: 3.69.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.68.0](https://img.shields.io/badge/Version-3.68.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.69.0](https://img.shields.io/badge/Version-3.69.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -484,6 +484,9 @@ helm install <RELEASE_NAME> \
 | agents.containers.securityAgent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off. If not set, fall back to the value of datadog.logLevel. |
 | agents.containers.securityAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.securityAgent.resources | object | `{}` | Resource requests and limits for the security-agent container |
+| agents.containers.securityAgent.securityContext.capabilities.add[0] | string | `"AUDIT_CONTROL"` |  |
+| agents.containers.securityAgent.securityContext.capabilities.add[1] | string | `"AUDIT_READ"` |  |
+| agents.containers.securityAgent.securityContext.privileged | bool | `false` |  |
 | agents.containers.systemProbe.env | list | `[]` | Additional environment variables for the system-probe container |
 | agents.containers.systemProbe.envDict | object | `{}` | Set environment variables specific to system-probe defined in a dict |
 | agents.containers.systemProbe.envFrom | list | `[]` | Set environment variables specific to system-probe from configMaps and/or secrets |

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -2,11 +2,7 @@
 - name: security-agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  {{- if eq  (include "should-enable-compliance" .) "true" }}
-  securityContext:
-    capabilities:
-      add: ["AUDIT_CONTROL", "AUDIT_READ"]
-  {{- end }}
+{{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.securityAgent.securityContext "targetSystem" .Values.targetSystem "seccomp" .Values.datadog.systemProbe.seccomp "kubeversion" .Capabilities.KubeVersion.Version) | indent 2 }}
   command: ["security-agent", "start", "-c={{ template "datadog.confPath" . }}/datadog.yaml"]
   resources:
 {{ toYaml .Values.agents.containers.securityAgent.resources | indent 4 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1755,6 +1755,12 @@ agents:
       #    cpu: 100m
       #    memory: 300Mi
 
+      ## agents.podSecurity.capabilities must reflect the changed made in securityContext.capabilities.
+      securityContext:
+        privileged: false
+        capabilities:
+          add: ["AUDIT_CONTROL", "AUDIT_READ"]
+
       # agents.containers.securityAgent.ports -- Allows to specify extra ports (hostPorts for instance) for this container
       ports: []
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR syncs the configuration of the security context of the security agent with how it's done for other agents (especially system probe).

The end motivation is to give access to other fields of the security context like `allowPrivilegeEscalation` which was not currently possible. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
