### PR TITLE
Fix format of teams listed in github_team_restrictions

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -10,11 +10,11 @@ github_teams_restrictions:
   - container-helm-chart-maintainers
   - container-integrations
   - container-t2
-  - Synthetics
-  - Documentation
-  - Observability Pipelines
-  - Telemetry and Analytics
-  - Vector
+  - synthetics
+  - documentation
+  - observability-pipelines
+  - telemetry-and-analytics
+  - vector
 github_users_restrictions:
   - cahillsf
   - clamoriniere


### PR DESCRIPTION
#### What this PR does / why we need it:

We are currently blocked from pushing a PR due to a mistake in how the allowed teams in `repository.datadog.yml` are formatted

#### Which issue this PR fixes

Fixes the listed teams so they are in the correct format

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
