### PR TITLE
Update private action image version to `v0.1.11-beta`

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.15.6
+
+* Update private action image version to `v0.1.11-beta`
+
 ## 0.15.5
 
 * Add gitlab credentials file example

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.15.5
+version: 0.15.6
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.15.5](https://img.shields.io/badge/Version-0.15.4-informational?style=flat-square) ![AppVersion: v0.1.10-beta](https://img.shields.io/badge/AppVersion-v0.1.6--beta-informational?style=flat-square)
+![Version: 0.15.6](https://img.shields.io/badge/Version-0.15.6-informational?style=flat-square) ![AppVersion: v0.1.11-beta](https://img.shields.io/badge/AppVersion-v0.1.11--beta-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 
@@ -42,7 +42,7 @@ helm repo update
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| common.image | object | `{"repository":"gcr.io/datadoghq/private-action-runner","tag":"v0.1.10-beta"}` | Current Datadog Private Action Runner image |
+| common.image | object | `{"repository":"gcr.io/datadoghq/private-action-runner","tag":"v0.1.11-beta"}` | Current Datadog Private Action Runner image |
 | credentialFiles | list | `[]` | List of credential files to be used by the Datadog Private Action Runner |
 | runners[0].config | object | `{"actionsAllowlist":[],"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":9016,"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
 | runners[0].config.actionsAllowlist | list | `[]` | List of actions that the Datadog Private Action Runner is allowed to execute |

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.15.5](https://img.shields.io/badge/Version-0.15.4-informational?style=flat-square) ![AppVersion: v0.1.10-beta](https://img.shields.io/badge/AppVersion-v0.1.6--beta-informational?style=flat-square)
+![Version: 0.15.6](https://img.shields.io/badge/Version-0.15.6-informational?style=flat-square) ![AppVersion: v0.1.11-beta](https://img.shields.io/badge/AppVersion-v0.1.11--beta-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -6,7 +6,7 @@ common:
   # -- Current Datadog Private Action Runner image
   image:
     repository: gcr.io/datadoghq/private-action-runner
-    tag: v0.1.10-beta
+    tag: v0.1.11-beta
 
 runners:
   # runners[0].name -- Name of the Datadog Private Action Runner

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -100,7 +100,7 @@ spec:
           value: nodeless
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v0.1.10-beta"
+          image: "gcr.io/datadoghq/private-action-runner:v0.1.11-beta"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -144,7 +144,7 @@ spec:
           value: nodeless
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v0.1.10-beta"
+          image: "gcr.io/datadoghq/private-action-runner:v0.1.11-beta"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the PAR image version to `v0.1.11-beta`

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
Also bumped some version numbers e.g. in shields.io that were left forgotten for too long

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
