### PR TITLE
Remove HA warning when existingClusterAgent.join is true

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.70.2
+
+* Prevent high availability warning when `existingClusterAgent.join` is set to true.
+ 
 ## 3.70.1
 
 * Fix datadog.kubelet.coreCheckEnabled conditional statement to accept false value

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.70.1
+version: 3.70.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.70.1](https://img.shields.io/badge/Version-3.70.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.70.2](https://img.shields.io/badge/Version-3.70.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -422,7 +422,7 @@ https://github.com/DataDog/helm-charts/tree/master/charts/datadog#dsd-config
 {{- end }}
 
 
-{{- if and (or .Values.clusterAgent.admissionController.enabled .Values.clusterAgent.metricsProvider.enabled) (or (le (int .Values.clusterAgent.replicas) 1) (not .Values.clusterAgent.createPodDisruptionBudget)) }}
+{{- if and (or .Values.clusterAgent.admissionController.enabled .Values.clusterAgent.metricsProvider.enabled) (or (le (int .Values.clusterAgent.replicas) 1) (not .Values.clusterAgent.createPodDisruptionBudget)) (not .Values.existingClusterAgent.join) }}
 
 ###################################################################################
 ####   WARNING: Cluster-Agent should be deployed in high availability mode     ####


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates the datadog Helm chart `Notes.txt` to prevent displaying the high availability warning when `existingClusterAgent.join` is set to `true`. This adjustment ensures that users following the [mixed-clusters-with-the-datadog-cluster-agent](https://docs.datadoghq.com/agent/troubleshooting/windows_containers/#mixed-clusters-with-the-datadog-cluster-agent) example are not misled by unnecessary warnings.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
The warning message will no longer appear when `existingClusterAgent.join` is enabled.:

```
###################################################################################
####   WARNING: Cluster-Agent should be deployed in high availability mode     ####
###################################################################################
```


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart version updated
- [x] Documentation updated (`.github/helm-docs.sh` run)
- [x] `CHANGELOG.md` updated
- [ ] Variables documented in `README.md`
- [ ] Test baselines updated (`make update-test-baselines` run)
