### PR TITLE
Delete default configuration files from cluster checks runner

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.77.1
+
+* Modify command that removes the default conf.d directory from the Cluster Checks Runners and only removes the default YAML files.
+
 ## 3.77.0
 
 * Add experimental support for overlayfs direct scan for SBOMs

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.77.0
+version: 3.77.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.77.0](https://img.shields.io/badge/Version-3.77.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.77.1](https://img.shields.io/badge/Version-3.77.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -109,8 +109,7 @@ spec:
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterChecksRunner.image) }}"
         command: ["bash", "-c"]
         args:
-          # elements in "checks" should not have spaces
-          - checks="snmp"; for c in $checks; do mv /etc/datadog-agent/conf.d/$c.d/ /etc/datadog-agent; done && rm -rf /etc/datadog-agent/conf.d && mkdir /etc/datadog-agent/conf.d && for c in $checks; do mv /etc/datadog-agent/$c.d/ /etc/datadog-agent/conf.d; done && touch /etc/datadog-agent/datadog.yaml && exec agent run
+          - find /etc/datadog-agent/conf.d/ -name "*.yaml.default" -type f -delete && touch /etc/datadog-agent/datadog.yaml && exec agent run
         imagePullPolicy: {{ .Values.clusterChecksRunner.image.pullPolicy }}
 {{- if .Values.clusterChecksRunner.ports }}
         ports:

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -109,7 +109,8 @@ spec:
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterChecksRunner.image) }}"
         command: ["bash", "-c"]
         args:
-          - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run
+          # elements in "checks" should not have spaces
+          - checks="snmp"; for c in $checks; do mv /etc/datadog-agent/conf.d/$c.d/ /etc/datadog-agent; done && rm -rf /etc/datadog-agent/conf.d && mkdir /etc/datadog-agent/conf.d && for c in $checks; do mv /etc/datadog-agent/$c.d/ /etc/datadog-agent/conf.d; done && touch /etc/datadog-agent/datadog.yaml && exec agent run
         imagePullPolicy: {{ .Values.clusterChecksRunner.image.pullPolicy }}
 {{- if .Values.clusterChecksRunner.ports }}
         ports:


### PR DESCRIPTION
#### What this PR does / why we need it:

Rather than delete the entire conf.d folder, only delete the configuration for checks enabled by default.

Currently, this list is

```
# find /etc/datadog-agent/conf.d/ -name "*.yaml.default" -type f
/etc/datadog-agent/conf.d/cri.d/conf.yaml.default
/etc/datadog-agent/conf.d/network.d/conf.yaml.default
/etc/datadog-agent/conf.d/container_image.d/conf.yaml.default
/etc/datadog-agent/conf.d/io.d/conf.yaml.default
/etc/datadog-agent/conf.d/ntp.d/conf.yaml.default
/etc/datadog-agent/conf.d/containerd.d/conf.yaml.default
/etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
/etc/datadog-agent/conf.d/sbom.d/conf.yaml.default
/etc/datadog-agent/conf.d/file_handle.d/conf.yaml.default
/etc/datadog-agent/conf.d/cpu.d/conf.yaml.default
/etc/datadog-agent/conf.d/ecs_fargate.d/conf.yaml.default
/etc/datadog-agent/conf.d/orchestrator_ecs.d/conf.yaml.default
/etc/datadog-agent/conf.d/orchestrator_pod.d/conf.yaml.default
/etc/datadog-agent/conf.d/container.d/conf.yaml.default
/etc/datadog-agent/conf.d/memory.d/conf.yaml.default
/etc/datadog-agent/conf.d/load.d/conf.yaml.default
/etc/datadog-agent/conf.d/container_lifecycle.d/conf.yaml.default
/etc/datadog-agent/conf.d/uptime.d/conf.yaml.default
/etc/datadog-agent/conf.d/eks_fargate.d/conf.yaml.default
/etc/datadog-agent/conf.d/telemetry.d/conf.yaml.default
/etc/datadog-agent/conf.d/service_discovery.d/conf.yaml.default
/etc/datadog-agent/conf.d/disk.d/conf.yaml.default
/etc/datadog-agent/conf.d/docker.d/conf.yaml.default
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated
- [X] Variables are documented in the `README.md`
