### PR TITLE
Fix typo in values.yaml

### DIFF
--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -399,8 +399,8 @@ datadog:
     unbundleEvents: false
     # datadog.kubernetesEvents.collectedEventTypes -- Event types to be collected. This requires datadog.kubernetesEvents.unbundleEvents to be set to true.
     collectedEventTypes:
-    # - kind: <kubernetes resource kind> # (optional if `source`` is provided)
-    #   source: <controller name> # (optional if `kind`` is provided)
+    # - kind: <kubernetes resource kind> # (optional if `source` is provided)
+    #   source: <controller name> # (optional if `kind` is provided)
     #   reasons: # (optional) if empty accept all event reasons
     #   - <kubernetes event reason>
       - kind: Pod


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix typo in `charts/datadog/values.yaml`.

#### Special notes for your reviewer:

I also triggered the `helm-docs.sh` script, but it did not update any `README` file

```bash
❯ .github/helm-docs.sh 

INFO[2025-01-31T13:33:29+01:00] Found Chart directories [charts/datadog, charts/datadog-crds, charts/datadog-operator, charts/extended-daemon-set, charts/observability-pipelines-worker, charts/private-action-runner, charts/synthetics-private-location] 
INFO[2025-01-31T13:33:29+01:00] Generating README Documentation for chart charts/observability-pipelines-worker 
INFO[2025-01-31T13:33:29+01:00] Generating README Documentation for chart charts/datadog 
INFO[2025-01-31T13:33:29+01:00] Generating README Documentation for chart charts/datadog-operator 
INFO[2025-01-31T13:33:29+01:00] Generating README Documentation for chart charts/private-action-runner 
INFO[2025-01-31T13:33:29+01:00] Generating README Documentation for chart charts/datadog-crds 
INFO[2025-01-31T13:33:29+01:00] Generating README Documentation for chart charts/extended-daemon-set 
INFO[2025-01-31T13:33:29+01:00] Generating README Documentation for chart charts/synthetics-private-location 
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
