### PR TITLE
OTAGENT-254 Add support for enhanced RBAC permissions for otel-agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.104.0
+
+* Add `datadog.otelCollector.rbac.create` to control creation additional ClusterRole for `otel-agent` required by Kubernetes Attributes processor.
+* Add `datadog.otelCollector.rbac.rules` to support additional RBAC permissions required by OTel components that are not included by default with `otel-agent`.
+
 ## 3.103.1
 
 * Update `fips.image.tag` to `1.1.8` fixing CVEs

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.103.1
+version: 3.104.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.103.1](https://img.shields.io/badge/Version-3.103.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.104.0](https://img.shields.io/badge/Version-3.104.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -810,6 +810,8 @@ helm install <RELEASE_NAME> \
 | datadog.otelCollector.config | string | `nil` | OTel collector configuration |
 | datadog.otelCollector.enabled | bool | `false` | Enable the OTel Collector |
 | datadog.otelCollector.ports | list | `[{"containerPort":"4317","name":"otel-grpc"},{"containerPort":"4318","name":"otel-http"}]` | Ports that OTel Collector is listening |
+| datadog.otelCollector.rbac.create | bool | `true` | If true, check OTel Collector config for k8sattributes processor and create required ClusterRole to access Kubernetes API |
+| datadog.otelCollector.rbac.rules | list | `[]` | A set of additional RBAC rules to apply to OTel Collector's ClusterRole |
 | datadog.otlp.logs.enabled | bool | `false` | Enable logs support in the OTLP ingest endpoint |
 | datadog.otlp.receiver.protocols.grpc.enabled | bool | `false` | Enable the OTLP/gRPC endpoint |
 | datadog.otlp.receiver.protocols.grpc.endpoint | string | `"0.0.0.0:4317"` | OTLP/gRPC endpoint |

--- a/charts/datadog/ci/agent-otel-collector-with-rbac-custom-rules-values.yaml
+++ b/charts/datadog/ci/agent-otel-collector-with-rbac-custom-rules-values.yaml
@@ -1,0 +1,47 @@
+targetSystem: "linux"
+agents:
+  image:
+    repository: datadog/agent-dev
+    tag: nightly-ot-beta-main
+    doNotCheckTag: true
+  containers:
+    agent:
+      env:
+        - name: DD_HOSTNAME
+          value: "datadog"
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  otelCollector:
+    enabled: true
+    rbac:
+      create: true
+      rules:
+        - apiGroups: [""]
+          resources: ["nodes"]
+          verbs: ["get", "watch", "list"]
+    config: |
+      processors:
+        k8sattributes/passthrough:
+          passthrough: true
+        k8sattributes:
+      receivers:
+        otlp:
+      exporters:
+        datadog:
+          api:
+            key: "00000000000000000000000000000000"
+      service:
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [k8sattributes]
+            exporters: [datadog]
+          metrics:
+            receivers: [otlp]
+            processors: [k8sattributes]
+            exporters: [datadog]
+          logs:
+            receivers: [otlp]
+            processors: [k8sattributes]
+            exporters: [datadog]

--- a/charts/datadog/ci/agent-otel-collector-with-rbac-values.yaml
+++ b/charts/datadog/ci/agent-otel-collector-with-rbac-values.yaml
@@ -1,0 +1,41 @@
+targetSystem: "linux"
+agents:
+  image:
+    repository: datadog/agent-dev
+    tag: nightly-ot-beta-main
+    doNotCheckTag: true
+  containers:
+    agent:
+      env:
+        - name: DD_HOSTNAME
+          value: "datadog"
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  otelCollector:
+    enabled: true
+    config: |
+      processors:
+        k8sattributes:
+        k8sattributes/passthrough:
+          passthrough: true
+      receivers:
+        otlp:
+      exporters:
+        datadog:
+          api:
+            key: "00000000000000000000000000000000"
+      service:
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [k8sattributes]
+            exporters: [datadog]
+          metrics:
+            receivers: [otlp]
+            processors: [k8sattributes]
+            exporters: [datadog]
+          logs:
+            receivers: [otlp]
+            processors: [k8sattributes]
+            exporters: [datadog]

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -156,6 +156,22 @@ false
 {{- end -}}
 
 {{/*
+Return true if k8sattributes RBAC rules should be added to the OTel Agent ClusterRole
+*/}}
+{{- define "should-add-otel-agent-k8sattributes-rules" -}}
+{{- $return := false }}
+{{- $config := .Values.datadog.otelCollector.config | default "" | fromYaml }}
+{{- range $key, $val := $config.processors }}
+  {{- if hasPrefix "k8sattributes" $key }}
+    {{- if or (empty $val) (empty $val.passthrough) }}
+      {{- $return = true }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $return }}
+{{- end -}}
+
+{{/*
 Return secret name to be used based on provided values.
 */}}
 {{- define "datadog.apiSecretName" -}}

