### PR TITLE
fix(datadog): RBAC for resources labels/annotations as tags

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.90.1
+
+* Fix RBAC rendering and map merge when `datadog.kubernetesResourcesAnnotationsAsTags` and/or `datadog.kubernetesResourcesLabelsAsTags` are used.
+
 ## 3.90.0
 
 * Set default `Agent` and `Cluster-Agent` version to `7.62.0`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.90.0
+version: 3.90.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.90.0](https://img.shields.io/badge/Version-3.90.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.90.1](https://img.shields.io/badge/Version-3.90.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -515,14 +515,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 {{- $groupedResources := dict }}
-{{- $mergedResources := merge (default dict .Values.datadog.kubernetesResourcesAnnotationsAsTags) (default dict .Values.datadog.kubernetesResourcesLabelsAsTags)}}
+{{- $mergedResources := mergeOverwrite dict (default dict .Values.datadog.kubernetesResourcesAnnotationsAsTags) (default dict .Values.datadog.kubernetesResourcesLabelsAsTags)}}
 {{- range $resource, $labels := $mergedResources }}
-  {{- $parts := split "." $resource }}
+  {{- $parts := splitList "." $resource }}
   {{- $apiGroup := "" }}
-  {{- $resourceName := $resource }}
-  {{- if eq (len $parts) 2 }}
-    {{- $apiGroup = index $parts "_1" }}
-    {{- $resourceName = index $parts "_0" }}
+  {{- $resourceName := mustFirst $parts }}
+  {{- if gt (len $parts) 1 }}
+    {{- $apiGroup = join "." (mustRest $parts) }}
   {{- end }}
   {{- $existing := index $groupedResources $apiGroup | default (list) }}
   {{- $groupedResources = set $groupedResources $apiGroup (append $existing $resourceName) }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This fixes two issues with how the chart it rendered when `datadog.kubernetesResourcesAnnotationsAsTags` and/or `datadog.kubernetesResourcesLabelsAsTags` are used:

- Keys with more than 1 `.` were incorrectly rendered, as is frequently used with CRDs.
- When both labels and annotations are specified, the labels map is merged into `DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS`

#### Which issue this PR fixes

  - fixes #1684

#### Special notes for your reviewer:

I verified the fix using helm template and the following values:

```yaml
datadog:
  kubernetesResourcesAnnotationsAsTags:
    pods:
      some-annotation: "some-value"
    deployments.apps:
      another-annotation: "another-value"
    customs.example.com:
      custom-annotation: "custom-value"
  kubernetesResourcesLabelsAsTags:
    services:
      some-label: "some-value"
    statefulsets.apps:
      another-label: "another-value"
    anotercustoms.example.com:
      custom-label: "custom-value"
```

The RBAC rules were correctly rendered as:

```yaml
rules:

# Iterate through the apiGroups and create rules for each resource
- apiGroups:
  - ""
  resources:
  - pods
  - services
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - "apps"
  resources:
  - deployments
  - statefulsets
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - "example.com"
  resources:
  - anotercustoms
  - customs
  verbs:
  - get
  - list
  - watch
```

And the cluster-agent env vars are correct:

```yaml
- name: DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS
  value: '{"anotercustoms.example.com":{"custom-label":"custom-value"},"services":{"some-label":"some-value"},"statefulsets.apps":{"another-label":"another-value"}}'
- name: DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS
  value: '{"customs.example.com":{"custom-annotation":"custom-value"},"deployments.apps":{"another-annotation":"another-value"},"pods":{"some-annotation":"some-value"}}'
```

#### Checklist

- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
