### PR TITLE
[CONTP-519] Support K8s admin events

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 * Set the default value of `datadog.processAgent.runInCoreAgent` to `true`.
 
-
 ## 3.83.1
 
 * Add /sys/fs/bpf to system-probe volume mounts

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 3.83.1
+
+* Added the configuration value `clusterAgent.admissionController.kubernetes_admission_events.enabled` to enabled/disable the Kubernetes Admission Events feature.
+
 ## 3.83.0
 
 * Added the configuration value `datadog.disablePasswdMount` to disable mounting the `/etc/passwd` path from the host filesystem. This option should be used when the underlying OS does not have these files (e.g., Talos OS).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.83.0
+version: 3.83.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.83.1
+version: 3.83.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.84.1
+version: 3.84.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.84.1](https://img.shields.io/badge/Version-3.84.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.84.2](https://img.shields.io/badge/Version-3.84.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.83.0](https://img.shields.io/badge/Version-3.83.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.83.1](https://img.shields.io/badge/Version-3.83.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -575,6 +575,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.admissionController.cwsInstrumentation.mode | string | `"remote_copy"` | Mode defines how the CWS Instrumentation should behave. Options are "remote_copy" or "init_container" |
 | clusterAgent.admissionController.enabled | bool | `true` | Enable the admissionController to be able to inject APM/Dogstatsd config and standard tags (env, service, version) automatically into your pods |
 | clusterAgent.admissionController.failurePolicy | string | `"Ignore"` | Set the failure policy for dynamic admission control.' |
+| clusterAgent.admissionController.kubernetesAdmissionEvents.enabled | bool | `false` | Enable the Kubernetes Admission Events feature. |
 | clusterAgent.admissionController.mutateUnlabelled | bool | `false` | Enable injecting config without having the pod label 'admission.datadoghq.com/enabled="true"' |
 | clusterAgent.admissionController.mutation | object | `{"enabled":true}` | Mutation Webhook configuration options |
 | clusterAgent.admissionController.mutation.enabled | bool | `true` | Enabled enables the Admission Controller mutation webhook. Default: true. (Requires Agent 7.59.0+). |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.84.1](https://img.shields.io/badge/Version-3.84.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.84.1](https://img.shields.io/badge/Version-3.84.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.83.1](https://img.shields.io/badge/Version-3.83.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.83.2](https://img.shields.io/badge/Version-3.83.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -258,6 +258,10 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_CWS_INSTRUMENTATION_MODE
             value: {{ .Values.clusterAgent.admissionController.cwsInstrumentation.mode | quote }}
           {{- end }}
+          {{- if .Values.clusterAgent.admissionController.kubernetesAdmissionEvents.enabled }}
+          - name: DD_ADMISSION_CONTROLLER_KUBERNETES_ADMISSION_EVENTS_ENABLED
+            value: "true"
+          {{- end }}
           {{ include "ac-agent-sidecar-env" . | nindent 10 }}
           - name: DD_REMOTE_CONFIGURATION_ENABLED
             value: {{ include "clusterAgent-remoteConfiguration-enabled" . | quote }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -6,10 +6,10 @@
 ## ONLY SET THE VALUES YOU WANT TO OVERRIDE IN YOUR values.yaml.
 
 # nameOverride -- Override name of app
-nameOverride: # ""
+nameOverride:  # ""
 
 # fullnameOverride -- Override the full qualified app name
-fullnameOverride: # ""
+fullnameOverride:  # ""
 
 # targetSystem -- Target OS for this deployment (possible values: linux, windows)
 targetSystem: "linux"
@@ -27,29 +27,29 @@ commonLabels: {}
 ## Azure - use datadoghq.azurecr.io
 ## AWS - use public.ecr.aws/datadog
 ## DockerHub - use docker.io/datadog
-registry: # gcr.io/datadoghq
+registry:  # gcr.io/datadoghq
 
 datadog:
   # datadog.apiKey -- Your Datadog API key
 
   ## ref: https://app.datadoghq.com/account/settings#agent/kubernetes
-  apiKey: # <DATADOG_API_KEY>
+  apiKey:  # <DATADOG_API_KEY>
 
   # datadog.apiKeyExistingSecret -- Use existing Secret which stores API key instead of creating a new one. The value should be set with the `api-key` key inside the secret.
 
   ## If set, this parameter takes precedence over "apiKey".
-  apiKeyExistingSecret: # <DATADOG_API_KEY_SECRET>
+  apiKeyExistingSecret:  # <DATADOG_API_KEY_SECRET>
 
   # datadog.appKey -- Datadog APP key required to use metricsProvider
 
   ## If you are using clusterAgent.metricsProvider.enabled = true, you must set
   ## a Datadog application key for read access to your metrics.
-  appKey: # <DATADOG_APP_KEY>
+  appKey:  # <DATADOG_APP_KEY>
 
   # datadog.appKeyExistingSecret -- Use existing Secret which stores APP key instead of creating a new one. The value should be set with the `app-key` key inside the secret.
 
   ## If set, this parameter takes precedence over "appKey".
-  appKeyExistingSecret: # <DATADOG_APP_KEY_SECRET>
+  appKeyExistingSecret:  # <DATADOG_APP_KEY_SECRET>
 
   # agents.secretAnnotations -- Annotations to add to the Secrets
   secretAnnotations: {}
@@ -62,13 +62,13 @@ datadog:
 
     ## Note: If the command value is "/readsecret_multiple_providers.sh", and datadog.secretBackend.enableGlobalPermissions is enabled below, the agents will have permissions to get secret objects across the cluster.
     ## Read more about "/readsecret_multiple_providers.sh": https://docs.datadoghq.com/agent/guide/secrets-management/#script-for-reading-from-multiple-secret-providers-readsecret_multiple_providerssh
-    command: # "/readsecret.sh" or "/readsecret_multiple_providers.sh" or any custom binary path
+    command:  # "/readsecret.sh" or "/readsecret_multiple_providers.sh" or any custom binary path
 
     # datadog.secretBackend.arguments -- Configure the secret backend command arguments (space-separated strings).
-    arguments: # "/etc/secret-volume" or any other custom arguments
+    arguments:  # "/etc/secret-volume" or any other custom arguments
 
     # datadog.secretBackend.timeout -- Configure the secret backend command timeout in seconds.
-    timeout: # 30
+    timeout:  # 30
 
     # datadog.secretBackend.enableGlobalPermissions -- Whether to create a global permission allowing Datadog agents to read all secrets when `datadog.secretBackend.command` is set to `"/readsecret_multiple_providers.sh"`.
     enableGlobalPermissions: true
@@ -103,7 +103,7 @@ datadog:
   ## * Overall length should not be higher than 80 characters.
   ## Compared to the rules of GKE, dots are allowed whereas they are not allowed on GKE:
   ## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
-  clusterName: # <CLUSTER_NAME>
+  clusterName:  # <CLUSTER_NAME>
 
   # datadog.site -- The site of the Datadog intake to send Agent data to.
   # (documentation: https://docs.datadoghq.com/getting_started/site/)
@@ -114,12 +114,12 @@ datadog:
   ## Set to 'us5.datadoghq.com' to send data to the US5 site.
   ## Set to 'ddog-gov.com' to send data to the US1-FED site.
   ## Set to 'ap1.datadoghq.com' to send data to the AP1 site.
-  site: # datadoghq.com
+  site:  # datadoghq.com
 
   # datadog.dd_url -- The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL
 
   ## Overrides the site setting defined in "site".
-  dd_url: # https://app.datadoghq.com
+  dd_url:  # https://app.datadoghq.com
 
   # datadog.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, off
   logLevel: INFO
@@ -141,7 +141,7 @@ datadog:
     enabled: true
 
     rbac:
-      # datadog.kubeStateMetricsCore.rbac.create -- If true, create & use RBAC resources
+    # datadog.kubeStateMetricsCore.rbac.create -- If true, create & use RBAC resources
       create: true
 
     # datadog.kubeStateMetricsCore.ignoreLegacyKSMCheck -- Disable the auto-configuration of legacy kubernetes_state check (taken into account only when datadog.kubeStateMetricsCore.enabled is true)
@@ -291,7 +291,7 @@ datadog:
   # datadog.checksCardinality -- Sets the tag cardinality for the checks run by the Agent.
 
   ## ref: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
-  checksCardinality: # low, orchestrator or high (not set by default to avoid overriding existing DD_CHECKS_TAG_CARDINALITY configurations, the default value in the Agent is low)
+  checksCardinality:  # low, orchestrator or high (not set by default to avoid overriding existing DD_CHECKS_TAG_CARDINALITY configurations, the default value in the Agent is low)
 
   # kubelet configuration
   kubelet:
@@ -302,7 +302,7 @@ datadog:
           fieldPath: status.hostIP
     # datadog.kubelet.tlsVerify -- Toggle kubelet TLS verification
     # @default -- true
-    tlsVerify: # false
+    tlsVerify:  # false
     # datadog.kubelet.hostCAPath -- Path (on host) where the Kubelet CA certificate is stored
     # @default -- None (no mount from host)
     hostCAPath:
@@ -400,10 +400,10 @@ datadog:
     unbundleEvents: false
     # datadog.kubernetesEvents.collectedEventTypes -- Event types to be collected. This requires datadog.kubernetesEvents.unbundleEvents to be set to true.
     collectedEventTypes:
-      # - kind: <kubernetes resource kind> # (optional if `source`` is provided)
-      #   source: <controller name> # (optional if `kind`` is provided)
-      #   reasons: # (optional) if empty accept all event reasons
-      #   - <kubernetes event reason>
+    # - kind: <kubernetes resource kind> # (optional if `source`` is provided)
+    #   source: <controller name> # (optional if `kind`` is provided)
+    #   reasons: # (optional) if empty accept all event reasons
+    #   - <kubernetes event reason>
       - kind: Pod
         reasons:
           - Failed
@@ -430,7 +430,7 @@ datadog:
   leaderElection: true
 
   # datadog.leaderLeaseDuration -- Set the lease time for leader election in second
-  leaderLeaseDuration: # 60
+  leaderLeaseDuration:  # 60
 
   # datadog.leaderElectionResource -- Selects the default resource to use for leader election.
   # Can be:
@@ -584,7 +584,8 @@ datadog:
     enabled: false
     # datadog.otelCollector.ports -- Ports that OTel Collector is listening
     ports:
-      # Default GRPC port of OTLP receiver
+
+        # Default GRPC port of OTLP receiver
       - containerPort: "4317"
         name: otel-grpc
         # Default HTTP port of OTLP receiver
@@ -660,10 +661,10 @@ datadog:
   #   service.py: |-
 
   # datadog.dockerSocketPath -- Path to the docker socket
-  dockerSocketPath: # /var/run/docker.sock
+  dockerSocketPath:  # /var/run/docker.sock
 
   # datadog.criSocketPath -- Path to the container runtime socket (if different from Docker)
-  criSocketPath: # /var/run/containerd/containerd.sock
+  criSocketPath:  # /var/run/containerd/containerd.sock
 
   # Configure how the agent interact with the host's container runtime
   containerRuntimeSupport:
@@ -691,11 +692,10 @@ datadog:
 
     # datadog.processAgent.runInCoreAgent -- Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery.
     ## This requires Agent 7.57.0+ and Linux.
-    runInCoreAgent:
-      false
+    runInCoreAgent: false
 
-      # datadog.processAgent.containerCollection -- Set this to true to enable container collection
-      ## ref: https://docs.datadoghq.com/infrastructure/containers/?tab=helm
+     # datadog.processAgent.containerCollection -- Set this to true to enable container collection
+     ## ref: https://docs.datadoghq.com/infrastructure/containers/?tab=helm
     containerCollection: true
 
   # datadog.disableDefaultOsReleasePaths -- Set this to true to disable mounting datadog.osReleasePath in all containers
@@ -709,6 +709,7 @@ datadog:
 
   ## Enable systemProbe agent and provide custom configs
   systemProbe:
+
     # datadog.systemProbe.debugPort -- Specify the port to expose pprof and expvar for system-probe agent
     debugPort: 0
 
@@ -759,7 +760,7 @@ datadog:
     maxTrackedConnections: 131072
 
     # datadog.systemProbe.conntrackMaxStateSize -- the maximum size of the userspace conntrack cache
-    conntrackMaxStateSize: 131072 # 2 * maxTrackedConnections by default, per  https://github.com/DataDog/datadog-agent/blob/d1c5de31e1bba72dfac459aed5ff9562c3fdcc20/pkg/process/config/config.go#L229
+    conntrackMaxStateSize: 131072  # 2 * maxTrackedConnections by default, per  https://github.com/DataDog/datadog-agent/blob/d1c5de31e1bba72dfac459aed5ff9562c3fdcc20/pkg/process/config/config.go#L229
 
     # datadog.systemProbe.conntrackInitTimeout -- the time to wait for conntrack to initialize before failing
     conntrackInitTimeout: 10s
@@ -770,6 +771,7 @@ datadog:
 
     # datadog.systemProbe.enableDefaultKernelHeadersPaths -- Enable mount of default paths where kernel headers are stored
     enableDefaultKernelHeadersPaths: true
+
 
   containerImageCollection:
     # datadog.containerImageCollection.enabled -- Enable collection of container image metadata
@@ -812,8 +814,7 @@ datadog:
 
     # datadog.helmCheck.valuesAsTags -- Collects Helm values from a release and uses them as tags (Requires Agent and Cluster Agent 7.40.0+).
     # This requires datadog.HelmCheck.enabled to be set to true
-    valuesAsTags:
-      {}
+    valuesAsTags: {}
       #   <HELM_VALUE>: <LABEL_NAME>
 
   networkMonitoring:
@@ -945,8 +946,7 @@ datadog:
     # datadog.prometheusScrape.serviceEndpoints -- Enable generating dedicated checks for service endpoints.
     serviceEndpoints: false
     # datadog.prometheusScrape.additionalConfigs -- Allows adding advanced openmetrics check configurations with custom discovery rules. (Requires Agent version 7.27+)
-    additionalConfigs:
-      []
+    additionalConfigs: []
       # -
       #   autodiscovery:
       #     kubernetes_annotations:
@@ -975,7 +975,7 @@ datadog:
   # datadog.containerExclude -- Exclude containers from Agent Autodiscovery, as a space-separated list
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
-  containerExclude: # "image:datadog/agent"
+  containerExclude:  # "image:datadog/agent"
 
   # datadog.containerInclude -- Include containers in Agent Autodiscovery, as a space-separated list.
   # If a container matches an include rule, it’s always included in Autodiscovery
@@ -1045,7 +1045,7 @@ clusterAgent:
     ## This boolean permits completely skipping this check.
     ## This is useful, for example, for custom tags that are not
     ## respecting semantic versioning.
-    doNotCheckTag: # false
+    doNotCheckTag:  # false
 
   # clusterAgent.securityContext -- Allows you to overwrite the default PodSecurityContext on the cluster-agent pods.
   securityContext: {}
@@ -1134,7 +1134,7 @@ clusterAgent:
       port: 8443
 
     # clusterAgent.metricsProvider.endpoint -- Override the external metrics provider endpoint. If not set, the cluster-agent defaults to `datadog.site`
-    endpoint: # https://api.datadoghq.com
+    endpoint:  # https://api.datadoghq.com
 
   # clusterAgent.env -- Set environment variables specific to Cluster Agent
 
@@ -1185,7 +1185,7 @@ clusterAgent:
     ##   * Otherwise, the Admission Controller defaults to hostip.
     ## Note: "service" mode relies on the internal traffic service to target the agent running on the local node (requires Kubernetes v1.22+).
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/#configure-apm-and-dogstatsd-communication-mode
-    configMode: # "hostip", "socket" or "service"
+    configMode:  # "hostip", "socket" or "service"
 
     # clusterAgent.admissionController.failurePolicy -- Set the failure policy for dynamic admission control.'
 
@@ -1245,8 +1245,7 @@ clusterAgent:
       imageTag:
 
       # clusterAgent.admissionController.agentSidecarInjection.selectors -- Defines the pod selector for sidecar injection, currently only one rule is supported.
-      selectors:
-        []
+      selectors: []
         # - objectSelector:
         #   matchLabels:
         #       "podlabelKey1": podlabelValue1
@@ -1259,8 +1258,7 @@ clusterAgent:
       # clusterAgent.admissionController.agentSidecarInjection.profiles -- Defines the sidecar configuration override, currently only one profile is supported.
 
       ## This setting allows overriding the sidecar Agent configuration by adding environment variables and providing resource settings.
-      profiles:
-        []
+      profiles: []
         # - env:
         #     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
         #       value: "true"
@@ -1314,7 +1312,7 @@ clusterAgent:
   #   memory: 256Mi
 
   # clusterAgent.priorityClassName -- Name of the priorityClass to apply to the Cluster Agent
-  priorityClassName: # system-cluster-critical
+  priorityClassName:  # system-cluster-critical
 
   # clusterAgent.nodeSelector -- Allow the Cluster Agent Deployment to be scheduled on selected nodes
 
@@ -1429,15 +1427,14 @@ clusterAgent:
     create: false
 
   # clusterAgent.additionalLabels -- Adds labels to the Cluster Agent deployment and pods
-  additionalLabels:
-    {}
+  additionalLabels: {}
     # key: "value"
 
   # clusterAgent.containerExclude -- Exclude containers from the Cluster Agent
   # Autodiscovery, as a space-separated list. (Requires Agent/Cluster Agent 7.50.0+)
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
-  containerExclude: # "image:datadog/agent"
+  containerExclude:  # "image:datadog/agent"
 
   # clusterAgent.containerInclude -- Include containers in the Cluster Agent Autodiscovery,
   # as a space-separated list.  If a container matches an include rule, it’s
@@ -1454,10 +1451,10 @@ existingClusterAgent:
   join: false
 
   # existingClusterAgent.tokenSecretName -- Existing secret name to use for external Cluster Agent token
-  tokenSecretName: # <EXISTING_DCA_SECRET_NAME>
+  tokenSecretName:  # <EXISTING_DCA_SECRET_NAME>
 
   # existingClusterAgent.serviceName -- Existing service name to use for reaching the external Cluster Agent
-  serviceName: # <EXISTING_DCA_SERVICE_NAME>
+  serviceName:  # <EXISTING_DCA_SERVICE_NAME>
 
   # existingClusterAgent.clusterchecksEnabled -- set this to false if you don’t want the agents to run the cluster checks of the joined external cluster agent
   clusterchecksEnabled: true
@@ -1480,8 +1477,7 @@ fips:
   use_https: false
 
   # fips.resources -- Resource requests and limits for the FIPS sidecar container.
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 256Mi
@@ -1513,7 +1509,7 @@ fips:
 
   ## Note: Use `|` to declare multi-line configuration.
   ## ref: https://docs.datadoghq.com/agent/guide/agent-fips-proxy
-  customFipsConfig: {} # |
+  customFipsConfig: {}  # |
   #  foobar
   #     foo bar baz
 
@@ -1563,7 +1559,7 @@ agents:
     ## This boolean permits to completely skip this check.
     ## This is useful, for example, for custom tags that are not
     ## respecting semantic versioning
-    doNotCheckTag: # false
+    doNotCheckTag:  # false
 
     # agents.image.pullPolicy -- Datadog Agent image pull policy
     pullPolicy: IfNotPresent
@@ -1675,7 +1671,7 @@ agents:
 
       # agents.containers.agent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel: # INFO
+      logLevel:  # INFO
 
       # agents.containers.agent.resources -- Resource requests and limits for the agent container.
       resources: {}
@@ -1739,7 +1735,7 @@ agents:
 
       # agents.containers.processAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel: # INFO
+      logLevel:  # INFO
 
       # agents.containers.processAgent.resources -- Resource requests and limits for the process-agent container
       resources: {}
@@ -1801,7 +1797,7 @@ agents:
       #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
 
       # agents.containers.traceAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
-      logLevel: # INFO
+      logLevel:  # INFO
 
       # agents.containers.traceAgent.resources -- Resource requests and limits for the trace-agent container
       resources: {}
@@ -1842,7 +1838,7 @@ agents:
 
       # agents.containers.systemProbe.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel: # INFO
+      logLevel:  # INFO
 
       # agents.containers.systemProbe.resources -- Resource requests and limits for the system-probe container
       resources: {}
@@ -1859,18 +1855,7 @@ agents:
       securityContext:
         privileged: false
         capabilities:
-          add:
-            [
-              "SYS_ADMIN",
-              "SYS_RESOURCE",
-              "SYS_PTRACE",
-              "NET_ADMIN",
-              "NET_BROADCAST",
-              "NET_RAW",
-              "IPC_LOCK",
-              "CHOWN",
-              "DAC_READ_SEARCH",
-            ]
+          add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN", "DAC_READ_SEARCH"]
 
       # agents.containers.systemProbe.ports -- Allows to specify extra ports (hostPorts for instance) for this container
       ports: []
@@ -1892,7 +1877,7 @@ agents:
 
       # agents.containers.securityAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel: # INFO
+      logLevel:  # INFO
 
       # agents.containers.securityAgent.resources -- Resource requests and limits for the security-agent container
       resources: {}
@@ -1999,12 +1984,11 @@ agents:
   podLabels: {}
 
   # agents.additionalLabels -- Adds labels to the Agent daemonset and pods
-  additionalLabels:
-    {}
+  additionalLabels: {}
     # key: "value"
 
   # agents.useConfigMap -- Configures a configmap to provide the agent configuration. Use this in combination with the `agents.customAgentConfig` parameter.
-  useConfigMap: # false
+  useConfigMap:  # false
 
   # agents.customAgentConfig -- Specify custom contents for the datadog agent config (datadog.yaml)
 
@@ -2151,7 +2135,7 @@ clusterChecksRunner:
   #    value: "1"
 
   # clusterChecksRunner.priorityClassName -- Name of the priorityClass to apply to the Cluster checks runners
-  priorityClassName: # system-cluster-critical
+  priorityClassName:  # system-cluster-critical
 
   # clusterChecksRunner.nodeSelector -- Allow the ClusterChecks Deployment to schedule on selected nodes
 
@@ -2264,8 +2248,7 @@ clusterChecksRunner:
     create: false
 
   # clusterChecksRunner.additionalLabels -- Adds labels to the cluster checks runner deployment and pods
-  additionalLabels:
-    {}
+  additionalLabels: {}
     # key: "value"
 
   # clusterChecksRunner.securityContext -- Allows you to overwrite the default PodSecurityContext on the clusterchecks pods.

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1181,7 +1181,7 @@ clusterAgent:
     ## If clusterAgent.admissionController.configMode is not set:
     ##   * and datadog.apm.socketEnabled is true, the Admission Controller uses socket.
     ##   * and datadog.apm.portEnabled is true, the Admission Controller uses hostip.
-    ##   * and datadog.apmadmissionController.useLocalService is true and the aformentioned two are false, the Admission Controller uses service.
+    ##   * and datadog.apm.useLocalService is true and the aformentioned two are false, the Admission Controller uses service.
     ##   * Otherwise, the Admission Controller defaults to hostip.
     ## Note: "service" mode relies on the internal traffic service to target the agent running on the local node (requires Kubernetes v1.22+).
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/#configure-apm-and-dogstatsd-communication-mode

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -6,10 +6,10 @@
 ## ONLY SET THE VALUES YOU WANT TO OVERRIDE IN YOUR values.yaml.
 
 # nameOverride -- Override name of app
-nameOverride:  # ""
+nameOverride: # ""
 
 # fullnameOverride -- Override the full qualified app name
-fullnameOverride:  # ""
+fullnameOverride: # ""
 
 # targetSystem -- Target OS for this deployment (possible values: linux, windows)
 targetSystem: "linux"
@@ -27,29 +27,29 @@ commonLabels: {}
 ## Azure - use datadoghq.azurecr.io
 ## AWS - use public.ecr.aws/datadog
 ## DockerHub - use docker.io/datadog
-registry:  # gcr.io/datadoghq
+registry: # gcr.io/datadoghq
 
 datadog:
   # datadog.apiKey -- Your Datadog API key
 
   ## ref: https://app.datadoghq.com/account/settings#agent/kubernetes
-  apiKey:  # <DATADOG_API_KEY>
+  apiKey: # <DATADOG_API_KEY>
 
   # datadog.apiKeyExistingSecret -- Use existing Secret which stores API key instead of creating a new one. The value should be set with the `api-key` key inside the secret.
 
   ## If set, this parameter takes precedence over "apiKey".
-  apiKeyExistingSecret:  # <DATADOG_API_KEY_SECRET>
+  apiKeyExistingSecret: # <DATADOG_API_KEY_SECRET>
 
   # datadog.appKey -- Datadog APP key required to use metricsProvider
 
   ## If you are using clusterAgent.metricsProvider.enabled = true, you must set
   ## a Datadog application key for read access to your metrics.
-  appKey:  # <DATADOG_APP_KEY>
+  appKey: # <DATADOG_APP_KEY>
 
   # datadog.appKeyExistingSecret -- Use existing Secret which stores APP key instead of creating a new one. The value should be set with the `app-key` key inside the secret.
 
   ## If set, this parameter takes precedence over "appKey".
-  appKeyExistingSecret:  # <DATADOG_APP_KEY_SECRET>
+  appKeyExistingSecret: # <DATADOG_APP_KEY_SECRET>
 
   # agents.secretAnnotations -- Annotations to add to the Secrets
   secretAnnotations: {}
@@ -62,13 +62,13 @@ datadog:
 
     ## Note: If the command value is "/readsecret_multiple_providers.sh", and datadog.secretBackend.enableGlobalPermissions is enabled below, the agents will have permissions to get secret objects across the cluster.
     ## Read more about "/readsecret_multiple_providers.sh": https://docs.datadoghq.com/agent/guide/secrets-management/#script-for-reading-from-multiple-secret-providers-readsecret_multiple_providerssh
-    command:  # "/readsecret.sh" or "/readsecret_multiple_providers.sh" or any custom binary path
+    command: # "/readsecret.sh" or "/readsecret_multiple_providers.sh" or any custom binary path
 
     # datadog.secretBackend.arguments -- Configure the secret backend command arguments (space-separated strings).
-    arguments:  # "/etc/secret-volume" or any other custom arguments
+    arguments: # "/etc/secret-volume" or any other custom arguments
 
     # datadog.secretBackend.timeout -- Configure the secret backend command timeout in seconds.
-    timeout:  # 30
+    timeout: # 30
 
     # datadog.secretBackend.enableGlobalPermissions -- Whether to create a global permission allowing Datadog agents to read all secrets when `datadog.secretBackend.command` is set to `"/readsecret_multiple_providers.sh"`.
     enableGlobalPermissions: true
@@ -103,7 +103,7 @@ datadog:
   ## * Overall length should not be higher than 80 characters.
   ## Compared to the rules of GKE, dots are allowed whereas they are not allowed on GKE:
   ## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
-  clusterName:  # <CLUSTER_NAME>
+  clusterName: # <CLUSTER_NAME>
 
   # datadog.site -- The site of the Datadog intake to send Agent data to.
   # (documentation: https://docs.datadoghq.com/getting_started/site/)
@@ -114,12 +114,12 @@ datadog:
   ## Set to 'us5.datadoghq.com' to send data to the US5 site.
   ## Set to 'ddog-gov.com' to send data to the US1-FED site.
   ## Set to 'ap1.datadoghq.com' to send data to the AP1 site.
-  site:  # datadoghq.com
+  site: # datadoghq.com
 
   # datadog.dd_url -- The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL
 
   ## Overrides the site setting defined in "site".
-  dd_url:  # https://app.datadoghq.com
+  dd_url: # https://app.datadoghq.com
 
   # datadog.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, off
   logLevel: INFO
@@ -141,7 +141,7 @@ datadog:
     enabled: true
 
     rbac:
-    # datadog.kubeStateMetricsCore.rbac.create -- If true, create & use RBAC resources
+      # datadog.kubeStateMetricsCore.rbac.create -- If true, create & use RBAC resources
       create: true
 
     # datadog.kubeStateMetricsCore.ignoreLegacyKSMCheck -- Disable the auto-configuration of legacy kubernetes_state check (taken into account only when datadog.kubeStateMetricsCore.enabled is true)
@@ -291,7 +291,7 @@ datadog:
   # datadog.checksCardinality -- Sets the tag cardinality for the checks run by the Agent.
 
   ## ref: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
-  checksCardinality:  # low, orchestrator or high (not set by default to avoid overriding existing DD_CHECKS_TAG_CARDINALITY configurations, the default value in the Agent is low)
+  checksCardinality: # low, orchestrator or high (not set by default to avoid overriding existing DD_CHECKS_TAG_CARDINALITY configurations, the default value in the Agent is low)
 
   # kubelet configuration
   kubelet:
@@ -302,7 +302,7 @@ datadog:
           fieldPath: status.hostIP
     # datadog.kubelet.tlsVerify -- Toggle kubelet TLS verification
     # @default -- true
-    tlsVerify:  # false
+    tlsVerify: # false
     # datadog.kubelet.hostCAPath -- Path (on host) where the Kubelet CA certificate is stored
     # @default -- None (no mount from host)
     hostCAPath:
@@ -400,10 +400,10 @@ datadog:
     unbundleEvents: false
     # datadog.kubernetesEvents.collectedEventTypes -- Event types to be collected. This requires datadog.kubernetesEvents.unbundleEvents to be set to true.
     collectedEventTypes:
-    # - kind: <kubernetes resource kind> # (optional if `source`` is provided)
-    #   source: <controller name> # (optional if `kind`` is provided)
-    #   reasons: # (optional) if empty accept all event reasons
-    #   - <kubernetes event reason>
+      # - kind: <kubernetes resource kind> # (optional if `source`` is provided)
+      #   source: <controller name> # (optional if `kind`` is provided)
+      #   reasons: # (optional) if empty accept all event reasons
+      #   - <kubernetes event reason>
       - kind: Pod
         reasons:
           - Failed
@@ -430,7 +430,7 @@ datadog:
   leaderElection: true
 
   # datadog.leaderLeaseDuration -- Set the lease time for leader election in second
-  leaderLeaseDuration:  # 60
+  leaderLeaseDuration: # 60
 
   # datadog.leaderElectionResource -- Selects the default resource to use for leader election.
   # Can be:
@@ -584,8 +584,7 @@ datadog:
     enabled: false
     # datadog.otelCollector.ports -- Ports that OTel Collector is listening
     ports:
-
-        # Default GRPC port of OTLP receiver
+      # Default GRPC port of OTLP receiver
       - containerPort: "4317"
         name: otel-grpc
         # Default HTTP port of OTLP receiver
@@ -661,10 +660,10 @@ datadog:
   #   service.py: |-
 
   # datadog.dockerSocketPath -- Path to the docker socket
-  dockerSocketPath:  # /var/run/docker.sock
+  dockerSocketPath: # /var/run/docker.sock
 
   # datadog.criSocketPath -- Path to the container runtime socket (if different from Docker)
-  criSocketPath:  # /var/run/containerd/containerd.sock
+  criSocketPath: # /var/run/containerd/containerd.sock
 
   # Configure how the agent interact with the host's container runtime
   containerRuntimeSupport:
@@ -692,10 +691,11 @@ datadog:
 
     # datadog.processAgent.runInCoreAgent -- Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery.
     ## This requires Agent 7.57.0+ and Linux.
-    runInCoreAgent: false
+    runInCoreAgent:
+      false
 
-     # datadog.processAgent.containerCollection -- Set this to true to enable container collection
-     ## ref: https://docs.datadoghq.com/infrastructure/containers/?tab=helm
+      # datadog.processAgent.containerCollection -- Set this to true to enable container collection
+      ## ref: https://docs.datadoghq.com/infrastructure/containers/?tab=helm
     containerCollection: true
 
   # datadog.disableDefaultOsReleasePaths -- Set this to true to disable mounting datadog.osReleasePath in all containers
@@ -709,7 +709,6 @@ datadog:
 
   ## Enable systemProbe agent and provide custom configs
   systemProbe:
-
     # datadog.systemProbe.debugPort -- Specify the port to expose pprof and expvar for system-probe agent
     debugPort: 0
 
@@ -760,7 +759,7 @@ datadog:
     maxTrackedConnections: 131072
 
     # datadog.systemProbe.conntrackMaxStateSize -- the maximum size of the userspace conntrack cache
-    conntrackMaxStateSize: 131072  # 2 * maxTrackedConnections by default, per  https://github.com/DataDog/datadog-agent/blob/d1c5de31e1bba72dfac459aed5ff9562c3fdcc20/pkg/process/config/config.go#L229
+    conntrackMaxStateSize: 131072 # 2 * maxTrackedConnections by default, per  https://github.com/DataDog/datadog-agent/blob/d1c5de31e1bba72dfac459aed5ff9562c3fdcc20/pkg/process/config/config.go#L229
 
     # datadog.systemProbe.conntrackInitTimeout -- the time to wait for conntrack to initialize before failing
     conntrackInitTimeout: 10s
@@ -771,7 +770,6 @@ datadog:
 
     # datadog.systemProbe.enableDefaultKernelHeadersPaths -- Enable mount of default paths where kernel headers are stored
     enableDefaultKernelHeadersPaths: true
-
 
   containerImageCollection:
     # datadog.containerImageCollection.enabled -- Enable collection of container image metadata
@@ -814,7 +812,8 @@ datadog:
 
     # datadog.helmCheck.valuesAsTags -- Collects Helm values from a release and uses them as tags (Requires Agent and Cluster Agent 7.40.0+).
     # This requires datadog.HelmCheck.enabled to be set to true
-    valuesAsTags: {}
+    valuesAsTags:
+      {}
       #   <HELM_VALUE>: <LABEL_NAME>
 
   networkMonitoring:
@@ -946,7 +945,8 @@ datadog:
     # datadog.prometheusScrape.serviceEndpoints -- Enable generating dedicated checks for service endpoints.
     serviceEndpoints: false
     # datadog.prometheusScrape.additionalConfigs -- Allows adding advanced openmetrics check configurations with custom discovery rules. (Requires Agent version 7.27+)
-    additionalConfigs: []
+    additionalConfigs:
+      []
       # -
       #   autodiscovery:
       #     kubernetes_annotations:
@@ -975,7 +975,7 @@ datadog:
   # datadog.containerExclude -- Exclude containers from Agent Autodiscovery, as a space-separated list
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
-  containerExclude:  # "image:datadog/agent"
+  containerExclude: # "image:datadog/agent"
 
   # datadog.containerInclude -- Include containers in Agent Autodiscovery, as a space-separated list.
   # If a container matches an include rule, it’s always included in Autodiscovery
@@ -1045,7 +1045,7 @@ clusterAgent:
     ## This boolean permits completely skipping this check.
     ## This is useful, for example, for custom tags that are not
     ## respecting semantic versioning.
-    doNotCheckTag:  # false
+    doNotCheckTag: # false
 
   # clusterAgent.securityContext -- Allows you to overwrite the default PodSecurityContext on the cluster-agent pods.
   securityContext: {}
@@ -1134,7 +1134,7 @@ clusterAgent:
       port: 8443
 
     # clusterAgent.metricsProvider.endpoint -- Override the external metrics provider endpoint. If not set, the cluster-agent defaults to `datadog.site`
-    endpoint:  # https://api.datadoghq.com
+    endpoint: # https://api.datadoghq.com
 
   # clusterAgent.env -- Set environment variables specific to Cluster Agent
 
@@ -1181,11 +1181,11 @@ clusterAgent:
     ## If clusterAgent.admissionController.configMode is not set:
     ##   * and datadog.apm.socketEnabled is true, the Admission Controller uses socket.
     ##   * and datadog.apm.portEnabled is true, the Admission Controller uses hostip.
-    ##   * and datadog.apm.useLocalService is true and the aformentioned two are false, the Admission Controller uses service.
+    ##   * and datadog.apmadmissionController.useLocalService is true and the aformentioned two are false, the Admission Controller uses service.
     ##   * Otherwise, the Admission Controller defaults to hostip.
     ## Note: "service" mode relies on the internal traffic service to target the agent running on the local node (requires Kubernetes v1.22+).
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/#configure-apm-and-dogstatsd-communication-mode
-    configMode:  # "hostip", "socket" or "service"
+    configMode: # "hostip", "socket" or "service"
 
     # clusterAgent.admissionController.failurePolicy -- Set the failure policy for dynamic admission control.'
 
@@ -1216,6 +1216,10 @@ clusterAgent:
       # Options are "remote_copy" or "init_container"
       mode: remote_copy
 
+    kubernetesAdmissionEvents:
+      # clusterAgent.admissionController.kubernetesAdmissionEvents.enabled -- Enable the Kubernetes Admission Events feature.
+      enabled: false
+
     agentSidecarInjection:
       # clusterAgent.admissionController.agentSidecarInjection.enabled -- Enables Datadog Agent sidecar injection.
 
@@ -1241,7 +1245,8 @@ clusterAgent:
       imageTag:
 
       # clusterAgent.admissionController.agentSidecarInjection.selectors -- Defines the pod selector for sidecar injection, currently only one rule is supported.
-      selectors: []
+      selectors:
+        []
         # - objectSelector:
         #   matchLabels:
         #       "podlabelKey1": podlabelValue1
@@ -1254,7 +1259,8 @@ clusterAgent:
       # clusterAgent.admissionController.agentSidecarInjection.profiles -- Defines the sidecar configuration override, currently only one profile is supported.
 
       ## This setting allows overriding the sidecar Agent configuration by adding environment variables and providing resource settings.
-      profiles: []
+      profiles:
+        []
         # - env:
         #     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
         #       value: "true"
@@ -1308,7 +1314,7 @@ clusterAgent:
   #   memory: 256Mi
 
   # clusterAgent.priorityClassName -- Name of the priorityClass to apply to the Cluster Agent
-  priorityClassName:  # system-cluster-critical
+  priorityClassName: # system-cluster-critical
 
   # clusterAgent.nodeSelector -- Allow the Cluster Agent Deployment to be scheduled on selected nodes
 
@@ -1423,14 +1429,15 @@ clusterAgent:
     create: false
 
   # clusterAgent.additionalLabels -- Adds labels to the Cluster Agent deployment and pods
-  additionalLabels: {}
+  additionalLabels:
+    {}
     # key: "value"
 
   # clusterAgent.containerExclude -- Exclude containers from the Cluster Agent
   # Autodiscovery, as a space-separated list. (Requires Agent/Cluster Agent 7.50.0+)
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
-  containerExclude:  # "image:datadog/agent"
+  containerExclude: # "image:datadog/agent"
 
   # clusterAgent.containerInclude -- Include containers in the Cluster Agent Autodiscovery,
   # as a space-separated list.  If a container matches an include rule, it’s
@@ -1447,10 +1454,10 @@ existingClusterAgent:
   join: false
 
   # existingClusterAgent.tokenSecretName -- Existing secret name to use for external Cluster Agent token
-  tokenSecretName:  # <EXISTING_DCA_SECRET_NAME>
+  tokenSecretName: # <EXISTING_DCA_SECRET_NAME>
 
   # existingClusterAgent.serviceName -- Existing service name to use for reaching the external Cluster Agent
-  serviceName:  # <EXISTING_DCA_SERVICE_NAME>
+  serviceName: # <EXISTING_DCA_SERVICE_NAME>
 
   # existingClusterAgent.clusterchecksEnabled -- set this to false if you don’t want the agents to run the cluster checks of the joined external cluster agent
   clusterchecksEnabled: true
@@ -1473,7 +1480,8 @@ fips:
   use_https: false
 
   # fips.resources -- Resource requests and limits for the FIPS sidecar container.
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 256Mi
@@ -1505,7 +1513,7 @@ fips:
 
   ## Note: Use `|` to declare multi-line configuration.
   ## ref: https://docs.datadoghq.com/agent/guide/agent-fips-proxy
-  customFipsConfig: {}  # |
+  customFipsConfig: {} # |
   #  foobar
   #     foo bar baz
 
@@ -1555,7 +1563,7 @@ agents:
     ## This boolean permits to completely skip this check.
     ## This is useful, for example, for custom tags that are not
     ## respecting semantic versioning
-    doNotCheckTag:  # false
+    doNotCheckTag: # false
 
     # agents.image.pullPolicy -- Datadog Agent image pull policy
     pullPolicy: IfNotPresent
@@ -1667,7 +1675,7 @@ agents:
 
       # agents.containers.agent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.agent.resources -- Resource requests and limits for the agent container.
       resources: {}
@@ -1731,7 +1739,7 @@ agents:
 
       # agents.containers.processAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.processAgent.resources -- Resource requests and limits for the process-agent container
       resources: {}
@@ -1793,7 +1801,7 @@ agents:
       #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
 
       # agents.containers.traceAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.traceAgent.resources -- Resource requests and limits for the trace-agent container
       resources: {}
@@ -1834,7 +1842,7 @@ agents:
 
       # agents.containers.systemProbe.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.systemProbe.resources -- Resource requests and limits for the system-probe container
       resources: {}
@@ -1851,7 +1859,18 @@ agents:
       securityContext:
         privileged: false
         capabilities:
-          add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN", "DAC_READ_SEARCH"]
+          add:
+            [
+              "SYS_ADMIN",
+              "SYS_RESOURCE",
+              "SYS_PTRACE",
+              "NET_ADMIN",
+              "NET_BROADCAST",
+              "NET_RAW",
+              "IPC_LOCK",
+              "CHOWN",
+              "DAC_READ_SEARCH",
+            ]
 
       # agents.containers.systemProbe.ports -- Allows to specify extra ports (hostPorts for instance) for this container
       ports: []
@@ -1873,7 +1892,7 @@ agents:
 
       # agents.containers.securityAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.securityAgent.resources -- Resource requests and limits for the security-agent container
       resources: {}
@@ -1980,11 +1999,12 @@ agents:
   podLabels: {}
 
   # agents.additionalLabels -- Adds labels to the Agent daemonset and pods
-  additionalLabels: {}
+  additionalLabels:
+    {}
     # key: "value"
 
   # agents.useConfigMap -- Configures a configmap to provide the agent configuration. Use this in combination with the `agents.customAgentConfig` parameter.
-  useConfigMap:  # false
+  useConfigMap: # false
 
   # agents.customAgentConfig -- Specify custom contents for the datadog agent config (datadog.yaml)
 
@@ -2131,7 +2151,7 @@ clusterChecksRunner:
   #    value: "1"
 
   # clusterChecksRunner.priorityClassName -- Name of the priorityClass to apply to the Cluster checks runners
-  priorityClassName:  # system-cluster-critical
+  priorityClassName: # system-cluster-critical
 
   # clusterChecksRunner.nodeSelector -- Allow the ClusterChecks Deployment to schedule on selected nodes
 
@@ -2244,7 +2264,8 @@ clusterChecksRunner:
     create: false
 
   # clusterChecksRunner.additionalLabels -- Adds labels to the cluster checks runner deployment and pods
-  additionalLabels: {}
+  additionalLabels:
+    {}
     # key: "value"
 
   # clusterChecksRunner.securityContext -- Allows you to overwrite the default PodSecurityContext on the clusterchecks pods.


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for the new feature for change tracking in k8s called "Kubernetes Admission Events".

#### Special notes for your reviewer:

Applicable on Agent v.7.62.0+

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
