### PR TITLE
imp: add talos.dev compatibility

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.77.2
 
-* Add  configuration values `datadog.processAgent.disableOsReleaseFileMount` and `datadog.processAgent.disablePasswdMount` to disable `/etc/passwd` and `datadog.osReleasePath` in processAgent container when underlying OS doesn't have these files (like talos.dev)
+* Add  configuration values `datadog.processAgent.disableOsReleaseFileMount` and `datadog.disablePasswdMount` to disable `/etc/passwd` and `datadog.osReleasePath` mounts when underlying OS doesn't have these files (like talos.dev)
 
 ## 3.77.1
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.77.2
+
+* Add  configuration values `datadog.processAgent.disableOsReleaseFileMount` and `datadog.processAgent.disablePasswdMount` to disable `/etc/passwd` and `datadog.osReleasePath` in processAgent container when underlying OS doesn't have these files (like talos.dev)
+
 ## 3.77.1
 
 * Modify command that removes the default conf.d directory from the Cluster Checks Runners and only removes the default YAML files.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 3.77.2
 
-* Add  configuration values `datadog.processAgent.disableOsReleaseFileMount` and `datadog.disablePasswdMount` to disable `/etc/passwd` and `datadog.osReleasePath` mounts when underlying OS doesn't have these files (like talos.dev)
+* Add configuration values `datadog.disableDefaultOsReleasePaths` and `datadog.disablePasswdMount` to disable `/etc/passwd` and `datadog.osReleasePath` mounts when underlying OS doesn't have these files (like talos.dev).
+
+* Deprecate `datadog.systemProbe.enableDefaultOsReleasePaths` in favor of `datadog.disableDefaultOsReleasePaths`.
 
 ## 3.77.1
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.77.1
+version: 3.77.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -793,7 +793,7 @@ helm install <RELEASE_NAME> \
 | datadog.processAgent.runInCoreAgent | bool | `false` | Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery. # This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation. |
 | datadog.processAgent.stripProcessArguments | bool | `false` | Set this to scrub all arguments from collected processes # Requires datadog.processAgent.processCollection to be set to true to have any effect # ref: https://docs.datadoghq.com/infrastructure/process/?tab=linuxwindows#process-arguments-scrubbing |
 | datadog.processAgent.disableOsReleaseFileMount | bool | `false` | Disables mounting `datadog.osReleasePath` |
-| datadog.processAgent.disablePasswdMount | bool | `false` | Disables mounting `/etc/passwd` |
+| datadog.disablePasswdMount | bool | `false` | Disables mounting `/etc/passwd` |
 | datadog.profiling.enabled | string | `nil` | Enable Continuous Profiler by injecting `DD_PROFILING_ENABLED` environment variable with the same value to all pods in the cluster Valid values are: - false: Profiler is turned off and can not be turned on by other means. - null: Profiler is turned off, but can be turned on by other means. - auto: Profiler is turned off, but the library will turn it on if the application is a good candidate for profiling. - true: Profiler is turned on. |
 | datadog.prometheusScrape.additionalConfigs | list | `[]` | Allows adding advanced openmetrics check configurations with custom discovery rules. (Requires Agent version 7.27+) |
 | datadog.prometheusScrape.enabled | bool | `false` | Enable autodiscovering pods and services exposing prometheus metrics. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -792,6 +792,8 @@ helm install <RELEASE_NAME> \
 | datadog.processAgent.processDiscovery | bool | `true` | Enables or disables autodiscovery of integrations |
 | datadog.processAgent.runInCoreAgent | bool | `false` | Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery. # This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation. |
 | datadog.processAgent.stripProcessArguments | bool | `false` | Set this to scrub all arguments from collected processes # Requires datadog.processAgent.processCollection to be set to true to have any effect # ref: https://docs.datadoghq.com/infrastructure/process/?tab=linuxwindows#process-arguments-scrubbing |
