### PR TITLE
[CONTP-375] Expose k8s resource labels as tags to configure tagger

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.71.2
+
+* Add `datadog.kubernetesResourcesLabelsAsTags` to assign Kubernetes Resources Labels as tags in the tagger
+* Add `datadog.kubernetesResourcesAnnotationsAsTags` to assign Kuberenetes Resources Annotations as tags in the tagger
+
 ## 3.71.1
 
 * Update `fips.image.tag` to `1.1.5` updating openSSL version to 3.0.15

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.71.1
+version: 3.71.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.71.1](https://img.shields.io/badge/Version-3.71.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.71.2](https://img.shields.io/badge/Version-3.71.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -750,6 +750,8 @@ helm install <RELEASE_NAME> \
 | datadog.kubelet.tlsVerify | string | true | Toggle kubelet TLS verification |
 | datadog.kubernetesEvents.collectedEventTypes | list | `[{"kind":"Pod","reasons":["Failed","BackOff","Unhealthy","FailedScheduling","FailedMount","FailedAttachVolume"]},{"kind":"Node","reasons":["TerminatingEvictedPod","NodeNotReady","Rebooted","HostPortConflict"]},{"kind":"CronJob","reasons":["SawCompletedJob"]}]` | Event types to be collected. This requires datadog.kubernetesEvents.unbundleEvents to be set to true. |
 | datadog.kubernetesEvents.unbundleEvents | bool | `false` | Allow unbundling kubernetes events, 1:1 mapping between Kubernetes and Datadog events. (Requires Cluster Agent 7.42.0+). |
+| datadog.kubernetesResourcesAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Resources Annotations to Datadog Tags |
+| datadog.kubernetesResourcesLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Resources Labels to Datadog Tags |
 | datadog.leaderElection | bool | `true` | Enables leader election mechanism for event collection |
 | datadog.leaderElectionResource | string | `"configmap"` | Selects the default resource to use for leader election. Can be: * "lease" / "leases". Only supported in agent 7.47+ * "configmap" / "configmaps". "" to automatically detect which one to use. |
 | datadog.leaderLeaseDuration | string | `nil` | Set the lease time for leader election in second |

--- a/charts/datadog/templates/_components-common-env.yaml
+++ b/charts/datadog/templates/_components-common-env.yaml
@@ -46,6 +46,14 @@
 - name: DD_KUBERNETES_NAMESPACE_ANNOTATIONS_AS_TAGS
   value: '{{ toJson .Values.datadog.namespaceAnnotationsAsTags }}'
 {{- end }}
+{{- if .Values.datadog.kubernetesResourcesLabelsAsTags }}
+- name: DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS
+  value: '{{ toJson .Values.datadog.kubernetesResourcesLabelsAsTags }}'
+{{- end}}
+{{- if .Values.datadog.kubernetesResourcesAnnotationsAsTags }}
+- name: DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS
+  value: '{{ toJson .Values.datadog.kubernetesResourcesAnnotationsAsTags }}'
+{{- end}}
 - name: KUBERNETES
   value: "yes"
 {{- if .Values.datadog.site }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -254,6 +254,28 @@ datadog:
   #   env: environment
   #   <KUBERNETES_NAMESPACE_ANNOTATIONS>: <DATADOG_TAG_KEY>
 
+  # datadog.kubernetesResourcesLabelsAsTags -- Provide a mapping of Kubernetes Resources Labels to Datadog Tags
+  kubernetesResourcesLabelsAsTags: {}
+  #    deployments.apps:
+  #      x-team: team-from-label
+  #    pods:
+  #      x-ref: reference
+  #    namespaces:
+  #      kubernetes.io/metadata.name: name-as-tag
+  #    <RESOURCE_TYPE>:
+  #      <KUBERNETES_RESOURCE_LABEL>: <DATADOG_TAG_KEY>
+
+  # datadog.kubernetesResourcesAnnotationsAsTags -- Provide a mapping of Kubernetes Resources Annotations to Datadog Tags
+  kubernetesResourcesAnnotationsAsTags: {}
+  #    deployments.apps:
+  #      x-team: team-from-annotation
+  #    pods:
+  #      x-ann: annotation-reference
+  #    namespaces:
+  #      stale-annotation: annotation-as-tag
+  #    <RESOURCE_TYPE>:
+  #      <KUBERNETES_RESOURCE_ANNOTATION>: <DATADOG_TAG_KEY>
+
   originDetectionUnified:
     # datadog.originDetectionUnified.enabled -- Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+).
     enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

[CONTP-375](https://datadoghq.atlassian.net/browse/CONTP-375) Exposing kubernetesResourcesAnnotationsAsTags and kubernetesResourcesLabelsAsTags options in a generic format. We recently added support for these fields in [PR](https://github.com/DataDog/datadog-agent/pull/27369), however, it's not exposed in the public helm chart.

#### Special notes for your reviewer:

QA'd locally via `helm install datadog-agent -f ~/.../values/linux.yaml ~/Desktop/Datadog/helm-charts/charts/datadog`following steps for [parent issue](https://datadoghq.atlassian.net/browse/CONTP-277)

```
datadog:
  logLevel: DEBUG
  kubelet:
    tlsVerify: false

  logs:
    enabled: true
    containerCollectAll: true

  clusterTagger:
    # datadog.clusterTagger.collectKubernetesTags -- Enables Kubernetes resources tags collection.
    collectKubernetesTags: true

  podLabelsAsTags:
    stale-label: stale-label
  podAnnotationsAsTags:
    stale-annotation: stale-annotation

  namespaceLabelsAsTags:
    stale-label: stale-label

  namespaceAnnotationsAsTags:
    stale-annotation: stale-annotation-should-be-overridden

  nodeLabelsAsTags:
    kubernetes.io/arch: should-not-be-used-should-be-overridden

  # NEW
  kubernetesResourcesLabelsAsTags:
    deployments.apps:
      x-team: team-from-label
    pods:
      x-ref: reference
    namespaces:
      kubernetes.io/metadata.name: name-as-tag
    nodes:
      kubernetes.io/os: os-as-tag
      kubernetes.io/arch: arch-as-tag

  # NEW
  kubernetesResourcesAnnotationsAsTags:
    deployments.apps:
      x-team: team-from-annotation
    pods:
      x-ann: annotation-reference
    namespaces:
      stale-annotation: annotation-as-tag

agents:
  enabled: true
  replicas: 1
  image:
    tag: 7.58.0-rc.1
    doNotCheckTag: true

clusterAgent:
  enabled: true
  replicas: 1
  image:
    tag: 7.58.0-rc.1
    doNotCheckTag: true
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`


[CONTP-375]: https://datadoghq.atlassian.net/browse/CONTP-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