### PR TITLE
Add admission controller port to cilium network policy for the cluster agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.70.2
+
+* Add admission controller port to cilium network policy for the cluster agent
+
 ## 3.70.1
 
 * Fix datadog.kubelet.coreCheckEnabled conditional statement to accept false value

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.70.1
+version: 3.70.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.70.1](https://img.shields.io/badge/Version-3.70.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.70.2](https://img.shields.io/badge/Version-3.70.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-cilium-network-policy.yaml
+++ b/charts/datadog/templates/cluster-agent-cilium-network-policy.yaml
@@ -189,4 +189,20 @@ specs:
               - port: {{ include "clusterAgent.metricsProvider.port" . | quote }}
                 protocol: TCP
 {{- end }}
+{{- if .Values.clusterAgent.admissionController.enabled }}
+  - description: Ingress from API server for admission controller
+    endpointSelector:
+      matchLabels:
+        app: {{ template "datadog.fullname" . }}-cluster-agent
+        {{- if .Values.clusterAgent.podLabels }}
+        {{ toYaml .Values.clusterAgent.podLabels | indent 8 }}
+        {{- end }}
+    ingress:
+      - fromEntities:
+          - kube-apiserver
+        toPorts:
+          - ports:
+              - port: {{ .Values.clusterAgent.admissionController.port | quote }}
+                protocol: TCP
+{{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds the admission controller port to the CiliumNetworkPolicy, when `clusterAgent.admissionController.enabled` is set to `true`. This port is already exposed by the kubernetes network policy, so this PR brings the cilium version in line with the other

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
