### PR TITLE
Add a new option `datadog.apm.useLocalService` to disable hostPorts for the trace-agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.74.1
+* Add a new option to disable hostPorts for the trace-agent with `datadog.apm.useLocalService`.
+* This is for K8s clusters that restrict hostPorts and hostPaths volumes, therefore can only use the K8s local service to send traces.
+
 ## 3.74.0
 
 * Simplify OTel Agent OOTB pipelines:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.74.0
+version: 3.74.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.74.0](https://img.shields.io/badge/Version-3.74.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.74.1](https://img.shields.io/badge/Version-3.74.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -683,6 +683,7 @@ helm install <RELEASE_NAME> \
 | datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (hostPort 8126 by default) |
 | datadog.apm.socketEnabled | bool | `true` | Enable APM over Socket (Unix Socket or windows named pipe) |
 | datadog.apm.socketPath | string | `"/var/run/datadog/apm.socket"` | Path to the trace-agent socket |
+| datadog.apm.useLocalService | bool | `false` | Enable APM over TCP communication use the local service only (requires Kubernetes v1.22+) Note: The hostPort 8126 is disabled when this is enabled. |
 | datadog.apm.useSocketVolume | bool | `false` | Enable APM over Unix Domain Socket DEPRECATED. Use datadog.apm.socketEnabled instead |
 | datadog.appKey | string | `nil` | Datadog APP key required to use metricsProvider |
 | datadog.appKeyExistingSecret | string | `nil` | Use existing Secret which stores APP key instead of creating a new one. The value should be set with the `app-key` key inside the secret. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -699,7 +699,7 @@ helm install <RELEASE_NAME> \
 | datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (hostPort 8126 by default) |
 | datadog.apm.socketEnabled | bool | `true` | Enable APM over Socket (Unix Socket or windows named pipe) |
 | datadog.apm.socketPath | string | `"/var/run/datadog/apm.socket"` | Path to the trace-agent socket |
-| datadog.apm.useLocalService | bool | `false` | Enable APM over TCP communication use the local service only (requires Kubernetes v1.22+) Note: The hostPort 8126 is disabled when this is enabled. |
+| datadog.apm.useLocalService | bool | `false` | Enable APM over TCP communication to use the local service only (requires Kubernetes v1.22+) Note: The hostPort 8126 is disabled when this is enabled. |
 | datadog.apm.useSocketVolume | bool | `false` | Enable APM over Unix Domain Socket DEPRECATED. Use datadog.apm.socketEnabled instead |
 | datadog.appKey | string | `nil` | Datadog APP key required to use metricsProvider |
 | datadog.appKeyExistingSecret | string | `nil` | Use existing Secret which stores APP key instead of creating a new one. The value should be set with the `app-key` key inside the secret. |

--- a/charts/datadog/ci/agent-apm-use-local-service-values.yaml
+++ b/charts/datadog/ci/agent-apm-use-local-service-values.yaml
@@ -1,0 +1,11 @@
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  kubelet:
+    tlsVerify: false
+  dogstatsd:
+    useSocketVolume: false
+  apm:
+    portEnabled: false
+    socketEnabled: false
+    useLocalService: true

--- a/charts/datadog/ci/agent-apm-use-local-service-values.yaml
+++ b/charts/datadog/ci/agent-apm-use-local-service-values.yaml
@@ -9,4 +9,3 @@ datadog:
     portEnabled: false
     socketEnabled: false
     useLocalService: true
-    

--- a/charts/datadog/ci/agent-apm-use-local-service-values.yaml
+++ b/charts/datadog/ci/agent-apm-use-local-service-values.yaml
@@ -9,3 +9,4 @@ datadog:
     portEnabled: false
     socketEnabled: false
     useLocalService: true
+    

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -240,6 +240,20 @@ The option `datadog.apm.socketEnabled` is enabled by default and can be used to 
 
 {{- end }}
 
+{{- if .Values.datadog.apm.useLocalService }}
+
+#################################################################
+####               WARNING: Configuration notice             ####
+#################################################################
+
+The option `datadog.apm.useLocalService` will disable the trace-agent's hostPort.
+Make sure that `datadog.apm.portEnabled` is set to `false` for this to take effect.
+
+If you are using the Admission Controller APM library injection method to send traces to Datadog, this option will send traces via TCP to the local service.
+Make sure that `datadog.apm.socketEnabled` is set to `false` when enabling this or it defaults to sending traces via UDS.
+
+{{- end }}
+
 {{- if or .Values.datadog.systemProbe.enableKernelHeaderDownload .Values.datadog.systemProbe.enableRuntimeCompiler }}
 
 #################################################################

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -466,7 +466,7 @@ false
 Return true if a trace-agent needs to be deployed.
 */}}
 {{- define "should-enable-trace-agent" -}}
-{{- if or (eq  (include "trace-agent-use-tcp-port" .) "true") (eq  (include "trace-agent-use-uds" .) "true") -}}
+{{- if or (eq  (include "trace-agent-use-tcp-port" .) "true") (eq  (include "trace-agent-use-uds" .) "true") (eq (include "trace-agent-use-local-service")) -}}
 true
 {{- else -}}
 false