+| datadog.processAgent.disableOsReleaseFileMount | bool | `false` | Disables mounting `datadog.osReleasePath` |
+| datadog.processAgent.disablePasswdMount | bool | `false` | Disables mounting `/etc/passwd` |
 | datadog.profiling.enabled | string | `nil` | Enable Continuous Profiler by injecting `DD_PROFILING_ENABLED` environment variable with the same value to all pods in the cluster Valid values are: - false: Profiler is turned off and can not be turned on by other means. - null: Profiler is turned off, but can be turned on by other means. - auto: Profiler is turned off, but the library will turn it on if the application is a good candidate for profiling. - true: Profiler is turned on. |
 | datadog.prometheusScrape.additionalConfigs | list | `[]` | Allows adding advanced openmetrics check configurations with custom discovery rules. (Requires Agent version 7.27+) |
 | datadog.prometheusScrape.enabled | bool | `false` | Enable autodiscovering pods and services exposing prometheus metrics. |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -792,7 +792,7 @@ helm install <RELEASE_NAME> \
 | datadog.processAgent.processDiscovery | bool | `true` | Enables or disables autodiscovery of integrations |
 | datadog.processAgent.runInCoreAgent | bool | `false` | Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery. # This is an experimental feature requiring Agent 7.53.0+ and Linux. Currently not compatible with APM Single Step Instrumentation. |
 | datadog.processAgent.stripProcessArguments | bool | `false` | Set this to scrub all arguments from collected processes # Requires datadog.processAgent.processCollection to be set to true to have any effect # ref: https://docs.datadoghq.com/infrastructure/process/?tab=linuxwindows#process-arguments-scrubbing |
-| datadog.processAgent.disableOsReleaseFileMount | bool | `false` | Disables mounting `datadog.osReleasePath` |
+| datadog.disableDefaultOsReleasePaths | bool | `false` | Disables mounting `datadog.osReleasePath` |
 | datadog.disablePasswdMount | bool | `false` | Disables mounting `/etc/passwd` |
 | datadog.profiling.enabled | string | `nil` | Enable Continuous Profiler by injecting `DD_PROFILING_ENABLED` environment variable with the same value to all pods in the cluster Valid values are: - false: Profiler is turned off and can not be turned on by other means. - null: Profiler is turned off, but can be turned on by other means. - auto: Profiler is turned off, but the library will turn it on if the application is a good candidate for profiling. - true: Profiler is turned on. |
 | datadog.prometheusScrape.additionalConfigs | list | `[]` | Allows adding advanced openmetrics check configurations with custom discovery rules. (Requires Agent version 7.27+) |
@@ -841,7 +841,7 @@ helm install <RELEASE_NAME> \
 | datadog.systemProbe.debugPort | int | `0` | Specify the port to expose pprof and expvar for system-probe agent |
 | datadog.systemProbe.enableConntrack | bool | `true` | Enable the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data |
 | datadog.systemProbe.enableDefaultKernelHeadersPaths | bool | `true` | Enable mount of default paths where kernel headers are stored |
-| datadog.systemProbe.enableDefaultOsReleasePaths | bool | `true` | enable default os-release files mount |
+| datadog.systemProbe.enableDefaultOsReleasePaths | bool | `true` | enable default os-release files mount DEPRECATED. Set `datadog.enableDefaultOsReleasePaths` instead. |
 | datadog.systemProbe.enableOOMKill | bool | `false` | Enable the OOM kill eBPF-based check |
 | datadog.systemProbe.enableTCPQueueLength | bool | `false` | Enable the TCP queue length eBPF-based check |
 | datadog.systemProbe.maxTrackedConnections | int | `131072` | the maximum number of tracked connections |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -257,7 +257,7 @@
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    {{- if and (eq (include "should-run-process-checks-on-core-agent" .) "true") (not .Values.datadog.processAgent.disablePasswdMount) }}
+    {{- if and (eq (include "should-run-process-checks-on-core-agent" .) "true") (not .Values.datadog.disablePasswdMount) }}
     - name: passwd
       mountPath: /etc/passwd
       readOnly: true

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -257,7 +257,7 @@
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    {{- if (eq (include "should-run-process-checks-on-core-agent" .) "true") }}
+    {{- if and (eq (include "should-run-process-checks-on-core-agent" .) "true") (not .Values.datadog.processAgent.disablePasswdMount) }}
     - name: passwd
       mountPath: /etc/passwd
       readOnly: true

--- a/charts/datadog/templates/_container-host-release-volumemounts.yaml
+++ b/charts/datadog/templates/_container-host-release-volumemounts.yaml
@@ -1,4 +1,5 @@
 {{- define "linux-container-host-release-volumemounts" -}}
+{{- if (not .Values.datadog.processAgent.disableOsReleaseFileMount) }}
 {{- if eq (include "should-enable-system-probe" .) "true" }}
 - name: os-release-file
   mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
@@ -7,5 +8,6 @@
 - name: os-release-file
   mountPath: /host{{ .Values.datadog.osReleasePath }}
   readOnly: true
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/datadog/templates/_container-host-release-volumemounts.yaml
+++ b/charts/datadog/templates/_container-host-release-volumemounts.yaml
@@ -1,5 +1,5 @@
 {{- define "linux-container-host-release-volumemounts" -}}
