### PR TITLE
[APPS-1924] Add ability to configure connection credentials in config.yaml

### DIFF
--- a/charts/private-action-runner/.helmignore
+++ b/charts/private-action-runner/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# Binaries
+helm-docs

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+### 0.9.1
+
+- Added ability to configure connection credentials in `config.yaml`.
+
 ### 0.9.0
 
 * Update private action image version to `v0.0.1-alpha29`.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -22,69 +22,6 @@ helm repo update
 1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
 2. Create a new Private Action Runner and follow the instructions for Kubernetes.
 
-## Use this chart with connection credentials
-1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
-2. Set up a new Private Action runner by following the Kubernetes instructions. When you reach step 4, instead of running `helm install`, make the following changes to the Helm chart.
-3. Download the chart locally.
-```bash
-helm pull datadog/private-action-runner --untar
-```
-4. Add connection credential json file to `templates/secrets.yaml` in the format corresponding to the credential and action types you want to use.
-
-HTTP Basic Auth:
-```
-{
-   auth_type: 'Basic Auth',
-   credentials: [
-      {
-         username: 'USERNAME',
-         password: 'PASSWORD',
-      },
-   ],
-}
-```
-HTTP Token Auth:
-```
-{
-   auth_type: 'Token Auth',
-   credentials: [
-      {
-         tokenName: 'TOKEN1',
-         tokenValue: 'VALUE1',
-      },
-   ],
-}
-```
-Jenkins:
-```
-{
-   auth_type: 'Token Auth',
-   credentials: [
-      {
-         username: 'USERNAME',
-         token: 'TOKEN',
-         domain: 'DOMAIN',
-      },
-   ],
-}
-```
-Postgres:
-```
-{
-   auth_type: 'Token Auth',
-   credentials: [
-      {
-         tokenName: 'connectionUri',
-         tokenValue: 'postgres://usr:password@example_host:5432/example_db',
-      },
-   ],
-}
-```
-5. Install the chart.
-```bash
-helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
-```
-
 ## To use Kubernetes actions
 1. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
 2. Create a new connection, select your private action runner, and use **Service account authentication**.
