### PR TITLE
[WF-8933] Bumping version to alpha29

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+### 0.9.0
+
+* Update private action image version to `v0.0.1-alpha29`.
+
 ### 0.8.0
 
 * Send MANAGED_BY environment variable to container. Update private action image version to `v0.0.1-alpha28`.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.8.0
+version: 0.9.0
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -97,16 +97,16 @@ helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
 
 ## Values
 
-| Key | Type | Default                                                                                                                                                                                                                                        | Description |
-|-----|------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.0.1-alpha29"}`                                                                                                                                   | Current Datadog Private Action Runner image |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.0.1-alpha29"}` | Current Datadog Private Action Runner image |
 | runners[0].config | object | `{"actionsAllowlist":["com.datadoghq.kubernetes.core.listPod"],"appBuilder":{"port":9016},"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"privateKey":"PRIVATE_KEY_FROM_CONFIG","urn":"URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
-| runners[0].config.actionsAllowlist | list | `["com.datadoghq.kubernetes.core.listPod"]`                                                                                                                                                                                                    | List of actions that the Datadog Private Action Runner is allowed to execute |
-| runners[0].config.appBuilder.port | int | `9016`                                                                                                                                                                                                                                         | Required port for App Builder Mode |
-| runners[0].config.ddBaseURL | string | `"https://app.datadoghq.com"`                                                                                                                                                                                                                  | Base URL of the Datadog app |
-| runners[0].config.modes | list | `["workflowAutomation","appBuilder"]`                                                                                                                                                                                                          | Modes that the runner can run in |
-| runners[0].config.privateKey | string | `"PRIVATE_KEY_FROM_CONFIG"`                                                                                                                                                                                                                    | The runner's privateKey from the enrollment page |
-| runners[0].config.urn | string | `"URN_FROM_CONFIG"`                                                                                                                                                                                                                            | The runner's URN from the enrollment page |
-| runners[0].kubernetesPermissions | list | `[{"apiGroups":[""],"resources":["pods"],"verbs":["list","get"]},{"apiGroups":["apps"],"resources":["deployments"],"verbs":["list","get"]}]`                                                                                                   | List of Kubernetes permissions that the Datadog Private Action Runner has |
-| runners[0].name | string | `"default"`                                                                                                                                                                                                                                    | Name of the Datadog Private Action Runner |
-| runners[0].replicas | int | `1`                                                                                                                                                                                                                                            | Number of pod instances for the Datadog Private Action Runner |
+| runners[0].config.actionsAllowlist | list | `["com.datadoghq.kubernetes.core.listPod"]` | List of actions that the Datadog Private Action Runner is allowed to execute |
+| runners[0].config.appBuilder.port | int | `9016` | Required port for App Builder Mode |
+| runners[0].config.ddBaseURL | string | `"https://app.datadoghq.com"` | Base URL of the Datadog app |
+| runners[0].config.modes | list | `["workflowAutomation","appBuilder"]` | Modes that the runner can run in |
+| runners[0].config.privateKey | string | `"PRIVATE_KEY_FROM_CONFIG"` | The runner's privateKey from the enrollment page |
+| runners[0].config.urn | string | `"URN_FROM_CONFIG"` | The runner's URN from the enrollment page |
+| runners[0].kubernetesPermissions | list | `[{"apiGroups":[""],"resources":["pods"],"verbs":["list","get"]},{"apiGroups":["apps"],"resources":["deployments"],"verbs":["list","get"]}]` | List of Kubernetes permissions that the Datadog Private Action Runner has |
+| runners[0].name | string | `"default"` | Name of the Datadog Private Action Runner |
+| runners[0].replicas | int | `1` | Number of pod instances for the Datadog Private Action Runner |

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha28](https://img.shields.io/badge/AppVersion-v0.0.1--alpha28-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha29](https://img.shields.io/badge/AppVersion-v0.0.1--alpha29-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 
@@ -97,16 +97,16 @@ helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.0.1-alpha28"}` | Current Datadog Private Action Runner image |
+| Key | Type | Default                                                                                                                                                                                                                                        | Description |
+|-----|------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.0.1-alpha29"}`                                                                                                                                   | Current Datadog Private Action Runner image |
 | runners[0].config | object | `{"actionsAllowlist":["com.datadoghq.kubernetes.core.listPod"],"appBuilder":{"port":9016},"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"privateKey":"PRIVATE_KEY_FROM_CONFIG","urn":"URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
-| runners[0].config.actionsAllowlist | list | `["com.datadoghq.kubernetes.core.listPod"]` | List of actions that the Datadog Private Action Runner is allowed to execute |
-| runners[0].config.appBuilder.port | int | `9016` | Required port for App Builder Mode |
-| runners[0].config.ddBaseURL | string | `"https://app.datadoghq.com"` | Base URL of the Datadog app |
-| runners[0].config.modes | list | `["workflowAutomation","appBuilder"]` | Modes that the runner can run in |
-| runners[0].config.privateKey | string | `"PRIVATE_KEY_FROM_CONFIG"` | The runner's privateKey from the enrollment page |
-| runners[0].config.urn | string | `"URN_FROM_CONFIG"` | The runner's URN from the enrollment page |
-| runners[0].kubernetesPermissions | list | `[{"apiGroups":[""],"resources":["pods"],"verbs":["list","get"]},{"apiGroups":["apps"],"resources":["deployments"],"verbs":["list","get"]}]` | List of Kubernetes permissions that the Datadog Private Action Runner has |
-| runners[0].name | string | `"default"` | Name of the Datadog Private Action Runner |
-| runners[0].replicas | int | `1` | Number of pod instances for the Datadog Private Action Runner |
+| runners[0].config.actionsAllowlist | list | `["com.datadoghq.kubernetes.core.listPod"]`                                                                                                                                                                                                    | List of actions that the Datadog Private Action Runner is allowed to execute |
+| runners[0].config.appBuilder.port | int | `9016`                                                                                                                                                                                                                                         | Required port for App Builder Mode |
+| runners[0].config.ddBaseURL | string | `"https://app.datadoghq.com"`                                                                                                                                                                                                                  | Base URL of the Datadog app |
+| runners[0].config.modes | list | `["workflowAutomation","appBuilder"]`                                                                                                                                                                                                          | Modes that the runner can run in |
+| runners[0].config.privateKey | string | `"PRIVATE_KEY_FROM_CONFIG"`                                                                                                                                                                                                                    | The runner's privateKey from the enrollment page |
+| runners[0].config.urn | string | `"URN_FROM_CONFIG"`                                                                                                                                                                                                                            | The runner's URN from the enrollment page |
+| runners[0].kubernetesPermissions | list | `[{"apiGroups":[""],"resources":["pods"],"verbs":["list","get"]},{"apiGroups":["apps"],"resources":["deployments"],"verbs":["list","get"]}]`                                                                                                   | List of Kubernetes permissions that the Datadog Private Action Runner has |
+| runners[0].name | string | `"default"`                                                                                                                                                                                                                                    | Name of the Datadog Private Action Runner |
+| runners[0].replicas | int | `1`                                                                                                                                                                                                                                            | Number of pod instances for the Datadog Private Action Runner |

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha28](https://img.shields.io/badge/AppVersion-v0.0.1--alpha28-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: v0.0.1-alpha29](https://img.shields.io/badge/AppVersion-v0.0.1--alpha29-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -6,7 +6,7 @@ common:
   # -- Current Datadog Private Action Runner image
   image:
     repository: us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner
-    tag: v0.0.1-alpha28
+    tag: v0.0.1-alpha29
 
 runners:
   # runners[0].name -- Name of the Datadog Private Action Runner


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR bumps the version to `alpha29` based on similar changes in the action runner.

Find the [changes here](https://github.com/DataDog/dd-source/pull/120604).

#### Which issue this PR fixes

Just bumping version.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
