### PR TITLE
fix: re-introduce k8s 1.18 CI testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,27 +117,37 @@ jobs:
       - kubeconform-chart
     strategy:
       matrix:
-        k8s:
-          # TODO: `kind create cluster --config .github/kind_config.yaml --name chart-testing --wait 60s --image kindest/node:v1.18.20` fails
-          # - v1.18.20
-          - v1.22.17
-          - v1.24.17
-          - v1.25.16
-          - v1.26.15
-          - v1.27.16
-          - v1.28.13
-          - v1.29.8
-          - v1.30.4
-          - v1.31.1
+        versions:
+          - k8s: v1.18.20
+            kind: v0.17.0
+          - k8s: v1.22.17
+            kind: v0.22.0
+          - k8s: v1.24.17
+            kind: v0.22.0
+          - k8s: v1.25.16
+            kind: v0.22.0
+          - k8s: v1.26.15
+            kind: v0.22.0
+          - k8s: v1.27.16
+            kind: v0.22.0
+          - k8s: v1.28.13
+            kind: v0.22.0
+          - k8s: v1.29.8
+            kind: v0.22.0
+          - k8s: v1.30.4
+            kind: v0.22.0
+          - k8s: v1.31.1
+            kind: v0.22.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Create kind ${{ matrix.k8s }} cluster
+      - name: Create kind ${{ matrix.versions.k8s }} cluster with kind version ${{ matrix.versions.kind }}
         uses: helm/kind-action@v1.10.0
         with:
-          node_image: kindest/node:${{ matrix.k8s }}
+          version: ${{ matrix.versions.kind }}
+          node_image: kindest/node:${{ matrix.versions.k8s}}
           config: .github/kind_config.yaml
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -39,28 +39,40 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        k8s:
-          - v1.16.15
-          - v1.18.20
-          - v1.22.17
-          - v1.24.17
-          - v1.25.16
-          - v1.26.15
-          - v1.27.16
-          - v1.28.13
-          - v1.29.9
-          - v1.30.4
-          - v1.31.1
+        versions:
+          - k8s: v1.16.15
+            kind: v0.15.0
+          - k8s: v1.18.20
+            kind: v0.17.0
+          - k8s: v1.22.17
+            kind: v0.22.0
+          - k8s: v1.24.17
+            kind: v0.22.0
+          - k8s: v1.25.16
+            kind: v0.22.0
+          - k8s: v1.26.15
+            kind: v0.22.0
+          - k8s: v1.27.16
+            kind: v0.22.0
+          - k8s: v1.28.13
+            kind: v0.22.0
+          - k8s: v1.29.8
+            kind: v0.22.0
+          - k8s: v1.30.4
+            kind: v0.22.0
+          - k8s: v1.31.1
+            kind: v0.22.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Create kind ${{ matrix.k8s }} cluster
+      - name: Create K8s ${{ matrix.versions.k8s }} cluster with kind version ${{ matrix.versions.kind }}
         uses: helm/kind-action@v1.10.0
         with:
-          node_image: kindest/node:${{ matrix.k8s }}
-          cluster_name: operator-ci-${{ matrix.k8s }}
+          version: ${{ matrix.versions.kind }}
+          node_image: kindest/node:${{ matrix.versions.k8s }}
+          cluster_name: operator-ci-${{ matrix.versions.k8s }}
           config: .github/kind_config.yaml
       - name: Add Cert Manager Helm repo
         run: helm repo add jetstack https://charts.jetstack.io && helm repo update
@@ -70,8 +82,8 @@ jobs:
         env:
           API_KEY: ${{ secrets.GO_INTEG_TEST_API_KEY }}
           APP_KEY: ${{ secrets.GO_INTEG_TEST_APP_KEY }}
-          CLUSTER_NAME: operator-ci-${{ matrix.k8s }}
-          K8S_VERSION: ${{ matrix.k8s }}
+          CLUSTER_NAME: operator-ci-${{ matrix.versions.k8s }}
+          K8S_VERSION: ${{ matrix.versions.k8s }}
         run: |
           kubectl cluster-info
           kubectl get nodes


### PR DESCRIPTION
#### What this PR does / why we need it:

Update our CI workflow configuration and add back CI chart testing with kubernetes v1.18.x.
Since #1486 the CI job was failing on the chart testing with kubernetes `v1.18`. To keep our capability to merge PRs, we commented the testing for 1.18 in #1576.

After investigation we understood the issue: #1486 has pumped the kind-action from `v1.5.0` to `v1.10.0` which pumps the kind-action version from `v0.17.0` to `v0.22.0`. However, kind `v0.22.0` is not able anymore to start the node image `v1.18`.

To solve the issue we now express which kind version needs to be used with each kubernetes version. So we can reintroduce the charts testing on kubernetes cluster `v1.18`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

the draft PR https://github.com/DataDog/helm-charts/pull/1580 is here to test that with this change the chart validation is able to run test on 1.18 cluster

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
