### PR TITLE
WIP: PoC of using actionsAllowlist in ClusterRole

### DIFF
--- a/charts/private-action-runner/templates/role.yaml
+++ b/charts/private-action-runner/templates/role.yaml
@@ -5,5 +5,27 @@ kind: ClusterRole
 metadata:
   namespace: {{ $.Release.Namespace }}
   name: {{ include "chart.roleName" $runner.name }}
-rules: {{ $runner.kubernetesPermissions | toJson }}
+rules:
+{{- if $runner.kubernetesPermissions }}
+{{ $runner.kubernetesPermissions | toYaml}}
+{{- else }}
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "list"
+      - "get"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "list"
+      - "get"
+{{- if has "com.datadoghq.kubernetes.apps.updateDeployment" $runner.config.actionsAllowlist  }}
+      - "patch"
+      - "update"
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -13,30 +13,22 @@ runners:
   - name: "default"
     # -- Number of pod instances for the Datadog Private Action Runner
     replicas: 1
-    # -- List of Kubernetes permissions that the Datadog Private Action Runner has
-    kubernetesPermissions:
-      - apiGroups:
-          - ""
-        resources:
-          - "pods"
-        verbs:
-          - "list"
-          - "get"
-          # - "create"
-          # - "patch"
-          # - "update"
-          # - "delete"
-      - apiGroups:
-          - "apps"
-        resources:
-          - "deployments"
-        verbs:
-          - "list"
-          - "get"
-          # - "create"
-          # - "patch"
-          # - "update"
-          # - "delete"
+    # -- Explicitly set Kubernetes permissions that the Datadog Private Action Runner has
+    # kubernetesPermissions:
+    #   - apiGroups:
+    #       - ""
+    #     resources:
+    #       - "pods"
+    #     verbs:
+    #       - "list"
+    #       - "get"
+    #   - apiGroups:
+    #       - "apps"
+    #     resources:
+    #       - "deployments"
+    #     verbs:
+    #       - "list"
+    #       - "get"
     # -- Configuration for the Datadog Private Action Runner
     config:
       # -- Base URL of the Datadog app


### PR DESCRIPTION
#### What this PR does / why we need it:

* PoC of simplified user configuration that consults the runner's `actionsAllowList` to configure RBAC (`ClusterRole`)
* Default to no explicitly set rules in `kubernetesPermissions` - the user still has the option to specify it (overrides configuration using `actionsAllowList`. 

How to test:
* In values add or uncomment `com.datadoghq.kubernetes.apps.updateDeployment` in `actionsAllowlist`
* Render the helm chart with `helm template ./`

Expected ClusterRole:
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  namespace: process
  name:  "private-action-runner-default-role"
rules:
  - apiGroups:
      - ""
    resources:
      - "pods"
    verbs:
      - "list"
      - "get"
  - apiGroups:
      - "apps"
    resources:
      - "deployments"
    verbs:
      - "list"
      - "get"
      - "patch"
      - "update"
```

Note that this is just a PoC and needs to be further evolved to support actions in the `actionsAllowlist`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
