### PR TITLE
Remove XValidation rule from DPA CRD as requires K8S >= 1.25

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.7.2
+
+* Remove XValidation as requires K8S >= 1.25.
+
+## 1.7.1
+
+* Add DPA CRD.
+
 ## 1.7.0
 * Update CRDs from Datadog Operator v1.7.0 tag.
 

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 1.7.1
+version: 1.7.2
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/ci/kubeconform-values.yaml
+++ b/charts/datadog-crds/ci/kubeconform-values.yaml
@@ -2,3 +2,6 @@ crds:
   datadogMetrics: true
   datadogAgents: true
   datadogMonitors: true
+  datadogSLOs: true
+  datadogAgentProfiles: true
+  datadogPodAutoscalers: true

--- a/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
@@ -330,9 +330,6 @@ spec:
                     - kind
                     - name
                   type: object
-                  x-kubernetes-validations:
-                    - message: Modifying the targetRef is not allowed. Please delete and re-create the DatadogPodAutoscaler object.
-                      rule: self == oldSelf
                 targets:
                   description: |-
                     Targets are objectives to reach and maintain for the target resource.


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove XValidation rule from DPA CRD as requires K8S >= 1.25

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
