### PR TITLE
Disable SBOM monitoring features for GKE Autopilot

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.87.2
+
+* Disable SBOM monitoring features for GKE Autopilot, as they are not supported
+
 ## 3.87.1
 
 * Add the ability to set the image tag to use for the APM Injector.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.87.1
+version: 3.87.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.87.1](https://img.shields.io/badge/Version-3.87.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.87.2](https://img.shields.io/badge/Version-3.87.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -424,6 +424,20 @@ The option is overriden to avoid mounting volumes that are not allowed which wou
 
 {{- end }}
 
+{{- if or .Values.providers.gke.autopilot .Values.providers.gke.gdc }}
+
+{{- if or .Values.datadog.sbom.containerImage.enabled .Values.datadog.sbom.host.enabled }}
+
+#######################################################################################
+####   WARNING: SBOM Monitoring is not supported on GKE Autopilot   ####
+#######################################################################################
+
+On GKE Autopilot environments, SBOM Monitoring is not supported. The options 'datadog.sbom.containerImage.enabled' and 'datadog.sbom.host.enabled' must be set to 'false'.
+
+{{- end }}
+
+{{- end }}
+
 {{- if and (.Values.datadog.dogstatsd.useSocketVolume) (eq .Values.targetSystem "windows") }}
 
 ###################################################################################
@@ -534,7 +548,7 @@ More information about this change: https://github.com/DataDog/helm-charts/pull/
 {{- end }}
 
 
-{{- if and (eq .Values.targetSystem "linux") (eq .Values.datadog.osReleasePath "") (eq (include "should-add-host-path-for-os-release-paths" .) "false") .Values.datadog.sbom.host.enabled }}
+{{- if and (eq .Values.targetSystem "linux") (eq .Values.datadog.osReleasePath "") (eq (include "should-add-host-path-for-os-release-paths" .) "false") (eq (include "should-enable-sbom-host-fs-collection" .) "true") }}
 #################################################################
 ####               ERROR: Configuration notice             ####
 #################################################################

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -170,7 +170,7 @@
     - name: DD_CONTAINER_IMAGE_ENABLED
       value: "true"
     {{- end }}
-    {{- if or .Values.datadog.sbom.host.enabled (eq (include "should-enable-sbom-container-image-collection" .) "true") }}
+    {{- if or (eq (include "should-enable-sbom-host-fs-collection" .) "true") (eq (include "should-enable-sbom-container-image-collection" .) "true") }}
     - name: DD_SBOM_ENABLED
       value: "true"
     {{- if eq (include "should-enable-sbom-container-image-collection" .) "true" }}
@@ -188,7 +188,7 @@
     {{- end }}
     {{- end }}
     {{- end }}
-    {{- if .Values.datadog.sbom.host.enabled }}
+    {{- if eq (include "should-enable-sbom-host-fs-collection" .) "true" }}
     - name: DD_SBOM_HOST_ENABLED
       value: "true"
     - name: HOST_ROOT
@@ -292,7 +292,7 @@
       mountPath: /host/var/lib/docker
       readOnly: true
     {{- end }}
-    {{- if .Values.datadog.sbom.host.enabled }}
+    {{- if eq (include "should-enable-sbom-host-fs-collection" .) "true" }}
     - name: host-apk-dir
       mountPath: /host/var/lib/apk
       readOnly: true

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -17,12 +17,12 @@
 - hostPath:
     path: /sys/fs/cgroup
   name: cgroups
-{{- if and (not .Values.providers.gke.autopilot) (or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath .Values.datadog.sbom.host.enabled) }}
+{{- if and (not .Values.providers.gke.autopilot) (or .Values.datadog.systemProbe.osReleasePath .Values.datadog.osReleasePath (eq (include "should-enable-sbom-host-fs-collection" .) "true")) }}
 - hostPath:
     path: {{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
   name: os-release-file
 {{- end }}
-{{- if and (eq (include "should-add-host-path-for-os-release-paths" .) "true") (or (eq (include "should-enable-system-probe" .) "true") .Values.datadog.sbom.host.enabled) }}
+{{- if and (eq (include "should-add-host-path-for-os-release-paths" .) "true") (or (eq (include "should-enable-system-probe" .) "true") (eq (include "should-enable-sbom-host-fs-collection" .) "true")) }}
 - hostPath:
     path: /etc/redhat-release
   name: etc-redhat-release
@@ -161,7 +161,7 @@
     path: /var/lib/docker
   name: host-docker-dir
 {{- end }}
-{{- if .Values.datadog.sbom.host.enabled }}
+{{- if eq (include "should-enable-sbom-host-fs-collection" .) "true" }}
 - hostPath:
     path: /var/lib/apk
   name: host-apk-dir

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -954,10 +954,21 @@ Create RBACs for custom resources
   Return true if SBOM collection for container image is enabled
 */}}
 {{- define "should-enable-sbom-container-image-collection" -}}
-  {{- if .Values.datadog.sbom.containerImage.enabled -}}
+  {{- if and (.Values.datadog.sbom.containerImage.enabled) (not (or .Values.providers.gke.autopilot .Values.providers.gke.gdc)) -}}
     {{- if not (eq (include "should-enable-container-image-collection" .) "true") -}}
       {{- fail "Container runtime support has to be enabled for SBOM collection to work. Please enable it using `datadog.containerRuntimeSupport.enabled`." -}}
     {{- end -}}
+    true
+  {{- else -}}
+    false
+  {{- end -}}
+{{- end -}}
+
+{{/*
+  Return true if SBOM collection for host filesystems is enabled
+*/}}
+{{- define "should-enable-sbom-host-fs-collection" -}}
+  {{- if and (.Values.datadog.sbom.host.enabled) (not (or .Values.providers.gke.autopilot .Values.providers.gke.gdc)) -}}
     true
   {{- else -}}
     false


### PR DESCRIPTION
#### What this PR does / why we need it:

Disable SBOM monitoring features for GKE Autopilot as the required hostPath mounts are not supported in the Datadog AllowlistedWorkload.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
