### PR TITLE
feat(datadog): allow bundling unspecified events

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.91.0
+
+* Add `datadog.kubernetesEvents.bundleUnspecifiedEvents` to allow bundling of unspecified Kubernetes events.
+
 ## 3.90.0
 
 * Set default `Agent` and `Cluster-Agent` version to `7.62.0`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.90.0
+version: 3.91.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -773,6 +773,7 @@ helm install <RELEASE_NAME> \
 | datadog.kubelet.hostCAPath | string | None (no mount from host) | Path (on host) where the Kubelet CA certificate is stored |
 | datadog.kubelet.podLogsPath | string | /var/log/pods on Linux, C:\var\log\pods on Windows | Path (on host) where the PODs logs are located |
 | datadog.kubelet.tlsVerify | string | true | Toggle kubelet TLS verification |
+| datadog.kubernetesEvents.bundleUnspecifiedEvents | bool | `false` | Events not specified in datadog.kubernetesEvents.collectedEventTypes will be bundled. This requires datadog.kubernetesEvents.unbundleEvents to be set to true. |
 | datadog.kubernetesEvents.collectedEventTypes | list | `[{"kind":"Pod","reasons":["Failed","BackOff","Unhealthy","FailedScheduling","FailedMount","FailedAttachVolume"]},{"kind":"Node","reasons":["TerminatingEvictedPod","NodeNotReady","Rebooted","HostPortConflict"]},{"kind":"CronJob","reasons":["SawCompletedJob"]}]` | Event types to be collected. This requires datadog.kubernetesEvents.unbundleEvents to be set to true. |
 | datadog.kubernetesEvents.filteringEnabled | bool | `false` | Enable this to only include events that match the pre-defined allowed events. (Requires Cluster Agent 7.57.0+). |
 | datadog.kubernetesEvents.sourceDetectionEnabled | bool | `false` | Enable this to map Kubernetes events to integration sources based on controller names. (Requires Cluster Agent 7.56.0+). |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.90.4](https://img.shields.io/badge/Version-3.90.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.91.0](https://img.shields.io/badge/Version-3.91.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_kubernetes_apiserver_config.yaml
+++ b/charts/datadog/templates/_kubernetes_apiserver_config.yaml
@@ -10,6 +10,9 @@ kubernetes_apiserver.yaml: |-
       {{- if .Values.datadog.kubernetesEvents.unbundleEvents }}
       collected_event_types:
 {{ .Values.datadog.kubernetesEvents.collectedEventTypes | toYaml | nindent 8 }}
+      {{- if .Values.datadog.kubernetesEvents.bundleUnspecifiedEvents }}
+      bundle_unspecified_events: true
+      {{- end -}}
       {{- end -}}
 {{- end }}
 {{- if .Values.clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -397,6 +397,8 @@ datadog:
     filteringEnabled: false
     # datadog.kubernetesEvents.unbundleEvents -- Allow unbundling kubernetes events, 1:1 mapping between Kubernetes and Datadog events. (Requires Cluster Agent 7.42.0+).
     unbundleEvents: false
+    # datadog.kubernetesEvents.bundleUnspecifiedEvents -- Events not specified in datadog.kubernetesEvents.collectedEventTypes will be bundled. This requires datadog.kubernetesEvents.unbundleEvents to be set to true.
+    bundleUnspecifiedEvents: false
     # datadog.kubernetesEvents.collectedEventTypes -- Event types to be collected. This requires datadog.kubernetesEvents.unbundleEvents to be set to true.
     collectedEventTypes:
     # - kind: <kubernetes resource kind> # (optional if `source`` is provided)


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds an option to the datadog chart to enabled the `bundle_unspecified_events` setting for the kubernetes apiserver check. When enabled along with `unbundleEvents`, events that are not specified in `collectedEventTypes` will be bundled. [Related agent config](https://github.com/DataDog/datadog-agent/blob/afb45257bea753d2e534ec9584bc1a3afe3fdee5/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go#L81)

Note: this is a duplicate of #1683. Just needed some lint fixes.

#### Special notes for your reviewer:

QA via `agent configcheck` and noted
```
=== kubernetes_apiserver check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/kubernetes_apiserver.yaml
Config for instance ID: kubernetes_apiserver:ad9a65b57804d691
bundle_unspecified_events: true
```

#### Checklist

- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

