### PR TITLE
feat(datadog-operator): add ValidatingWebhookConfigurations RBAC

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+* Add `admissionregistration.k8s.io/v1/validatingwebhookconfigurations` RBACs to the Operator.
+
 ## 2.0.1
 
 * Make Operator `livenessProbe` configurable.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.8.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -199,16 +199,10 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
+  - validatingwebhookconfigurations
   - mutatingwebhookconfigurations
   verbs:
   - '*'
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - validatingwebhookconfigurations
-  verbs:
-  - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.0.1
+    helm.sh/chart: datadog-operator-2.0.2
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the necessary RBACs for the Cluster Agent to modify the `ValidatingWebhookConfigurations`.

This is needed to support the new `ValidatingAdmissionWebhook` controller in the Agent's Admission Controller.

#### Special notes for your reviewer:

QA:
For the Datadog Operator Helm Chart:
```
➜ k describe clusterroles.rbac.authorization.k8s.io datadog-operator
Name:         datadog-operator
Labels:       app.kubernetes.io/instance=datadog-operator
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=datadog-operator
              app.kubernetes.io/version=1.8.0
              helm.sh/chart=datadog-operator-2.0.1
Annotations:  meta.helm.sh/release-name: datadog-operator
              meta.helm.sh/release-namespace: default
PolicyRule:
  Resources                                                     Non-Resource URLs  Resource Names  Verbs
  ---------                                                     -----------------  --------------  -----
  apiservices.apiregistration.k8s.io                            []                 []              [* list watch]
  mutatingwebhookconfigurations.admissionregistration.k8s.io    []                 []              [*]
  validatingwebhookconfigurations.admissionregistration.k8s.io  []                 []              [*]
```
Since the Operator that applies the `validatingwebhookconfigurations.admissionregistration.k8s.io` RBACs to the Cluster Agent is not yet released, the Cluster Agent will not have the correct RBACs, that is expected.
```
➜  k exec -it deployments/datadog-cluster-agent -- agent status
[...]
====================
Admission Controller
====================

    Webhooks info
    -------------

      ValidatingWebhookConfigurations name: datadog-webhook
      Error: validatingwebhookconfigurations.admissionregistration.k8s.io "datadog-webhook" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "validatingwebhookconfigurations" in API group "admissionregistration.k8s.io" at the cluster scope


      MutatingWebhookConfigurations name: datadog-webhook
      Created at: 2024-08-30 13:07:45 +0000 UTC
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
