### PR TITLE
Reverts #1541: do not attempt to mount `/usr/lib/sysimage/rpm`

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.74.3
+
+* Do not mount `/usr/lib/sysimage/rpm` (reverts https://github.com/DataDog/helm-charts/pull/1541): in some operating systems such as Bottlerocket, `/usr` is `read-only`, preventing the Agent from being deployed when `datadog.sbom.host.enabled` is set to `true` as kubelet cannot create the directory at this location if it does not exist.
+
 ## 3.74.2
 
 * Mount `/usr/lib/sysimage/rpm` in the Agent DaemonSet when using host SBOM feature (required on hosts running Amazon Linux distributions).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.74.2
+version: 3.74.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.74.2](https://img.shields.io/badge/Version-3.74.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.74.3](https://img.shields.io/badge/Version-3.74.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -291,9 +291,6 @@
     - name: host-rpm-dir
       mountPath: /host/var/lib/rpm
       readOnly: true
-    - name: host-sysimage-rpm
-      mountPath: /host/usr/lib/sysimage/rpm
-      readOnly: true
     {{- if ne .Values.datadog.osReleasePath "/etc/redhat-release" }}
     - name: etc-redhat-release
       mountPath: /host/etc/redhat-release

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -162,9 +162,6 @@
 - hostPath:
     path: /var/lib/rpm
   name: host-rpm-dir
-- hostPath:
-    path: /usr/lib/sysimage/rpm
-  name: host-sysimage-rpm
 {{- end }}
 {{- if eq  (include "should-enable-security-agent" .) "true" }}
 {{- if .Values.datadog.securityAgent.compliance.enabled }}


### PR DESCRIPTION
#### What this PR does / why we need it:
* Reverts https://github.com/DataDog/helm-charts/pull/1541: the SBOM feature is not compatible with Bottlerocket nodes. When enabling this feature, kubelet tries to create `/usr/lib/sysimage/rpm` on the node if the directory does not exist, but `/usr` is read-only, thus causing the pod to not be scheduled
```shell
  Warning  Failed     12m                  kubelet            Error: failed to generate container "9ccab0256589e0b5c0aae5d8f0f32dad3912f67ebf1595883a02b473a32e06b1" spec: failed to apply OCI options: failed to mkdir "/usr/lib/sysimage/rpm": mkdir /usr/lib/sysimage: read-only file system
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
