### PR TITLE
Bumping runner version to alpha27

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+### 0.6.0
+
+* Update private action image version to `v0.0.1-alpha27`.
+
 ### 0.5.0
 
 * Update private action image version to `v0.0.1-alpha26`.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha26](https://img.shields.io/badge/AppVersion-v0.0.1--alpha26-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha27](https://img.shields.io/badge/AppVersion-v0.0.1--alpha27-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 
@@ -41,7 +41,7 @@ This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cl
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| common.image | string | `"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner:v0.0.1-alpha26"` | Current Datadog Private Action Runner image |
+| common.image | string | `"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner:v0.0.1-alpha27"` | Current Datadog Private Action Runner image |
 | runners[0].config | object | `{"actionsAllowlist":["com.datadoghq.kubernetes.core.listPod"],"appBuilder":{"port":9016},"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"privateKey":"PRIVATE_KEY_FROM_CONFIG","urn":"URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
 | runners[0].config.actionsAllowlist | list | `["com.datadoghq.kubernetes.core.listPod"]` | List of actions that the Datadog Private Action Runner is allowed to execute |
 | runners[0].config.appBuilder.port | int | `9016` | Required port for App Builder Mode |

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha26](https://img.shields.io/badge/AppVersion-v0.0.1--alpha26-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha27](https://img.shields.io/badge/AppVersion-v0.0.1--alpha27-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -4,7 +4,7 @@
 
 common:
   # -- Current Datadog Private Action Runner image
-  image: us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner:v0.0.1-alpha26
+  image: us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner:v0.0.1-alpha27
 
 runners:
   # runners[0].name -- Name of the Datadog Private Action Runner


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR bumps the version of the private action runner image to alpha27

#### Which issue this PR fixes
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)

