### PR TITLE
Correct otelCollector.config variable type

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.71.2
+
+* Correct expected type for `datadog.otelCollector.config` (from object to string).
+
 ## 3.71.1
 
 * Update `fips.image.tag` to `1.1.5` updating openSSL version to 3.0.15

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.71.1
+version: 3.71.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.71.1](https://img.shields.io/badge/Version-3.71.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.71.2](https://img.shields.io/badge/Version-3.71.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -770,7 +770,7 @@ helm install <RELEASE_NAME> \
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
 | datadog.originDetectionUnified.enabled | bool | `false` | Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+). |
 | datadog.osReleasePath | string | `"/etc/os-release"` | Specify the path to your os-release file |
-| datadog.otelCollector.config | object | `{}` | OTel collector configuration |
+| datadog.otelCollector.config | string | `""` | OTel collector configuration |
 | datadog.otelCollector.enabled | bool | `false` | Enable the OTel Collector |
 | datadog.otelCollector.ports | list | `[{"containerPort":"4317","name":"otel-grpc"},{"containerPort":"4318","name":"otel-http"}]` | Ports that OTel Collector is listening |
 | datadog.otlp.logs.enabled | bool | `false` | Enable logs support in the OTLP ingest endpoint |

--- a/charts/datadog/templates/_otel_agent_config.yaml
+++ b/charts/datadog/templates/_otel_agent_config.yaml
@@ -1,5 +1,5 @@
 {{- define "otel-agent-config-configmap-content" -}}
-otel-config.yaml: {{- if .Values.datadog.otelCollector.config }} {{ toYaml .Values.datadog.otelCollector.config | indent 4 }}
+otel-config.yaml: {{- if .Values.datadog.otelCollector.config }} {{ toYaml .Values.datadog.otelCollector.config }}
   {{- else }} |
     receivers:
       prometheus:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -534,7 +534,7 @@ datadog:
       - containerPort: "4318"
         name: otel-http
     # datadog.otelCollector.config -- OTel collector configuration
-    config: {}
+    config: ""
   ## OTLP ingest related configuration
   otlp:
     receiver:


### PR DESCRIPTION
#### What this PR does / why we need it:

The PR redeclares `datadog.otelCollector.config` to be a string rather than an object. The code was already expecting this (including the ci setup in https://github.com/DataDog/helm-charts/pull/1429), but using a string resulted in these warnings:

```
coalesce.go:286: warning: cannot overwrite table with non table for datadog.datadog.otelCollector.config (map[])
coalesce.go:286: warning: cannot overwrite table with non table for datadog.datadog.otelCollector.config (map[])
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
