### PR TITLE
[synthetics]  Add support for PDB for private location deployment

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.17.0
+
+* Add `podDisruptionBudget` to allow creating and configuring PodDisruptionBudget for deployment.
+
 ## 0.16.4
 
 * Update private location image version to `1.49.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.16.4
+version: 0.17.0
 appVersion: 1.49.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.16.4](https://img.shields.io/badge/Version-0.16.4-informational?style=flat-square) ![AppVersion: 1.49.0](https://img.shields.io/badge/AppVersion-1.49.0-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![AppVersion: 1.49.0](https://img.shields.io/badge/AppVersion-1.49.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations/?tab=helmchart).
 
@@ -46,6 +46,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Synthetics Private Location on specific nodes |
 | podAnnotations | object | `{}` | Annotations to set to Datadog Synthetics Private Location PODs |
+| podDisruptionBudget | object | `{"enabled":false,"minAvailable":1}` | Allows to create and configure PodDisruptionBudget for Datadog Synthetics Private Location deployment |
 | podLabels | object | `{}` | Labels to be placed on pods managed by the deployment |
 | podSecurityContext | object | `{}` | Security context to set to Datadog Synthetics Private Location PODs |
 | priorityClassName | string | `""` | Allows to specify PriorityClass for Datadog Synthetics Private Location PODs |

--- a/charts/synthetics-private-location/templates/_helpers.tpl
+++ b/charts/synthetics-private-location/templates/_helpers.tpl
@@ -63,3 +63,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for PodDisruptionBudget policy APIs.
+*/}}
+{{- define "policy.poddisruptionbudget.apiVersion" -}}
+{{- if or (.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21" .Capabilities.KubeVersion.Version) -}}
+"policy/v1"
+{{- else -}}
+"policy/v1beta1"
+{{- end -}}
+{{- end -}}

--- a/charts/synthetics-private-location/templates/pdb.yaml
+++ b/charts/synthetics-private-location/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: {{ template "policy.poddisruptionbudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "synthetics-private-location.fullname" . }}
+  labels:
+    {{- include "synthetics-private-location.labels" . | nindent 4 }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels: {{- include "synthetics-private-location.selectorLabels" . | nindent 6 }}
+{{- end -}}

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -124,3 +124,9 @@ enableStatusProbes: false
 
 # priorityClassName -- Allows to specify PriorityClass for Datadog Synthetics Private Location PODs
 priorityClassName: ""
+
+# podDisruptionBudget -- Allows to create and configure PodDisruptionBudget for Datadog Synthetics Private Location deployment
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1


### PR DESCRIPTION
#### What this PR does / why we need it:

It is crucial to have at least one instance of a private location running at any moment of time (not to lose visibility of your endpoints). Currently, there is no way to specify [PodDisruptionBudget ](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)to prevent downtime during maintenance of k8s cluster. This pr introduces it (in the similar way it is done for other Dadadog product, for example https://github.com/DataDog/helm-charts/blob/main/charts/observability-pipelines-worker/templates/pdb.yaml


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