@@ -502,9 +502,17 @@ false
 {{- end -}}
 
 {{/*
-Return true if a traffic over TCP is configured for APM.
+Return true if APM is configured to only use local service via the trace-agent's containerPort otherwise matches datadog.apm.portEnabled.
 */}}
-{{- define "trace-agent-use-tcp-port" -}}
+{{- define "trace-agent-use-local-service" -}}
+{{- default (include "trace-agent-use-host-port" .) .Values.datadog.apm.useLocalService -}}
+{{- end -}}
+
+
+{{/*
+Return true if a host port is desired for APM.
+*/}}
+{{- define "trace-agent-use-host-port" -}}
 {{- if or .Values.datadog.apm.portEnabled .Values.datadog.apm.enabled -}}
 true
 {{- else -}}
@@ -512,6 +520,16 @@ false
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return true if a traffic over TCP is configured for APM.
+*/}}
+{{- define "trace-agent-use-tcp-port" -}}
+{{- if or (eq  (include "trace-agent-use-host-port" .) "true") (eq  (include "trace-agent-use-local-service" .) "true") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
 
 {{/*
 Return true if Kubernetes resource monitoring (orchestrator explorer) should be enabled.

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -466,7 +466,7 @@ false
 Return true if a trace-agent needs to be deployed.
 */}}
 {{- define "should-enable-trace-agent" -}}
-{{- if or (eq  (include "trace-agent-use-tcp-port" .) "true") (eq  (include "trace-agent-use-uds" .) "true") (eq (include "trace-agent-use-local-service")) -}}
+{{- if or (eq  (include "trace-agent-use-tcp-port" .) "true") (eq  (include "trace-agent-use-uds" .) "true") (eq (include "trace-agent-use-local-service" .) "true") -}}
 true
 {{- else -}}
 false

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -213,8 +213,10 @@ spec:
             value: {{ .Values.clusterAgent.admissionController.configMode }}
             {{- else if eq (include "trace-agent-use-uds" .) "true" }}
             value: socket
-            {{- else if or (eq (include "trace-agent-use-tcp-port" .) "true") ( .Values.providers.gke.autopilot )}}
+            {{- else if or (eq (include "trace-agent-use-host-port" .) "true") ( .Values.providers.gke.autopilot )}}
             value: hostip
+            {{- else if (eq (include "trace-agent-use-local-service" .) "true")}}
+            value: service
             {{- else if or (not .Values.datadog.apm.enabled ) (and (eq (include "trace-agent-use-tcp-port" .) "true") (eq (include "trace-agent-use-uds" .) "true")) }}
             value: socket
             {{- else }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -479,6 +479,12 @@ datadog:
     ## ref: https://docs.datadoghq.com/agent/kubernetes/apm/
     portEnabled: false
 
+    # datadog.apm.useLocalService -- Enable APM over TCP communication use the local service only (requires Kubernetes v1.22+)
+    # Note: The hostPort 8126 is disabled when this is enabled.
+
+    ## ref: https://docs.datadoghq.com/tracing/guide/setting_up_apm_with_kubernetes_service/?tab=helm
+    useLocalService: false
+
     # datadog.apm.enabled -- Enable this to enable APM and tracing, on port 8126
     # DEPRECATED. Use datadog.apm.portEnabled instead
 
@@ -1150,6 +1156,7 @@ clusterAgent:
     ## If clusterAgent.admissionController.configMode is not set:
     ##   * and datadog.apm.socketEnabled is true, the Admission Controller uses socket.
     ##   * and datadog.apm.portEnabled is true, the Admission Controller uses hostip.
+    ##   * and datadog.apm.useLocalService is true and the aformentioned two are false, the Admission Controller uses service.
     ##   * Otherwise, the Admission Controller defaults to hostip.
     ## Note: "service" mode relies on the internal traffic service to target the agent running on the local node (requires Kubernetes v1.22+).
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/#configure-apm-and-dogstatsd-communication-mode

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -481,7 +481,7 @@ datadog:
     ## ref: https://docs.datadoghq.com/agent/kubernetes/apm/
     portEnabled: false
 
-    # datadog.apm.useLocalService -- Enable APM over TCP communication use the local service only (requires Kubernetes v1.22+)
+    # datadog.apm.useLocalService -- Enable APM over TCP communication to use the local service only (requires Kubernetes v1.22+)
     # Note: The hostPort 8126 is disabled when this is enabled.
 
     ## ref: https://docs.datadoghq.com/tracing/guide/setting_up_apm_with_kubernetes_service/?tab=helm


### PR DESCRIPTION
#### What this PR does / why we need it:
- Add a new option to disable hostPorts for the trace-agent with `datadog.apm.useLocalService`.
- This is for K8s clusters that restrict hostPorts and hostPaths volumes, therefore can only use the K8s local service to send traces. 

#### Which issue this PR fixes
Currently there is no option to disable the trace-agent's host port and disable UDS for APM since at the moment, the trace-agent gets disabled if both of these are disabled when `datadog.portEnabled` and `datadog.socketEnabled` are both set to `false` respectively.
This PR aims to provide a more flexible option to disable both the host port and UDS and still being able to send traces to the local service.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
