### PR TITLE
APM instrumentation increase default memory limit

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.70.8
+
+* Increased the default memory request/limit values for APM Auto-Instrumentation init-containers to `128Mi` to prevent Out-of-Memory errors with certain APM library languages. The previous default value in agent version `v5.57.0` was `20Mi`.
+
 ## 3.70.7
 
 * Set default `Agent` and `Cluster-Agent` version to `7.56.2`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.70.7
+version: 3.70.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.70.7](https://img.shields.io/badge/Version-3.70.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.70.8](https://img.shields.io/badge/Version-3.70.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -241,6 +241,8 @@ spec:
           {{- if .Values.datadog.apm.instrumentation.enabled }}
           - name: DD_APM_INSTRUMENTATION_ENABLED
             value: {{ .Values.datadog.apm.instrumentation.enabled | quote }}
+          - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY
+            value: 128Mi
           {{- end }}
           {{- if .Values.datadog.apm.instrumentation.enabledNamespaces }}
           - name: DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES


### PR DESCRIPTION
#### What this PR does / why we need it:

The [default chosen](https://github.com/DataDog/datadog-agent/blob/e141eadad35bdf8f82b253bea45a6a71eaf3a471/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go#L44) (20MB) in 7.57.0 of the agent is too low which results in OOMKills for some of the APM library InitContainers. This is likely due to a regression in the size of the APM libraries. Once a fix is merged upstream in the Agent we should add a version gate on this setting so it only applies to the versions affected.

64Mi was successfully tested in a default GKE cluster and a local minikube. Since we'd like to mitigate the issue immediately 128Mi should be more than safe enough given that 64Mi worked to protect against any further regressions in the library InitContainers.

[](https://datadoghq.atlassian.net/browse/APMON-1472)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
