### PR TITLE
Fix a bug where setting `datadog.containerImageCollection.enabled` to `false` does not disable image collection

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.95.0
+* Fix a bug where setting `datadog.containerImageCollection.enabled` to `false` does not disable image collection.
+
+
 ## 3.94.0
 
 * Support adding labels to the Agent service account via `agents.rbac.serviceAccountAdditionalLabels`.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Datadog changelog
 
 ## 3.95.0
-* Fix a bug where setting `datadog.containerImageCollection.enabled` to `false` does not disable image collection.
 
+* Fix a bug where setting `datadog.containerImageCollection.enabled` to `false` does not disable image collection.
 
 ## 3.94.0
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.94.0
+version: 3.95.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.94.0](https://img.shields.io/badge/Version-3.94.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.95.0](https://img.shields.io/badge/Version-3.95.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -172,13 +172,8 @@
       value: {{ .Values.datadog.expvarPort | quote }}
     - name: DD_COMPLIANCE_CONFIG_ENABLED
       value: {{ .Values.datadog.securityAgent.compliance.enabled | quote }}
-    {{- if eq (include "should-enable-container-image-collection" .) "true" }}
     - name: DD_CONTAINER_IMAGE_ENABLED
-      value: "true"
-    {{- else }}
-    - name: DD_CONTAINER_IMAGE_ENABLED
-      value: "false"    
-    {{- end }}
+      value: {{ include "should-enable-container-image-collection" . | quote }}
     {{- if or (eq (include "should-enable-sbom-host-fs-collection" .) "true") (eq (include "should-enable-sbom-container-image-collection" .) "true") }}
     - name: DD_SBOM_ENABLED
       value: "true"

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -175,6 +175,9 @@
     {{- if eq (include "should-enable-container-image-collection" .) "true" }}
     - name: DD_CONTAINER_IMAGE_ENABLED
       value: "true"
+    {{- else }}
+    - name: DD_CONTAINER_IMAGE_ENABLED
+      value: "false"    
     {{- end }}
     {{- if or (eq (include "should-enable-sbom-host-fs-collection" .) "true") (eq (include "should-enable-sbom-container-image-collection" .) "true") }}
     - name: DD_SBOM_ENABLED


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
Fix a bug where setting `datadog.containerImageCollection.enabled` to `false` does not disable image collection

Before, if `datadog.containerImageCollection.enabled` to `false`, it doesn't set `DD_CONTAINER_IMAGE_ENABLED` at all. Unfortunately when the environment variable isn't set, container image collection is still enabled by default in the agent, so we needed to adjust this setting so that if this is explicitly set to `false`, it sets the environment variable to `false` as well.

With this change, even if `datadog.containerImageCollection.enabled` to `false` but they have `datadog.sbom.containerImage.enabled` set to `true`, image collection will be enabled.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
