### PR TITLE
Update addon to Operator 1.7.0

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.7.0
+* Update CRDs from Datadog Operator v1.7.0 tag.
+
+## 1.6.0
+* Update CRDs from Datadog Operator v1.6.0 tag.
+
+## 1.5.0
+* Update CRDs from Datadog Operator v1.5.0 tag.
+
 ## 1.4.0
 * Update CRDs from Datadog Operator v1.4.0 tag.
 

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 1.4.0
+version: 1.7.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 
@@ -22,6 +22,7 @@ But the recommended Kubernetes versions are `1.16+`.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| crds.datadogAgentProfiles | bool | `false` | Set to true to deploy the DatadogAgentProfiles CRD |
 | crds.datadogAgents | bool | `false` | Set to true to deploy the DatadogAgents CRD |
 | crds.datadogMetrics | bool | `false` | Set to true to deploy the DatadogMetrics CRD |
 | crds.datadogMonitors | bool | `false` | Set to true to deploy the DatadogMonitors CRD |

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -5894,12 +5894,190 @@ spec:
                       properties:
                         agentCommunicationMode:
                           type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
                         enabled:
                           type: boolean
                         failurePolicy:
                           type: string
                         mutateUnlabelled:
                           type: boolean
+                        registry:
+                          type: string
                         serviceName:
                           type: string
                         webhookName:
@@ -5917,12 +6095,49 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
                         unixDomainSocketConfig:
                           properties:
                             enabled:
                               type: boolean
                             path:
                               type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
                           type: object
                       type: object
                     clusterChecks:
@@ -6125,6 +6340,17 @@ spec:
                           type: boolean
                         wpaController:
                           type: boolean
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
                       type: object
                     kubeStateMetricsCore:
                       properties:
@@ -6412,6 +6638,86 @@ spec:
                         url:
                           type: string
                       type: object
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
                     kubelet:
                       properties:
                         agentCAPath:
@@ -6519,6 +6825,11 @@ spec:
                     nodeLabelsAsTags:
                       additionalProperties:
                         type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     podAnnotationsAsTags:
                       additionalProperties:
@@ -8418,15 +8729,685 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            mutateUnlabelled:
+                              type: boolean
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
               type: object
           type: object
-      {{- if eq .Values.migration.datadogAgents.version "v2alpha1" }}
       served: true
       storage: true
-      {{- else }}
-      served: true
-      storage: false
-      {{- end }}
       subresources:
         status: {}
 status:

--- a/charts/datadog-crds/values.yaml
+++ b/charts/datadog-crds/values.yaml
@@ -11,6 +11,8 @@ crds:
   datadogMonitors: false
   # crds.datadogSLOs -- Set to true to deploy the DatadogSLO CRD
   datadogSLOs: false
+  # crds.datadogAgentProfiles -- Set to true to deploy the DatadogAgentProfiles CRD
+  datadogAgentProfiles: false
 
 migration:
   datadogAgents:

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 1.8.1
+
+* Configure tool version.
+
+## 1.8.0
+
+* Update Datadog Operator version to 1.7.0.
+
+## 1.7.1
+
+* Add `DD_TOOL_VERSION` to operator deployment.
+
+## 1.7.0
+
+* Update Datadog Operator version to 1.6.0.
+
+## 1.6.1
+
+* Fix clusterRole when DatadogAgentProfiles are enabled.
+
+## 1.6.0
+
+* Update Datadog Operator version to 1.5.0.
+
+## 1.5.2
+
+* Add deprecation warning for `DatadogAgent` `v1alpha1` CRD version.
+
 ## 1.5.1
 
 * Add configuration for Operator flag `introspectionEnabled`: this parameter is used to enable the Introspection. It is disabled by default.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: file://../datadog-crds/
-  version: 1.4.0
-digest: sha256:e8c6cfa94f13dc849deccbf84a8d521ff1c83c2cecaeb79eaf2234e5c83af557
-generated: "2024-03-13T21:12:40.350938-04:00"
+  version: 1.7.0
+digest: sha256:232159e0104e09c251e407ecb09675f10d6304a8bb88550526989eef89819e81
+generated: "2024-07-01T17:24:08.752356-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 1.5.1
-appVersion: 1.4.0
+version: 1.8.1
+appVersion: 1.7.0
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "=1.4.0"
+  version: "=1.7.0"
   alias: datadogCRDs
   repository: file://../datadog-crds/
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 ## Values
 
