### PR TITLE
Fix a few typos on otel agent in values.yaml

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.73.3
+
+* Fix a few typos on OTel Agent configs.
+
 ## 3.73.1
 
 * Add `admissionregistration.k8s.io/v1/validatingwebhookconfigurations` RBACs to the Cluster Agent.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fix a few typos on OTel Agent configs.
 
-## 3.73.1
+## 3.73.2
 
 * Add `admissionregistration.k8s.io/v1/validatingwebhookconfigurations` RBACs to the Cluster Agent.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.73.2
+version: 3.73.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.73.2](https://img.shields.io/badge/Version-3.73.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.73.3](https://img.shields.io/badge/Version-3.73.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -471,12 +471,12 @@ helm install <RELEASE_NAME> \
 | agents.containers.initContainers.resources | object | `{}` | Resource requests and limits for the init containers |
 | agents.containers.initContainers.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the init containers. |
 | agents.containers.initContainers.volumeMounts | list | `[]` | Specify additional volumes to mount for the init containers |
-| agents.containers.otelAgent.env | list | `[]` | Additional environment variables for the trace-agent container |
-| agents.containers.otelAgent.envDict | object | `{}` | Set environment variables specific to trace-agent defined in a dict |
-| agents.containers.otelAgent.envFrom | list | `[]` | Set environment variables specific to trace-agent from configMaps and/or secrets |
+| agents.containers.otelAgent.env | list | `[]` | Additional environment variables for the otel-agent container |
+| agents.containers.otelAgent.envDict | object | `{}` | Set environment variables specific to otel-agent defined in a dict |
+| agents.containers.otelAgent.envFrom | list | `[]` | Set environment variables specific to otel-agent from configMaps and/or secrets |
 | agents.containers.otelAgent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
-| agents.containers.otelAgent.resources | object | `{}` | Resource requests and limits for the trace-agent container |
-| agents.containers.otelAgent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the trace-agent container. |
+| agents.containers.otelAgent.resources | object | `{}` | Resource requests and limits for the otel-agent container |
+| agents.containers.otelAgent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the otel-agent container. |
 | agents.containers.processAgent.env | list | `[]` | Additional environment variables for the process-agent container |
 | agents.containers.processAgent.envDict | object | `{}` | Set environment variables specific to process-agent defined in a dict |
 | agents.containers.processAgent.envFrom | list | `[]` | Set environment variables specific to process-agent from configMaps and/or secrets |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1709,21 +1709,21 @@ agents:
       ports: []
 
     otelAgent:
-      # agents.containers.otelAgent.env -- Additional environment variables for the trace-agent container
+      # agents.containers.otelAgent.env -- Additional environment variables for the otel-agent container
       env: []
 
-      # agents.containers.otelAgent.envFrom -- Set environment variables specific to trace-agent from configMaps and/or secrets
+      # agents.containers.otelAgent.envFrom -- Set environment variables specific to otel-agent from configMaps and/or secrets
       envFrom: []
       #   - configMapRef:
       #       name: <CONFIGMAP_NAME>
       #   - secretRef:
       #       name: <SECRET_NAME>
 
-      # agents.containers.otelAgent.envDict -- Set environment variables specific to trace-agent defined in a dict
+      # agents.containers.otelAgent.envDict -- Set environment variables specific to otel-agent defined in a dict
       envDict: {}
       #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
 
-      # agents.containers.otelAgent.resources -- Resource requests and limits for the trace-agent container
+      # agents.containers.otelAgent.resources -- Resource requests and limits for the otel-agent container
       resources: {}
       #  requests:
       #    cpu: 100m
@@ -1732,7 +1732,7 @@ agents:
       #    cpu: 100m
       #    memory: 200Mi
 
-      # agents.containers.otelAgent.securityContext -- Allows you to overwrite the default container SecurityContext for the trace-agent container.
+      # agents.containers.otelAgent.securityContext -- Allows you to overwrite the default container SecurityContext for the otel-agent container.
       securityContext: {}
 
       # agents.containers.otelAgent.ports -- Allows to specify extra ports (hostPorts for instance) for this container


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix typos: trace-agent -> otel-agent

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
