### PR TITLE
[USMON-1389] service discovery: Add support

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.85.0
+
+* Add `datadog.discovery.enabled` configuration to control service-discovery
+
 ## 3.84.3
 
 * Added the configuration value `clusterAgent.admissionController.kubernetes_admission_events.enabled` to enabled/disable the Kubernetes Admission Events feature.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.84.2
+version: 3.85.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.84.2](https://img.shields.io/badge/Version-3.84.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.85.0](https://img.shields.io/badge/Version-3.85.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -730,6 +730,7 @@ helm install <RELEASE_NAME> \
 | datadog.dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | datadog.disableDefaultOsReleasePaths | bool | `false` | Set this to true to disable mounting datadog.osReleasePath in all containers |
 | datadog.disablePasswdMount | bool | `false` | Set this to true to disable mounting /etc/passwd in all containers |
+| datadog.discovery.enabled | bool | `nil` | Enable Service Discovery |
 | datadog.dockerSocketPath | string | `nil` | Path to the docker socket |
 | datadog.dogstatsd.hostSocketPath | string | `"/var/run/datadog/"` | Host path to the DogStatsD socket |
 | datadog.dogstatsd.nonLocalTraffic | bool | `true` | Enable this to make each node accept non-local statsd traffic (from outside of the pod) |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -352,7 +352,7 @@ On GKE Autopilot, only one "datadog" Helm chart release is allowed by Kubernetes
 #####################################################################
 ####   WARNING: System Probe is not supported on GKE Autopilot   ####
 #####################################################################
-{{- fail "On GKE Autopilot environments, System Probe is not supported. The option 'datadog.securityAgent.runtime.enabled', 'datadog.securityAgent.runtime.fimEnabled', 'datadog.networkMonitoring.enabled', 'datadog.systemProbe.enableTCPQueueLength', 'datadog.systemProbe.enableOOMKill' and 'datadog.serviceMonitoring.enabled' must be set 'false'" }}
+{{- fail "On GKE Autopilot environments, System Probe is not supported. The option 'datadog.securityAgent.runtime.enabled', 'datadog.securityAgent.runtime.fimEnabled', 'datadog.networkMonitoring.enabled', 'datadog.systemProbe.enableTCPQueueLength', 'datadog.systemProbe.enableOOMKill', 'datadog.serviceMonitoring.enabled' and 'datadog.discovery.enabled' must be set 'false'" }}
 
 {{- end }}
 

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -331,7 +331,7 @@ Return a remote image path based on `.Values` (passed as root) and `.` (any `.im
 Return true if a system-probe feature is enabled.
 */}}
 {{- define "system-probe-feature" -}}
-{{- if or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.securityAgent.runtime.fimEnabled .Values.datadog.networkMonitoring.enabled .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill .Values.datadog.serviceMonitoring.enabled -}}
+{{- if or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.securityAgent.runtime.fimEnabled .Values.datadog.networkMonitoring.enabled .Values.datadog.systemProbe.enableTCPQueueLength .Values.datadog.systemProbe.enableOOMKill .Values.datadog.serviceMonitoring.enabled .Values.datadog.discovery.enabled -}}
 true
 {{- else -}}
 false

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -43,6 +43,10 @@ data:
       conntrack_init_timeout: {{ $.Values.datadog.systemProbe.conntrackInitTimeout }}
     service_monitoring_config:
       enabled: {{ $.Values.datadog.serviceMonitoring.enabled }}
+    {{- if not (eq .Values.datadog.discovery.enabled nil) }}
+    discovery:
+      enabled: {{ $.Values.datadog.discovery.enabled }}
+    {{- end }}
     runtime_security_config:
       enabled: {{ $.Values.datadog.securityAgent.runtime.enabled }}
       fim_enabled: {{ $.Values.datadog.securityAgent.runtime.fimEnabled }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -824,6 +824,10 @@ datadog:
     # datadog.serviceMonitoring.enabled -- Enable Universal Service Monitoring
     enabled: false
 
+  discovery:
+    # datadog.discovery.enabled -- (bool) Enable Service Discovery
+    enabled: #  false
+
   # Software Bill of Materials configuration
   sbom:
     containerImage:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -826,7 +826,7 @@ datadog:
 
   discovery:
     # datadog.discovery.enabled -- (bool) Enable Service Discovery
-    enabled: #  false
+    enabled:  # false
 
   # Software Bill of Materials configuration
   sbom:


### PR DESCRIPTION
#### What this PR does / why we need it:

The PR provides easy configuration option to enable or disable service discovery feature of the agent.

The PR introduces the configuration option
```yaml
datadog:
  discovery:
    enabled: <true/false>
```

The customer can enable or disable the feature using this configuration option.

On purpose I left the default value as empty, to allow the agent to fallback into the default mechanism, as we're in the process to enable the feature by default under some conditions.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Testing 4 options:

##### Enabling SD via the chart

Goal: Enable SD directly

How to test:

Install the agent with the following configuration
```yaml
datadog:
  discovery:
    enabled: true
```

What to expect?
1. Run `k logs -n <namespace> -c system-probe $(k get pod -n <namespace> | tail -n1 | awk '{print $1}') | grep disc`
    1. Expect to see `SYS-PROBE | INFO | (cmd/system-probe/api/module/loader.go:117 in Register) | module discovery started`
2. Run `k exec -it -n <namespace> -c system-probe $(k get pod -n <namespace> | tail -n1 | awk '{print $1}') -- cat /etc/datadog-agent/system-probe.yaml`
    1. Expect to see
    ```yaml
    discovery:
      enabled: true
    ```

##### Disabling SD via the chart

Goal: Disable SD directly

How to test:

Install the agent with the following configuration (enabling NPM to have system-probe)
```yaml
datadog:
  networkMonitoring:
    enabled: true
  discovery:
    enabled: false
```

What to expect?
1. Run `k logs -n <namespace> -c system-probe $(k get pod -n <namespace> | tail -n1 | awk '{print $1}') | grep disc`
    1. Expect to see `SYS-PROBE | INFO | (cmd/system-probe/api/module/loader.go:71 in Register) | module discovery disabled`
2. Run `k exec -it -n <namespace> -c system-probe $(k get pod -n <namespace> | tail -n1 | awk '{print $1}') -- cat /etc/datadog-agent/system-probe.yaml`
    1. Expect to see
    ```yaml
    discovery:
      enabled: false
    ```

##### Empty value, with USM enabled

Goal: If no specific value was given and USM was enabled, the agent will enable by default SD

How to test:

Install the agent with the following configuration
```yaml
datadog:
  serviceMonitoring:
    enabled: true
```

What to expect?
1. Run `k logs -n <namespace> -c system-probe $(k get pod -n <namespace> | tail -n1 | awk '{print $1}') | grep disc`
    1. Expect to see `SYS-PROBE | INFO | (cmd/system-probe/api/module/loader.go:117 in Register) | module discovery started`
2. Run `k exec -it -n <namespace> -c system-probe $(k get pod -n <namespace> | tail -n1 | awk '{print $1}') -- cat /etc/datadog-agent/system-probe.yaml`
    1. Expect to don't have `discovery` key

##### Empty value, without USM enabled

Goal: If no specific value was given and USM was not enabled, the agent will not run SD

How to test:

Install the agent with the following configuration (enabling npm, to enable system-probe)
```yaml
datadog:
  networkMonitoring:
    enabled: true
```

What to expect?
1. Run `k logs -n <namespace> -c system-probe $(k get pod -n <namespace> | tail -n1 | awk '{print $1}') | grep disc`
    1. Expect to see `SYS-PROBE | INFO | (cmd/system-probe/api/module/loader.go:71 in Register) | module discovery disabled`
2. Run `k exec -it -n <namespace> -c system-probe $(k get pod -n <namespace> | tail -n1 | awk '{print $1}') -- cat /etc/datadog-agent/system-probe.yaml`
    1. Expect to don't have `discovery` key

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
