### PR TITLE
fix(mergequeue): check gitlab-ci to merge PR

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,7 +1,7 @@
 ---
 schema-version: v1
 kind: mergequeue
-gitlab_check_enable: false
+gitlab_check_enable: true
 github_teams_restrictions:
   - action-platform
   - agent-all


### PR DESCRIPTION
#### What this PR does / why we need it:

Since we want to run e2e tests in gitlab during the merge queue, the parameter `gitlab_check_enable` must be true.

#### Which issue this PR fixes

Mergequeue should check the gitlab pipeline status before merging

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
