### PR TITLE
docs(datadog): update autopilot requirements to match values

### DIFF
--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -328,7 +328,15 @@ On GKE Autopilot, only one "datadog" Helm chart release is allowed by Kubernetes
 #####################################################################
 ####   WARNING: System Probe is not supported on GKE Autopilot   ####
 #####################################################################
-{{- fail "On GKE Autopilot environments, System Probe is not supported. The option 'datadog.securityAgent.runtime.enabled' must be set 'false'" }}
+{{- fail "On GKE Autopilot environments, System Probe is not supported. }} 
+
+All of the following options must be set to false:
+* datadog.securityAgent.runtime.enabled
+* datadog.securityAgent.runtime.fimEnabled 
+* datadog.networkMonitoring.enabled 
+* datadog.systemProbe.enableTCPQueueLength 
+* datadog.enableOOMKill 
+* datadog.serviceMonitoring.enabled
 
 {{- end }}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

It updates the `NOTES` to correctly state all flags that must be set false in an AutoPilot environment.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