-{{- if (not .Values.datadog.processAgent.disableOsReleaseFileMount) }}
+{{- if (not .Values.datadog.disableDefaultOsReleasePaths) }}
 {{- if eq (include "should-enable-system-probe" .) "true" }}
 - name: os-release-file
   mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -79,7 +79,7 @@
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    {{- if or .Values.datadog.processAgent.processCollection .Values.datadog.processAgent.processDiscovery .Values.datadog.processAgent.containerCollection}}
+    {{- if and (or .Values.datadog.processAgent.processCollection .Values.datadog.processAgent.processDiscovery .Values.datadog.processAgent.containerCollection) (not .Values.datadog.processAgent.disablePasswdMount) }}
     - name: passwd
       mountPath: /etc/passwd
       readOnly: true

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -79,7 +79,7 @@
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
-    {{- if and (or .Values.datadog.processAgent.processCollection .Values.datadog.processAgent.processDiscovery .Values.datadog.processAgent.containerCollection) (not .Values.datadog.processAgent.disablePasswdMount) }}
+    {{- if and (or .Values.datadog.processAgent.processCollection .Values.datadog.processAgent.processDiscovery .Values.datadog.processAgent.containerCollection) (not .Values.datadog.disablePasswdMount) }}
     - name: passwd
       mountPath: /etc/passwd
       readOnly: true

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -91,7 +91,7 @@
     - name: cgroups
       mountPath: /host/sys/fs/cgroup
       readOnly: true
-    {{- if not .Values.datadog.processAgent.disablePasswdMount }}
+    {{- if not .Values.datadog.disablePasswdMount }}
     - name: passwd
       mountPath: /etc/passwd
       readOnly: true

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -91,9 +91,11 @@
     - name: cgroups
       mountPath: /host/sys/fs/cgroup
       readOnly: true
+    {{- if not .Values.datadog.processAgent.disablePasswdMount }}
     - name: passwd
       mountPath: /etc/passwd
       readOnly: true
