### PR TITLE
OTEL-2003: Bind ports 4317/4318 by default

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.69.3
+## 3.69.4
 
 * Add hostPort `4317` and `4318` for otel agent.
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.69.3
 
+* Add hostPort `4317` and `4318` for otel agent.
+
+## 3.69.3
+
 * Update `datadog-crds` dependency to `1.7.2`.
 
 ## 3.69.2

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.69.3
+version: 3.69.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.69.3](https://img.shields.io/badge/Version-3.69.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.69.4](https://img.shields.io/badge/Version-3.69.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -772,7 +772,7 @@ helm install <RELEASE_NAME> \
 | datadog.osReleasePath | string | `"/etc/os-release"` | Specify the path to your os-release file |
 | datadog.otelCollector.config | object | `{}` | OTel collector configuration |
 | datadog.otelCollector.enabled | bool | `false` | Enable the OTel Collector |
-| datadog.otelCollector.ports | list | `[{"containerPort":"4317","name":"otel-grpc"},{"containerPort":"4318","name":"otel-http"}]` | Ports that OTel Collector is listening |
+| datadog.otelCollector.ports | list | `[{"containerPort":"4317","hostPort":"4317","name":"otel-grpc"},{"containerPort":"4318","hostPort":"4318","name":"otel-http"}]` | Ports that OTel Collector is listening |
 | datadog.otlp.logs.enabled | bool | `false` | Enable logs support in the OTLP ingest endpoint |
 | datadog.otlp.receiver.protocols.grpc.enabled | bool | `false` | Enable the OTLP/gRPC endpoint |
 | datadog.otlp.receiver.protocols.grpc.endpoint | string | `"0.0.0.0:4317"` | OTLP/gRPC endpoint |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -526,12 +526,13 @@ datadog:
     enabled: false
     # datadog.otelCollector.ports -- Ports that OTel Collector is listening
     ports:
-
         # Default GRPC port of OTLP receiver
       - containerPort: "4317"
+        hostPort: "4317"
         name: otel-grpc
         # Default HTTP port of OTLP receiver
       - containerPort: "4318"
+        hostPort: "4318"
         name: otel-http
     # datadog.otelCollector.config -- OTel collector configuration
     config: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR binds host ports 4317/4318 by default for the OTel Agent. This change enables Daemonset deployment to work OOTB, without needing to bind the ports manually.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
