### PR TITLE
ci: update Kube and test workflows

### DIFF
--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-HELM_DOCS_VERSION="1.10.0"
+HELM_DOCS_VERSION="1.14.2"
 OS=$(uname)
 ARCH=$(uname -m)
 

--- a/.github/kubeconform.sh
+++ b/.github/kubeconform.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-KUBECONFORM_VERSION="v0.6.4"
+KUBECONFORM_VERSION="v0.6.7"
 # https://github.com/yannh/kubeconform/issues/51
 CRD_SPEC_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/v3/apis__apiextensions.k8s.io__v1_openapi.json"
 # Remove after v1.16 support / testing is dropped

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       charts: ${{ steps.list-changed.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Helm
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.6.1
       - name: Run chart-testing (list-changed)
         id: list-changed
         env:
@@ -47,14 +47,14 @@ jobs:
       - changed
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.6.1
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
 
@@ -64,7 +64,7 @@ jobs:
       - changed
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run helm-docs
@@ -87,10 +87,15 @@ jobs:
           - v1.22.17
           - v1.24.17
           - v1.25.16
-          - v1.26.13
+          - v1.26.15
+          - v1.27.16
+          - v1.28.13
+          - v1.29.8
+          - v1.30.4
+          - v1.31.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Add datadog helm repo
@@ -114,17 +119,22 @@ jobs:
       matrix:
         k8s:
           - v1.18.20
-          - v1.22.9
-          - v1.24.2
+          - v1.22.17
+          - v1.24.17
           - v1.25.16
-          - v1.26.13
+          - v1.26.15
+          - v1.27.16
+          - v1.28.13
+          - v1.29.8
+          - v1.30.4
+          - v1.31.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Create kind ${{ matrix.k8s }} cluster
-        uses: helm/kind-action@v1.5.0
+        uses: helm/kind-action@v1.10.0
         with:
           node_image: kindest/node:${{ matrix.k8s }}
           config: .github/kind_config.yaml
@@ -132,7 +142,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.6.1
       - name: Run chart-testing (install)
         run: ct install --config .github/ct.yaml
 

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -21,9 +21,9 @@ jobs:
         go-version: 1.21
       id: go
     - name: Set up Helm
-      uses: azure/setup-helm@v3.5
+      uses: azure/setup-helm@v4.2.0
       with:
-        version: v3.10.1
+        version: v3.14.0
     - name: Add Datadog Helm repo
       run: helm repo add datadog https://helm.datadoghq.com && helm repo update
     - name: Check out code into the Go module directory
@@ -42,21 +42,22 @@ jobs:
         k8s:
           - v1.16.15
           - v1.18.20
-          - v1.22.9
-          - v1.24.2
-          - v1.25.2
-          - v1.26.6
-          - v1.27.3
-          - v1.28.7
-          - v1.29.2
-          - v1.30.0
+          - v1.22.17
+          - v1.24.17
+          - v1.25.16
+          - v1.26.15
+          - v1.27.16
+          - v1.28.13
+          - v1.29.9
+          - v1.30.4
+          - v1.31.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Create kind ${{ matrix.k8s }} cluster
-        uses: helm/kind-action@v1.5.0
+        uses: helm/kind-action@v1.10.0
         with:
           node_image: kindest/node:${{ matrix.k8s }}
           cluster_name: operator-ci-${{ matrix.k8s }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This just updates and standardizes the Kube versions.

- Update Kubernetes versions and standardize across test matrices
- Update helm-docs to v1.14.2
- Update actions/checkout to v4 in two workflows
- Update helm/chart-testing-action to v2.6.1
- Update setup-helm action to 4.x (4.x is just for node version update)
- Update helm/kind-action to v1.10.0
- Update kubeconform to v0.6.7

See #1199. It had been mentioned there or in another place that 1.16 was still supported - wondering if 1.16 or 1.18 still need to be tested against (I can remove them if wanted).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
