### PR TITLE
feat(admission): add delete RBAC for datadog-webhook

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Datadog changelog
 
+## 3.86.0
+
+* Add `delete` permission for `datadog-webhook` Admission Registration RBACs.
+
 ## 3.85.0
 
-* Add `datadog.discovery.enabled` configuration to control service-discovery
+* Add `datadog.discovery.enabled` configuration to control service-discovery.
 
 ## 3.84.4
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.85.0
+version: 3.86.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.85.0](https://img.shields.io/badge/Version-3.85.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.86.0](https://img.shields.io/badge/Version-3.86.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -257,7 +257,7 @@ rules:
   - mutatingwebhookconfigurations
   resourceNames:
     - {{ .Values.clusterAgent.admissionController.webhookName | quote }}
-  verbs: ["get", "list", "watch", "update"]
+  verbs: ["get", "list", "watch", "update", "delete"]
 - apiGroups:
   - admissionregistration.k8s.io
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the necessary RBACs for the Cluster Agent to delete the `datadog-webhook` Validating and Mutating webhook configurations.

```
➜  kubectl describe clusterroles.rbac.authorization.k8s.io datadog-agent-cluster-agent
Name:         datadog-agent-cluster-agent
[...]
  mutatingwebhookconfigurations.admissionregistration.k8s.io    []                 [datadog-webhook]                [get list watch update delete]
  validatingwebhookconfigurations.admissionregistration.k8s.io  []                 [datadog-webhook]                [get list watch update delete]
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
