### PR TITLE
[CONTINT-4500] [helm] Add EKS Clusterrole Rule for EKS control plane metrics

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.90.1
+
+* Add rule to clusterrole to allow the node agent to query the EKS control plane metrics API
+
 ## 3.90.0
 
 * Set default `Agent` and `Cluster-Agent` version to `7.62.0`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.90.0
+version: 3.90.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.90.0](https://img.shields.io/badge/Version-3.90.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.90.1](https://img.shields.io/badge/Version-3.90.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -129,6 +129,13 @@ rules:
   resources: ["secrets"]
   verbs: ["get"]
 {{- end }}
+- apiGroups:  # EKS kube_scheduler and kube_controller_manager control plane metrics
+  - "metrics.eks.amazonaws.com"
+  resources:
+  - kcm/metrics
+  - ksh/metrics
+  verbs:
+  - get
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds a clusterrole rule necessary to allow the agent to query the EKS metrics API as described in the official [AWS blog post](https://aws.amazon.com/blogs/containers/amazon-eks-enhances-kubernetes-control-plane-observability/)

#### Which issue this PR fixes

#### Special notes for your reviewer:
I tested this by deploying the updated chart to my EKS cluster and validated that the `datadog-agent` clusterrole contains the new rule

##### Validate the helm chart is using the latest local 
```
❯ helm ls
NAME         	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART         	APP VERSION
datadog-agent	default  	1       	2025-02-03 15:12:57.193742 -0500 EST	deployed	datadog-3.90.1	7

```

##### Validate the last rule is allowing EKS queries
```
❯ k get clusterrole datadog-agent -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    meta.helm.sh/release-name: datadog-agent
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2025-02-03T20:12:58Z"
  labels:
    app.kubernetes.io/instance: datadog-agent
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: datadog-agent
    app.kubernetes.io/version: "7"
    helm.sh/chart: datadog-3.90.1
  name: datadog-agent
  resourceVersion: "1704410"
  uid: e8e54a1b-4b5a-4636-877f-9ff57eecc0c0
rules:
- nonResourceURLs:
  - /metrics
  - /metrics/slis
  verbs:
  - get
- apiGroups:
  - ""
  resources:
  - nodes/metrics
  - nodes/spec
  - nodes/proxy
  - nodes/stats
  verbs:
  - get
- apiGroups:
  - ""
  resources:
  - endpoints
  verbs:
  - get
- apiGroups:
  - security.openshift.io
  resourceNames:
  - datadog-agent
  - hostaccess
  - privileged
  resources:
  - securitycontextconstraints
  verbs:
  - use
- apiGroups:
  - coordination.k8s.io
  resources:
  - leases
  verbs:
  - get
- apiGroups:
  - metrics.eks.amazonaws.com
  resources:
  - kcm/metrics
  - ksh/metrics
  verbs:
  - get
```
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
