### PR TITLE
Add the ability to include security contexts in container level for cluster checks runners

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.77.2
+
+* Add ability to include security contexts in container level for cluster checks runners.
+
 ## 3.77.1
 
 * Modify command that removes the default conf.d directory from the Cluster Checks Runners and only removes the default YAML files.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.77.2
 
-* Add ability to include security contexts in container level for cluster checks runners.
+* Add the ability to include security contexts in container level for cluster checks runners.
 
 ## 3.77.1
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.77.1
+version: 3.77.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.77.1](https://img.shields.io/badge/Version-3.77.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.77.2](https://img.shields.io/badge/Version-3.77.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -629,6 +629,8 @@ helm install <RELEASE_NAME> \
 | clusterAgent.volumes | list | `[]` | Specify additional volumes to mount in the cluster-agent container |
 | clusterChecksRunner.additionalLabels | object | `{}` | Adds labels to the cluster checks runner deployment and pods |
 | clusterChecksRunner.affinity | object | `{}` | Allow the ClusterChecks Deployment to schedule using affinity rules. |
+| clusterChecksRunner.containers.agent.securityContext | object | `{}` | Specify securityContext on the agent container |
+| clusterChecksRunner.containers.initContainers.securityContext | object | `{}` | Specify securityContext on the init containers |
 | clusterChecksRunner.createPodDisruptionBudget | bool | `false` | Create the pod disruption budget to apply to the cluster checks agents |
 | clusterChecksRunner.deploymentAnnotations | object | `{}` | Annotations to add to the cluster-checks-runner's Deployment |
 | clusterChecksRunner.dnsConfig | object | `{}` | specify dns configuration options for datadog cluster agent containers e.g ndots |

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -78,6 +78,10 @@ spec:
         command: ["bash", "-c"]
         args:
           - cp -r /etc/datadog-agent /opt
+{{- if .Values.clusterChecksRunner.containers.initContainers.securityContext }}
+        securityContext:
+{{ toYaml .Values.clusterChecksRunner.containers.initContainers.securityContext | indent 10 }}
+{{- end }}
         volumeMounts:
           - name: config
             mountPath: /opt/datadog-agent
@@ -90,6 +94,10 @@ spec:
         command: ["bash", "-c"]
         args:
           - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+{{- if .Values.clusterChecksRunner.containers.initContainers.securityContext }}
+        securityContext:
+{{ toYaml .Values.clusterChecksRunner.containers.initContainers.securityContext | indent 10 }}
+{{- end }}
         volumeMounts:
           - name: config
             mountPath: /etc/datadog-agent
@@ -177,6 +185,10 @@ spec:
           {{- include "additional-env-dict-entries" .Values.clusterChecksRunner.envDict | indent 10 }}
         resources:
 {{ toYaml .Values.clusterChecksRunner.resources | indent 10 }}
+{{- if .Values.clusterChecksRunner.containers.agent.securityContext }}
+        securityContext:
+{{ toYaml .Values.clusterChecksRunner.containers.agent.securityContext | indent 10 }}
+{{- end }}
         volumeMounts:
           - name: installinfo
             subPath: install_info

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2034,6 +2034,14 @@ clusterChecksRunner:
   # clusterChecksRunner.createPodDisruptionBudget -- Create the pod disruption budget to apply to the cluster checks agents
   createPodDisruptionBudget: false
 
+  containers:
+    agent:
+      # clusterChecksRunner.containers.agent.securityContext -- Specify securityContext on the agent container
+      securityContext: {}
+    initContainers:
+      # clusterChecksRunner.containers.initContainers.securityContext -- Specify securityContext on the init containers
+      securityContext: {}
+
   # Provide Cluster Checks Deployment pods RBAC configuration
   rbac:
     # clusterChecksRunner.rbac.create -- If true, create & use RBAC resources


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
  - CONS-6803
  - https://github.com/DataDog/datadog-agent/issues/30676

#### Special notes for your reviewer:
Test plan:
Use the following configuration in your values.yaml:
```
clusterChecksRunner:
  enabled: true
  containers:
    agent:
      securityContext:
        runAsUser: 100
        readOnlyRootFilesystem: true
        allowPrivilegeEscalation: false
        capabilities:
          drop:
            - ALL
    initContainers:
      securityContext:
        runAsUser: 100
        readOnlyRootFilesystem: true
        allowPrivilegeEscalation: false
        capabilities:
          drop:
            - ALL
```

- Run `kubectl get pod <cluster check pod> -o jsonpath='{.spec.containers[*].securityContext}' | jq .` and double check that the security context are appropriately configured in the `agent` container.

The result should be:
```
{
  "allowPrivilegeEscalation": false,
  "capabilities": {
    "drop": [
      "ALL"
    ]
  },
  "readOnlyRootFilesystem": true,
  "runAsUser": 100
}
```

- Run `kubectl get pod <cluster check pod> -o jsonpath='{.spec.initContainers[*].securityContext}' | jq .` and double check that the security  context are appropriately configured in the init containers.

The result should be the following for the `init-config` and `init-volume` init containers:
```
{
  "allowPrivilegeEscalation": false,
  "capabilities": {
    "drop": [
      "ALL"
    ]
  },
  "readOnlyRootFilesystem": true,
  "runAsUser": 100
}
{
  "allowPrivilegeEscalation": false,
  "capabilities": {
    "drop": [
      "ALL"
    ]
  },
  "readOnlyRootFilesystem": true,
  "runAsUser": 100
}
```

Also check if cluster checks work fine, can set the following to see if the KSM core check works fine as a cluster check
```
datadog:
  kubeStateMetricsCore:
    useClusterCheckRunners: true
```
...or use an integration check like Openmetrics.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
