### PR TITLE
Update crds for operator v1.9.0

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+
+* Update CRDs from Datadog Operator v1.9.0 tag.
+* Add DatadogDashboards CRD.
+
 ## 2.0.0
 
 * Update CRDs from Datadog Operator v1.8.0 tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.0.0
+version: 2.1.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 
@@ -24,6 +24,7 @@ But the recommended Kubernetes versions are `1.16+`.
 |-----|------|---------|-------------|
 | crds.datadogAgentProfiles | bool | `false` | Set to true to deploy the DatadogAgentProfiles CRD |
 | crds.datadogAgents | bool | `false` | Set to true to deploy the DatadogAgents CRD |
+| crds.datadogDashboards | bool | `false` | Set to true to deploy the DatadogDashboards CRD |
 | crds.datadogMetrics | bool | `false` | Set to true to deploy the DatadogMetrics CRD |
 | crds.datadogMonitors | bool | `false` | Set to true to deploy the DatadogMonitors CRD |
 | crds.datadogPodAutoscalers | bool | `false` | Set to true to deploy the DatadogPodAutoscalers CRD |

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
@@ -250,7 +250,40 @@ spec:
                               If not specified, the pod priority will be default or zero if there is no
                               default.
                             type: string
+                          updateStrategy:
+                            description: |-
+                              The deployment strategy to use to replace existing pods with new ones.
+                              Valid types are `RollingUpdate` or `OnDelete` for DaemonSets
+                            properties:
+                              rollingUpdate:
+                                description: Configure the rolling update strategy of the Deployment or DaemonSet.
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      MaxSurge behaves differently based on the Kubernetes resource. Refer to the
+                                      Kubernetes API documentation for additional details.
+                                    x-kubernetes-int-or-string: true
+                                  maxUnavailable:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      The maximum number of pods that can be unavailable during the update.
+                                      Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                      Refer to the Kubernetes API documentation for additional details..
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: |-
+                                  Type can be "RollingUpdate" or "OnDelete" for DaemonSets and "RollingUpdate"
+                                  or "Recreate" for Deployments
+                                type: string
+                            type: object
                         type: object
+                      description: Override the default configurations of the node agent.
                       type: object
                   type: object
                 profileAffinity:
@@ -373,6 +406,29 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                createStrategy:
+                  description: CreateStrategy is the state of the create strategy feature.
+                  properties:
+                    lastTransition:
+                      description: LastTransition is the last time the status was updated.
+                      format: date-time
+                      type: string
+                    maxUnavailable:
+                      description: MaxUnavailable shows the number of pods that can be in an unready state.
+                      format: int32
+                      type: integer
+                    nodesLabeled:
+                      description: NodesLabeled shows the number of nodes currently labeled.
+                      format: int32
+                      type: integer
+                    podsReady:
+                      description: PodsReady shows the number of pods in the ready state.
+                      format: int32
+                      type: integer
+                    status:
+                      description: Status shows the current state of the feature.
+                      type: string
+                  type: object
                 currentHash:
                   description: CurrentHash is the stored hash of the DatadogAgentProfile.
                   type: string

