### PR TITLE
Simplify OTel Agent default pipelines

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 3.74.0
+
+* Simplify OTel Agent OOTB pipelines:
+  * Remove `traces/otlp` pipeline from the default OTel Agent config
+  * Add `infaattributes` processor and `datadog` exporter to the `traces` pipeline.
+
 ## 3.73.3
 
 * Fix a few typos on OTel Agent configs.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.73.3
+version: 3.74.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.73.3](https://img.shields.io/badge/Version-3.73.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.74.0](https://img.shields.io/badge/Version-3.74.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_otel_agent_config.yaml
+++ b/charts/datadog/templates/_otel_agent_config.yaml
@@ -36,12 +36,8 @@ otel-config.yaml: {{- if .Values.datadog.otelCollector.config }} {{ toYaml .Valu
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [batch]
-          exporters: [datadog/connector]
-        traces/otlp:
-          receivers: [otlp]
           processors: [infraattributes, batch]
-          exporters: [datadog]
+          exporters: [datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector, prometheus]
           processors: [infraattributes, batch]


### PR DESCRIPTION
#### What this PR does / why we need it:

Simplifies OTel Agent OOTB pipelines.

#### Special notes for your reviewer:

- OTel Agent is in private beta; no actual customers will be affected by the change.
- The initial OTel Agent config had 2 traces pipelines: `traces` to compute APM stats and `traces/otlp` _potentially_ for probabilistic sampling. After internal discussions, we decided that `traces/otlp` pipeline is not required in OOTB config.

**Pipelines before:**
![OTel-config-2-otel-config drawio](https://github.com/user-attachments/assets/a5da5379-2815-4ee9-9a4a-39bfd8e9a75a)

**Pipelines after:**
![OTel-config-2-otel-config-simplified drawio](https://github.com/user-attachments/assets/2f2b9d15-2f9f-4d07-bb88-908e0525cfe8)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- N/A Variables are documented in the `README.md`
- N/A For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
