### PR TITLE
[synthetics-private-location] Add service account annotations

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.17.6
+
+* Add optional annotations for service account.
+
 ## 0.17.5
 
 * Update private location image version to `1.54.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.17.5
+version: 0.17.6
 appVersion: 1.54.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.17.5](https://img.shields.io/badge/Version-0.17.5-informational?style=flat-square) ![AppVersion: 1.54.0](https://img.shields.io/badge/AppVersion-1.54.0-informational?style=flat-square)
+![Version: 0.17.6](https://img.shields.io/badge/Version-0.17.6-informational?style=flat-square) ![AppVersion: 1.54.0](https://img.shields.io/badge/AppVersion-1.54.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations/?tab=helmchart).
 
@@ -53,6 +53,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | replicaCount | int | `1` | Number of instances of Datadog Synthetics Private Location |
 | resources | object | `{}` | Set resources requests/limits for Datadog Synthetics Private Location PODs |
 | securityContext | object | `{}` | Security context to set to the Datadog Synthetics Private Location container |
+| serviceAccount.annotations | object | `{}` | Annotations for the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set name is generated using the fullname template |
 | tolerations | list | `[]` | Allows to schedule Datadog Synthetics Private Location on tainted nodes |

--- a/charts/synthetics-private-location/templates/service_account.yaml
+++ b/charts/synthetics-private-location/templates/service_account.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ template "synthetics-private-location.serviceAccountName" . }}
   labels:
 {{ include "synthetics-private-location.labels" . | indent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -34,6 +34,8 @@ serviceAccount:
   create: true
   # serviceAccount.name -- The name of the service account to use. If not set name is generated using the fullname template
   name: ""
+  # serviceAccount.annotations -- Annotations for the service account
+  annotations: {}
 
 # Create a ConfigMap containing the PEM files of your custom CA Root certificate
 # Then add it as an extra volume mounted on /etc/datadog/certs/


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds an optional annotations block for the synthetics-private-location service account, to use with AWS IAM roles, for example.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