--- a/charts/datadog-crds/templates/datadoghq.com_datadogdashboards_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogdashboards_v1.yaml
@@ -1,0 +1,268 @@
+{{- if and .Values.crds.datadogDashboards (semverCompare ">1.21-0" .Capabilities.KubeVersion.GitVersion ) }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: datadogdashboards.datadoghq.com
+  labels:
+    helm.sh/chart: '{{ include "datadog-crds.chart" . }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "datadog-crds.name" . }}'
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: |-
+                      Condition contains details for one aspect of the current state of this API Resource.
+                      ---
+                      This struct is intended for direct use as an array at the field path .status.conditions.  For example,
+
+
+                      	type FooStatus struct{
+                      	    // Represents the observations of a foo's current state.
+                      	    // Known .status.conditions.type are: "Available", "Progressing", and "Degraded"
+                      	    // +patchMergeKey=type
+                      	    // +patchStrategy=merge
+                      	    // +listType=map
+                      	    // +listMapKey=type
+                      	    Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+
+                      	    // other fields
+                      	}
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+{{- end }}

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -132,6 +132,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     notifyNoData:
                       description: A Boolean indicating whether this monitor notifies when data stops reporting.
                       type: boolean
@@ -159,6 +160,7 @@ spec:
                         description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     requireFullWindow:
                       description: |-
                         A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
@@ -278,9 +280,11 @@ spec:
                 downtimeStatus:
                   description: DowntimeStatus defines whether the monitor is downtimed
                   properties:
-                    downtimeId:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
                       type: integer
                     isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
                       type: boolean
                   type: object
                 id:
@@ -301,14 +305,14 @@ spec:
                   description: MonitorStateLastUpdateTime is the last time the monitor state updated
                   format: date-time
                   type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
                 primary:
                   description: |-
                     Primary defines whether the monitor is managed by the Kubernetes custom
                     resource (true) or outside Kubernetes (false)
                   type: boolean
-                syncStatus:
-                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
-                  type: string
                 triggeredState:
                   description: TriggeredState only includes details for monitor groups that are triggering
                   items:

--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -59,3 +59,4 @@ download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogmonitors da
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogslos datadogSLOs v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogagentprofiles datadogAgentProfiles v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogpodautoscalers datadogPodAutoscalers v1
+download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogdashboards datadogDashboards v1

--- a/charts/datadog-crds/values.yaml
+++ b/charts/datadog-crds/values.yaml
@@ -15,6 +15,8 @@ crds:
   datadogAgentProfiles: false
   # crds.datadogPodAutoscalers -- Set to true to deploy the DatadogPodAutoscalers CRD
   datadogPodAutoscalers: false
+  # crds.datadogDashboards -- Set to true to deploy the DatadogDashboards CRD
+  datadogDashboards: false
 
 # nameOverride -- Override name of app
 nameOverride: ""

--- a/crds/datadoghq.com_datadogagentprofiles.yaml
+++ b/crds/datadoghq.com_datadogagentprofiles.yaml
@@ -244,7 +244,40 @@ spec:
                               If not specified, the pod priority will be default or zero if there is no
                               default.
                             type: string
+                          updateStrategy:
+                            description: |-
+                              The deployment strategy to use to replace existing pods with new ones.
+                              Valid types are `RollingUpdate` or `OnDelete` for DaemonSets
+                            properties:
+                              rollingUpdate:
+                                description: Configure the rolling update strategy of the Deployment or DaemonSet.
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      MaxSurge behaves differently based on the Kubernetes resource. Refer to the
+                                      Kubernetes API documentation for additional details.
+                                    x-kubernetes-int-or-string: true
+                                  maxUnavailable:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      The maximum number of pods that can be unavailable during the update.
+                                      Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                      Refer to the Kubernetes API documentation for additional details..
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: |-
+                                  Type can be "RollingUpdate" or "OnDelete" for DaemonSets and "RollingUpdate"
+                                  or "Recreate" for Deployments
+                                type: string
+                            type: object
                         type: object
+                      description: Override the default configurations of the node agent.
                       type: object
                   type: object
                 profileAffinity:
@@ -367,6 +400,29 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                createStrategy:
+                  description: CreateStrategy is the state of the create strategy feature.
+                  properties:
+                    lastTransition:
+                      description: LastTransition is the last time the status was updated.
+                      format: date-time
+                      type: string
+                    maxUnavailable:
+                      description: MaxUnavailable shows the number of pods that can be in an unready state.
+                      format: int32
+                      type: integer
+                    nodesLabeled:
+                      description: NodesLabeled shows the number of nodes currently labeled.
+                      format: int32
+                      type: integer
+                    podsReady:
+                      description: PodsReady shows the number of pods in the ready state.
+                      format: int32
+                      type: integer
+                    status:
+                      description: Status shows the current state of the feature.
+                      type: string
+                  type: object
                 currentHash:
                   description: CurrentHash is the stored hash of the DatadogAgentProfile.
                   type: string

--- a/crds/datadoghq.com_datadogdashboards.yaml
+++ b/crds/datadoghq.com_datadogdashboards.yaml
@@ -1,0 +1,261 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: datadogdashboards.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+      - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.id
+          name: id
+          type: string
+        - jsonPath: .status.syncStatus
+          name: sync status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DatadogDashboard is the Schema for the datadogdashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+              properties:
+                description:
+                  description: Description is the description of the dashboard.
+                  type: string
+                layoutType:
+                  description: LayoutType is the layout type of the dashboard.
+                  type: string
+                notifyList:
+                  description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                reflowType:
+                  description: |-
+                    Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                    If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                    widgets should not have layouts.
+                  type: string
+                tags:
+                  description: Tags is a list of team names representing ownership of a dashboard.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                templateVariablePresets:
+                  description: TemplateVariablePresets is an array of template variables saved views.
+                  items:
+                    description: DashboardTemplateVariablePreset Template variables saved views.
+                    properties:
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      templateVariables:
+                        description: List of variables.
+                        items:
+                          description: DashboardTemplateVariablePresetValue Template variables saved views.
+                          properties:
+                            name:
+                              description: The name of the variable.
+                              type: string
+                            values:
+                              description: One or many template variable values within the saved view, which will be unioned together using `OR` if more than one is specified. Cannot be used in conjunction with `value`.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                templateVariables:
+                  description: TemplateVariables is a list of template variables for this dashboard.
+                  items:
+                    description: DashboardTemplateVariable Template variable.
+                    properties:
+                      availableValues:
+                        description: The list of values that the template variable drop-down is limited to.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: One or many default values for template variables on load. If more than one default is specified, they will be unioned together with `OR`. Cannot be used in conjunction with `default`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      name:
+                        description: The name of the variable.
+                        type: string
+                      prefix:
+                        description: The tag prefix associated with the variable. Only tags with this prefix appear in the variable drop-down.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                title:
+                  description: Title is the title of the dashboard.
+                  type: string
+                widgets:
+                  description: Widgets is a JSON string representation of a list of Datadog API Widgets
+                  type: string
+              type: object
+            status:
+              description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the state of a DatadogDashboard.
+                  items:
+                    description: |-
+                      Condition contains details for one aspect of the current state of this API Resource.
+                      ---
+                      This struct is intended for direct use as an array at the field path .status.conditions.  For example,
+
+
+                      	type FooStatus struct{
+                      	    // Represents the observations of a foo's current state.
+                      	    // Known .status.conditions.type are: "Available", "Progressing", and "Degraded"
+                      	    // +patchMergeKey=type
+                      	    // +patchStrategy=merge
+                      	    // +listType=map
+                      	    // +listMapKey=type
+                      	    Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+
+                      	    // other fields
+                      	}
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                created:
+                  description: Created is the time the dashboard was created.
+                  format: date-time
+                  type: string
+                creator:
+                  description: Creator is the identity of the dashboard creator.
+                  type: string
+                currentHash:
+                  description: |-
+                    CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                    if the Spec has changed and needs an update.
+                  type: string
+                id:
+                  description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
+                  format: date-time
+                  type: string
+                syncStatus:
+                  description: SyncStatus shows the health of syncing the dashboard state to Datadog.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/crds/datadoghq.com_datadogmonitors.yaml
+++ b/crds/datadoghq.com_datadogmonitors.yaml
@@ -126,6 +126,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     notifyNoData:
                       description: A Boolean indicating whether this monitor notifies when data stops reporting.
                       type: boolean
@@ -153,6 +154,7 @@ spec:
                         description: MonitorRenotifyStatusType The different statuses for which renotification is supported.
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     requireFullWindow:
                       description: |-
                         A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
@@ -272,9 +274,11 @@ spec:
                 downtimeStatus:
                   description: DowntimeStatus defines whether the monitor is downtimed
                   properties:
-                    downtimeId:
+                    downtimeID:
+                      description: DowntimeID is the downtime ID.
                       type: integer
                     isDowntimed:
+                      description: IsDowntimed shows the downtime status of the monitor.
                       type: boolean
                   type: object
                 id:
@@ -295,14 +299,14 @@ spec:
                   description: MonitorStateLastUpdateTime is the last time the monitor state updated
                   format: date-time
                   type: string
+                monitorStateSyncStatus:
+                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
+                  type: string
                 primary:
                   description: |-
                     Primary defines whether the monitor is managed by the Kubernetes custom
                     resource (true) or outside Kubernetes (false)
                   type: boolean
-                syncStatus:
-                  description: MonitorStateSyncStatus shows the health of syncing the monitor state to Datadog
-                  type: string
                 triggeredState:
                   description: TriggeredState only includes details for monitor groups that are triggering
                   items:


### PR DESCRIPTION
#### What this PR does / why we need it:

* Updates `datadog-crds` chart for operator v1.9.0
* Adds DatadogDashboards CRD

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
