### PR TITLE
Add terminationGracePeriodSeconds option

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 3.68.3
+* Add `agents.terminationGracePeriodSeconds`, `clusterAgent.terminationGracePeriodSeconds` and `clusterChecksRunner.terminationGracePeriodSeconds`
+
 ## 3.68.2
 * Fix datadog.containerLifecycle.enabled conditional statement to accept flase value
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -339,4 +339,10 @@
 {{- $startup := .Values.agents.containers.agent.startupProbe }}
 {{ include "probe.http" (dict "path" "/startup" "port" $healthPort "settings" $startup) | indent 4 }}
 {{- end }}
+  {{- if .Values.agents.terminationGracePeriodSeconds }}
+  lifecycle:
+    preStop:
+      exec:
+        command: ["/bin/sh", "-c", "sleep 10"]
+  {{- end }}
 {{- end -}}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -104,4 +104,10 @@
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}
 {{- end }}
+  {{- if .Values.agents.terminationGracePeriodSeconds }}
+  lifecycle:
+    preStop:
+      exec:
+        command: ["/bin/sh", "-c", "sleep 10"]
+  {{- end }}
 {{- end -}}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -130,4 +130,10 @@
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}
 {{- end }}
+  {{- if .Values.agents.terminationGracePeriodSeconds }}
+  lifecycle:
+    preStop:
+      exec:
+        command: ["/bin/sh", "-c", "sleep 10"]
+  {{- end }}
 {{- end -}}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -151,4 +151,10 @@
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}
 {{- end }}
+  {{- if .Values.agents.terminationGracePeriodSeconds }}
+  lifecycle:
+    preStop:
+      exec:
+        command: ["/bin/sh", "-c", "sleep 10"]
+  {{- end }}
 {{- end -}}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -119,4 +119,10 @@
   livenessProbe:
 {{- $live := .Values.agents.containers.traceAgent.livenessProbe }}
 {{ include "probe.tcp" (dict "port" .Values.datadog.apm.port "settings" $live ) | indent 4 }}
+  {{- if .Values.agents.terminationGracePeriodSeconds }}
+  lifecycle:
+    preStop:
+      exec:
+        command: ["/bin/sh", "-c", "sleep 10"]
+  {{- end }}
 {{- end -}}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -50,6 +50,9 @@ spec:
       {{- if .Values.clusterChecksRunner.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.clusterChecksRunner.shareProcessNamespace }}
       {{- end }}
+      {{- if .Values.clusterChecksRunner.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.clusterChecksRunner.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if or (eq (include "should-enable-cluster-check-workers" .) "true") .Values.clusterChecksRunner.rbac.dedicated }}
       serviceAccountName: {{ if .Values.clusterChecksRunner.rbac.create }}{{ template "datadog.fullname" . }}-cluster-checks{{ else }}"{{ .Values.clusterChecksRunner.rbac.serviceAccountName }}"{{ end }}
       {{- else }}
@@ -261,6 +264,12 @@ spec:
                 matchLabels:
                   app: {{ template "datadog.fullname" . }}-clusterchecks
               topologyKey: kubernetes.io/hostname
+{{- end }}
+{{- if .Values.agents.terminationGracePeriodSeconds }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 10"]
 {{- end }}
       nodeSelector:
         {{ template "label.os" . }}: {{ .Values.targetSystem }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -71,6 +71,9 @@ spec:
       {{- if .Values.clusterAgent.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.clusterAgent.shareProcessNamespace }}
       {{- end }}
+      {{- if .Values.clusterAgent.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.clusterAgent.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.clusterAgent.priorityClassName }}
       priorityClassName: "{{ .Values.clusterAgent.priorityClassName }}"
       {{- end }}
@@ -129,6 +132,12 @@ spec:
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         resources:
 {{ toYaml .Values.clusterAgent.resources | indent 10 }}
+        {{- if .Values.agents.terminationGracePeriodSeconds }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 10"]
+        {{- end }}
         ports:
         - containerPort: 5005
           name: agentport

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1339,6 +1339,10 @@ clusterAgent:
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#include-containers
   containerInclude:
 
+  # clusterAgent.terminationGracePeriodSeconds -- Set terminationGracePeriodSeconds for cluster agent pod
+  # See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+  terminationGracePeriodSeconds:
+
 ## This section lets you configure the agents deployed by this chart to connect to a Cluster Agent
 ## deployed independently
 existingClusterAgent:
@@ -1548,6 +1552,10 @@ agents:
 
     # agents.podSecurity.defaultApparmor -- Default AppArmor profile for all containers but system-probe
     defaultApparmor: runtime/default
+
+  # agents.terminationGracePeriodSeconds -- Set terminationGracePeriodSeconds for agent pod
+  # See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+  terminationGracePeriodSeconds:
 
   containers:
     agent:
@@ -2123,6 +2131,10 @@ clusterChecksRunner:
 
   # clusterChecksRunner.ports -- Allows to specify extra ports (hostPorts for instance) for this container
   ports: []
+
+  # clusterChecksRunner.terminationGracePeriodSeconds -- Set terminationGracePeriodSeconds for cluster checks runner pod
+  # See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+  terminationGracePeriodSeconds:
 
 datadog-crds:
   crds:


### PR DESCRIPTION
### What this PR does / why we need it:
Requested via support. This is made by internal TEE and reaching out to Engineering separately.

### Which issue this PR fixes
Add option to set terminationGracePeriodSeconds for the agent, cluster agent and cluster checks runner.