--- a/charts/datadog/templates/otel-agent-rbac.yaml
+++ b/charts/datadog/templates/otel-agent-rbac.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.agents.rbac.create (eq (include "should-enable-otel-agent" .) "true") .Values.datadog.otelCollector.rbac.create -}}
+{{- if or (eq (include "should-add-otel-agent-k8sattributes-rules" .) "true") .Values.datadog.otelCollector.rbac.rules -}}
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ template "datadog.fullname" . }}-otel-agent
+  labels:
+{{ include "datadog.labels" . | indent 4 }}
+rules:
+{{- if eq (include "should-add-otel-agent-k8sattributes-rules" .) "true" }}
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+{{- end -}}
+{{- if .Values.datadog.otelCollector.rbac.rules -}}
+{{ toYaml .Values.datadog.otelCollector.rbac.rules | nindent 2 -}}
+{{- end }}
+---
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "datadog.fullname" . }}-otel-agent
+  labels:
+{{ include "datadog.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "datadog.fullname" . }}-otel-agent
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agents.serviceAccountName" . }}-otel-agent
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/charts/datadog/templates/otel-agent-rbac.yaml
+++ b/charts/datadog/templates/otel-agent-rbac.yaml
@@ -34,7 +34,7 @@ roleRef:
   name: {{ template "datadog.fullname" . }}-otel-agent
 subjects:
   - kind: ServiceAccount
-    name: {{ include "agents.serviceAccountName" . }}-otel-agent
+    name: {{ include "agents.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -604,6 +604,17 @@ datadog:
     # datadog.otelCollector.config -- OTel collector configuration
     config: null
 
+    ## Provide OTel Collector RBAC configuration
+    rbac:
+      # datadog.otelCollector.rbac.create -- If true, check OTel Collector config for k8sattributes processor
+      # and create required ClusterRole to access Kubernetes API
+      create: true
+      # datadog.otelCollector.rbac.rules -- A set of additional RBAC rules to apply to OTel Collector's ClusterRole
+      rules: []
+      #   - apiGroups: [""]
+      #     resources: ["pods", "nodes"]
+      #     verbs: ["get", "list", "watch"]
+
   ## Continuous Profiler configuration
   ##
   ## Continuous Profiler is disabled by default and can be enabled by setting the `enabled` field to


### PR DESCRIPTION
#### What this PR does / why we need it:

Add support for additional RBAC permissions required by `k8sattributes` processor.


#### RBAC Permission Issues in otel-agent

The OpenTelemetry Collector’s [k8sattributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md) requires [specific RBAC permissions](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#role-based-access-control) to connect to the Kubernetes API server in order to enrich telemetry data with Kubernetes metadata. However, the default Service Account created by the Helm chart doesn't have these permissions: node agent (deployed as DaemonSet) retrieves pod information from the Kubelet `/pod` endpoints. This approach avoids overloading the Kubernetes API server in large clusters, but leads to errors in otel-agent when k8sattributes enabled: (`Failed to watch *v1.Pod: failed to list *v1.Pod: pods is forbidden: User <serviceAccount> cannot list resource "pods" in API group "" at the cluster scope`)


#### Proposed Solution

Create the necessary RBAC ClusterRole and ClusterRoleBinding for the `k8sattributes` processor. The creation logic will be tied to a new boolean parameter – `datadog.otelCollector.rbac.create`, which, when set to `true`, enables the chart to inspect the OTel configuration. If any `k8sattributes` processor is set to `passthrough: false` (i.e., it needs to call the Kubernetes API), the Helm chart will generate the required RBAC resources.

#### Implementation Details

1. **New boolean parameter**: `datadog.otelCollector.rbac.create` (`true` | `false`).
2. **Conditional RBAC generation**:
    1. If `agents.rbac.create: true` and `datadog.otelCollector.rbac.create: true`, the Helm chart checks the OTel Collector configuration for any `k8sattributes` processors configured with `passthrough` option disabled (either by omitting it or by explicitly setting it `passthrough: false`).
    2. If found, the necessary K8s ClusterRole and ClusterRoleBinding are generated and associated with the default agent’s Service Account.
3. **New list parameter**: `datadog.otelCollector.rbac.rules: []`
    1. If `agents.rbac.create:true` and `datadog.otelCollector.rbac.create:true`, and `datadog.otelCollector.rbac.rules` provided, these rules are added to the `otel-agent` ClusterRole.


#### Special notes for your reviewer:

##### Why Cluster Role for additional RBAC permissions?

With just a role binding, the `k8sattributes` processor cannot query metadata such as labels and annotations from k8s `nodes` and `namespaces` which are cluster-scoped objects. This also means that the processor cannot set the value for `k8s.cluster.uid` attribute if enabled, since the `k8s.cluster.uid` attribute is set to the uid of the namespace `kube-system` which is not queryable with namespaced rbac.

##### Why introduce a separate `datadog.otelCollector.rbac` parameter vs reusing `agents.rbac`?

1. **Granular Control**: separate parameter allows enabling or disabling additional permissions independently.
2. **Clarity Around OTel Functionality**: Tying these specific permissions to the section of the Helm chart that configures Embedded OTel Collector helps customers understand what feature is driving the need for the extra RBAC. 

Note: technically, any ClusterRole and ClusterRoleBinding introduced under `datadog.otelCollector.rbac` will apply to the entire pod housing the Datadog Agent with Embedded OTel Collector. While this may not perfectly map to the container-based naming convention, it provides a convenient and explicit toggle for customers. Existing precedent – [datadog.secretBackend.roles](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/templates/rbac.yaml#L166-L202) parameter: scoped to Secret Backend feature; changes affect the default Service Account, and thus additional permissions available to all containers in the node agent pod.

#### Checklist

- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

