### PR TITLE
[CONTP-375] Adding RBACs for DCA to read resource annotations and labels for tagging

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.73.1
+
+* Add role-based access control rules to Datadog Cluster Agent to read k8s resources annotations and labels to create tags.
+
 ## 3.73.0
 
 * Add Azure Container Registry, enabled automatically when targeting `us3.datadoghq.com`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.73.0
+version: 3.73.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.73.0](https://img.shields.io/badge/Version-3.73.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.73.1](https://img.shields.io/badge/Version-3.73.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -486,4 +486,61 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "datadog.fullname" . }}-cluster-agent
     namespace: {{ .Release.Namespace }}
+{{- end}}
+
+{{- if or .Values.datadog.kubernetesResourcesAnnotationsAsTags .Values.datadog.kubernetesResourcesLabelsAsTags}}
+---
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  labels:
+{{ include "datadog.labels" . | indent 4 }}
+  name: {{ template "datadog.fullname" . }}-cluster-agent-annotations-and-labels-as-tags
+  namespace: {{ .Release.Namespace }}
+
+{{- $groupedResources := dict }}
+{{- $mergedResources := merge (default dict .Values.datadog.kubernetesResourcesAnnotationsAsTags) (default dict .Values.datadog.kubernetesResourcesLabelsAsTags)}}
+{{- range $resource, $labels := $mergedResources }}
+  {{- $parts := split "." $resource }}
+  {{- $apiGroup := "" }}
+  {{- $resourceName := $resource }}
+  {{- if eq (len $parts) 2 }}
+    {{- $apiGroup = index $parts "_1" }}
+    {{- $resourceName = index $parts "_0" }}
+  {{- end }}
+  {{- $existing := index $groupedResources $apiGroup | default (list) }}
+  {{- $groupedResources = set $groupedResources $apiGroup (append $existing $resourceName) }}
+{{- end }}
+
+rules:
+
+# Iterate through the apiGroups and create rules for each resource
+{{- range $apiGroup, $resources := $groupedResources }}
+- apiGroups:
+  - "{{ $apiGroup }}"
+  resources:
+  {{- range $resource := $resources }}
+  - {{ $resource }}
+  {{- end }}
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+
+---
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+{{ include "datadog.labels" . | indent 4 }}
+  name: {{ template "datadog.fullname" . }}-cluster-agent-annotations-and-labels-as-tags
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "datadog.fullname" . }}-cluster-agent-annotations-and-labels-as-tags
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "datadog.fullname" . }}-cluster-agent
+    namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds needed RBACs to the DCA in order for the k8s resource annotations as tags and k8s resource labels as tags feature to work. Follow up to last [PR](https://github.com/DataDog/helm-charts/pull/1534) which added the feature.

#### Special notes for your reviewer:

<img width="874" alt="Screenshot 2024-10-03 at 2 52 31 PM" src="https://github.com/user-attachments/assets/2bbcdd93-6207-415d-91dd-64a52b09c81a">

<img width="1073" alt="Screenshot 2024-10-03 at 2 54 22 PM" src="https://github.com/user-attachments/assets/57898722-dc77-4234-a36d-0045598c91cb">


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] `CHANGELOG.md` has been updated
