### PR TITLE
doc(datadog): docuement datadog.envDict usage

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.79.1
+
+* Document how to use `datadog.envDict` option with the `--set` helm's flag.
+
 ## 3.79.0
 
 * Add Logs Collection support for Google GKE on GDC

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 3.79.0
+version: 3.79.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.79.0](https://img.shields.io/badge/Version-3.79.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.79.1](https://img.shields.io/badge/Version-3.79.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -439,6 +439,16 @@ agents:
       enabled: false
 
 # (...)
+```
+
+## Set an environment variable with the `--set` helm flag
+
+You can set environment variables using the `--set` helm's flag  thanks to the `datadog.envDict` field.
+
+For example, to set the `DD_ENV` environment variable:
+
+```console
+$ helm install --set datadog.envDict.DD_ENV=prod <release name> datadog/datadog
 ```
 
 ## All configuration options

--- a/charts/datadog/README.md.gotmpl
+++ b/charts/datadog/README.md.gotmpl
@@ -437,6 +437,16 @@ agents:
 # (...)
 ```
 
+## Set an environment variable with the `--set` helm flag
+
+You can set environment variables using the `--set` helm's flag  thanks to the `datadog.envDict` field.
+
+For example, to set the `DD_ENV` environment variable:
+
+```console
+$ helm install --set datadog.envDict.DD_ENV=prod <release name> datadog/datadog
+```
+
 ## All configuration options
 
 The following table lists the configurable parameters of the Datadog chart and their default values. Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,


### PR DESCRIPTION
#### What this PR does / why we need it:

* Document how to use `datadog.envDict` option with the `--set` helm's flag.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
