### PR TITLE
feat(clusterChecksRunner) Add hostaliases to clusterchecksrunner

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 3.78.1
+* Add hostAliases to clusterChecksRunner deployment.
+
 ## 3.78.0
 
 * Set default `Agent` and `Cluster-Agent` version to `7.59.0`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.78.0
+version: 3.78.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.78.0](https://img.shields.io/badge/Version-3.78.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.78.1](https://img.shields.io/badge/Version-3.78.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -639,6 +639,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.envDict | object | `{}` | Set environment variables specific to Cluster Checks Runner defined in a dict |
 | clusterChecksRunner.envFrom | list | `[]` | Set environment variables specific to Cluster Checks Runner from configMaps and/or secrets |
 | clusterChecksRunner.healthPort | int | `5557` | Port number to use in the Cluster Checks Runner for the healthz endpoint |
+| clusterChecksRunner.hostAliases | list | `[]` | Add entries to the agent container /etc/hosts file. |
 | clusterChecksRunner.image.digest | string | `""` | Define Agent image digest to use, takes precedence over tag if specified |
 | clusterChecksRunner.image.name | string | `"agent"` | Datadog Agent image name to use (relative to `registry`) |
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |

--- a/charts/datadog/ci/clusterchecksrunner-hostaliases.yaml
+++ b/charts/datadog/ci/clusterchecksrunner-hostaliases.yaml
@@ -1,0 +1,7 @@
+datadog:
+  clusterChecksRunner:
+    enabled: true
+    hostAliases:
+     - ip: "10.0.0.1"
+       hostnames:
+       - "host.domain.com"

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -71,6 +71,11 @@ spec:
       securityContext:
         {{ toYaml .Values.clusterChecksRunner.securityContext | nindent 8 }}
       {{- end }}
+      {{- if .Values.clusterChecksRunner.hostAliases }}
+      hostAliases:
+        {{ .Values.clusterChecksRunner.hostAliases | toYaml | nindent 8 }}
+      {{- end }}
+
       initContainers:
       - name: init-volume
         image: "{{ include "image-path" (dict "root" .Values "image" .Values.clusterChecksRunner.image) }}"

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2229,6 +2229,12 @@ clusterChecksRunner:
   # clusterChecksRunner.ports -- Allows to specify extra ports (hostPorts for instance) for this container
   ports: []
 
+  # clusterChecksRunner.hostAliases -- Add entries to the agent container /etc/hosts file.
+  hostAliases: []
+  #  - ip: "10.0.0.1"
+  #    hostnames:
+  #    - "host.domain.com"
+
 datadog-crds:
   crds:
     # datadog-crds.crds.datadogMetrics -- Set to true to deploy the DatadogMetrics CRD


### PR DESCRIPTION
#### What this PR does / why we need it:
We want to enable the [TLS integration](https://docs.datadoghq.com/integrations/tls/?tab=containerized) as a clustercheck, but we need to point it to some endpoints that are not present in our DNS.

An alternative solution is to implement the TLS test through a synthetic test runner (where hostAliases are available), but this solution is better from a self-service perspective.

#### Special notes for your reviewer:

I pretty much copy-pasted the contents of [this](https://github.com/DataDog/helm-charts/blob/main/charts/synthetics-private-location/templates/deployment.yaml#L41). This is my first time contributing, so let me know if I could have done anything better the next time 🙂 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
