### PR TITLE
[ci] rm paths-ignore from lint and test charts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,6 @@ on:
   pull_request:
     paths:
       - "charts/**"
-    paths-ignore:
-      - 'test/**'
 
 jobs:
   changed:


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove paths-ignore which was added in #1538 and had unintended consequences

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
