### PR TITLE
Bump runner version to v0.1.4-beta

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.14.3
+
+* Add GitLab private actions
+
 ## 0.14.2
 
 * Update private action image version to `v0.1.3-beta`

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.14.3
 
-* Add GitLab private actions
+* Add GitLab private actions and fix image repository link.
 
 ## 0.14.2
 

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.14.2
+version: 0.14.3
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![AppVersion: v0.1.3-beta](https://img.shields.io/badge/AppVersion-v0.1.3--beta-informational?style=flat-square)
+![Version: 0.14.3](https://img.shields.io/badge/Version-0.14.3-informational?style=flat-square) ![AppVersion: v0.1.4-beta](https://img.shields.io/badge/AppVersion-v0.1.4--beta-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 
@@ -42,7 +42,7 @@ helm repo update
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| common.image | object | `{"repository":"us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner","tag":"v0.1.3-beta"}` | Current Datadog Private Action Runner image |
+| common.image | object | `{"repository":"gcr.io/datadoghq/private-action-runner","tag":"v0.1.4-beta"}` | Current Datadog Private Action Runner image |
 | credentialFiles | list | `[]` | List of credential files to be used by the Datadog Private Action Runner |
 | runners[0].config | object | `{"actionsAllowlist":[],"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":9016,"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
 | runners[0].config.actionsAllowlist | list | `[]` | List of actions that the Datadog Private Action Runner is allowed to execute |

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![AppVersion: v0.1.3-beta](https://img.shields.io/badge/AppVersion-v0.1.3--beta-informational?style=flat-square)
+![Version: 0.14.3](https://img.shields.io/badge/Version-0.14.3-informational?style=flat-square) ![AppVersion: v0.1.4-beta](https://img.shields.io/badge/AppVersion-v0.1.4--beta-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -5,8 +5,8 @@
 common:
   # -- Current Datadog Private Action Runner image
   image:
-    repository: us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner
-    tag: v0.1.3-beta
+    repository: gcr.io/datadoghq/private-action-runner
+    tag: v0.1.4-beta
 
 runners:
   # runners[0].name -- Name of the Datadog Private Action Runner

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -100,7 +100,7 @@ spec:
           value: nodeless
       containers:
         - name: runner
-          image: "us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner:v0.1.3-beta"
+          image: "gcr.io/datadoghq/private-action-runner:v0.1.4-beta"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -144,7 +144,7 @@ spec:
           value: nodeless
       containers:
         - name: runner
-          image: "us-east4-docker.pkg.dev/datadog-sandbox/apps-on-prem/onprem-runner:v0.1.3-beta"
+          image: "gcr.io/datadoghq/private-action-runner:v0.1.4-beta"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Description
Bump Private Actions Runner version in order to include recent GitLab changes. DD-Source changes https://github.com/DataDog/dd-source/pull/147598