### PR TITLE
Bump private action runner to v0.0.1-alpha31

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+### 0.10.0
+
+* Update private action image version to `v0.0.1-alpha30`.
+
 ### 0.9.1
 
 - Added ability to configure connection credentials in `config.yaml`.

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.10.0
 
-* Update private action image version to `v0.0.1-alpha30`.
+* Update private action image version to `v0.0.1-alpha31`.
 
 ### 0.9.1
 

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.9.1
+version: 0.10.0
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -41,7 +41,7 @@ helm repo update
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.0.1-alpha29"}` | Current Datadog Private Action Runner image |
+| common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.0.1-alpha30"}` | Current Datadog Private Action Runner image |
 | connectionCredentials.basicAuth.credentials | list | `[]` | List of credentials for Basic Auth |
 | connectionCredentials.jenkinsAuth.credentials | list | `[]` | List of credentials for Jenkins Auth |
 | connectionCredentials.postgresAuth.credentials | list | `[]` | List of credentials for Postgres Auth |

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -41,7 +41,7 @@ helm repo update
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.0.1-alpha30"}` | Current Datadog Private Action Runner image |
+| common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.0.1-alpha31"}` | Current Datadog Private Action Runner image |
 | connectionCredentials.basicAuth.credentials | list | `[]` | List of credentials for Basic Auth |
 | connectionCredentials.jenkinsAuth.credentials | list | `[]` | List of credentials for Jenkins Auth |
 | connectionCredentials.postgresAuth.credentials | list | `[]` | List of credentials for Postgres Auth |

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -6,7 +6,7 @@ common:
   # -- Current Datadog Private Action Runner image
   image:
     repository: us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner
-    tag: v0.0.1-alpha29
+    tag: v0.0.1-alpha30
 
 runners:
   # runners[0].name -- Name of the Datadog Private Action Runner

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -6,7 +6,7 @@ common:
   # -- Current Datadog Private Action Runner image
   image:
     repository: us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner
-    tag: v0.0.1-alpha30
+    tag: v0.0.1-alpha31
 
 runners:
   # runners[0].name -- Name of the Datadog Private Action Runner


### PR DESCRIPTION
#### What this PR does / why we need it:

There is a new version of the private action runner available

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`