### PR TITLE
fix: Move DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY outside of sidecar condition

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Datadog changelog
+## 3.73.4
+
+* Define `admission_controller.container_registry` regardless of `clusterAgent.admissionController.agentSidecarInjection` feature status.
 
 ## 3.74.3
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.74.3
+version: 3.74.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.74.3](https://img.shields.io/badge/Version-3.74.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.74.4](https://img.shields.io/badge/Version-3.74.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_ac-agent-sidecar-env.yaml
+++ b/charts/datadog/templates/_ac-agent-sidecar-env.yaml
@@ -14,14 +14,6 @@
   value: {{ .Values.clusterAgent.admissionController.agentSidecarInjection.provider }}
 {{- end }}
 
-{{- if .Values.clusterAgent.admissionController.containerRegistry }}
-- name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-  value: {{ .Values.clusterAgent.admissionController.containerRegistry }}
-{{- else if .Values.registry }}
-- name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-  value: {{ .Values.registry }}
-{{- end }}
-
 {{- if .Values.clusterAgent.admissionController.agentSidecarInjection.containerRegistry }}
 - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_CONTAINER_REGISTRY
   value: {{ .Values.clusterAgent.admissionController.agentSidecarInjection.containerRegistry }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -236,6 +236,12 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PATCHER_ENABLED
             value: "true"
           {{- end }}
+          - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
+          {{- if .Values.clusterAgent.admissionController.containerRegistry }}
+            value: {{ .Values.clusterAgent.admissionController.containerRegistry | quote }}
+          {{- else }}
+            value: {{ include "registry" .Values | quote }}
+          {{- end }}
           {{ include "ac-agent-sidecar-env" . | nindent 10 }}
           - name: DD_REMOTE_CONFIGURATION_ENABLED
             value: {{ include "clusterAgent-remoteConfiguration-enabled" . | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:
The value `clusterAgent.admissionController.containerRegistry` was added in https://github.com/DataDog/helm-charts/pull/1376, as a fix for https://github.com/DataDog/helm-charts/issues/1078.

However, in the original implementation that env var was added to `_ac-agent-sidecar-env.yaml` template, which makes it working only if `clusterAgent.admissionController.agentSidecarInjection.enabled` is `true`.

That should not be the case - the option `DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY` has a wider use case and does not depend on the `agentSidecarInjection` feature, which was rightly noted in that comment: https://github.com/DataDog/helm-charts/issues/1078#issuecomment-2158033251

#### Which issue this PR fixes
This PR fixes that behavior described above: `DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY` will be added to the Cluster Agent's env vars regardless of the state of  `clusterAgent.admissionController.agentSidecarInjection.enabled` value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
