### PR TITLE
Add note for OTel collector

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.69.4
+
+* Add private beta note for OTel Collector. 
+
 ## 3.69.3
 
 * Update `datadog-crds` dependency to `1.7.2`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.69.3
+version: 3.69.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.69.3](https://img.shields.io/badge/Version-3.69.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.69.4](https://img.shields.io/badge/Version-3.69.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -599,3 +599,11 @@ More information about this change: https://github.com/DataDog/helm-charts/pull/
 OTel collector is not supported on GKE Autopilot.
 {{- fail "The OTel collector cannot be run on GKE Autopilot." }}
 {{- end }}
+
+
+{{- if (eq (include "should-enable-otel-agent" .) "true")  }}
+#################################################################
+####               WARNING: Private Beta notice              ####
+#################################################################
+OTel collector is in private beta. Please reach out to your Datadog representative for more information.
+{{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds note of private beta for OTel collector. We are seeing support tickets by customers using OTel collector with regular Agent image. 


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