@@ -11,12 +11,14 @@
 | apiKeyExistingSecret | string | `nil` | Use existing Secret which stores API key instead of creating a new one |
 | appKey | string | `nil` | Your Datadog APP key |
 | appKeyExistingSecret | string | `nil` | Use existing Secret which stores APP key instead of creating a new one |
+| clusterName | string | `nil` | Set a unique cluster name reporting from the Datadog Operator. |
 | collectOperatorMetrics | bool | `true` | Configures an openmetrics check to collect operator metrics |
 | containerSecurityContext | object | `{}` | A security context defines privileges and access control settings for a container. |
 | datadogAgent.enabled | bool | `true` | Enables Datadog Agent controller |
+| datadogAgentProfile.enabled | bool | `false` | If true, enables DatadogAgentProfile controller (beta). Requires v1.5.0+ |
 | datadogCRDs.crds.datadogAgents | bool | `true` | Set to true to deploy the DatadogAgents CRD |
 | datadogCRDs.crds.datadogMetrics | bool | `true` | Set to true to deploy the DatadogMetrics CRD |
-| datadogCRDs.crds.datadogMonitors | bool | `false` | Set to true to deploy the DatadogMonitors CRD |
+| datadogCRDs.crds.datadogMonitors | bool | `true` | Set to true to deploy the DatadogMonitors CRD |
 | datadogCRDs.crds.datadogSLOs | bool | `false` | Set to true to deploy the DatadogSLO CRD |
 | datadogCRDs.migration.datadogAgents.conversionWebhook.enabled | bool | `false` |  |
 | datadogCRDs.migration.datadogAgents.conversionWebhook.name | string | `"datadog-operator-webhook-service"` |  |
@@ -29,8 +31,8 @@
 | env | list | `[]` | Define any environment variables to be passed to the operator. |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
-| image.repository | string | `"709825985650.dkr.ecr.us-east-1.amazonaws.com/datadog/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.4.0"` | Define the Datadog Operator version to use |
+| image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
+| image.tag | string | `"1.7.0"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |
@@ -39,10 +41,11 @@
 | metricsPort | int | `8383` | Port used for OpenMetrics endpoint |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Operator on specific nodes |
-| operatorMetricsEnabled | string | `"false"` | Enable forwarding of Datadog Operator metrics and events to Datadog. |
+| operatorMetricsEnabled | string | `"true"` | Enable forwarding of Datadog Operator metrics and events to Datadog. |
 | podAnnotations | object | `{}` | Allows setting additional annotations for Datadog Operator PODs |
 | podLabels | object | `{}` | Allows setting additional labels for for Datadog Operator PODs |
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |
+| remoteConfiguration.enabled | bool | `false` | If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set. |
 | replicaCount | int | `1` | Number of instances of Datadog Operator |
 | resources | object | `{}` | Set resources requests/limits for Datadog Operator PODs |
 | secretBackend.arguments | string | `""` | Specifies the space-separated arguments passed to the command that implements the secret backend api |
@@ -121,7 +124,7 @@ You can update with the following:
 ```
 helm upgrade \
     datadog-operator datadog/datadog-operator \
-    --set image.tag=1.4.0 \
+    --set image.tag=1.7.0 \
     --set datadogCRDs.migration.datadogAgents.version=v2alpha1 \
     --set datadogCRDs.migration.datadogAgents.useCertManager=true \
     --set datadogCRDs.migration.datadogAgents.conversionWebhook.enabled=true

