### PR TITLE
feat(admission controller): Add new webhook settings

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.75.0
+
+* Add `datadog.admissionController.validation` and `datadog.admissionController.mutation` to enable/disable the admission controller validation and mutation webhooks.
+
 ## 3.74.5
 
 * Add configuration option for `datadog.KubernetesEvents.sourceDetectionEnabled` to map Kubernetes events to integration sources based on controller names. Disabled by default.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.74.5
+version: 3.75.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.74.5](https://img.shields.io/badge/Version-3.74.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.75.0](https://img.shields.io/badge/Version-3.75.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -564,8 +564,12 @@ helm install <RELEASE_NAME> \
 | clusterAgent.admissionController.enabled | bool | `true` | Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods |
 | clusterAgent.admissionController.failurePolicy | string | `"Ignore"` | Set the failure policy for dynamic admission control.' |
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |
+| clusterAgent.admissionController.mutation | object | `{"enabled":true}` | Mutation Webhook configuration options |
+| clusterAgent.admissionController.mutation.enabled | bool | `true` | Enabled enables the Admission Controller mutation webhook. Default: true. (Requires Agent 7.59.0+). |
 | clusterAgent.admissionController.port | int | `8000` | Set port of cluster-agent admission controller service |
 | clusterAgent.admissionController.remoteInstrumentation.enabled | bool | `false` | Enable polling and applying library injection using Remote Config. # This feature is in beta, and enables Remote Config in the Cluster Agent. It also requires Cluster Agent version 7.43+. # Enabling this feature grants the Cluster Agent the permissions to patch Deployment objects in the cluster. |
+| clusterAgent.admissionController.validation | object | `{"enabled":true}` | Validation Webhook configuration options |
+| clusterAgent.admissionController.validation.enabled | bool | `true` | Enabled enables the Admission Controller validation webhook. Default: true. (Requires Agent 7.59.0+). |
 | clusterAgent.admissionController.webhookName | string | `"datadog-webhook"` | Name of the validatingwebhookconfiguration and mutatingwebhookconfiguration created by the cluster-agent |
 | clusterAgent.advancedConfd | object | `{}` | Provide additional cluster check configurations. Each key is an integration containing several config files. |
 | clusterAgent.affinity | object | `{}` | Allow the Cluster Agent Deployment to schedule using affinity rules |

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -203,6 +203,10 @@ spec:
           {{- if .Values.clusterAgent.admissionController.enabled }}
           - name: DD_ADMISSION_CONTROLLER_ENABLED
             value: {{ .Values.clusterAgent.admissionController.enabled | quote }}
+          - name: DD_ADMISSION_CONTROLLER_VALIDATION_ENABLED
+            value: {{ .Values.clusterAgent.admissionController.validation.enabled | quote }}
+          - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
+            value: {{ .Values.clusterAgent.admissionController.mutation.enabled | quote }}
           - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
             value: {{ .Values.clusterAgent.admissionController.webhookName | quote }}
           - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1141,6 +1141,16 @@ clusterAgent:
     # clusterAgent.admissionController.enabled -- Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods
     enabled: true
 
+    # clusterAgent.admissionController.validation -- Validation Webhook configuration options
+    validation:
+      # clusterAgent.admissionController.validation.enabled -- Enabled enables the Admission Controller validation webhook. Default: true. (Requires Agent 7.59.0+).
+      enabled: true
+
+    # clusterAgent.admissionController.mutation -- Mutation Webhook configuration options
+    mutation:
+      # clusterAgent.admissionController.mutation.enabled -- Enabled enables the Admission Controller mutation webhook. Default: true. (Requires Agent 7.59.0+).
+      enabled: true
+
     # clusterAgent.admissionController.webhookName -- Name of the validatingwebhookconfiguration and mutatingwebhookconfiguration created by the cluster-agent
     webhookName: datadog-webhook
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Add support for the new Cluster Agent Admission settings.

#### Special notes for your reviewer:

Using the following settings:
```
clusterAgent:
  enabled: true
  admissionController:
    enabled: true
    validation:
      enabled: false
    mutation:
      enabled: false
```

Make sure that the output of those commands is as follows:
```
➜ kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io -A
No resources found
➜ kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io -A
No resources found
```

Modify the setting with:
```
clusterAgent:
  enabled: true
  admissionController:
    enabled: true
    validation:
      enabled: true
    mutation:
      enabled: true
```
Make sure that the output changes to:
```
➜ kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io -A
NAME              WEBHOOKS   AGE
datadog-webhook   0          18s
➜ kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io -A
NAME              WEBHOOKS   AGE
datadog-webhook   3          25s
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
