### PR TITLE
[APF-14] Update chart instructions to reflect new UI and split image value

### DIFF
--- a/.github/workflows/labeler/labels.yaml
+++ b/.github/workflows/labeler/labels.yaml
@@ -27,6 +27,10 @@ chart/synthetics-private-location:
     - changed-files:
         - any-glob-to-any-file: "charts/synthetics-private-location/**"
 
+chart/private-action-runner:
+    - changed-files:
+          - any-glob-to-any-file: "charts/private-action-runner/**"
+
 tools/tests:
     - changed-files:
         - any-glob-to-any-file: "tests/**"

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.7.0
 
-* Simplify README instructions to reflect the new Kubernetes UI. Split image value to be consistent with other charts.
+* Simplify README instructions to reflect the new Kubernetes UI. Split image value to be consistent with other charts. Fix bug requiring port for Workflow mode.
 
 ### 0.6.0
 

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.7.0
 
-* Simplify README instructions to reflect the new Kubernetes UI. Split image value to be consistent with other charts. Fix bug requiring port for Workflow mode. Open `/etc/dd-action-runner/` write access so template connection credential files can be generated.
+* Simplify README instructions to reflect the new Kubernetes UI. Split image value to be consistent with other charts. Fix bug requiring port for Workflow mode.
 
 ### 0.6.0
 

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+### 0.7.0
+
+* Simplify README instructions to reflect the new Kubernetes UI.
+
 ### 0.6.0
 
 * Update private action image version to `v0.0.1-alpha27`.

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.7.0
 
-* Simplify README instructions to reflect the new Kubernetes UI.
+* Simplify README instructions to reflect the new Kubernetes UI. Split image value to be consistent with other charts.
 
 ### 0.6.0
 

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.7.0
 
-* Simplify README instructions to reflect the new Kubernetes UI. Split image value to be consistent with other charts. Fix bug requiring port for Workflow mode.
+* Simplify README instructions to reflect the new Kubernetes UI. Split image value to be consistent with other charts. Fix bug requiring port for Workflow mode. Open `/etc/dd-action-runner/` write access so template connection credential files can be generated.
 
 ### 0.6.0
 

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -29,9 +29,9 @@ helm repo update
 ```bash
 helm pull datadog/private-action-runner --untar
 ```
-4. Add connection credential json file to `templates/secrets.yaml` in the format corresponding to the credential type you want to use.
+4. Add connection credential json file to `templates/secrets.yaml` in the format corresponding to the credential and action types you want to use.
 
-For HTTP Basic Auth:
+HTTP Basic Auth:
 ```
 {
    auth_type: 'Basic Auth',
@@ -43,7 +43,7 @@ For HTTP Basic Auth:
    ],
 }
 ```
-For HTTP Token Auth:
+HTTP Token Auth:
 ```
 {
    auth_type: 'Token Auth',
@@ -55,7 +55,7 @@ For HTTP Token Auth:
    ],
 }
 ```
-For Jenkins:
+Jenkins:
 ```
 {
    auth_type: 'Token Auth',
@@ -68,7 +68,7 @@ For Jenkins:
    ],
 }
 ```
-For Postgres:
+Postgres:
 ```
 {
    auth_type: 'Token Auth',
@@ -80,7 +80,7 @@ For Postgres:
    ],
 }
 ```
-5. Install the chart locally:
+5. Install the chart locally.
 ```bash
 helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
 ```

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -80,7 +80,7 @@ Postgres:
    ],
 }
 ```
-5. Install the chart locally.
+5. Install the chart.
 ```bash
 helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
 ```

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -32,7 +32,7 @@ helm pull datadog/private-action-runner --untar
 4. Add connection credential json file to `templates/secrets.yaml` in the format corresponding to the credential type you want to use.
 
 For HTTP Basic Auth:
-```json
+```
 {
    auth_type: 'Basic Auth',
    credentials: [
@@ -44,7 +44,7 @@ For HTTP Basic Auth:
 }
 ```
 For Jenkins:
-```json
+```
 {
    auth_type: 'Token Auth',
    credentials: [
@@ -55,10 +55,9 @@ For Jenkins:
       },
    ],
 }