--- a/charts/datadog-operator/README.md.gotmpl
+++ b/charts/datadog-operator/README.md.gotmpl
@@ -68,7 +68,7 @@ You can update with the following:
 ```
 helm upgrade \
     datadog-operator datadog/datadog-operator \
-    --set image.tag=1.4.0 \
+    --set image.tag=1.7.0 \
     --set datadogCRDs.migration.datadogAgents.version=v2alpha1 \
     --set datadogCRDs.migration.datadogAgents.useCertManager=true \
     --set datadogCRDs.migration.datadogAgents.conversionWebhook.enabled=true

--- a/charts/datadog-operator/templates/NOTES.txt
+++ b/charts/datadog-operator/templates/NOTES.txt
@@ -40,6 +40,22 @@ The maximumGoroutines parameter isn't supported by the Operator 1.0.0-rc.12 and 
 Setting a value will not change the default defined in the Operator.
     {{- end }}
 {{- end }}
+
+{{- if (semverCompare ">=1.0.0" .Values.image.tag) }}
+    {{- if .Values.datadogCRDs.migration.datadogAgents.conversionWebhook.enabled }}
+##############################################################################
+####         WARNING: v1alpha1 and conversion webhook deprecation.        ####
+##############################################################################
+
+DatadogAgent v1alpha1 reconciliation in the Operator is deprecated since v1.2.0+ and will be removed in v1.7.0.
+Once removed, the Datadog Operator cannot be configured to reconcile the v1alpha1 DatadogAgent CRD.
+However, you will still be able to apply a v1alpha1 manifest with the conversion webhook enabled (using `datadogCRDs.migration.datadogAgents.conversionWebhook.enabled`).
+DatadogAgent v1alpha1 and the conversion webhook will be removed in v1.8.0.
+See the migration page for instructions on migrating to v2alpha1: https://docs.datadoghq.com/containers/guide/datadogoperator_migration/
+    {{- end }}
+{{- end }}
+
+
 {{- if not (and (semverCompare ">=1.0.0-0" .Values.image.tag) (eq .Values.datadogCRDs.migration.datadogAgents.version "v2alpha1")) }}
 {{- fail "The Datadog Operator `1.0.0` reconciles `DatadogAgent` versions `v2alpha1`. Using an old version of the Datadog Operator (< 1.0.0) with the new version of the DatadogAgent Customer Resource, or the Datadog Operator `1.X` with the `v1alpha1` as stored version of the DatadogAgent is not supported. If you are using a DatadogAgent `v1alpha1`, refer to the Migration Steps: https://github.com/DataDog/helm-charts/blob/main/charts/datadog-operator/README.md#migrating-to-the-version-10-of-the-datadog-operator."}}
 {{- end }}

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -696,4 +696,44 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+    - ""
+  resources:
+    - pods/exec
+  verbs:
+    - create
+{{- if .Values.datadogAgentProfile.enabled }}
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadogagentprofiles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadogagentprofiles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadogagentprofiles/finalizers
+  verbs:
+  - update
+{{- end }}
 {{- end -}}

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -62,6 +62,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- if (semverCompare ">=1.7.0-0" .Values.image.tag) }}
+            - name: DD_TOOL_VERSION
+              value: {{ .Values.toolVersion | default "helm" }}
+            {{- end }}
+            {{- if .Values.clusterName }}
+            - name: DD_CLUSTER_NAME
+              value: {{ .Values.clusterName }}
+            {{- end }}
             {{- if or .Values.apiKey .Values.apiKeyExistingSecret }}
             - name: DD_API_KEY
               valueFrom:
@@ -111,12 +119,18 @@ spec:
           {{- if (semverCompare ">=1.4.0" .Values.image.tag) }}
             - "-introspectionEnabled={{ .Values.introspection.enabled }}"
           {{- end }}
+          {{- if (semverCompare ">=1.5.0" .Values.image.tag) }}
+            - "-datadogAgentProfileEnabled={{ .Values.datadogAgentProfile.enabled }}"
+          {{- end }}
             - "-datadogMonitorEnabled={{ .Values.datadogMonitor.enabled }}"
           {{- if (semverCompare ">=1.0.0-rc.13" .Values.image.tag) }}
             - "-datadogAgentEnabled={{ .Values.datadogAgent.enabled }}"
           {{- end }}
           {{- if (semverCompare ">=1.3.0" .Values.image.tag) }}
             - "-datadogSLOEnabled={{ .Values.datadogSLO.enabled }}"
+          {{- end }}
+          {{- if (semverCompare ">=1.7.0" .Values.image.tag) }}
+            - "-remoteConfigEnabled={{ .Values.remoteConfiguration.enabled }}"
           {{- end }}
           ports:
             - name: metrics

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -16,6 +16,10 @@ apiKeyExistingSecret:  # <DATADOG_API_KEY_SECRET>
 # appKey -- Your Datadog APP key
 appKey:  # <DATADOG_APP_KEY>
 
+
+# clusterName -- Set a unique cluster name reporting from the Datadog Operator.
+clusterName:
+
 # site -- The site of the Datadog intake to send data to (documentation: https://docs.datadoghq.com/getting_started/site/)
 
 ## Set to 'datadoghq.com' to send data to the US1 site (default).
@@ -43,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/datadog/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.4.0
+  tag: 1.7.0
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
 # imagePullSecrets -- Datadog Operator repository pullSecret (ex: specify docker registry credentials)
@@ -60,6 +64,9 @@ maximumGoroutines:
 
 introspection:
 # introspection.enabled -- If true, enables introspection feature (beta). Requires v1.4.0+
+  enabled: false
+datadogAgentProfile:
+# datadogAgentProfile.enabled -- If true, enables DatadogAgentProfile controller (beta). Requires v1.5.0+
   enabled: false
 # supportExtendedDaemonset -- If true, supports using ExtendedDaemonSet CRD
 supportExtendedDaemonset: "false"
@@ -83,6 +90,10 @@ datadogMonitor:
 datadogSLO:
   # datadogSLO.enabled -- Enables the Datadog SLO controller
   enabled: false
+remoteConfiguration:
+  # remoteConfiguration.enabled -- If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set.
+  enabled: false
+
 rbac:
   # rbac.create -- Specifies whether the RBAC resources should be created
   create: true

--- a/charts/operator-eks-addon/CHANGELOG.md
+++ b/charts/operator-eks-addon/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.9
+
+Release for Operator 1.7.0
+
+## 0.1.8
+
+Release for Operator 1.7.0
+
 ## 0.1.5
 * Bump datadog-operator chart dependency to v1.4.1
 

--- a/charts/operator-eks-addon/Chart.lock
+++ b/charts/operator-eks-addon/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-operator
   repository: file://../datadog-operator/
-  version: 1.5.1
-digest: sha256:373ddf35571aab3ae1a3b559a2bd6fcb2ed55fcb9a5c8e6118e029e4759d182d
-generated: "2024-03-13T21:13:17.627503-04:00"
+  version: 1.8.1
+digest: sha256:a67341e2b837b6d80526c69ae40b4d809765bcd9bdf5a7a9272b8a90d92e6de8
+generated: "2024-07-01T17:25:35.701537-04:00"

--- a/charts/operator-eks-addon/Chart.yaml
+++ b/charts/operator-eks-addon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: operator-eks-addon
-version: 0.1.7
+version: 0.1.9
 appVersion: 0.1.0
 description: Datadog Operator Wrapper
 home: https://www.datadoghq.com
@@ -10,6 +10,6 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-operator
-  version: "=1.5.1"
+  version: "=1.8.1"
   alias: datadog-operator
   repository: file://../datadog-operator/

--- a/charts/operator-eks-addon/README.md
+++ b/charts/operator-eks-addon/README.md
@@ -8,6 +8,9 @@ This is a wrapper chart for installing EKS add-on. Charts required for the add-o
 | < 0.1.6 | 1.0.5 | 1.0.1 | 1.0.3 | 7.43.1 | 7.43.1 | 
 | 0.1.6 | 1.4.1 | 1.3.0 | 1.3.0 | 7.47.1 | 7.47.1 |
 | 0.1.7 | 1.5.1 | 1.4.0 | 1.4.0 | 7.50.3 | 7.50.3 |
+| 0.1.9 | 1.8.1 | 1.7.0 | 1.7.0 | 7.54.0 | 7.54.0 |
+
+0.1.8 failed validation and didn't go through.
 
 ## Pushing Add-on Chart
 Below steps have been validated using `Helm v3.12.0`.

--- a/charts/operator-eks-addon/values.yaml
+++ b/charts/operator-eks-addon/values.yaml
@@ -1,0 +1,2 @@
+datadog-operator:
+  toolVersion: eks-addon

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.5.1
+    helm.sh/chart: datadog-operator-1.8.1
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/managed-by: eks-addon
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "709825985650.dkr.ecr.us-east-1.amazonaws.com/datadog/operator:1.4.0"
+          image: "709825985650.dkr.ecr.us-east-1.amazonaws.com/datadog/operator:1.7.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -46,6 +46,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DD_TOOL_VERSION
+              value: helm
           args:
             - "-supportExtendedDaemonset=false"
             - "-logEncoder=json"
@@ -54,9 +56,11 @@ spec:
             - "-operatorMetricsEnabled=false"
             - "-webhookEnabled=false"
             - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
             - "-datadogSLOEnabled=false"
+            - "-remoteConfigEnabled=false"
           ports:
             - name: metrics
               containerPort: 8383

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -116,7 +116,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "709825985650.dkr.ecr.us-east-1.amazonaws.com/datadog/operator:1.4.0", operatorContainer.Image)
+	assert.Equal(t, "709825985650.dkr.ecr.us-east-1.amazonaws.com/datadog/operator:1.7.0", operatorContainer.Image)
 	assert.Contains(t, operatorContainer.Args, "-webhookEnabled=false")
 }
 

--- a/test/operator-eks-addon/baseline/chart_render_default.yaml
+++ b/test/operator-eks-addon/baseline/chart_render_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.5.1
+    helm.sh/chart: datadog-operator-1.8.1
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/managed-by: eks-addon
 ---
 # Source: operator-eks-addon/charts/datadog-operator/charts/datadogCRDs/templates/datadoghq.com_datadogagents_v1.yaml
@@ -21,7 +21,7 @@ metadata:
   creationTimestamp: null
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-1.4.0'
+    helm.sh/chart: 'datadogCRDs-1.7.0'
     app.kubernetes.io/managed-by: eks-addon
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -5888,12 +5888,190 @@ spec:
                       properties:
                         agentCommunicationMode:
                           type: string
+                        agentSidecarInjection:
+                          properties:
+                            clusterAgentCommunicationEnabled:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            image:
+                              properties:
+                                jmxEnabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                pullPolicy:
+                                  type: string
+                                pullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            profiles:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            provider:
+                              type: string
+                            registry:
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  objectSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        cwsInstrumentation:
+                          properties:
+                            enabled:
+                              type: boolean
+                            mode:
+                              type: string
+                          type: object
                         enabled:
                           type: boolean
                         failurePolicy:
                           type: string
                         mutateUnlabelled:
                           type: boolean
+                        registry:
+                          type: string
                         serviceName:
                           type: string
                         webhookName:
@@ -5911,12 +6089,49 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        instrumentation:
+                          properties:
+                            disabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            enabled:
+                              type: boolean
+                            enabledNamespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            libVersions:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
                         unixDomainSocketConfig:
                           properties:
                             enabled:
                               type: boolean
                             path:
                               type: string
+                          type: object
+                      type: object
+                    asm:
+                      properties:
+                        iast:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sca:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        threats:
+                          properties:
+                            enabled:
+                              type: boolean
                           type: object
                       type: object
                     clusterChecks:
@@ -6119,6 +6334,17 @@ spec:
                           type: boolean
                         wpaController:
                           type: boolean
+                      type: object
+                    helmCheck:
+                      properties:
+                        collectEvents:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        valuesAsTags:
+                          additionalProperties:
+                            type: string
+                          type: object
                       type: object
                     kubeStateMetricsCore:
                       properties:
@@ -6406,6 +6632,86 @@ spec:
                         url:
                           type: string
                       type: object
+                    fips:
+                      properties:
+                        customFIPSConfig:
+                          properties:
+                            configData:
+                              type: string
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        enabled:
+                          type: boolean
+                        image:
+                          properties:
+                            jmxEnabled:
+                              type: boolean
+                            name:
+                              type: string
+                            pullPolicy:
+                              type: string
+                            pullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            tag:
+                              type: string
+                          type: object
+                        localAddress:
+                          type: string
+                        port:
+                          format: int32
+                          type: integer
+                        portRange:
+                          format: int32
+                          type: integer
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        useHTTPS:
+                          type: boolean
+                      type: object
                     kubelet:
                       properties:
                         agentCAPath:
@@ -6513,6 +6819,11 @@ spec:
                     nodeLabelsAsTags:
                       additionalProperties:
                         type: string
+                      type: object
+                    originDetectionUnified:
+                      properties:
+                        enabled:
+                          type: boolean
                       type: object
                     podAnnotationsAsTags:
                       additionalProperties:
@@ -8412,6 +8723,681 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                remoteConfigConfiguration:
+                  properties:
+                    features:
+                      properties:
+                        admissionController:
+                          properties:
+                            agentCommunicationMode:
+                              type: string
+                            agentSidecarInjection:
+                              properties:
+                                clusterAgentCommunicationEnabled:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                                image:
+                                  properties:
+                                    jmxEnabled:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pullPolicy:
+                                      type: string
+                                    pullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    tag:
+                                      type: string
+                                  type: object
+                                profiles:
+                                  items:
+                                    properties:
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                provider:
+                                  type: string
+                                registry:
+                                  type: string
+                                selectors:
+                                  items:
+                                    properties:
+                                      namespaceSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      objectSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            cwsInstrumentation:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                mode:
+                                  type: string
+                              type: object
+                            enabled:
+                              type: boolean
+                            failurePolicy:
+                              type: string
+                            mutateUnlabelled:
+                              type: boolean
+                            registry:
+                              type: string
+                            serviceName:
+                              type: string
+                            webhookName:
+                              type: string
+                          type: object
+                        apm:
+                          properties:
+                            enabled:
+                              type: boolean
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            instrumentation:
+                              properties:
+                                disabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                                enabledNamespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                libVersions:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        asm:
+                          properties:
+                            iast:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            sca:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            threats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        clusterChecks:
+                          properties:
+                            enabled:
+                              type: boolean
+                            useClusterChecksRunners:
+                              type: boolean
+                          type: object
+                        cspm:
+                          properties:
+                            checkInterval:
+                              type: string
+                            customBenchmarks:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            hostBenchmarks:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        cws:
+                          properties:
+                            customPolicies:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                            network:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            remoteConfiguration:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            securityProfiles:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
+                            syscallMonitorEnabled:
+                              type: boolean
+                          type: object
+                        dogstatsd:
+                          properties:
+                            hostPortConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            mapperProfiles:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            originDetectionEnabled:
+                              type: boolean
+                            tagCardinality:
+                              type: string
+                            unixDomainSocketConfig:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                path:
+                                  type: string
+                              type: object
+                          type: object
+                        ebpfCheck:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        eventCollection:
+                          properties:
+                            collectKubernetesEvents:
+                              type: boolean
+                          type: object
+                        externalMetricsServer:
+                          properties:
+                            enabled:
+                              type: boolean
+                            endpoint:
+                              properties:
+                                credentials:
+                                  properties:
+                                    apiKey:
+                                      type: string
+                                    apiSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                    appKey:
+                                      type: string
+                                    appSecret:
+                                      properties:
+                                        keyName:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                        - secretName
+                                      type: object
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            port:
+                              format: int32
+                              type: integer
+                            registerAPIService:
+                              type: boolean
+                            useDatadogMetrics:
+                              type: boolean
+                            wpaController:
+                              type: boolean
+                          type: object
+                        helmCheck:
+                          properties:
+                            collectEvents:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            valuesAsTags:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        kubeStateMetricsCore:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveContainerCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        liveProcessCollection:
+                          properties:
+                            enabled:
+                              type: boolean
+                            scrubProcessArguments:
+                              type: boolean
+                            stripProcessArguments:
+                              type: boolean
+                          type: object
+                        logCollection:
+                          properties:
+                            containerCollectAll:
+                              type: boolean
+                            containerCollectUsingFiles:
+                              type: boolean
+                            containerLogsPath:
+                              type: string
+                            containerSymlinksPath:
+                              type: string
+                            enabled:
+                              type: boolean
+                            openFilesLimit:
+                              format: int32
+                              type: integer
+                            podLogsPath:
+                              type: string
+                            tempStoragePath:
+                              type: string
+                          type: object
+                        npm:
+                          properties:
+                            collectDNSStats:
+                              type: boolean
+                            enableConntrack:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                          type: object
+                        oomKill:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        orchestratorExplorer:
+                          properties:
+                            conf:
+                              properties:
+                                configData:
+                                  type: string
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            customResources:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            ddUrl:
+                              type: string
+                            enabled:
+                              type: boolean
+                            extraTags:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            scrubContainers:
+                              type: boolean
+                          type: object
+                        otlp:
+                          properties:
+                            receiver:
+                              properties:
+                                protocols:
+                                  properties:
+                                    grpc:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                    http:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        endpoint:
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        processDiscovery:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        prometheusScrape:
+                          properties:
+                            additionalConfigs:
+                              type: string
+                            enableServiceEndpoints:
+                              type: boolean
+                            enabled:
+                              type: boolean
+                            version:
+                              type: integer
+                          type: object
+                        remoteConfiguration:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        sbom:
+                          properties:
+                            containerImage:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                            enabled:
+                              type: boolean
+                            host:
+                              properties:
+                                analyzers:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                enabled:
+                                  type: boolean
+                              type: object
+                          type: object
+                        tcpQueueLength:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                        usm:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
               type: object
           type: object
       served: true
@@ -8434,7 +9420,7 @@ metadata:
   creationTimestamp: null
   name: datadogmetrics.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-1.4.0'
+    helm.sh/chart: 'datadogCRDs-1.7.0'
     app.kubernetes.io/managed-by: eks-addon
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -8556,9 +9542,9 @@ metadata:
   name: datadog-operator
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.5.1
+    helm.sh/chart: datadog-operator-1.8.1
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/managed-by: eks-addon
 rules:
 - nonResourceURLs:
@@ -9251,6 +10237,12 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+    - ""
+  resources:
+    - pods/exec
+  verbs:
+    - create
 ---
 # Source: operator-eks-addon/charts/datadog-operator/templates/clusterrole_binding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -9274,9 +10266,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-1.5.1
+    helm.sh/chart: datadog-operator-1.8.1
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/managed-by: eks-addon
 spec:
   replicas: 1
@@ -9302,7 +10294,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "709825985650.dkr.ecr.us-east-1.amazonaws.com/datadog/operator:1.4.0"
+          image: "709825985650.dkr.ecr.us-east-1.amazonaws.com/datadog/operator:1.7.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -9313,6 +10305,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DD_TOOL_VERSION
+              value: eks-addon
           args:
             - "-supportExtendedDaemonset=false"
             - "-logEncoder=json"
@@ -9321,9 +10315,11 @@ spec:
             - "-operatorMetricsEnabled=false"
             - "-webhookEnabled=false"
             - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
             - "-datadogSLOEnabled=false"
+            - "-remoteConfigEnabled=false"
           ports:
             - name: metrics
               containerPort: 8383

--- a/test/operator-eks-addon/baseline_test.go
+++ b/test/operator-eks-addon/baseline_test.go
@@ -22,7 +22,9 @@ func Test_baseline_manifests(t *testing.T) {
 				ChartPath:   "../../charts/operator-eks-addon",
 				ShowOnly:    []string{},
 				Values:      []string{"../../charts/operator-eks-addon/values.yaml"},
-				Overrides:   map[string]string{},
+				Overrides:   map[string]string{
+					// "datadog-operator.image.tag": "1.7.0",
+				},
 			},
 			baselineManifestPath: "./baseline/chart_render_default.yaml",
 			assertions:           verify,


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates add-on for Operator 1.7.0. Addon version was bumped from 0.1.7->0.1.9 as 0.1.8 failed validation (and can't be mutated).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
