### PR TITLE
add verb escalate to clusterroles

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.2
+* Add the `escalate` verb to `clusterroles` so the operator can update the orchestrator check's cluster role to collect custom resources.
+
 ## 2.0.1
 
 * Make Operator `livenessProbe` configurable.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.8.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -312,6 +312,7 @@ rules:
   - patch
   - update
   - watch
+  - escalate
 - apiGroups:
   - authorization.k8s.io
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

Add the escalate verb to clusterroles so the operator can update the orchestrator check's cluster role to collect custom resources. 

https://kubernetes.io/docs/concepts/security/rbac-good-practices/#escalate-verb

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
