### PR TITLE
default to gcr on us3 when autopilot

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.90.3
 
-* Defaults `registry` to `gcr.io/datadoghq` when setting `datadog.site: us3.datadoghq.com` and deploying on GKE Autopilot (`providers.gke.autopilot: true`).
+* If empty, defaults `registry` to `gcr.io/datadoghq` when setting `datadog.site: us3.datadoghq.com` and deploying on GKE Autopilot (`providers.gke.autopilot: true`).
 
 ## 3.90.2
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.90.3
+
+* Defaults `registry` to `gcr.io/datadoghq` when setting `datadog.site: us3.datadoghq.com` and deploying on GKE Autopilot (`providers.gke.autopilot: true`).
+
 ## 3.90.2
 
 * Adds env vars `DD_AGENT_IPC_PORT` and `DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL` when Otel Agent is enabled and adds flag `--sync-delay=30s` to otel agent.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.90.3
 
-* If empty, defaults `registry` to `gcr.io/datadoghq` when setting `datadog.site: us3.datadoghq.com` and deploying on GKE Autopilot (`providers.gke.autopilot: true`).
+* Defaults `registry` to `gcr.io/datadoghq` when setting `datadog.site: us3.datadoghq.com` and deploying on GKE Autopilot (`providers.gke.autopilot: true`).
 
 ## 3.90.2
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.90.2
+version: 3.90.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.90.2](https://img.shields.io/badge/Version-3.90.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.90.3](https://img.shields.io/badge/Version-3.90.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -295,7 +295,7 @@ eu.gcr.io/datadoghq
 public.ecr.aws/datadog
 {{- else if eq .datadog.site "ap1.datadoghq.com" -}}
 asia.gcr.io/datadoghq
-{{- else if eq .datadog.site "us3.datadoghq.com" -}}
+{{- else if and (eq .datadog.site "us3.datadoghq.com") (not .providers.gke.autopilot) -}}
 datadoghq.azurecr.io
 {{- else -}}
 gcr.io/datadoghq

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -27,6 +27,7 @@ commonLabels: {}
 ## Azure - use datadoghq.azurecr.io
 ## AWS - use public.ecr.aws/datadog
 ## DockerHub - use docker.io/datadog
+## If you are on GKE Autopilot, you must use a gcr.io variant registry.
 registry:  # gcr.io/datadoghq
 
 datadog:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -28,6 +28,7 @@ commonLabels: {}
 ## AWS - use public.ecr.aws/datadog
 ## DockerHub - use docker.io/datadog
 ## If you are on GKE Autopilot, you must use a gcr.io variant registry.
+
 registry:  # gcr.io/datadoghq
 
 datadog:


### PR DESCRIPTION
#### What this PR does / why we need it:

* On GKE Autopilot, whitelisted Agent images are on `gcr.io` solely. When using US3 and not providing a registry, we default to Azure registry not whitelisted. We therefore add a condition on this defaulting to prevent using Azure if US3 and Autopilot.

#### Which issue this PR fixes

- fixes #1697

#### Special notes for your reviewer:
QA'd with:
1. Site is US3, Autopilot not provided (defaults to false)
```shell
╰─❯ helm template dd charts/datadog/ --set datadog.site=us3.datadoghq.com --set datadog.apiKey=foo | grep -i "image:"
        image: "datadoghq.azurecr.io/agent:7.62.0"
        image: "datadoghq.azurecr.io/agent:7.62.0"
        image: "datadoghq.azurecr.io/agent:7.62.0"
        image: "datadoghq.azurecr.io/agent:7.62.0"
        image: "datadoghq.azurecr.io/cluster-agent:7.62.0"
        image: "datadoghq.azurecr.io/cluster-agent:7.62.0"
```

2. Site is US3, Autopilot is provided
```shell
╰─❯ helm template dd charts/datadog/ --set datadog.site=us3.datadoghq.com --set providers.gke.autopilot=true --set datadog.apiKey=foo | grep -i "image:"
        image: "gcr.io/datadoghq/agent:7.62.0"
        image: "gcr.io/datadoghq/agent:7.62.0"
        image: "gcr.io/datadoghq/agent:7.62.0"
        image: "gcr.io/datadoghq/agent:7.62.0"
        image: "gcr.io/datadoghq/cluster-agent:7.62.0"
        image: "gcr.io/datadoghq/cluster-agent:7.62.0"
```

3. Site is something else, regular behaviour based on it:
```shell
╰─❯ helm template dd charts/datadog/ --set datadog.site=datadoghq.eu --set providers.gke.autopilot=true --set datadog.apiKey=foo | grep -i "image:"
        image: "eu.gcr.io/datadoghq/agent:7.62.0"
        image: "eu.gcr.io/datadoghq/agent:7.62.0"
        image: "eu.gcr.io/datadoghq/agent:7.62.0"
        image: "eu.gcr.io/datadoghq/agent:7.62.0"
        image: "eu.gcr.io/datadoghq/cluster-agent:7.62.0"
        image: "eu.gcr.io/datadoghq/cluster-agent:7.62.0"
╰─❯ helm template dd charts/datadog/ --set datadog.site=datadoghq.com --set datadog.apiKey=foo | grep -i "image:"
        image: "gcr.io/datadoghq/agent:7.62.0"
        image: "gcr.io/datadoghq/agent:7.62.0"
        image: "gcr.io/datadoghq/agent:7.62.0"
        image: "gcr.io/datadoghq/agent:7.62.0"
        image: "gcr.io/datadoghq/cluster-agent:7.62.0"
        image: "gcr.io/datadoghq/cluster-agent:7.62.0"
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
