### PR TITLE
[CONTINT-4500] [operator] Add EKS Clusterrole Rule to Operator for EKS control plane metrics

### DIFF
--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.5.1
+version: 2.5.2
 appVersion: 1.11.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.5.1](https://img.shields.io/badge/Version-2.5.1-informational?style=flat-square) ![AppVersion: 1.11.1](https://img.shields.io/badge/AppVersion-1.11.1-informational?style=flat-square)
+![Version: 2.5.2](https://img.shields.io/badge/Version-2.5.2-informational?style=flat-square) ![AppVersion: 1.11.1](https://img.shields.io/badge/AppVersion-1.11.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -347,6 +347,13 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:  # EKS kube_scheduler and kube_controller_manager control plane metrics
+  - "metrics.eks.amazonaws.com"
+  resources:
+  - kcm/metrics
+  - ksh/metrics
+  verbs:
+  - get
 {{- if .Values.datadogAgentProfile.enabled }}
 - apiGroups:
   - ""


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR is related to https://github.com/DataDog/datadog-operator/pull/1651

This is necessary so that the `datadog-operator` can grant these permissions to the agent or the cluster checks runner

#### Which issue this PR fixes

#### Special notes for your reviewer:

##### Validate the deployment is using the latest helm-chart
```
❯ helm ls
NAME               	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART                 	APP VERSION
my-datadog-operator	default  	1       	2025-02-04 11:21:48.141738 -0500 EST	deployed	datadog-operator-2.5.1	1.11.1
```

##### Validate the cluster-checks-runner role is updated
```
❯ k get clusterrole datadog-cluster-checks-runner -o yaml | grep -B 1 -A 5 eks
- apiGroups:
  - metrics.eks.amazonaws.com
  resources:
  - kcm/metrics
  - ksh/metrics
  verbs:
  - get
```

##### Validate the agent role is updated
```
❯ k get clusterrole datadog-agent -o yaml | grep -B 1 -A 5 eks
- apiGroups:
  - metrics.eks.amazonaws.com
  resources:
  - kcm/metrics
  - ksh/metrics
  verbs:
  - get
```
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