@@ -100,6 +37,10 @@ helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.0.1-alpha29"}` | Current Datadog Private Action Runner image |
+| connectionCredentials.basicAuth.credentials | list | `[]` | List of credentials for Basic Auth |
+| connectionCredentials.jenkinsAuth.credentials | list | `[]` | List of credentials for Jenkins Auth |
+| connectionCredentials.postgresAuth.credentials | list | `[]` | List of credentials for Postgres Auth |
+| connectionCredentials.tokenAuth.credentials | list | `[]` | List of credentials for Token Auth |
 | runners[0].config | object | `{"actionsAllowlist":["com.datadoghq.kubernetes.core.listPod"],"appBuilder":{"port":9016},"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"privateKey":"PRIVATE_KEY_FROM_CONFIG","urn":"URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
 | runners[0].config.actionsAllowlist | list | `["com.datadoghq.kubernetes.core.listPod"]` | List of actions that the Datadog Private Action Runner is allowed to execute |
 | runners[0].config.appBuilder.port | int | `9016` | Required port for App Builder Mode |

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -22,6 +22,11 @@ helm repo update
 1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
 2. Create a new Private Action Runner and follow the instructions for Kubernetes.
 
+## Use this chart with connection credentials
+1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
+2. Create a new Private Action Runner and follow the instructions for Kubernetes.
+3. Configure [connection credentials](https://docs.datadoghq.com/service_management/workflows/private_actions/private_action_credentials) for the selected private actions via `config.yaml`.
+
 ## To use Kubernetes actions
 1. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
 2. Create a new connection, select your private action runner, and use **Service account authentication**.

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -22,69 +22,6 @@ helm repo update
 1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
 2. Create a new Private Action Runner and follow the instructions for Kubernetes.
 
-## Use this chart with connection credentials
-1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
-2. Set up a new Private Action runner by following the Kubernetes instructions. When you reach step 4, instead of running `helm install`, make the following changes to the Helm chart.
-3. Download the chart locally.
-```bash
-helm pull datadog/private-action-runner --untar
-```
-4. Add connection credential json file to `templates/secrets.yaml` in the format corresponding to the credential and action types you want to use.
-
-HTTP Basic Auth:
-```
-{
-   auth_type: 'Basic Auth',
-   credentials: [
-      {
-         username: 'USERNAME',
-         password: 'PASSWORD',
-      },
-   ],
-}
-```
-HTTP Token Auth:
-```
-{
-   auth_type: 'Token Auth',
-   credentials: [
-      {
-         tokenName: 'TOKEN1',
-         tokenValue: 'VALUE1',
-      },
-   ],
-}
-```
-Jenkins:
-```
-{
-   auth_type: 'Token Auth',
-   credentials: [
-      {
-         username: 'USERNAME',
-         token: 'TOKEN',
-         domain: 'DOMAIN',
-      },
-   ],
-}
-```
-Postgres:
-```
-{
-   auth_type: 'Token Auth',
-   credentials: [
-      {
-         tokenName: 'connectionUri',
-         tokenValue: 'postgres://usr:password@example_host:5432/example_db',
-      },
-   ],
-}
-```
-5. Install the chart.
-```bash
-helm install <RELEASE_NAME> ./private-action-runner -f ./config.yaml
-```
-
 ## To use Kubernetes actions
 1. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
 2. Create a new connection, select your private action runner, and use **Service account authentication**.

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -22,6 +22,11 @@ helm repo update
 1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
 2. Create a new Private Action Runner and follow the instructions for Kubernetes.
 
+## Use this chart with connection credentials
+1. Go to the [Private Action Runner tab](https://app.datadoghq.com/workflow/private-action-runners).
+2. Create a new Private Action Runner and follow the instructions for Kubernetes.
+3. Configure [connection credentials](https://docs.datadoghq.com/service_management/workflows/private_actions/private_action_credentials) for the selected private actions via `config.yaml`.
+
 ## To use Kubernetes actions
 1. Go to the [Workflow connections page](https://app.datadoghq.com/workflow/connections).
 2. Create a new connection, select your private action runner, and use **Service account authentication**.

--- a/charts/private-action-runner/examples/config.yaml
+++ b/charts/private-action-runner/examples/config.yaml
@@ -39,29 +39,31 @@ runners:
 connectionCredentials:
   basicAuth:
     credentials:
-      - fileName: "basic.json"
+      - fileName: "creds/http_basic_creds.json"
         username: "username"
         password: "password"
-      - fileName: "another_basic.json"
+      - fileName: "creds/another_http_basic_creds.json"
         username: "another_username"
         password: "another_password"
   tokenAuth:
     credentials:
-      - fileName: "token.json"
+      - fileName: "creds/http_token_creds.json"
         tokenName: "name"
         tokenValue: "value"
   jenkinsAuth:
     credentials:
-      - fileName: "jenkins.json"
+      - fileName: "creds/jenkins_creds.json"
         username: "username"
         token: "token"
         domain: "domain"
   postgresAuth:
     credentials:
-      - fileName: "postgres.json"
+      - fileName: "creds/creds.pgpass"
         host: "host"
         port: "port"
         user: "user"
         password: "password"
         database: "database"
         sslMode: "sslMode"
+        applicationName: "applicationName"
+        searchPath: "searchPath"

--- a/charts/private-action-runner/examples/config.yaml
+++ b/charts/private-action-runner/examples/config.yaml
@@ -35,3 +35,29 @@ runners:
         - com.datadoghq.kubernetes.core.listPod
         - com.datadoghq.http.request
         - com.datadoghq.jenkins.buildJenkinsJob
+
+connectionCredentials:
+  basicAuth:
+    credentials:
+      - key: "basic.json"
+        username: "username"
+        password: "password"
+      - key: "another_basic.json"
+        username: "another_username"
+        password: "another_password"
+  tokenAuth:
+    credentials:
+      - key: "token.json"
+        tokenName: "name"
+        tokenValue: "value"
+  jenkinsAuth:
+    credentials:
+      - key: "jenkins.json"
+        username: "username"
+        token: "token"
+        domain: "domain"
+  postgresAuth:
+    credentials:
+      - key: "postgres.json"
+        tokenName: "name"
+        tokenValue: "value"

--- a/charts/private-action-runner/examples/config.yaml
+++ b/charts/private-action-runner/examples/config.yaml
@@ -39,25 +39,29 @@ runners:
 connectionCredentials:
   basicAuth:
     credentials:
-      - key: "basic.json"
+      - fileName: "basic.json"
         username: "username"
         password: "password"
-      - key: "another_basic.json"
+      - fileName: "another_basic.json"
         username: "another_username"
         password: "another_password"
   tokenAuth:
     credentials:
-      - key: "token.json"
+      - fileName: "token.json"
         tokenName: "name"
         tokenValue: "value"
   jenkinsAuth:
     credentials:
-      - key: "jenkins.json"
+      - fileName: "jenkins.json"
         username: "username"
         token: "token"
         domain: "domain"
   postgresAuth:
     credentials:
-      - key: "postgres.json"
-        tokenName: "name"
-        tokenValue: "value"
+      - fileName: "postgres.json"
+        host: "host"
+        port: "port"
+        user: "user"
+        password: "password"
+        database: "database"
+        sslMode: "sslMode"

--- a/charts/private-action-runner/examples/config.yaml
+++ b/charts/private-action-runner/examples/config.yaml
@@ -39,26 +39,26 @@ runners:
 connectionCredentials:
   basicAuth:
     credentials:
-      - fileName: "creds/http_basic_creds.json"
+      - fileName: "http_basic_creds.json"
         username: "username"
         password: "password"
-      - fileName: "creds/another_http_basic_creds.json"
+      - fileName: "another_http_basic_creds.json"
         username: "another_username"
         password: "another_password"
   tokenAuth:
     credentials:
-      - fileName: "creds/http_token_creds.json"
+      - fileName: "http_token_creds.json"
         tokenName: "name"
         tokenValue: "value"
   jenkinsAuth:
     credentials:
-      - fileName: "creds/jenkins_creds.json"
+      - fileName: "jenkins_creds.json"
         username: "username"
         token: "token"
         domain: "domain"
   postgresAuth:
     credentials:
-      - fileName: "creds/creds.pgpass"
+      - fileName: "creds.pgpass"
         host: "host"
         port: "port"
         user: "user"

--- a/charts/private-action-runner/templates/_helpers.tpl
+++ b/charts/private-action-runner/templates/_helpers.tpl
@@ -4,3 +4,73 @@
 {{- define "chart.roleBindingName" }} "private-action-runner-{{.}}-rolebinding" {{ end }}
 {{- define "chart.serviceName" }} "private-action-runner-{{.}}-service" {{ end }}
 {{- define "chart.secretName" }} "private-action-runner-{{.}}-secrets" {{ end }}
+
+{{- define "chart.basicAuth" -}}
+{{- if hasKey $.Values.connectionCredentials.basicAuth "credentials" }}
+{{- range $c := $.Values.connectionCredentials.basicAuth.credentials }}
+{{ $c.key }}: |
+  {
+     auth_type: 'Basic Auth',
+     credentials: [
+        {
+           username: {{ $c.username }},
+           password: {{ $c.password }},
+        },
+     ],
+  }
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "chart.tokenAuth" -}}
+{{- if hasKey $.Values.connectionCredentials.tokenAuth "credentials" }}
+{{- range $c := $.Values.connectionCredentials.tokenAuth.credentials }}
+{{ $c.key }}: |
+  {
+     auth_type: 'Token Auth',
+     credentials: [
+        {
+           tokenName: {{ $c.tokenName }},
+           tokenValue: {{ $c.tokenValue }},
+        },
+     ],
+  }
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "chart.jenkinsAuth" -}}
+{{- if hasKey $.Values.connectionCredentials.jenkinsAuth "credentials" }}
+{{- range $c := $.Values.connectionCredentials.jenkinsAuth.credentials }}
+{{ $c.key }}: |
+  {
+     auth_type: 'Token Auth',
+     credentials: [
+        {
+           username: {{ $c.username }},
+           token: {{ $c.token }},
+           domain: {{ $c.domain }},
+        },
+     ],
+  }
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "chart.postgresAuth" -}}
+{{- if hasKey $.Values.connectionCredentials.postgresAuth "credentials" }}
+{{- range $c := $.Values.connectionCredentials.postgresAuth.credentials }}
+{{ $c.key }}: |
+  {
+     auth_type: 'Token Auth',
+     credentials: [
+        {
+           tokenName: {{ $c.tokenName }},
+           tokenValue: {{ $c.tokenValue }},
+        },
+     ],
+  }
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/private-action-runner/templates/_helpers.tpl
+++ b/charts/private-action-runner/templates/_helpers.tpl
@@ -10,13 +10,13 @@
 {{- range $c := $.Values.connectionCredentials.basicAuth.credentials }}
 {{ $c.fileName }}: |
   {
-     auth_type: 'Basic Auth',
-     credentials: [
-        {
-           username: {{ $c.username }},
-           password: {{ $c.password }},
-        },
-     ],
+    auth_type: 'Basic Auth',
+    credentials: [
+      {
+        username: {{ $c.username | quote }},
+        password: {{ $c.password | quote }}
+      },
+    ],
   }
 {{- end -}}
 {{- end -}}
@@ -27,13 +27,13 @@
 {{- range $c := $.Values.connectionCredentials.tokenAuth.credentials }}
 {{ $c.fileName }}: |
   {
-     auth_type: 'Token Auth',
-     credentials: [
-        {
-           tokenName: {{ $c.tokenName }},
-           tokenValue: {{ $c.tokenValue }},
-        },
-     ],
+    auth_type: 'Token Auth',
+    credentials: [
+      {
+        tokenName: {{ $c.tokenName | quote }},
+        tokenValue: {{ $c.tokenValue | quote }}
+      },
+    ],
   }
 {{- end -}}
 {{- end -}}
@@ -44,36 +44,64 @@
 {{- range $c := $.Values.connectionCredentials.jenkinsAuth.credentials }}
 {{ $c.fileName }}: |
   {
-     auth_type: 'Token Auth',
-     credentials: [
-        {
-           username: {{ $c.username }},
-           token: {{ $c.token }},
-           domain: {{ $c.domain }},
-        },
-     ],
+    auth_type: 'Token Auth',
+    credentials: [
+      {
+        username: {{ $c.username | quote }},
+        token: {{ $c.token | quote }},
+        domain: {{ $c.domain | quote }}
+      },
+    ],
   }
 {{- end -}}
 {{- end -}}
 {{- end -}}
-
 
 {{- define "chart.postgresAuth" -}}
 {{- if hasKey $.Values.connectionCredentials.postgresAuth "credentials" }}
 {{- range $c := $.Values.connectionCredentials.postgresAuth.credentials }}
 {{ $c.fileName }}: |
   {
-     auth_type: 'Token Auth',
-     credentials: [
-        {
-           host: {{ $c.host }}
-           port: {{ $c.port }}
-           user: {{ $c.user }}
-           password: {{ $c.password }}
-           database: {{ $c.database }}
-           sslMode: {{ $c.sslMode }}
-        },
-     ],
+    auth_type: 'Token Auth',
+    credentials: [
+      {
+        "tokenName": "host",
+        "tokenValue": {{ $c.host | quote }}
+      },
+      {
+        "tokenName": "port",
+        "tokenValue": {{ $c.port | quote }}
+      },
+      {
+        "tokenName": "user",
+        "tokenValue": {{ $c.user | quote }}
+      },
+      {
+        "tokenName": "password",
+        "tokenValue": {{ $c.password | quote }}
+      },
+      {
+        "tokenName": "database",
+        "tokenValue": {{ $c.database | quote }}
+      },
+      {
+        "tokenName": "sslmode",
+        "tokenValue": {{ $c.sslMode | quote }}
+      },
+    {{- if $c.applicationName }}
+      {
+        "tokenName": "applicationName",
+        "tokenValue": {{ $c.applicationName | quote }}
+      },
+    {{ end }}
+    {{- if $c.searchPath }}
+      {
+      {
+        "tokenName": "searchPath",
+        "tokenValue": {{ $c.searchPath | quote }}
+      }
+    {{ end }}
+    ],
   }
 {{- end -}}
 {{- end -}}

--- a/charts/private-action-runner/templates/_helpers.tpl
+++ b/charts/private-action-runner/templates/_helpers.tpl
@@ -8,7 +8,7 @@
 {{- define "chart.basicAuth" -}}
 {{- if hasKey $.Values.connectionCredentials.basicAuth "credentials" }}
 {{- range $c := $.Values.connectionCredentials.basicAuth.credentials }}
-{{ $c.key }}: |
+{{ $c.fileName }}: |
   {
      auth_type: 'Basic Auth',
      credentials: [
@@ -25,7 +25,7 @@
 {{- define "chart.tokenAuth" -}}
 {{- if hasKey $.Values.connectionCredentials.tokenAuth "credentials" }}
 {{- range $c := $.Values.connectionCredentials.tokenAuth.credentials }}
-{{ $c.key }}: |
+{{ $c.fileName }}: |
   {
      auth_type: 'Token Auth',
      credentials: [
@@ -42,7 +42,7 @@
 {{- define "chart.jenkinsAuth" -}}
 {{- if hasKey $.Values.connectionCredentials.jenkinsAuth "credentials" }}
 {{- range $c := $.Values.connectionCredentials.jenkinsAuth.credentials }}
-{{ $c.key }}: |
+{{ $c.fileName }}: |
   {
      auth_type: 'Token Auth',
      credentials: [
@@ -61,13 +61,17 @@
 {{- define "chart.postgresAuth" -}}
 {{- if hasKey $.Values.connectionCredentials.postgresAuth "credentials" }}
 {{- range $c := $.Values.connectionCredentials.postgresAuth.credentials }}
-{{ $c.key }}: |
+{{ $c.fileName }}: |
   {
      auth_type: 'Token Auth',
      credentials: [
         {
-           tokenName: {{ $c.tokenName }},
-           tokenValue: {{ $c.tokenValue }},
+           host: {{ $c.host }}
+           port: {{ $c.port }}
+           user: {{ $c.user }}
+           password: {{ $c.password }}
+           database: {{ $c.database }}
+           sslMode: {{ $c.sslMode }}
         },
      ],
   }

--- a/charts/private-action-runner/templates/secrets.yaml
+++ b/charts/private-action-runner/templates/secrets.yaml
@@ -22,4 +22,8 @@ stringData:
     {{- range $action := $runner.config.actionsAllowlist }}
       - {{ $action }}
     {{- end }}
+  {{- include "chart.basicAuth" $ | indent 2 }}
+  {{- include "chart.tokenAuth" $ | indent 2 }}
+  {{- include "chart.jenkinsAuth" $ | indent 2 }}
+  {{- include "chart.postgresAuth" $ | indent 2 }}
 {{- end }}

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -110,3 +110,17 @@ runners:
         # - com.datadoghq.temporal.getWorkflowResult
         # - com.datadoghq.temporal.listWorkflows
         # - com.datadoghq.temporal.runWorkflow
+
+connectionCredentials:
+  basicAuth:
+    # -- List of credentials for Basic Auth
+    credentials: []
+  tokenAuth:
+    # -- List of credentials for Token Auth
+    credentials: []
+  jenkinsAuth:
+    # -- List of credentials for Jenkins Auth
+    credentials: []
+  postgresAuth:
+    # -- List of credentials for Postgres Auth
+    credentials: []

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -111,6 +111,7 @@ runners:
         # - com.datadoghq.temporal.listWorkflows
         # - com.datadoghq.temporal.runWorkflow
 
+# see examples/config.yaml for credential keys
 connectionCredentials:
   basicAuth:
     # -- List of credentials for Basic Auth


### PR DESCRIPTION
#### What this PR does / why we need it:
- Add ability to configure connection credentials (Basic Auth, Token Auth, Jenkins, Postgres) in `config.yaml`
  - [docs](https://docs.datadoghq.com/service_management/workflows/private_actions/private_action_credentials)
- Users shouldn't pull and untar to add their credentials to `secrets.yaml`

#### Checklist
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
