### PR TITLE
[CI] Remove k8s 1.18.20 from testing matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,7 +118,8 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.18.20
+          # TODO: `kind create cluster --config .github/kind_config.yaml --name chart-testing --wait 60s --image kindest/node:v1.18.20` fails
+          # - v1.18.20
           - v1.22.17
           - v1.24.17
           - v1.25.16


### PR DESCRIPTION
#### What this PR does / why we need it:
* Removes Kubernetes `v1.18.20` from testing matrix as the underlying action fails since https://github.com/DataDog/helm-charts/pull/1486:
```shell
╰─❯ kind create cluster --config .github/kind_config.yaml --name chart-testing --wait 60s --image kindest/node:v1.18.20
Creating cluster "chart-testing" ...
 ✓ Ensuring node image (kindest/node:v1.18.20) 🖼
 ✓ Preparing nodes 📦 📦
 ✓ Writing configuration 📜
 ✗ Starting control-plane 🕹️
Deleted nodes: ["chart-testing-worker" "chart-testing-control-plane"]
ERROR: failed to create cluster: failed to init node with kubeadm: command "docker exec --privileged chart-testing-control-plane kubeadm init --config=/kind/kubeadm.conf --skip-token-print --v=6 --skip-phases=preflight" failed with error: exit status 1
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