+    {{- end }}
     - name: group
       mountPath: /etc/group
       readOnly: true

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -65,7 +65,7 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
     {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
-  {{- if .Values.datadog.systemProbe.enableDefaultOsReleasePaths }}
+    {{- if or .Values.datadog.systemProbe.enableDefaultOsReleasePaths (not .Values.datadog.disableDefaultOsReleasePaths) }}
     {{- if ne .Values.datadog.osReleasePath "/etc/redhat-release" }}
     - name: etc-redhat-release
       mountPath: /host/etc/redhat-release

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -65,7 +65,7 @@
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
       readOnly: true
     {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
-    {{- if or .Values.datadog.systemProbe.enableDefaultOsReleasePaths (not .Values.datadog.disableDefaultOsReleasePaths) }}
+    {{- if and .Values.datadog.systemProbe.enableDefaultOsReleasePaths (not .Values.datadog.disableDefaultOsReleasePaths) }}
     {{- if ne .Values.datadog.osReleasePath "/etc/redhat-release" }}
     - name: etc-redhat-release
       mountPath: /host/etc/redhat-release

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -9,7 +9,7 @@
 - hostPath:
     path: /sys/fs/cgroup
   name: cgroups
-{{- if and (not .Values.providers.gke.autopilot) (or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath .Values.datadog.sbom.host.enabled) }}
+{{- if and (not .Values.providers.gke.autopilot) (not .Values.datadog.processAgent.disableOsReleaseFileMount) (or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath .Values.datadog.sbom.host.enabled) }}
 - hostPath:
     path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   name: os-release-file
@@ -137,7 +137,7 @@
   name: btf-path
 {{- end }}
 {{- end }}
-{{- if or (eq (include "process-checks-enabled" .) "true") (eq (include "should-run-process-checks-on-core-agent" .) "true") (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true") }}
+{{- if and (or (eq (include "process-checks-enabled" .) "true") (eq (include "should-run-process-checks-on-core-agent" .) "true") (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true")) (not .Values.datadog.processAgent.disablePasswdMount) }}
 - hostPath:
     path: /etc/passwd
   name: passwd

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -137,7 +137,7 @@
   name: btf-path
 {{- end }}
 {{- end }}
-{{- if and (or (eq (include "process-checks-enabled" .) "true") (eq (include "should-run-process-checks-on-core-agent" .) "true") (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true")) (not .Values.datadog.processAgent.disablePasswdMount) }}
+{{- if and (or (eq (include "process-checks-enabled" .) "true") (eq (include "should-run-process-checks-on-core-agent" .) "true") (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-security-agent" .) "true")) (not .Values.datadog.disablePasswdMount) }}
 - hostPath:
     path: /etc/passwd
   name: passwd

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -14,7 +14,7 @@
     path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   name: os-release-file
 {{- end }}
-{{- if or (and (eq (include "should-enable-system-probe" .) "true") (or .Values.datadog.systemProbe.enableDefaultOsReleasePaths (not .Values.datadog.disableDefaultOsReleasePaths))) .Values.datadog.sbom.host.enabled }}
+{{- if or (and (eq (include "should-enable-system-probe" .) "true") (and .Values.datadog.systemProbe.enableDefaultOsReleasePaths (not .Values.datadog.disableDefaultOsReleasePaths))) .Values.datadog.sbom.host.enabled }}
 - hostPath:
     path: /etc/redhat-release
   name: etc-redhat-release

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -9,12 +9,12 @@
 - hostPath:
     path: /sys/fs/cgroup
   name: cgroups
-{{- if and (not .Values.providers.gke.autopilot) (not .Values.datadog.processAgent.disableOsReleaseFileMount) (or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath .Values.datadog.sbom.host.enabled) }}
+{{- if and (not .Values.providers.gke.autopilot) (not .Values.datadog.disableDefaultOsReleasePaths) (or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath .Values.datadog.sbom.host.enabled) }}
 - hostPath:
     path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   name: os-release-file
 {{- end }}
-{{- if or (and (eq (include "should-enable-system-probe" .) "true") .Values.datadog.systemProbe.enableDefaultOsReleasePaths) .Values.datadog.sbom.host.enabled }}
+{{- if or (and (eq (include "should-enable-system-probe" .) "true") (or .Values.datadog.systemProbe.enableDefaultOsReleasePaths (not .Values.datadog.disableDefaultOsReleasePaths))) .Values.datadog.sbom.host.enabled }}
 - hostPath:
     path: /etc/redhat-release
   name: etc-redhat-release

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -692,10 +692,10 @@ datadog:
      ## ref: https://docs.datadoghq.com/infrastructure/containers/?tab=helm
     containerCollection: true
 
-    # datadog.processAgent.disableOsReleaseFileMount -- Set this to true to disable mounting datadog.osReleasePath in processAgent container
-    disableOsReleaseFileMount: false
+  # datadog.disableDefaultOsReleasePaths -- Set this to true to disable mounting datadog.osReleasePath in all containers
+  disableDefaultOsReleasePaths: false
 
-  # datadog.disablePasswdMount -- Set this to true to disable mounting /etc/passwd in processAgent container
+  # datadog.disablePasswdMount -- Set this to true to disable mounting /etc/passwd in all containers
   disablePasswdMount: false
 
   # datadog.osReleasePath -- Specify the path to your os-release file
@@ -759,6 +759,7 @@ datadog:
     # datadog.systemProbe.conntrackInitTimeout -- the time to wait for conntrack to initialize before failing
     conntrackInitTimeout: 10s
 
+    # DEPRECATED. Use datadog.disableDefaultOsReleasePaths instead.
     # datadog.systemProbe.enableDefaultOsReleasePaths -- enable default os-release files mount
     enableDefaultOsReleasePaths: true
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -692,11 +692,11 @@ datadog:
      ## ref: https://docs.datadoghq.com/infrastructure/containers/?tab=helm
     containerCollection: true
 
-    # datadog.processAgent.disablePasswdMount -- Set this to true to disable mounting /etc/passwd in processAgent container
-    disablePasswdMount: false
-
     # datadog.processAgent.disableOsReleaseFileMount -- Set this to true to disable mounting datadog.osReleasePath in processAgent container
     disableOsReleaseFileMount: false
+
+  # datadog.disablePasswdMount -- Set this to true to disable mounting /etc/passwd in processAgent container
+  disablePasswdMount: false
 
   # datadog.osReleasePath -- Specify the path to your os-release file
   osReleasePath: /etc/os-release

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -692,6 +692,12 @@ datadog:
      ## ref: https://docs.datadoghq.com/infrastructure/containers/?tab=helm
     containerCollection: true
 
+    # datadog.processAgent.disablePasswdMount -- Set this to true to disable mounting /etc/passwd in processAgent container
+    disablePasswdMount: false
+
+    # datadog.processAgent.disableOsReleaseFileMount -- Set this to true to disable mounting datadog.osReleasePath in processAgent container
+    disableOsReleaseFileMount: false
+
   # datadog.osReleasePath -- Specify the path to your os-release file
   osReleasePath: /etc/os-release
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
Fix processAgent crash when Running on talos.dev cluster. It's because it try to mount files which don't exist on the OS.

#### Special notes for your reviewer:
I didn't managed to run `make update-test-baselines`

#### Checklist
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
