### PR TITLE
[PROCS-4293] Improve support for `processAgent.runInCoreAgent` feature

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.70.2
+## 3.70.3
 
 * Improve support for `processAgent.runInCoreAgent` feature.
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.70.2
 
+* Improve support for `processAgent.runInCoreAgent` feature.
+
+## 3.70.2
+
 * Add admission controller port to cilium network policy for the cluster agent
 
 ## 3.70.1

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.70.3
+version: 3.70.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.70.2
+version: 3.70.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.70.3](https://img.shields.io/badge/Version-3.70.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.70.4](https://img.shields.io/badge/Version-3.70.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.70.2](https://img.shields.io/badge/Version-3.70.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.70.3](https://img.shields.io/badge/Version-3.70.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -251,7 +251,7 @@
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    {{- if .Values.datadog.processAgent.runInCoreAgent }}
+    {{- if (eq (include "should-run-process-checks-on-core-agent" .) "true") }}
     - name: passwd
       mountPath: /etc/passwd
       readOnly: true

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -137,7 +137,7 @@
   name: btf-path
 {{- end }}
 {{- end }}
-{{- if or (eq (include "process-checks-enabled" .) "true") .Values.datadog.processAgent.runInCoreAgent (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true") }}
+{{- if or (eq (include "process-checks-enabled" .) "true") (eq (include "should-run-process-checks-on-core-agent" .) "true") (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true") }}
 - hostPath:
     path: /etc/passwd
   name: passwd

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -965,7 +965,7 @@ Create RBACs for custom resources
   Returns true if process-related checks should run on the core agent.
 */}}
 {{- define "should-run-process-checks-on-core-agent" -}}
-  {{- if and (ne .Values.targetSystem "linux") (eq (include "process-checks-enabled" .) "true") -}}
+  {{- if ne .Values.targetSystem "linux" -}}
     false
   {{- else if (ne (include "get-process-checks-in-core-agent-envvar" .) "") -}}
     {{- include "get-process-checks-in-core-agent-envvar" . -}}

--- a/charts/datadog/templates/_processes-common-env.yaml
+++ b/charts/datadog/templates/_processes-common-env.yaml
@@ -8,8 +8,8 @@
   value: {{ .Values.datadog.processAgent.processDiscovery | quote }}
 - name: DD_STRIP_PROCESS_ARGS
   value: {{ .Values.datadog.processAgent.stripProcessArguments | quote }}
-{{- if eq .Values.targetSystem "linux" }}
+{{- if and (eq .Values.targetSystem "linux") (eq (include "get-process-checks-in-core-agent-envvar" .) "") }}
 - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
-  value: {{ .Values.datadog.processAgent.runInCoreAgent | quote }}
-{{- end }}  
+  value: {{ (include "should-run-process-checks-on-core-agent" .) | quote }}
+{{- end }} 
 {{- end -}}

--- a/test/datadog/values/process-run-in-core-envvars.yaml
+++ b/test/datadog/values/process-run-in-core-envvars.yaml
@@ -1,0 +1,10 @@
+agents:
+  containers:
+    agent:
+      env:
+        - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+          value: "true"
+    processAgent:
+      env:
+        - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+          value: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:
 This PR updates the chart logic for using the `processAgent.runInCoreAgent` features. The changes aim to:
 * Make the logic for enabling the process agent container easier to follow.
 * Guard the `DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED` from being mistakenly set to `true` in unsupported environments.
 * Add a method to ignore any compatibility checks by specifying an env var override. This was mostly done to support testing with custom agent images.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
