### PR TITLE
Increase prometheus receiver scrape interval

### DIFF
--- a/charts/datadog/templates/_otel_agent_config.yaml
+++ b/charts/datadog/templates/_otel_agent_config.yaml
@@ -6,7 +6,7 @@ otel-config.yaml: {{- if .Values.datadog.otelCollector.config }} {{ toYaml .Valu
         config:
           scrape_configs:
             - job_name: "otelcol"
-              scrape_interval: 10s
+              scrape_interval: 60s
               static_configs:
                 - targets: ["0.0.0.0:8888"]
       otlp:

--- a/examples/datadog/otel_collector_config.yaml
+++ b/examples/datadog/otel_collector_config.yaml
@@ -3,7 +3,7 @@ receivers:
     config:
       scrape_configs:
         - job_name: "otel-agent"
-          scrape_interval: 10s
+          scrape_interval: 60s
           static_configs:
             - targets: ["0.0.0.0:8888"]
   otlp:


### PR DESCRIPTION
#### What this PR does / why we need it:
Current interval leads to too much metric volume

Same as: https://github.com/DataDog/datadog-agent/pull/33714 but for helm chart defaults.
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
