### PR TITLE
[datadog-operator] expose CRD-specific watch namespace settings

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.1
+
+* Expose CRD-specific namespace watch configuration added in Operator 1.8.0 release.
+
 ## 2.5.0
 
 * Update Datadog Operator version to 1.11.1.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.5.0
+version: 2.5.1
 appVersion: 1.11.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![AppVersion: 1.11.1](https://img.shields.io/badge/AppVersion-1.11.1-informational?style=flat-square)
+![Version: 2.5.1](https://img.shields.io/badge/Version-2.5.1-informational?style=flat-square) ![AppVersion: 1.11.1](https://img.shields.io/badge/AppVersion-1.11.1-informational?style=flat-square)
 
 ## Values
 
@@ -60,7 +60,11 @@
 | tolerations | list | `[]` | Allows to schedule Datadog Operator on tainted nodes |
 | volumeMounts | list | `[]` | Specify additional volumes to mount in the container |
 | volumes | list | `[]` | Specify additional volumes to mount in the container |
-| watchNamespaces | list | `[]` | Restricts the Operator to watch its managed resources on specific namespaces |
+| watchNamespaces | list | `[]` | Restricts the Operator to watch its managed resources on specific namespaces unless CRD-specific watchNamespaces properties are set |
+| watchNamespacesAgent | list | `[]` | Restricts the Operator to watch DatadogAgent resources on specific namespaces. Requires v1.8.0+ |
+| watchNamespacesAgentProfile | list | `[]` | Restricts the Operator to watch DatadogAgentProfile resources on specific namespaces. Requires v1.8.0+ |
+| watchNamespacesMonitor | list | `[]` | Restricts the Operator to watch DatadogMonitor resources on specific namespaces. Requires v1.8.0+ |
+| watchNamespacesSLO | list | `[]` | Restricts the Operator to watch DatadogSLO resources on specific namespaces. Requires v1.8.0+ |
 
 ## How to configure which namespaces are watched by the Operator.
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -62,6 +62,22 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             {{- end }}
+            {{- if .Values.watchNamespacesAgent }}
+            - name: DD_AGENT_WATCH_NAMESPACE
+              value: {{ .Values.watchNamespacesAgent | join "," }}
+            {{- end }}
+            {{- if .Values.watchNamespacesMonitor }}
+            - name: DD_MONITOR_WATCH_NAMESPACE
+              value: {{ .Values.watchNamespacesMonitor | join "," }}
+            {{- end }}
+            {{- if .Values.watchNamespacesSLO }}
+            - name: DD_SLO_WATCH_NAMESPACE
+              value: {{ .Values.watchNamespacesSLO | join "," }}
+            {{- end }}
+            {{- if .Values.watchNamespacesAgentProfile }}
+            - name: DD_AGENT_PROFILE_WATCH_NAMESPACE
+              value: {{ .Values.watchNamespacesAgentProfile | join "," }}
+            {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -157,6 +157,7 @@ podLabels: {}
 collectOperatorMetrics: true
 
 # watchNamespaces -- Restricts the Operator to watch its managed resources on specific namespaces
+# unless CRD-specific watchNamespaces properties are set
 watchNamespaces: []
 # example: watch only two namespaces:
 # watchNamespaces:
@@ -165,6 +166,54 @@ watchNamespaces: []
 #
 # to watch all namespaces
 # watchNamespaces:
+# - ""
+
+# watchNamespacesAgent -- Restricts the Operator to watch DatadogAgent resources on specific namespaces.
+# Requires v1.8.0+
+watchNamespacesAgent: []
+# example: watch only two namespaces:
+# watchNamespacesAgent:
+# - "default"
+# - "datadog"
+#
+# to watch all namespaces
+# watchNamespacesAgent:
+# - ""
+
+# watchNamespacesMonitor -- Restricts the Operator to watch DatadogMonitor resources on specific namespaces.
+# Requires v1.8.0+
+watchNamespacesMonitor: []
+# example: watch only two namespaces:
+# watchNamespacesMonitor:
+# - "default"
+# - "datadog"
+#
+# to watch all namespaces
+# watchNamespacesMonitor:
+# - ""
+
+# watchNamespacesSLO -- Restricts the Operator to watch DatadogSLO resources on specific namespaces.
+# Requires v1.8.0+
+watchNamespacesSLO: []
+# example: watch only two namespaces:
+# watchNamespacesSLO:
+# - "default"
+# - "datadog"
+#
+# to watch all namespaces
+# watchNamespacesSLO:
+# - ""
+
+# watchNamespacesAgentProfile -- Restricts the Operator to watch DatadogAgentProfile resources on specific namespaces.
+# Requires v1.8.0+
+watchNamespacesAgentProfile: []
+# example: watch only two namespaces:
+# watchNamespacesAgentProfile:
+# - "default"
+# - "datadog"
+#
+# to watch all namespaces
+# watchNamespacesAgentProfile:
 # - ""
 
 # containerSecurityContext -- A security context defines privileges and access control settings for a container.

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -84,6 +84,23 @@ func Test_operator_chart(t *testing.T) {
 			assertions: verifyLivenessProbeOverride,
 			skipTest:   SkipTest,
 		},
+		{
+			name: "Watch namespaces correctly set",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"watchNamespaces":        "{common1,common2}",
+					"watchNamespacesAgent":   "{dda-ns}",
+					"watchNamespacesMonitor": "{monitor-ns}",
+					"watchNamespacesSLO":     "{}",
+				},
+			},
+			assertions: verifyWatchNamespaces,
+			skipTest:   SkipTest,
+		},
 	}
 
 	for _, tt := range tests {
@@ -130,4 +147,31 @@ func verifyLivenessProbeOverride(t *testing.T, manifest string) {
 	assert.Equal(t, int32(20), operatorContainer.LivenessProbe.PeriodSeconds)
 	assert.Equal(t, int32(20), operatorContainer.LivenessProbe.TimeoutSeconds)
 	assert.Equal(t, int32(3), operatorContainer.LivenessProbe.FailureThreshold)
+}
+
+func verifyWatchNamespaces(t *testing.T, manifest string) {
+	var deployment appsv1.Deployment
+	common.Unmarshal(t, manifest, &deployment)
+	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
+	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+	watchNsEnv := FindEnvVarByName(operatorContainer.Env, "WATCH_NAMESPACE")
+	agentNsEnv := FindEnvVarByName(operatorContainer.Env, "DD_AGENT_WATCH_NAMESPACE")
+	monitorNsEnv := FindEnvVarByName(operatorContainer.Env, "DD_MONITOR_WATCH_NAMESPACE")
+	sloNsEnv := FindEnvVarByName(operatorContainer.Env, "DD_SLO_WATCH_NAMESPACE")
+	dapNsEnv := FindEnvVarByName(operatorContainer.Env, "DD_AGENT_PROFILE_WATCH_NAMESPACE")
+
+	assert.Equal(t, "common1,common2", watchNsEnv.Value)
+	assert.Equal(t, "dda-ns", agentNsEnv.Value)
+	assert.Equal(t, "monitor-ns", monitorNsEnv.Value)
+	assert.Equal(t, "", sloNsEnv.Value)
+	assert.Nil(t, dapNsEnv)
+}
+
+func FindEnvVarByName(envs []v1.EnvVar, name string) *v1.EnvVar {
+	for i, env := range envs {
+		if env.Name == name {
+			return &envs[i]
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds configuration for CRD-specific watch namespaces added in Operator 1.8.0
https://github.com/DataDog/datadog-operator/pull/1235

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
