### PR TITLE
Update helm chart to allow `kubelet.coreCheckEnabled` to be set to false

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.70.1
+
+* Fix datadog.kubelet.coreCheckEnabled conditional statement to accept false value
+
 ## 3.70.0
 
 * Set default `Agent` and `Cluster-Agent` version to `7.56.0`.
@@ -22,7 +26,7 @@
 
 ## 3.68.2
 
-* Fix datadog.containerLifecycle.enabled conditional statement to accept flase value
+* Fix datadog.containerLifecycle.enabled conditional statement to accept false value
 
 ## 3.68.1
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.70.0
+version: 3.70.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.70.0](https://img.shields.io/badge/Version-3.70.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.70.1](https://img.shields.io/badge/Version-3.70.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -189,10 +189,8 @@
       value: /host
     {{- end }}
     {{- end }}
-    {{- if .Values.datadog.kubelet.coreCheckEnabled }}
     - name: DD_KUBELET_CORE_CHECK_ENABLED
-      value: {{ .Values.datadog.kubelet.coreCheckEnabled | quote }}
-    {{- end }}
+      value: {{ .Values.datadog.kubelet.coreCheckEnabled | quote | default "true" }}
     {{- if eq (include "should-enable-otel-agent" .) "true" }}
     - name: DD_OTELCOLLECTOR_ENABLED
       value: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:
Update helm chart to allow `kubelet.coreCheckEnabled` to be set to `false`. Currently when set to `false`, the value is ignored. 

Similar fix to https://github.com/DataDog/helm-charts/pull/1460.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
