### PR TITLE
[Orch] Add additional permissions for operator to view CRDs

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.0
+
+* Add clusterRole.allowReadAllResources to allow viewing all resources. This is required for collecting custom resources in the Kubernetes Explorer
+
 ## 2.1.0
 
 * Update Datadog Operator version to 1.9.0.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.1.0
+version: 2.2.0
 appVersion: 1.9.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![AppVersion: 1.9.0](https://img.shields.io/badge/AppVersion-1.9.0-informational?style=flat-square)
 
 ## Values
 
@@ -12,6 +12,7 @@
 | appKey | string | `nil` | Your Datadog APP key |
 | appKeyExistingSecret | string | `nil` | Use existing Secret which stores APP key instead of creating a new one |
 | clusterName | string | `nil` | Set a unique cluster name reporting from the Datadog Operator. |
+| clusterRole | object | `{"allowReadAllResources":false}` | Set specific configuration for the cluster role |
 | collectOperatorMetrics | bool | `true` | Configures an openmetrics check to collect operator metrics |
 | containerSecurityContext | object | `{}` | A security context defines privileges and access control settings for a container. |
 | datadogAgent.enabled | bool | `true` | Enables Datadog Agent controller |

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -794,5 +794,20 @@ rules:
   - patch
   - update
 {{- end }}
+{{- if .Values.orchestratorExplorer.listAndWatchAll }}
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - list
+  - watch
 {{- end }}
-
+{{- end }}

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -794,7 +794,7 @@ rules:
   - patch
   - update
 {{- end }}
-{{- if .Values.orchestratorExplorer.listAndWatchAll }}
+{{- if .Values.clusterRole.allowReadAllResources }}
 - apiGroups:
   - '*'
   resources:

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -802,12 +802,5 @@ rules:
   verbs:
   - list
   - watch
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - list
-  - watch
 {{- end }}
 {{- end }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -190,3 +190,8 @@ livenessProbe:
   # timeoutSeconds: 1
   # successThreshold: 1
   # failureThreshold: 3
+
+# orchestratorExplorer -- Set specific configuration for orchestratorExplorer in the operator
+orchestratorExplorer:
+  #listAndWatchAll is required to allow the operator to view all custom resources
+  listAndWatchAll: false

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -191,7 +191,8 @@ livenessProbe:
   # successThreshold: 1
   # failureThreshold: 3
 
-# orchestratorExplorer -- Set specific configuration for orchestratorExplorer in the operator
-orchestratorExplorer:
-  #listAndWatchAll is required to allow the operator to view all custom resources
-  listAndWatchAll: false
+# clusterRole -- Set specific configuration for the cluster role
+clusterRole:
+  # allowReadAllResources is required to allow the operator to view all custom resources.
+  # If collecting CRDs in the Kubernetes Explorer this is required
+  allowReadAllResources: false


### PR DESCRIPTION
#### What this PR does / why we need it:
When using the Operator, we need additional permissions for CRDs. We need to allow the cluster agent to view these custom resources and in order to do that the operator needs permission to see them. This is currently disabled by default

#### Which issue this PR fixes
This fixes a current bug in the operator where users are unable to configure the orchestrator explorer to view and index custom resources

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