-
 ```
 For Postgres:
-```json
+```
 {
    auth_type: 'Token Auth',
    credentials: [

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -14,14 +14,65 @@ helm repo update
 ```
 
 ## Requirements
-* A Datadog account with private actions enabled
-* The `kubectl` cli
-* Helm
-* Sufficient permissions to the Kubernetes cluster
+* `kubectl` CLI is installed on my machine
+* Helm is installed on my machine
+* The permissions of my Kubernetes environment allow the Datadog Private Action Runner to read and write using a Kubernetes service account
 
 ## Use this chart
 1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
 2. Create a new private action runner and follow the instructions for Kubernetes.
+
+## Use this chart with connection credentials
+1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
+2. Create a new private action runner and follow the instructions for Kubernetes but make some changes instead of running `helm install` in step 4.
+3. Download the chart locally.
+```bash
+helm pull datadog/private-action-runner --untar
+```
+4. Add connection credential json file to `templates/secrets.yaml` in the format corresponding to the credential type you want to use.
+
+For HTTP Basic Auth:
+```json
+{
+   auth_type: 'Basic Auth',
+   credentials: [
+      {
+         username: 'USERNAME',
+         password: 'PASSWORD',
+      },
+   ],
+}
+```
+For Jenkins:
+```json
+{
+   auth_type: 'Token Auth',
+   credentials: [
+      {
+         username: 'USERNAME',
+         token: 'TOKEN',
+         domain: 'DOMAIN',
+      },
+   ],
+}
+
+```
+For Postgres:
+```json
+{
+   auth_type: 'Token Auth',
+   credentials: [
+      {
+         tokenName: 'connectionUri',
+         tokenValue: 'postgres://usr:password@example_host:5432/example_db',
+      },
+   ],
+}
+```
+5. Install the chart locally:
+```bash
+helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
+```
 
 ## To use Kubernetes Actions
 1. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -43,6 +43,18 @@ For HTTP Basic Auth:
    ],
 }
 ```
+For HTTP Token Auth:
+```
+{
+   auth_type: 'Token Auth',
+   credentials: [
+      {
+         tokenName: 'TOKEN1',
+         tokenValue: 'VALUE1',
+      },
+   ],
+}
+```
 For Jenkins:
 ```
 {

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -36,7 +36,7 @@ helm repo update
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| common.image | string | `"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner:v0.0.1-alpha27"` | Current Datadog Private Action Runner image |
+| common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.0.1-alpha27"}` | Current Datadog Private Action Runner image |
 | runners[0].config | object | `{"actionsAllowlist":["com.datadoghq.kubernetes.core.listPod"],"appBuilder":{"port":9016},"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"privateKey":"PRIVATE_KEY_FROM_CONFIG","urn":"URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
 | runners[0].config.actionsAllowlist | list | `["com.datadoghq.kubernetes.core.listPod"]` | List of actions that the Datadog Private Action Runner is allowed to execute |
 | runners[0].config.appBuilder.port | int | `9016` | Required port for App Builder Mode |

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -85,7 +85,7 @@ Postgres:
 helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
 ```
 
-## To use Kubernetes Actions
+## To use Kubernetes actions
 1. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
 2. Create a new connection, select your private action runner, and use **Service account authentication**.
 3. Create a new workflow and use a Kubernetes action like **List pod** or **List deployment**.

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -19,12 +19,12 @@ helm repo update
 * The permissions of my Kubernetes environment allow the Datadog Private Action Runner to read and write using a Kubernetes service account
 
 ## Use this chart
-1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
-2. Create a new private action runner and follow the instructions for Kubernetes.
+1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
+2. Create a new Private Action Runner and follow the instructions for Kubernetes.
 
 ## Use this chart with connection credentials
-1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
-2. Create a new private action runner and follow the instructions for Kubernetes but make some changes instead of running `helm install` in step 4.
+1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
+2. Set up a new Private Action runner by following the Kubernetes instructions. When you reach step 4, instead of running `helm install`, make the following changes to the Helm chart.
 3. Download the chart locally.
 ```bash
 helm pull datadog/private-action-runner --untar

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,8 +1,17 @@
 # Datadog Private Action Runner
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha27](https://img.shields.io/badge/AppVersion-v0.0.1--alpha27-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha27](https://img.shields.io/badge/AppVersion-v0.0.1--alpha27-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
+
+## How to use Datadog Helm repository
+
+You need to add this repository to your Helm repositories:
+
+```
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+```
 
 ## Requirements
 * A Datadog account with private actions enabled
@@ -13,24 +22,10 @@ This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cl
 ## Use this chart
 
 1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
-2. Create a new private action runner.
-3. Follow the instructions. You now have a running docker container and `config/config.yaml` file.
-4. Stop the docker container (`docker stop <name-of-the-container>` or `docker compose stop`).
-5. Create a `config.yaml` file with the appropriate values. An example `config.yaml` file is provided in the `examples` directory for you to copy.
-    * Replace the `URN_FROM_CONFIG` and the `PRIVATE_KEY_FROM_CONFIG` in the example file with with the `urn` and the `privateKey` from the `config/config.yaml` of the docker container.
-    * You can reconfigure other values or use the defaults in the example.
-6. Add this repository to your Helm repositories:
-    ```
-    helm repo add datadog https://helm.datadoghq.com
-    helm repo update
-    ```
-7. Install the Helm chart:
-    ```bash
-        helm install <RELEASE_NAME> datadog/private-action-runner -f ./config.yaml
-    ```
-8. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
-9. Create a new connection, select your private action runner, and use **Service account authentication**.
-10. Create a new workflow and use a Kubernetes action like **List pod** or **List deployment**.
+2. Create a new private action runner and follow the instructions for Kubernetes.
+3. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
+4. Create a new connection, select your private action runner, and use **Service account authentication**.
+5. Create a new workflow and use a Kubernetes action like **List pod** or **List deployment**.
 
 ## Going further
 * Adjust the service account permissions according to your needs. Learn more about [Kubernetes RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac).

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -20,12 +20,13 @@ helm repo update
 * Sufficient permissions to the Kubernetes cluster
 
 ## Use this chart
-
 1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
 2. Create a new private action runner and follow the instructions for Kubernetes.
-3. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
-4. Create a new connection, select your private action runner, and use **Service account authentication**.
-5. Create a new workflow and use a Kubernetes action like **List pod** or **List deployment**.
+
+## To use Kubernetes Actions
+1. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
+2. Create a new connection, select your private action runner, and use **Service account authentication**.
+3. Create a new workflow and use a Kubernetes action like **List pod** or **List deployment**.
 
 ## Going further
 * Adjust the service account permissions according to your needs. Learn more about [Kubernetes RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac).

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -29,9 +29,9 @@ helm repo update
 ```bash
 helm pull datadog/private-action-runner --untar
 ```
-4. Add connection credential json file to `templates/secrets.yaml` in the format corresponding to the credential type you want to use.
+4. Add connection credential json file to `templates/secrets.yaml` in the format corresponding to the credential and action types you want to use.
 
-For HTTP Basic Auth:
+HTTP Basic Auth:
 ```
 {
    auth_type: 'Basic Auth',
@@ -43,7 +43,7 @@ For HTTP Basic Auth:
    ],
 }
 ```
-For HTTP Token Auth:
+HTTP Token Auth:
 ```
 {
    auth_type: 'Token Auth',
@@ -55,7 +55,7 @@ For HTTP Token Auth:
    ],
 }
 ```
-For Jenkins:
+Jenkins:
 ```
 {
    auth_type: 'Token Auth',
@@ -68,7 +68,7 @@ For Jenkins:
    ],
 }
 ```
-For Postgres:
+Postgres:
 ```
 {
    auth_type: 'Token Auth',
@@ -80,7 +80,7 @@ For Postgres:
    ],
 }
 ```
-5. Install the chart locally:
+5. Install the chart locally.
 ```bash
 helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
 ```

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -80,7 +80,7 @@ Postgres:
    ],
 }
 ```
-5. Install the chart locally.
+5. Install the chart.
 ```bash
 helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
 ```

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -14,14 +14,65 @@ helm repo update
 ```
 
 ## Requirements
-* A Datadog account with private actions enabled
-* The `kubectl` cli
-* Helm
-* Sufficient permissions to the Kubernetes cluster
+* `kubectl` CLI is installed on my machine
+* Helm is installed on my machine
+* The permissions of my Kubernetes environment allow the Datadog Private Action Runner to read and write using a Kubernetes service account
 
 ## Use this chart
 1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
 2. Create a new private action runner and follow the instructions for Kubernetes.
+
+## Use this chart with connection credentials
+1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
+2. Create a new private action runner and follow the instructions for Kubernetes but make some changes instead of running `helm install` in step 4.
+3. Download the chart locally.
+```bash
+helm pull datadog/private-action-runner --untar
+```
+4. Add connection credential json file to `templates/secrets.yaml` in the format corresponding to the credential type you want to use.
+
+For HTTP Basic Auth:
+```json
+{
+   auth_type: 'Basic Auth',
+   credentials: [
+      {
+         username: 'USERNAME',
+         password: 'PASSWORD',
+      },
+   ],
+}
+```
+For Jenkins:
+```json
+{
+   auth_type: 'Token Auth',
+   credentials: [
+      {
+         username: 'USERNAME',
+         token: 'TOKEN',
+         domain: 'DOMAIN',
+      },
+   ],
+}
+
+```
+For Postgres:
+```json
+{
+   auth_type: 'Token Auth',
+   credentials: [
+      {
+         tokenName: 'connectionUri',
+         tokenValue: 'postgres://usr:password@example_host:5432/example_db',
+      },
+   ],
+}
+```
+5. Install the chart locally:
+```bash
+helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
+```
 
 ## To use Kubernetes Actions
 1. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -85,7 +85,7 @@ Postgres:
 helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
 ```
 
-## To use Kubernetes Actions
+## To use Kubernetes actions
 1. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
 2. Create a new connection, select your private action runner, and use **Service account authentication**.
 3. Create a new workflow and use a Kubernetes action like **List pod** or **List deployment**.

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -19,12 +19,12 @@ helm repo update
 * The permissions of my Kubernetes environment allow the Datadog Private Action Runner to read and write using a Kubernetes service account
 
 ## Use this chart
-1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
-2. Create a new private action runner and follow the instructions for Kubernetes.
+1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
+2. Create a new Private Action Runner and follow the instructions for Kubernetes.
 
 ## Use this chart with connection credentials
-1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
-2. Create a new private action runner and follow the instructions for Kubernetes but make some changes instead of running `helm install` in step 4.
+1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
+2. Set up a new Private Action runner by following the Kubernetes instructions. When you reach step 4, instead of running `helm install`, make the following changes to the Helm chart.
 3. Download the chart locally.
 ```bash
 helm pull datadog/private-action-runner --untar

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -1,8 +1,17 @@
 # Datadog Private Action Runner
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha27](https://img.shields.io/badge/AppVersion-v0.0.1--alpha27-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha27](https://img.shields.io/badge/AppVersion-v0.0.1--alpha27-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
+
+## How to use Datadog Helm repository
+
+You need to add this repository to your Helm repositories:
+
+```
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+```
 
 ## Requirements
 * A Datadog account with private actions enabled
@@ -13,24 +22,10 @@ This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cl
 ## Use this chart
 
 1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
-2. Create a new private action runner.
-3. Follow the instructions. You now have a running docker container and `config/config.yaml` file.
-4. Stop the docker container (`docker stop <name-of-the-container>` or `docker compose stop`).
-5. Create a `config.yaml` file with the appropriate values. An example `config.yaml` file is provided in the `examples` directory for you to copy.
-    * Replace the `URN_FROM_CONFIG` and the `PRIVATE_KEY_FROM_CONFIG` in the example file with with the `urn` and the `privateKey` from the `config/config.yaml` of the docker container.
-    * You can reconfigure other values or use the defaults in the example.
-6. Add this repository to your Helm repositories:
-    ```
-    helm repo add datadog https://helm.datadoghq.com
-    helm repo update
-    ```
-7. Install the Helm chart:
-    ```bash
-        helm install <RELEASE_NAME> datadog/private-action-runner -f ./config.yaml
-    ```
-8. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
-9. Create a new connection, select your private action runner, and use **Service account authentication**.
-10. Create a new workflow and use a Kubernetes action like **List pod** or **List deployment**.
+2. Create a new private action runner and follow the instructions for Kubernetes.
+3. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
+4. Create a new connection, select your private action runner, and use **Service account authentication**.
+5. Create a new workflow and use a Kubernetes action like **List pod** or **List deployment**.
 
 ## Going further
 * Adjust the service account permissions according to your needs. Learn more about [Kubernetes RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac).

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -32,7 +32,7 @@ helm pull datadog/private-action-runner --untar
 4. Add connection credential json file to `templates/secrets.yaml` in the format corresponding to the credential type you want to use.
 
 For HTTP Basic Auth:
-```json
+```
 {
    auth_type: 'Basic Auth',
    credentials: [
@@ -43,8 +43,20 @@ For HTTP Basic Auth:
    ],
 }
 ```
+For HTTP Token Auth:
+```
+{
+   auth_type: 'Token Auth',
+   credentials: [
+      {
+         tokenName: 'TOKEN1',
+         tokenValue: 'VALUE1',
+      },
+   ],
+}
+```
 For Jenkins:
-```json
+```
 {
    auth_type: 'Token Auth',
    credentials: [
@@ -55,10 +67,9 @@ For Jenkins:
       },
    ],
 }
-
 ```
 For Postgres:
-```json
+```
 {
    auth_type: 'Token Auth',
    credentials: [

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -20,12 +20,13 @@ helm repo update
 * Sufficient permissions to the Kubernetes cluster
 
 ## Use this chart
-
 1. Go to the [private action runner tab](https://app.datadoghq.com/workflow/private-action-runners).
 2. Create a new private action runner and follow the instructions for Kubernetes.
-3. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
-4. Create a new connection, select your private action runner, and use **Service account authentication**.
-5. Create a new workflow and use a Kubernetes action like **List pod** or **List deployment**.
+
+## To use Kubernetes Actions
+1. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
+2. Create a new connection, select your private action runner, and use **Service account authentication**.
+3. Create a new workflow and use a Kubernetes action like **List pod** or **List deployment**.
 
 ## Going further
 * Adjust the service account permissions according to your needs. Learn more about [Kubernetes RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac).

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           image: "{{ $.Values.common.image.repository }}:{{ $.Values.common.image.tag }}"
           command: [ 'sh', '-c', 'cp -r /etc/templates/* /etc/dd-action-runner/' ]
           volumeMounts:
-            - name: config-volume
+            - name: secrets
               mountPath: /etc/templates
             - name: config
               mountPath: /etc/dd-action-runner

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: nodeless
       containers:
         - name: runner
-          image: "{{ .$.Values.common.image.repository }}:{{ $.Values.common.image.tag }}"
+          image: "{{ $.Values.common.image.repository }}:{{ $.Values.common.image.tag }}"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: nodeless
       containers:
         - name: runner
-          image: {{ $.Values.common.image }}
+          image: "{{ .$.Values.common.image.repository }}:{{ $.Values.common.image.tag }}"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -28,15 +28,6 @@ spec:
           key: node
           operator: Equal
           value: nodeless
-      initContainers:
-        - name: init-copy
-          image: "{{ $.Values.common.image.repository }}:{{ $.Values.common.image.tag }}"
-          command: [ 'sh', '-c', 'cp -r /etc/templates/* /etc/dd-action-runner/' ]
-          volumeMounts:
-            - name: secrets
-              mountPath: /etc/templates
-            - name: config
-              mountPath: /etc/dd-action-runner
       containers:
         - name: runner
           image: "{{ $.Values.common.image.repository }}:{{ $.Values.common.image.tag }}"
@@ -53,8 +44,6 @@ spec:
               memory: 2Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/templates
-            - name: config
               mountPath: /etc/dd-action-runner
           env:
             # Node memory limits
@@ -66,7 +55,4 @@ spec:
         - name: secrets
           secret:
             secretName: {{ include "chart.secretName" $runner.name }}
-        - name: config
-          emptyDir:
-            medium: Memory
 {{- end }}

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -55,8 +55,7 @@ spec:
             - name: secrets
               mountPath: /etc/templates
             - name: config
-              mountPath: /etc/dd-action-runner/config.yaml
-              subPath: config.yaml
+              mountPath: /etc/dd-action-runner
           env:
             # Node memory limits
             - name: NODE_OPTIONS

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
       containers:
         - name: runner
           image: "{{ $.Values.common.image.repository }}:{{ $.Values.common.image.tag }}"
+          args:
+            - -once
+            - -template=/etc/templates/config.yaml:/etc/dd-action-runner/config.yaml
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -44,7 +47,10 @@ spec:
               memory: 2Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/templates
+            - name: config
+              mountPath: /etc/dd-action-runner/config.yaml
+              subPath: config.yaml
           env:
             # Node memory limits
             - name: NODE_OPTIONS
@@ -55,4 +61,7 @@ spec:
         - name: secrets
           secret:
             secretName: {{ include "chart.secretName" $runner.name }}
+        - name: config
+          emptyDir:
+            medium: Memory
 {{- end }}

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -28,12 +28,18 @@ spec:
           key: node
           operator: Equal
           value: nodeless
+      initContainers:
+        - name: init-copy
+          image: "{{ $.Values.common.image.repository }}:{{ $.Values.common.image.tag }}"
+          command: [ 'sh', '-c', 'cp -r /etc/templates/* /etc/dd-action-runner/' ]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/templates
+            - name: config
+              mountPath: /etc/dd-action-runner
       containers:
         - name: runner
           image: "{{ $.Values.common.image.repository }}:{{ $.Values.common.image.tag }}"
-          args:
-            - -once
-            - -template=/etc/templates/config.yaml:/etc/dd-action-runner/config.yaml
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/charts/private-action-runner/templates/secrets.yaml
+++ b/charts/private-action-runner/templates/secrets.yaml
@@ -14,8 +14,10 @@ stringData:
     {{- range $mode := $runner.config.modes }}
       - {{ $mode }}
     {{- end }}
+    {{- if $runner.config.appBuilder }}
     appBuilder:
       port: {{ $runner.config.appBuilder.port }}
+    {{- end }}
     actionsAllowlist:
     {{- range $action := $runner.config.actionsAllowlist }}
       - {{ $action }}

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -4,7 +4,9 @@
 
 common:
   # -- Current Datadog Private Action Runner image
-  image: us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner:v0.0.1-alpha27
+  image:
+    repository: us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner
+    tag: v0.0.1-alpha27
 
 runners:
   # runners[0].name -- Name of the Datadog Private Action Runner

--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -3,6 +3,7 @@ schema-version: v1
 kind: mergequeue
 gitlab_check_enable: false
 github_teams_restrictions:
+  - action-platform
   - agent-all
   - container-app
   - container-ecosystems


### PR DESCRIPTION
#### What this PR does / why we need it:
Simplifies README instructions to reflect the new Kubernetes UI.

Includes updates after [discussion ](https://docs.google.com/document/d/1UnKppoT-b6q2cEmFelCfJcmUvEz7VUHi4wNv0cJaOKY/edit)with agent team:
- Splits image into `repository` and `tag` to be consistent with the other charts.
- Updates labeler config to get our chart PRs properly labeled.
- Adds action-platform to the merge queue config 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #
  - Fixes bug where port is required in the config even if the runner is in Workflows mode

#### Testing 
Tested using an EC2 instance following: https://datadoghq.atlassian.net/wiki/spaces/SYN/pages/3587637521/How+to+test+the+PL+chart+from+helm-charts+repo

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)

#### Followup
Create nicer templated way for users to add connection credentials via `config.yaml`: https://datadoghq.atlassian.net/browse/APPS-1924

