### PR TITLE
Fix helm installation warnings

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.75.0
+* Fix warning message displayed when installing/upgrading the Agent with OTel collector. 
+* Add preview message in values.yaml file 
+
 ## 3.74.0
 
 * Simplify OTel Agent OOTB pipelines:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.74.0
+version: 3.75.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -450,6 +450,9 @@ helm install <RELEASE_NAME> \
   --set datadog.apiKey=<DATADOG_API_KEY>,datadog.logLevel=DEBUG \
   datadog/datadog
 ```
+## OTel Collector
+
+The OTel collector is in preview. Please reach out to your Datadog representative for more information. You can use OTLP ingest, a GA feature for sending OTLP data to Agent.
 
 ## Values
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.74.0](https://img.shields.io/badge/Version-3.74.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.75.0](https://img.shields.io/badge/Version-3.75.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -450,9 +450,6 @@ helm install <RELEASE_NAME> \
   --set datadog.apiKey=<DATADOG_API_KEY>,datadog.logLevel=DEBUG \
   datadog/datadog
 ```
-## OTel Collector
-
-The OTel collector is in preview. Please reach out to your Datadog representative for more information. You can use OTLP ingest, a GA feature for sending OTLP data to Agent.
 
 ## Values
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -773,7 +773,7 @@ helm install <RELEASE_NAME> \
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
 | datadog.originDetectionUnified.enabled | bool | `false` | Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+). |
 | datadog.osReleasePath | string | `"/etc/os-release"` | Specify the path to your os-release file |
-| datadog.otelCollector.config | object | `{}` | OTel collector configuration |
+| datadog.otelCollector.config | string | `nil` | OTel collector configuration |
 | datadog.otelCollector.enabled | bool | `false` | Enable the OTel Collector |
 | datadog.otelCollector.ports | list | `[{"containerPort":"4317","name":"otel-grpc"},{"containerPort":"4318","name":"otel-http"}]` | Ports that OTel Collector is listening |
 | datadog.otlp.logs.enabled | bool | `false` | Enable logs support in the OTLP ingest endpoint |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -605,5 +605,5 @@ OTel collector is not supported on GKE Autopilot.
 #################################################################
 ####               WARNING: Private Beta notice              ####
 #################################################################
-OTel collector is in private beta. Please reach out to your Datadog representative for more information.
+OTel collector is in preview. Please reach out to your Datadog representative for more information.
 {{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -544,22 +544,6 @@ datadog:
     iast:
       # datadog.asm.iast.enabled -- Enable Application Security Management Interactive Application Security Testing by injecting `DD_IAST_ENABLED=true` environment variable to all pods in the cluster
       enabled: false
-
-  ## OTel collector related configuration
-  otelCollector:
-    # datadog.otelCollector.enabled -- Enable the OTel Collector
-    enabled: false
-    # datadog.otelCollector.ports -- Ports that OTel Collector is listening
-    ports:
-
-        # Default GRPC port of OTLP receiver
-      - containerPort: "4317"
-        name: otel-grpc
-        # Default HTTP port of OTLP receiver
-      - containerPort: "4318"
-        name: otel-http
-    # datadog.otelCollector.config -- OTel collector configuration
-    config: {}
   ## OTLP ingest related configuration
   otlp:
     receiver:
@@ -584,6 +568,23 @@ datadog:
     logs:
       # datadog.otlp.logs.enabled -- Enable logs support in the OTLP ingest endpoint
       enabled: false
+  ## OTel collector is currently in preview. Please reach out to your Datadog representative for more information.
+  ## For sending OTLP data to Datadog, you can use the Datadog OTLP ingest.
+  ## OTel collector related configuration
+  otelCollector:
+    # datadog.otelCollector.enabled -- Enable the OTel Collector
+    enabled: false
+    # datadog.otelCollector.ports -- Ports that OTel Collector is listening
+    ports:
+
+        # Default GRPC port of OTLP receiver
+      - containerPort: "4317"
+        name: otel-grpc
+        # Default HTTP port of OTLP receiver
+      - containerPort: "4318"
+        name: otel-http
+    # datadog.otelCollector.config -- OTel collector configuration
+    config: null
 
   ## Continuous Profiler configuration
   ##

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -569,7 +569,7 @@ datadog:
       # datadog.otlp.logs.enabled -- Enable logs support in the OTLP ingest endpoint
       enabled: false
   ## OTel collector is currently in preview. Please reach out to your Datadog representative for more information.
-  ## For sending OTLP data to Datadog, you can use the Datadog OTLP ingest.
+  ## OTLP Ingest is the GA feature for sending OTLP data to Datadog Agent.
   ## OTel collector related configuration
   otelCollector:
     # datadog.otelCollector.enabled -- Enable the OTel Collector


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes the warning message during the installation of Agent with Otel Collector. Adds preview message. 
Previously we were getting 
```
coalesce.go:286: warning: cannot overwrite table with non table for datadog.datadog.otelCollector.config (map[])
coalesce.go:286: warning: cannot overwrite table with non table for datadog.datadog.otelCollector.config (map[])
```
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
