### PR TITLE
Filter dynamic fields in datadog chart baseline tests

### DIFF
--- a/.github/workflows/no-ci.yaml
+++ b/.github/workflows/no-ci.yaml
@@ -3,7 +3,6 @@ on:
   pull_request:
     paths-ignore:
       - 'charts/**'
-      - 'test/**'
 jobs:
   pr-validated:
     name: pr-validated

--- a/.github/workflows/no-ci.yaml
+++ b/.github/workflows/no-ci.yaml
@@ -1,4 +1,4 @@
-name: No lint and test needed
+name: No chart lint and test needed
 on:
   pull_request:
     paths-ignore:

--- a/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-clusterchecks
   namespace: datadog-agent
 spec:
@@ -23,9 +22,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        checksum/clusteragent_token: 46c57eb56ed9b06c80f95be1db78e7ada68e05d60e70cd05adbe44dce4d458ad
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog-clusterchecks

--- a/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
@@ -1,92 +1,70 @@
----
-# Source: datadog/templates/agent-clusterchecks-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/component: clusterchecks-agent
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+    helm.sh/chart: datadog-3.98.1
   name: datadog-clusterchecks
   namespace: datadog-agent
-  labels:
-    helm.sh/chart: "datadog-3.98.1"
-    app.kubernetes.io/name: "datadog"
-    app.kubernetes.io/instance: "datadog"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "7"
-    app.kubernetes.io/component: clusterchecks-agent
-
 spec:
   replicas: 2
   revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: datadog-clusterchecks
   strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
     type: RollingUpdate
-  selector:
-    matchLabels:
-      app: datadog-clusterchecks
   template:
     metadata:
+      annotations:
+        checksum/clusteragent_token: 46c57eb56ed9b06c80f95be1db78e7ada68e05d60e70cd05adbe44dce4d458ad
+        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
       labels:
-        app.kubernetes.io/name: "datadog"
-        app.kubernetes.io/instance: "datadog"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: clusterchecks-agent
         admission.datadoghq.com/enabled: "false"
         app: datadog-clusterchecks
-
+        app.kubernetes.io/component: clusterchecks-agent
+        app.kubernetes.io/instance: datadog
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: datadog
       name: datadog-clusterchecks
-      annotations:
-        checksum/clusteragent_token: ce75393cbdc42f29bc23068e7ebd685d85a9d00f6eab86c9030153d065d7c2bc
-        checksum/install_info: 5dc2ee139450be3da942ecdcd059c0481d4422714c642d6592cba7c2779ee0f4
     spec:
-      serviceAccountName: datadog-cluster-checks
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-clusterchecks
+                topologyKey: kubernetes.io/hostname
+              weight: 50
       automountServiceAccountToken: true
-      imagePullSecrets: []
-      initContainers:
-        - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command: ["bash", "-c"]
-          args:
-            - cp -r /etc/datadog-agent /opt
-          volumeMounts:
-            - name: config
-              mountPath: /opt/datadog-agent
-              readOnly: false # Need RW for writing agent config files
-          resources: {}
-        - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command: ["bash", "-c"]
-          args:
-            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
-          volumeMounts:
-            - name: config
-              mountPath: /etc/datadog-agent
-              readOnly: false # Need RW for writing datadog.yaml config file
-          resources: {}
       containers:
-        - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          command: ["bash", "-c"]
-          args:
+        - args:
             - find /etc/datadog-agent/conf.d/ -name "*.yaml.default" -type f -delete && touch /etc/datadog-agent/datadog.yaml && exec agent run
-          imagePullPolicy: IfNotPresent
+          command:
+            - bash
+            - -c
           env:
             - name: KUBERNETES
               value: "yes"
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-secret"
                   key: api-key
+                  name: datadog-secret
             - name: DD_LOG_LEVEL
-              value: "INFO"
+              value: INFO
             - name: DD_EXTRA_CONFIG_PROVIDERS
-              value: "clusterchecks"
+              value: clusterchecks
             - name: DD_HEALTH_PORT
               value: "5557"
-            # Cluster checks (cluster-agent communication)
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -94,12 +72,10 @@ spec:
             - name: DD_CLUSTER_AGENT_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: datadog-cluster-agent
                   key: token
-            # Safely run alongside the daemonset
+                  name: datadog-cluster-agent
             - name: DD_ENABLE_METADATA_COLLECTION
               value: "false"
-            # Expose CLC stats
             - name: DD_CLC_RUNNER_ENABLED
               value: "true"
             - name: DD_CLC_RUNNER_HOST
@@ -110,7 +86,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            # Remove unused features
             - name: DD_USE_DOGSTATSD
               value: "false"
             - name: DD_PROCESS_AGENT_ENABLED
@@ -125,16 +100,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-
-          resources: {}
-          volumeMounts:
-            - name: installinfo
-              subPath: install_info
-              mountPath: /etc/datadog-agent/install_info
-              readOnly: true
-            - name: config
-              mountPath: /etc/datadog-agent
-              readOnly: false # Need RW for config path
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -145,6 +112,7 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          name: agent
           readinessProbe:
             failureThreshold: 6
             httpGet:
@@ -155,6 +123,7 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          resources: {}
           startupProbe:
             failureThreshold: 6
             httpGet:
@@ -165,22 +134,49 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
-      volumes:
-        - name: installinfo
-          configMap:
-            name: datadog-installinfo
-        - name: config
-          emptyDir: {}
-      affinity:
-        # Prefer scheduling the runners on different nodes if possible
-        # for better checks stability in case of node failure.
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 50
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app: datadog-clusterchecks
-                topologyKey: kubernetes.io/hostname
+          volumeMounts:
+            - mountPath: /etc/datadog-agent/install_info
+              name: installinfo
+              readOnly: true
+              subPath: install_info
+            - mountPath: /etc/datadog-agent
+              name: config
+              readOnly: false
+      imagePullSecrets: []
+      initContainers:
+        - args:
+            - cp -r /etc/datadog-agent /opt
+          command:
+            - bash
+            - -c
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-volume
+          resources: {}
+          volumeMounts:
+            - mountPath: /opt/datadog-agent
+              name: config
+              readOnly: false
+        - args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          command:
+            - bash
+            - -c
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-config
+          resources: {}
+          volumeMounts:
+            - mountPath: /etc/datadog-agent
+              name: config
+              readOnly: false
       nodeSelector:
         kubernetes.io/os: linux
+      serviceAccountName: datadog-cluster-checks
+      volumes:
+        - configMap:
+            name: datadog-installinfo
+          name: installinfo
+        - emptyDir: {}
+          name: config
+---

--- a/test/datadog/baseline/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
 spec:
@@ -23,12 +22,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        checksum/api_key: b9ca61ea0157739747185859ecd177e8bd37d7614c90db55d68a3eeb7a23061e
-        checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/clusteragent-configmap: 78ab32266531527cc470ed026dbb918f2d545a1744a8e0c78b63cedd3fab3d46
-        checksum/clusteragent_token: ba677e8b323af8e8a1bf50dd0aa672fbb7ea7bfcd8b5a6017f36a3a92efc1b93
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent

--- a/test/datadog/baseline/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default.yaml
@@ -1,78 +1,55 @@
----
-# Source: datadog/templates/cluster-agent-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/component: cluster-agent
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
-  labels:
-    helm.sh/chart: "datadog-3.98.1"
-    app.kubernetes.io/name: "datadog"
-    app.kubernetes.io/instance: "datadog"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "7"
-    app.kubernetes.io/component: cluster-agent
-
 spec:
   replicas: 1
   revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: datadog-cluster-agent
   strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
     type: RollingUpdate
-  selector:
-    matchLabels:
-      app: datadog-cluster-agent
   template:
     metadata:
+      annotations:
+        checksum/api_key: b9ca61ea0157739747185859ecd177e8bd37d7614c90db55d68a3eeb7a23061e
+        checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/clusteragent-configmap: 78ab32266531527cc470ed026dbb918f2d545a1744a8e0c78b63cedd3fab3d46
+        checksum/clusteragent_token: ba677e8b323af8e8a1bf50dd0aa672fbb7ea7bfcd8b5a6017f36a3a92efc1b93
+        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
       labels:
-        app.kubernetes.io/name: "datadog"
-        app.kubernetes.io/instance: "datadog"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: cluster-agent
         admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent
-
+        app.kubernetes.io/component: cluster-agent
+        app.kubernetes.io/instance: datadog
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: datadog
       name: datadog-cluster-agent
-      annotations:
-        checksum/clusteragent_token: 34148a29542217f2ac0f20b3b8be5eba4fb54f6cc59d7dc3c81f9098e32e80b5
-        checksum/clusteragent-configmap: 23aba2cccbdf1563326d25166e91751298fdd7d6d2d545db2c9402170d19a8a8
-        checksum/api_key: 0ad0c720629ae13ef081208d24bd515121f08686f472fd690fdce6e482fd6be9
-        checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/install_info: 5dc2ee139450be3da942ecdcd059c0481d4422714c642d6592cba7c2779ee0f4
     spec:
-      serviceAccountName: datadog-cluster-agent
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
+              weight: 50
       automountServiceAccountToken: true
-      initContainers:
-        - name: init-volume
-          image: "gcr.io/datadoghq/cluster-agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command:
-            - cp
-            - -r
-          args:
-            - /etc/datadog-agent
-            - /opt
-          volumeMounts:
-            - name: config
-              mountPath: /opt/datadog-agent
       containers:
-        - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          resources: {}
-          ports:
-            - containerPort: 5005
-              name: agentport
-              protocol: TCP
-            - containerPort: 5000
-              name: agentmetrics
-              protocol: TCP
-            - containerPort: 8000
-              name: datadog-webhook
-              protocol: TCP
-          env:
+        - env:
             - name: DD_POD_NAME
               valueFrom:
                 fieldRef:
@@ -86,10 +63,9 @@ spec:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog"
                   key: api-key
+                  name: datadog
                   optional: true
-
             - name: KUBERNETES
               value: "yes"
             - name: DD_LANGUAGE_DETECTION_ENABLED
@@ -103,7 +79,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
-              value: "datadog-webhook"
+              value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
               value: "false"
             - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
@@ -113,26 +89,25 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
               value: datadog
             - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
-              value: "Ignore"
+              value: Ignore
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: "gcr.io/datadoghq"
-
+              value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
-              value: "kube_endpoints kube_services"
+              value: kube_endpoints kube_services
             - name: DD_EXTRA_LISTENERS
-              value: "kube_endpoints kube_services"
+              value: kube_endpoints kube_services
             - name: DD_LOG_LEVEL
-              value: "INFO"
+              value: INFO
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
-              value: "configmap"
+              value: configmap
             - name: DD_LEADER_LEASE_NAME
               value: datadog-leader-election
             - name: DD_CLUSTER_AGENT_TOKEN_NAME
@@ -148,14 +123,14 @@ spec:
             - name: DD_CLUSTER_AGENT_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: datadog-cluster-agent
                   key: token
+                  name: datadog-cluster-agent
             - name: DD_CLUSTER_AGENT_COLLECT_KUBERNETES_TAGS
               value: "false"
             - name: DD_KUBE_RESOURCES_NAMESPACE
               value: datadog-agent
             - name: CHART_RELEASE_NAME
-              value: "datadog"
+              value: datadog
             - name: AGENT_DAEMONSET
               value: datadog
             - name: CLUSTER_AGENT_DEPLOYMENT
@@ -169,19 +144,20 @@ spec:
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_time
+                  name: datadog-kpi-telemetry-configmap
             - name: DD_INSTRUMENTATION_INSTALL_ID
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_id
+                  name: datadog-kpi-telemetry-configmap
             - name: DD_INSTRUMENTATION_INSTALL_TYPE
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_type
-
+                  name: datadog-kpi-telemetry-configmap
+          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -192,6 +168,17 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          name: cluster-agent
+          ports:
+            - containerPort: 5005
+              name: agentport
+              protocol: TCP
+            - containerPort: 5000
+              name: agentmetrics
+              protocol: TCP
+            - containerPort: 8000
+              name: datadog-webhook
+              protocol: TCP
           readinessProbe:
             failureThreshold: 6
             httpGet:
@@ -202,6 +189,10 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           startupProbe:
             failureThreshold: 6
             httpGet:
@@ -212,58 +203,59 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
           volumeMounts:
-            - name: datadogrun
-              mountPath: /opt/datadog-agent/run
+            - mountPath: /opt/datadog-agent/run
+              name: datadogrun
               readOnly: false
-            - name: varlog
-              mountPath: /var/log/datadog
+            - mountPath: /var/log/datadog
+              name: varlog
               readOnly: false
-            - name: tmpdir
-              mountPath: /tmp
+            - mountPath: /tmp
+              name: tmpdir
               readOnly: false
-            - name: installinfo
+            - mountPath: /etc/datadog-agent/install_info
+              name: installinfo
+              readOnly: true
               subPath: install_info
-              mountPath: /etc/datadog-agent/install_info
+            - mountPath: /conf.d
+              name: confd
               readOnly: true
-            - name: confd
-              mountPath: /conf.d
-              readOnly: true
-            - name: config
-              mountPath: /etc/datadog-agent
+            - mountPath: /etc/datadog-agent
+              name: config
+      initContainers:
+        - args:
+            - /etc/datadog-agent
+            - /opt
+          command:
+            - cp
+            - -r
+          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-volume
+          volumeMounts:
+            - mountPath: /opt/datadog-agent
+              name: config
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: datadog-cluster-agent
       volumes:
-        - name: datadogrun
-          emptyDir: {}
-        - name: varlog
-          emptyDir: {}
-        - name: tmpdir
-          emptyDir: {}
-        - name: installinfo
-          configMap:
+        - emptyDir: {}
+          name: datadogrun
+        - emptyDir: {}
+          name: varlog
+        - emptyDir: {}
+          name: tmpdir
+        - configMap:
             name: datadog-installinfo
-        - name: confd
-          configMap:
-            name: datadog-cluster-agent-confd
+          name: installinfo
+        - configMap:
             items:
               - key: kubernetes_state_core.yaml.default
                 path: kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.yaml
-        - name: config
-          emptyDir: {}
-      affinity:
-        # Prefer scheduling the cluster agents on different nodes
-        # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 50
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app: datadog-cluster-agent
-                topologyKey: kubernetes.io/hostname
-      nodeSelector:
-        kubernetes.io/os: linux
+            name: datadog-cluster-agent-confd
+          name: confd
+        - emptyDir: {}
+          name: config
+---

--- a/test/datadog/baseline/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
 spec:
@@ -23,12 +22,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        checksum/api_key: b9ca61ea0157739747185859ecd177e8bd37d7614c90db55d68a3eeb7a23061e
-        checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/clusteragent-configmap: 78ab32266531527cc470ed026dbb918f2d545a1744a8e0c78b63cedd3fab3d46
-        checksum/clusteragent_token: 22226c9c062bb4932462ccc9488667d2d2eaa50025fcd567eb1f4184110e2556
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent

--- a/test/datadog/baseline/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -1,78 +1,55 @@
----
-# Source: datadog/templates/cluster-agent-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/component: cluster-agent
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
-  labels:
-    helm.sh/chart: "datadog-3.98.1"
-    app.kubernetes.io/name: "datadog"
-    app.kubernetes.io/instance: "datadog"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "7"
-    app.kubernetes.io/component: cluster-agent
-
 spec:
   replicas: 1
   revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: datadog-cluster-agent
   strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
     type: RollingUpdate
-  selector:
-    matchLabels:
-      app: datadog-cluster-agent
   template:
     metadata:
+      annotations:
+        checksum/api_key: b9ca61ea0157739747185859ecd177e8bd37d7614c90db55d68a3eeb7a23061e
+        checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/clusteragent-configmap: 78ab32266531527cc470ed026dbb918f2d545a1744a8e0c78b63cedd3fab3d46
+        checksum/clusteragent_token: 22226c9c062bb4932462ccc9488667d2d2eaa50025fcd567eb1f4184110e2556
+        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
       labels:
-        app.kubernetes.io/name: "datadog"
-        app.kubernetes.io/instance: "datadog"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: cluster-agent
         admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent
-
+        app.kubernetes.io/component: cluster-agent
+        app.kubernetes.io/instance: datadog
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: datadog
       name: datadog-cluster-agent
-      annotations:
-        checksum/clusteragent_token: f6e2f64e9a4f2f4115bef3a3abb83debde7a322cc6226606ed8e2ba84eafa597
-        checksum/clusteragent-configmap: 23aba2cccbdf1563326d25166e91751298fdd7d6d2d545db2c9402170d19a8a8
-        checksum/api_key: 0ad0c720629ae13ef081208d24bd515121f08686f472fd690fdce6e482fd6be9
-        checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/install_info: 5dc2ee139450be3da942ecdcd059c0481d4422714c642d6592cba7c2779ee0f4
     spec:
-      serviceAccountName: datadog-cluster-agent
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
+              weight: 50
       automountServiceAccountToken: true
-      initContainers:
-        - name: init-volume
-          image: "gcr.io/datadoghq/cluster-agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command:
-            - cp
-            - -r
-          args:
-            - /etc/datadog-agent
-            - /opt
-          volumeMounts:
-            - name: config
-              mountPath: /opt/datadog-agent
       containers:
-        - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          resources: {}
-          ports:
-            - containerPort: 5005
-              name: agentport
-              protocol: TCP
-            - containerPort: 5000
-              name: agentmetrics
-              protocol: TCP
-            - containerPort: 8000
-              name: datadog-webhook
-              protocol: TCP
-          env:
+        - env:
             - name: DD_POD_NAME
               valueFrom:
                 fieldRef:
@@ -86,10 +63,9 @@ spec:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog"
                   key: api-key
+                  name: datadog
                   optional: true
-
             - name: KUBERNETES
               value: "yes"
             - name: DD_LANGUAGE_DETECTION_ENABLED
@@ -103,7 +79,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
-              value: "datadog-webhook"
+              value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
               value: "false"
             - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
@@ -113,12 +89,11 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
               value: datadog
             - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
-              value: "Ignore"
+              value: Ignore
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: "gcr.io/datadoghq"
-
+              value: gcr.io/datadoghq
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_ENABLED
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_CLUSTER_AGENT_ENABLED
@@ -138,15 +113,15 @@ spec:
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
-              value: "kube_endpoints kube_services"
+              value: kube_endpoints kube_services
             - name: DD_EXTRA_LISTENERS
-              value: "kube_endpoints kube_services"
+              value: kube_endpoints kube_services
             - name: DD_LOG_LEVEL
-              value: "INFO"
+              value: INFO
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
-              value: "configmap"
+              value: configmap
             - name: DD_LEADER_LEASE_NAME
               value: datadog-leader-election
             - name: DD_CLUSTER_AGENT_TOKEN_NAME
@@ -162,14 +137,14 @@ spec:
             - name: DD_CLUSTER_AGENT_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: datadog-cluster-agent
                   key: token
+                  name: datadog-cluster-agent
             - name: DD_CLUSTER_AGENT_COLLECT_KUBERNETES_TAGS
               value: "false"
             - name: DD_KUBE_RESOURCES_NAMESPACE
               value: datadog-agent
             - name: CHART_RELEASE_NAME
-              value: "datadog"
+              value: datadog
             - name: AGENT_DAEMONSET
               value: datadog
             - name: CLUSTER_AGENT_DEPLOYMENT
@@ -183,19 +158,20 @@ spec:
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_time
+                  name: datadog-kpi-telemetry-configmap
             - name: DD_INSTRUMENTATION_INSTALL_ID
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_id
+                  name: datadog-kpi-telemetry-configmap
             - name: DD_INSTRUMENTATION_INSTALL_TYPE
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_type
-
+                  name: datadog-kpi-telemetry-configmap
+          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -206,6 +182,17 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          name: cluster-agent
+          ports:
+            - containerPort: 5005
+              name: agentport
+              protocol: TCP
+            - containerPort: 5000
+              name: agentmetrics
+              protocol: TCP
+            - containerPort: 8000
+              name: datadog-webhook
+              protocol: TCP
           readinessProbe:
             failureThreshold: 6
             httpGet:
@@ -216,6 +203,10 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           startupProbe:
             failureThreshold: 6
             httpGet:
@@ -226,58 +217,59 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
           volumeMounts:
-            - name: datadogrun
-              mountPath: /opt/datadog-agent/run
+            - mountPath: /opt/datadog-agent/run
+              name: datadogrun
               readOnly: false
-            - name: varlog
-              mountPath: /var/log/datadog
+            - mountPath: /var/log/datadog
+              name: varlog
               readOnly: false
-            - name: tmpdir
-              mountPath: /tmp
+            - mountPath: /tmp
+              name: tmpdir
               readOnly: false
-            - name: installinfo
+            - mountPath: /etc/datadog-agent/install_info
+              name: installinfo
+              readOnly: true
               subPath: install_info
-              mountPath: /etc/datadog-agent/install_info
+            - mountPath: /conf.d
+              name: confd
               readOnly: true
-            - name: confd
-              mountPath: /conf.d
-              readOnly: true
-            - name: config
-              mountPath: /etc/datadog-agent
+            - mountPath: /etc/datadog-agent
+              name: config
+      initContainers:
+        - args:
+            - /etc/datadog-agent
+            - /opt
+          command:
+            - cp
+            - -r
+          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-volume
+          volumeMounts:
+            - mountPath: /opt/datadog-agent
+              name: config
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: datadog-cluster-agent
       volumes:
-        - name: datadogrun
-          emptyDir: {}
-        - name: varlog
-          emptyDir: {}
-        - name: tmpdir
-          emptyDir: {}
-        - name: installinfo
-          configMap:
+        - emptyDir: {}
+          name: datadogrun
+        - emptyDir: {}
+          name: varlog
+        - emptyDir: {}
+          name: tmpdir
+        - configMap:
             name: datadog-installinfo
-        - name: confd
-          configMap:
-            name: datadog-cluster-agent-confd
+          name: installinfo
+        - configMap:
             items:
               - key: kubernetes_state_core.yaml.default
                 path: kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.yaml
-        - name: config
-          emptyDir: {}
-      affinity:
-        # Prefer scheduling the cluster agents on different nodes
-        # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 50
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app: datadog-cluster-agent
-                topologyKey: kubernetes.io/hostname
-      nodeSelector:
-        kubernetes.io/os: linux
+            name: datadog-cluster-agent-confd
+          name: confd
+        - emptyDir: {}
+          name: config
+---

--- a/test/datadog/baseline/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -1,78 +1,55 @@
----
-# Source: datadog/templates/cluster-agent-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/component: cluster-agent
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
-  labels:
-    helm.sh/chart: "datadog-3.98.1"
-    app.kubernetes.io/name: "datadog"
-    app.kubernetes.io/instance: "datadog"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "7"
-    app.kubernetes.io/component: cluster-agent
-
 spec:
   replicas: 1
   revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: datadog-cluster-agent
   strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
     type: RollingUpdate
-  selector:
-    matchLabels:
-      app: datadog-cluster-agent
   template:
     metadata:
+      annotations:
+        checksum/api_key: b9ca61ea0157739747185859ecd177e8bd37d7614c90db55d68a3eeb7a23061e
+        checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/clusteragent-configmap: 78ab32266531527cc470ed026dbb918f2d545a1744a8e0c78b63cedd3fab3d46
+        checksum/clusteragent_token: 96e9e09ad2f5522df113058aa00bcce374e9676aab9eb164fb3cf1d9b4d65a14
+        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
       labels:
-        app.kubernetes.io/name: "datadog"
-        app.kubernetes.io/instance: "datadog"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: cluster-agent
         admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent
-
+        app.kubernetes.io/component: cluster-agent
+        app.kubernetes.io/instance: datadog
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: datadog
       name: datadog-cluster-agent
-      annotations:
-        checksum/clusteragent_token: 576e732a32a1d08d77384a65ed64027db154c2a6254a456a75948b7de4278242
-        checksum/clusteragent-configmap: 23aba2cccbdf1563326d25166e91751298fdd7d6d2d545db2c9402170d19a8a8
-        checksum/api_key: 0ad0c720629ae13ef081208d24bd515121f08686f472fd690fdce6e482fd6be9
-        checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/install_info: 5dc2ee139450be3da942ecdcd059c0481d4422714c642d6592cba7c2779ee0f4
     spec:
-      serviceAccountName: datadog-cluster-agent
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: datadog-cluster-agent
+                topologyKey: kubernetes.io/hostname
+              weight: 50
       automountServiceAccountToken: true
-      initContainers:
-        - name: init-volume
-          image: "gcr.io/datadoghq/cluster-agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command:
-            - cp
-            - -r
-          args:
-            - /etc/datadog-agent
-            - /opt
-          volumeMounts:
-            - name: config
-              mountPath: /opt/datadog-agent
       containers:
-        - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          resources: {}
-          ports:
-            - containerPort: 5005
-              name: agentport
-              protocol: TCP
-            - containerPort: 5000
-              name: agentmetrics
-              protocol: TCP
-            - containerPort: 8000
-              name: datadog-webhook
-              protocol: TCP
-          env:
+        - env:
             - name: DD_POD_NAME
               valueFrom:
                 fieldRef:
@@ -86,10 +63,9 @@ spec:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog"
                   key: api-key
+                  name: datadog
                   optional: true
-
             - name: KUBERNETES
               value: "yes"
             - name: DD_LANGUAGE_DETECTION_ENABLED
@@ -103,7 +79,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
-              value: "datadog-webhook"
+              value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
               value: "false"
             - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
@@ -113,12 +89,11 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
               value: datadog
             - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
-              value: "Ignore"
+              value: Ignore
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: "gcr.io/datadoghq"
-
+              value: gcr.io/datadoghq
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_ENABLED
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_CLUSTER_AGENT_ENABLED
@@ -134,15 +109,15 @@ spec:
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
-              value: "kube_endpoints kube_services"
+              value: kube_endpoints kube_services
             - name: DD_EXTRA_LISTENERS
-              value: "kube_endpoints kube_services"
+              value: kube_endpoints kube_services
             - name: DD_LOG_LEVEL
-              value: "INFO"
+              value: INFO
             - name: DD_LEADER_ELECTION
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
-              value: "configmap"
+              value: configmap
             - name: DD_LEADER_LEASE_NAME
               value: datadog-leader-election
             - name: DD_CLUSTER_AGENT_TOKEN_NAME
@@ -158,14 +133,14 @@ spec:
             - name: DD_CLUSTER_AGENT_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: datadog-cluster-agent
                   key: token
+                  name: datadog-cluster-agent
             - name: DD_CLUSTER_AGENT_COLLECT_KUBERNETES_TAGS
               value: "false"
             - name: DD_KUBE_RESOURCES_NAMESPACE
               value: datadog-agent
             - name: CHART_RELEASE_NAME
-              value: "datadog"
+              value: datadog
             - name: AGENT_DAEMONSET
               value: datadog
             - name: CLUSTER_AGENT_DEPLOYMENT
@@ -179,19 +154,20 @@ spec:
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_time
+                  name: datadog-kpi-telemetry-configmap
             - name: DD_INSTRUMENTATION_INSTALL_ID
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_id
+                  name: datadog-kpi-telemetry-configmap
             - name: DD_INSTRUMENTATION_INSTALL_TYPE
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_type
-
+                  name: datadog-kpi-telemetry-configmap
+          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -202,6 +178,17 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          name: cluster-agent
+          ports:
+            - containerPort: 5005
+              name: agentport
+              protocol: TCP
+            - containerPort: 5000
+              name: agentmetrics
+              protocol: TCP
+            - containerPort: 8000
+              name: datadog-webhook
+              protocol: TCP
           readinessProbe:
             failureThreshold: 6
             httpGet:
@@ -212,6 +199,10 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           startupProbe:
             failureThreshold: 6
             httpGet:
@@ -222,58 +213,59 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
           volumeMounts:
-            - name: datadogrun
-              mountPath: /opt/datadog-agent/run
+            - mountPath: /opt/datadog-agent/run
+              name: datadogrun
               readOnly: false
-            - name: varlog
-              mountPath: /var/log/datadog
+            - mountPath: /var/log/datadog
+              name: varlog
               readOnly: false
-            - name: tmpdir
-              mountPath: /tmp
+            - mountPath: /tmp
+              name: tmpdir
               readOnly: false
-            - name: installinfo
+            - mountPath: /etc/datadog-agent/install_info
+              name: installinfo
+              readOnly: true
               subPath: install_info
-              mountPath: /etc/datadog-agent/install_info
+            - mountPath: /conf.d
+              name: confd
               readOnly: true
-            - name: confd
-              mountPath: /conf.d
-              readOnly: true
-            - name: config
-              mountPath: /etc/datadog-agent
+            - mountPath: /etc/datadog-agent
+              name: config
+      initContainers:
+        - args:
+            - /etc/datadog-agent
+            - /opt
+          command:
+            - cp
+            - -r
+          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-volume
+          volumeMounts:
+            - mountPath: /opt/datadog-agent
+              name: config
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: datadog-cluster-agent
       volumes:
-        - name: datadogrun
-          emptyDir: {}
-        - name: varlog
-          emptyDir: {}
-        - name: tmpdir
-          emptyDir: {}
-        - name: installinfo
-          configMap:
+        - emptyDir: {}
+          name: datadogrun
+        - emptyDir: {}
+          name: varlog
+        - emptyDir: {}
+          name: tmpdir
+        - configMap:
             name: datadog-installinfo
-        - name: confd
-          configMap:
-            name: datadog-cluster-agent-confd
+          name: installinfo
+        - configMap:
             items:
               - key: kubernetes_state_core.yaml.default
                 path: kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.yaml
-        - name: config
-          emptyDir: {}
-      affinity:
-        # Prefer scheduling the cluster agents on different nodes
-        # to guarantee that the standby instance can immediately take the lead from a leader running of a faulty node.
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 50
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app: datadog-cluster-agent
-                topologyKey: kubernetes.io/hostname
-      nodeSelector:
-        kubernetes.io/os: linux
+            name: datadog-cluster-agent-confd
+          name: confd
+        - emptyDir: {}
+          name: config
+---

--- a/test/datadog/baseline/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
 spec:
@@ -23,12 +22,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        checksum/api_key: b9ca61ea0157739747185859ecd177e8bd37d7614c90db55d68a3eeb7a23061e
-        checksum/application_key: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/clusteragent-configmap: 78ab32266531527cc470ed026dbb918f2d545a1744a8e0c78b63cedd3fab3d46
-        checksum/clusteragent_token: 96e9e09ad2f5522df113058aa00bcce374e9676aab9eb164fb3cf1d9b4d65a14
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent

--- a/test/datadog/baseline/daemonset_default.yaml
+++ b/test/datadog/baseline/daemonset_default.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog
   namespace: datadog-agent
 spec:
@@ -17,12 +16,7 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations:
-        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
-        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/clusteragent_token: 0b52485673a4bc26ed99a829df0e4aa4aaad46740afa7f8875464f0c4714ebc6
-        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog

--- a/test/datadog/baseline/daemonset_default.yaml
+++ b/test/datadog/baseline/daemonset_default.yaml
@@ -1,18 +1,15 @@
----
-# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+    helm.sh/chart: datadog-3.98.1
   name: datadog
   namespace: datadog-agent
-  labels:
-    helm.sh/chart: "datadog-3.98.1"
-    app.kubernetes.io/name: "datadog"
-    app.kubernetes.io/instance: "datadog"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "7"
-    app.kubernetes.io/component: agent
-
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -20,47 +17,37 @@ spec:
       app: datadog
   template:
     metadata:
+      annotations:
+        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
+        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+        checksum/clusteragent_token: 0b52485673a4bc26ed99a829df0e4aa4aaad46740afa7f8875464f0c4714ebc6
+        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
       labels:
-        app.kubernetes.io/name: "datadog"
-        app.kubernetes.io/instance: "datadog"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: agent
         admission.datadoghq.com/enabled: "false"
         app: datadog
-
+        app.kubernetes.io/component: agent
+        app.kubernetes.io/instance: datadog
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: datadog
       name: datadog
-      annotations:
-        checksum/clusteragent_token: 3be632e3858cae1c7ddb79bbe1f7e1ce4a1174cfb3bfeadc4cf97243b9ca20a5
-        checksum/install_info: 5dc2ee139450be3da942ecdcd059c0481d4422714c642d6592cba7c2779ee0f4
-        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
-        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
     spec:
-      securityContext:
-        runAsUser: 0
-      hostPID: true
+      affinity: {}
+      automountServiceAccountToken: true
       containers:
-        - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command: ["agent", "run"]
-
-          resources: {}
-          ports:
-            - containerPort: 8125
-              name: dogstatsdport
-              protocol: UDP
+        - command:
+            - agent
+            - run
           env:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-secret"
                   key: api-key
+                  name: datadog-secret
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
-
             - name: KUBERNETES
               value: "yes"
             - name: DD_LANGUAGE_DETECTION_ENABLED
@@ -73,7 +60,6 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
@@ -85,13 +71,13 @@ spec:
             - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
               value: "true"
             - name: DD_LOG_LEVEL
-              value: "INFO"
+              value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
             - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
-              value: "low"
+              value: low
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -99,8 +85,8 @@ spec:
             - name: DD_CLUSTER_AGENT_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: datadog-cluster-agent
                   key: token
+                  name: datadog-cluster-agent
             - name: DD_APM_ENABLED
               value: "true"
             - name: DD_LOGS_ENABLED
@@ -114,11 +100,11 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
-              value: "/var/run/datadog/dsd.socket"
+              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
-              value: "clusterchecks endpointschecks"
+              value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF
-              value: "kubernetes_state"
+              value: kubernetes_state
             - name: DD_CONTAINER_LIFECYCLE_ENABLED
               value: "true"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
@@ -131,47 +117,8 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          volumeMounts:
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
-            - name: installinfo
-              subPath: install_info
-              mountPath: /etc/datadog-agent/install_info
-              readOnly: true
-            - name: tmpdir
-              mountPath: /tmp
-              readOnly: false # Need RW to write to /tmp directory
-
-            - name: os-release-file
-              mountPath: /host/etc/os-release
-              readOnly: true
-            - name: config
-              mountPath: /etc/datadog-agent
-              readOnly: false # Need RW to mount to config path
-            - name: auth-token
-              mountPath: /etc/datadog-agent/auth
-              readOnly: false # Need RW to write auth token
-
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              mountPropagation: None
-              readOnly: true
-
-            - name: dsdsocket
-              mountPath: /var/run/datadog
-              readOnly: false
-            - name: procdir
-              mountPath: /host/proc
-              mountPropagation: None
-              readOnly: true
-            - name: cgroups
-              mountPath: /host/sys/fs/cgroup
-              mountPropagation: None
-              readOnly: true
-            - name: passwd
-              mountPath: /etc/passwd
-              readOnly: true
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -182,6 +129,11 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          name: agent
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
           readinessProbe:
             failureThreshold: 6
             httpGet:
@@ -192,6 +144,7 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          resources: {}
           startupProbe:
             failureThreshold: 6
             httpGet:
@@ -202,26 +155,57 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
-        - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
-          resources: {}
-          ports:
-            - containerPort: 8126
-              name: traceport
-              protocol: TCP
+          volumeMounts:
+            - mountPath: /var/log/datadog
+              name: logdatadog
+              readOnly: false
+            - mountPath: /etc/datadog-agent/install_info
+              name: installinfo
+              readOnly: true
+              subPath: install_info
+            - mountPath: /tmp
+              name: tmpdir
+              readOnly: false
+            - mountPath: /host/etc/os-release
+              name: os-release-file
+              readOnly: true
+            - mountPath: /etc/datadog-agent
+              name: config
+              readOnly: false
+            - mountPath: /etc/datadog-agent/auth
+              name: auth-token
+              readOnly: false
+            - mountPath: /host/var/run
+              mountPropagation: None
+              name: runtimesocketdir
+              readOnly: true
+            - mountPath: /var/run/datadog
+              name: dsdsocket
+              readOnly: false
+            - mountPath: /host/proc
+              mountPropagation: None
+              name: procdir
+              readOnly: true
+            - mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              name: cgroups
+              readOnly: true
+            - mountPath: /etc/passwd
+              name: passwd
+              readOnly: true
+        - command:
+            - trace-agent
+            - -config=/etc/datadog-agent/datadog.yaml
           env:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-secret"
                   key: api-key
+                  name: datadog-secret
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
-
             - name: KUBERNETES
               value: "yes"
             - name: DD_LANGUAGE_DETECTION_ENABLED
@@ -234,7 +218,6 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -242,11 +225,10 @@ spec:
             - name: DD_CLUSTER_AGENT_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: datadog-cluster-agent
                   key: token
-
+                  name: datadog-cluster-agent
             - name: DD_LOG_LEVEL
-              value: "INFO"
+              value: INFO
             - name: DD_APM_ENABLED
               value: "true"
             - name: DD_APM_NON_LOCAL_TRAFFIC
@@ -254,107 +236,96 @@ spec:
             - name: DD_APM_RECEIVER_PORT
               value: "8126"
             - name: DD_APM_RECEIVER_SOCKET
-              value: "/var/run/datadog/apm.socket"
+              value: /var/run/datadog/apm.socket
             - name: DD_DOGSTATSD_SOCKET
-              value: "/var/run/datadog/dsd.socket"
+              value: /var/run/datadog/dsd.socket
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_time
+                  name: datadog-kpi-telemetry-configmap
             - name: DD_INSTRUMENTATION_INSTALL_ID
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_id
+                  name: datadog-kpi-telemetry-configmap
             - name: DD_INSTRUMENTATION_INSTALL_TYPE
               valueFrom:
                 configMapKeyRef:
-                  name: datadog-kpi-telemetry-configmap
                   key: install_type
-          volumeMounts:
-            - name: config
-              mountPath: /etc/datadog-agent
-              readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
-            - name: auth-token
-              mountPath: /etc/datadog-agent/auth
-              readOnly: true
-            - name: procdir
-              mountPath: /host/proc
-              mountPropagation: None
-              readOnly: true
-            - name: cgroups
-              mountPath: /host/sys/fs/cgroup
-              mountPropagation: None
-              readOnly: true
-            - name: tmpdir
-              mountPath: /tmp
-              readOnly: false # Need RW for tmp directory
-            - name: dsdsocket
-              mountPath: /var/run/datadog
-              readOnly: false # Need RW for UDS DSD socket
-
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              mountPropagation: None
-              readOnly: true
-
+                  name: datadog-kpi-telemetry-configmap
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
             periodSeconds: 15
             tcpSocket:
               port: 8126
             timeoutSeconds: 5
-      initContainers:
-        - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command: ["bash", "-c"]
-          args:
-            - cp -r /etc/datadog-agent /opt
-          volumeMounts:
-            - name: config
-              mountPath: /opt/datadog-agent
-              readOnly: false # Need RW for config path
+          name: trace-agent
+          ports:
+            - containerPort: 8126
+              name: traceport
+              protocol: TCP
           resources: {}
-        - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /etc/datadog-agent
+              name: config
+              readOnly: true
+            - mountPath: /var/log/datadog
+              name: logdatadog
+              readOnly: false
+            - mountPath: /etc/datadog-agent/auth
+              name: auth-token
+              readOnly: true
+            - mountPath: /host/proc
+              mountPropagation: None
+              name: procdir
+              readOnly: true
+            - mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              name: cgroups
+              readOnly: true
+            - mountPath: /tmp
+              name: tmpdir
+              readOnly: false
+            - mountPath: /var/run/datadog
+              name: dsdsocket
+              readOnly: false
+            - mountPath: /host/var/run
+              mountPropagation: None
+              name: runtimesocketdir
+              readOnly: true
+      hostPID: true
+      initContainers:
+        - args:
+            - cp -r /etc/datadog-agent /opt
           command:
             - bash
             - -c
-          args:
-            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-volume
+          resources: {}
           volumeMounts:
-            - name: config
-              mountPath: /etc/datadog-agent
-              readOnly: false # Need RW for config path
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
-            - name: procdir
-              mountPath: /host/proc
-              mountPropagation: None
-              readOnly: true
-
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              mountPropagation: None
-              readOnly: true
+            - mountPath: /opt/datadog-agent
+              name: config
+              readOnly: false
+        - args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          command:
+            - bash
+            - -c
           env:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-secret"
                   key: api-key
+                  name: datadog-secret
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
-
             - name: KUBERNETES
               value: "yes"
             - name: DD_LANGUAGE_DETECTION_ENABLED
@@ -367,23 +338,45 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-config
           resources: {}
+          volumeMounts:
+            - mountPath: /etc/datadog-agent
+              name: config
+              readOnly: false
+            - mountPath: /var/log/datadog
+              name: logdatadog
+              readOnly: false
+            - mountPath: /host/proc
+              mountPropagation: None
+              name: procdir
+              readOnly: true
+            - mountPath: /host/var/run
+              mountPropagation: None
+              name: runtimesocketdir
+              readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsUser: 0
+      serviceAccountName: datadog
+      tolerations: null
       volumes:
-        - name: auth-token
-          emptyDir: {}
-        - name: installinfo
-          configMap:
+        - emptyDir: {}
+          name: auth-token
+        - configMap:
             name: datadog-installinfo
-        - name: config
-          emptyDir: {}
-
-        - name: logdatadog
-          emptyDir: {}
-        - name: tmpdir
-          emptyDir: {}
-        - name: s6-run
-          emptyDir: {}
+          name: installinfo
+        - emptyDir: {}
+          name: config
+        - emptyDir: {}
+          name: logdatadog
+        - emptyDir: {}
+          name: tmpdir
+        - emptyDir: {}
+          name: s6-run
         - hostPath:
             path: /proc
           name: procdir
@@ -407,13 +400,8 @@ spec:
         - hostPath:
             path: /var/run
           name: runtimesocketdir
-      tolerations:
-      affinity: {}
-      serviceAccountName: "datadog"
-      automountServiceAccountToken: true
-      nodeSelector:
-        kubernetes.io/os: linux
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---

--- a/test/datadog/baseline/default_all.yaml
+++ b/test/datadog/baseline/default_all.yaml
@@ -8,8 +8,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    chart: datadog-3.98.1
-    helm.sh/chart: datadog-3.98.1
     heritage: Helm
     release: datadog
   name: datadog-cluster-agent
@@ -24,13 +22,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog
   namespace: datadog-agent
 ---
 apiVersion: v1
-data:
-  token: Sk9uTmV1a3c0MkdSNk9LVFBTdTFST1F6MTcwN3dDbnM=
+data: {}
 kind: Secret
 metadata:
   labels:
@@ -38,7 +34,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
 type: Opaque
@@ -84,42 +79,30 @@ data:
           {}
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+  annotations: {}
   labels:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent-confd
   namespace: datadog-agent
 ---
 apiVersion: v1
-data:
-  install_info: |
-    ---
-    install_method:
-      tool: helm
-      tool_version: Helm
-      installer_version: datadog-3.98.1
+data: {}
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+  annotations: {}
   labels:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-installinfo
   namespace: datadog-agent
 ---
 apiVersion: v1
 data:
-  install_id: 04c6da3a-747e-49bd-8eef-16800a36816c
-  install_time: "1740674045"
   install_type: k8s_manual
 kind: ConfigMap
 metadata:
@@ -128,7 +111,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-kpi-telemetry-configmap
   namespace: datadog-agent
 ---
@@ -140,7 +122,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
 rules:
   - apiGroups:
@@ -381,7 +362,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-ksm-core
 rules:
   - apiGroups:
@@ -475,7 +455,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog
 rules:
   - nonResourceURLs:
@@ -530,7 +509,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -549,7 +527,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-ksm-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -568,7 +545,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -587,7 +563,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent-main
   namespace: datadog-agent
 rules:
@@ -610,7 +585,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-dca-flare
   namespace: datadog-agent
 rules:
@@ -631,7 +605,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent-main
   namespace: datadog-agent
 roleRef:
@@ -651,7 +624,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-dca-flare
   namespace: datadog-agent
 roleRef:
@@ -671,7 +643,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
 spec:
@@ -692,8 +663,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    chart: datadog-3.98.1
-    helm.sh/chart: datadog-3.98.1
     heritage: Helm
     release: datadog
   name: datadog-cluster-agent-admission-controller
@@ -716,8 +685,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    chart: datadog-3.98.1
-    helm.sh/chart: datadog-3.98.1
     heritage: Helm
     release: datadog
   name: datadog
@@ -745,7 +712,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog
   namespace: datadog-agent
 spec:
@@ -755,12 +721,7 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations:
-        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
-        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/clusteragent_token: 2c9e6add8c182591d748b885c8fab84f44d4fe24b9ebe35b0f4cd6ee0a16bb0e
-        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
@@ -1152,7 +1113,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
 spec:
@@ -1168,10 +1128,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        checksum/clusteragent-configmap: 78ab32266531527cc470ed026dbb918f2d545a1744a8e0c78b63cedd3fab3d46
-        checksum/clusteragent_token: c628abda688d8e850b721781640642609902a64d848c3248a6b0e1086afcbc97
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent

--- a/test/datadog/baseline/default_all.yaml
+++ b/test/datadog/baseline/default_all.yaml
@@ -1,54 +1,3 @@
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  labels:
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
-  name: datadog-clusterchecks
-  namespace: datadog-agent
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app: datadog-clusterchecks
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  labels:
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
-  name: datadog-cluster-agent
-  namespace: datadog-agent
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: datadog-cluster-agent
----
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    chart: datadog-3.98.1
-    helm.sh/chart: datadog-3.98.1
-    heritage: Helm
-    release: datadog
-  name: datadog-cluster-checks
-  namespace: datadog-agent
----
 apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
@@ -81,7 +30,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  token: ZjJRWVVVemlHeE5HSmx0SUU5eFZYVlY3eWVDdmdNamM=
+  token: Sk9uTmV1a3c0MkdSNk9LVFBTdTFST1F6MTcwN3dDbnM=
 kind: Secret
 metadata:
   labels:
@@ -103,7 +52,6 @@ data:
         filtering_enabled: false
         unbundle_events: false
   kubernetes_state_core.yaml.default: |-
-    cluster_check: true
     init_config:
     instances:
       - collectors:
@@ -130,7 +78,6 @@ data:
         - storageclasses
         - volumeattachments
         - ingresses
-        skip_leader_election: true
         labels_as_tags:
           {}
         annotations_as_tags:
@@ -171,8 +118,8 @@ metadata:
 ---
 apiVersion: v1
 data:
-  install_id: 083e3522-1c60-4b40-8824-6e600021198c
-  install_time: "1740674044"
+  install_id: 04c6da3a-747e-49bd-8eef-16800a36816c
+  install_time: "1740674045"
   install_type: k8s_manual
 kind: ConfigMap
 metadata:
@@ -584,25 +531,6 @@ metadata:
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
     helm.sh/chart: datadog-3.98.1
-  name: datadog-cluster-checks
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: datadog
-subjects:
-  - kind: ServiceAccount
-    name: datadog-cluster-checks
-    namespace: datadog-agent
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -629,7 +557,7 @@ roleRef:
   name: datadog-ksm-core
 subjects:
   - kind: ServiceAccount
-    name: datadog-cluster-checks
+    name: datadog-cluster-agent
     namespace: datadog-agent
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -830,7 +758,7 @@ spec:
       annotations:
         checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
         checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/clusteragent_token: 2afb21b22cd9b1aabbd81594a8d849dfd6ef642f6522541af35670dd9e4c1f88
+        checksum/clusteragent_token: 2c9e6add8c182591d748b885c8fab84f44d4fe24b9ebe35b0f4cd6ee0a16bb0e
         checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
       labels:
@@ -912,7 +840,7 @@ spec:
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
-              value: endpointschecks
+              value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF
               value: kubernetes_state
             - name: DD_CONTAINER_LIFECYCLE_ENABLED
@@ -1219,188 +1147,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: clusterchecks-agent
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
-  name: datadog-clusterchecks
-  namespace: datadog-agent
-spec:
-  replicas: 2
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      app: datadog-clusterchecks
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-        checksum/clusteragent_token: 9ec6cecd9fccff195795f3b3d2fceab0bcfcd6feda9a6c645053469519edb5a6
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
-      labels:
-        admission.datadoghq.com/enabled: "false"
-        app: datadog-clusterchecks
-        app.kubernetes.io/component: clusterchecks-agent
-        app.kubernetes.io/instance: datadog
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: datadog
-      name: datadog-clusterchecks
-    spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app: datadog-clusterchecks
-                topologyKey: kubernetes.io/hostname
-              weight: 50
-      automountServiceAccountToken: true
-      containers:
-        - args:
-            - find /etc/datadog-agent/conf.d/ -name "*.yaml.default" -type f -delete && touch /etc/datadog-agent/datadog.yaml && exec agent run
-          command:
-            - bash
-            - -c
-          env:
-            - name: KUBERNETES
-              value: "yes"
-            - name: DD_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: datadog-secret
-            - name: DD_LOG_LEVEL
-              value: INFO
-            - name: DD_EXTRA_CONFIG_PROVIDERS
-              value: clusterchecks
-            - name: DD_HEALTH_PORT
-              value: "5557"
-            - name: DD_CLUSTER_AGENT_ENABLED
-              value: "true"
-            - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
-              value: datadog-cluster-agent
-            - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  key: token
-                  name: datadog-cluster-agent
-            - name: DD_ENABLE_METADATA_COLLECTION
-              value: "false"
-            - name: DD_CLC_RUNNER_ENABLED
-              value: "true"
-            - name: DD_CLC_RUNNER_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: DD_CLC_RUNNER_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: DD_USE_DOGSTATSD
-              value: "false"
-            - name: DD_PROCESS_AGENT_ENABLED
-              value: "false"
-            - name: DD_LOGS_ENABLED
-              value: "false"
-            - name: DD_APM_ENABLED
-              value: "false"
-            - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
-            - name: DD_HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.63.0
-          imagePullPolicy: IfNotPresent
-          livenessProbe:
-            failureThreshold: 6
-            httpGet:
-              path: /live
-              port: 5557
-              scheme: HTTP
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            successThreshold: 1
-            timeoutSeconds: 5
-          name: agent
-          readinessProbe:
-            failureThreshold: 6
-            httpGet:
-              path: /ready
-              port: 5557
-              scheme: HTTP
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            successThreshold: 1
-            timeoutSeconds: 5
-          resources: {}
-          startupProbe:
-            failureThreshold: 6
-            httpGet:
-              path: /startup
-              port: 5557
-              scheme: HTTP
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            successThreshold: 1
-            timeoutSeconds: 5
-          volumeMounts:
-            - mountPath: /etc/datadog-agent/install_info
-              name: installinfo
-              readOnly: true
-              subPath: install_info
-            - mountPath: /etc/datadog-agent
-              name: config
-              readOnly: false
-      imagePullSecrets: []
-      initContainers:
-        - args:
-            - cp -r /etc/datadog-agent /opt
-          command:
-            - bash
-            - -c
-          image: gcr.io/datadoghq/agent:7.63.0
-          imagePullPolicy: IfNotPresent
-          name: init-volume
-          resources: {}
-          volumeMounts:
-            - mountPath: /opt/datadog-agent
-              name: config
-              readOnly: false
-        - args:
-            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
-          command:
-            - bash
-            - -c
-          image: gcr.io/datadoghq/agent:7.63.0
-          imagePullPolicy: IfNotPresent
-          name: init-config
-          resources: {}
-          volumeMounts:
-            - mountPath: /etc/datadog-agent
-              name: config
-              readOnly: false
-      nodeSelector:
-        kubernetes.io/os: linux
-      serviceAccountName: datadog-cluster-checks
-      volumes:
-        - configMap:
-            name: datadog-installinfo
-          name: installinfo
-        - emptyDir: {}
-          name: config
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
     app.kubernetes.io/component: cluster-agent
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
@@ -1423,8 +1169,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/clusteragent-configmap: 192a72a1adcb4888ce9a7b181b10569bc24a09e8ccf6c513d524b0a115bd460b
-        checksum/clusteragent_token: d33eef7d18b9450d98fa1adfa95e732fce9b3aef3e2ca5fe6f38894adf4d2d05
+        checksum/clusteragent-configmap: 78ab32266531527cc470ed026dbb918f2d545a1744a8e0c78b63cedd3fab3d46
+        checksum/clusteragent_token: c628abda688d8e850b721781640642609902a64d848c3248a6b0e1086afcbc97
         checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
       labels:
         admission.datadoghq.com/enabled: "false"
@@ -1505,8 +1251,6 @@ spec:
               value: "true"
             - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
               value: configmap
-            - name: DD_LEADER_LEASE_DURATION
-              value: "15"
             - name: DD_LEADER_LEASE_NAME
               value: datadog-leader-election
             - name: DD_CLUSTER_AGENT_TOKEN_NAME

--- a/test/datadog/baseline/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/gdc_daemonset_default.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
     env.datadoghq.com/kind: gke-gdc
-    helm.sh/chart: datadog-3.98.1
   name: datadog
   namespace: datadog-agent
 spec:
@@ -18,12 +17,7 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations:
-        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
-        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/clusteragent_token: 22ebc3963e8d071b46e4dcf4d6c43130b1f186f40d3822402a5130c395b4269a
-        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog

--- a/test/datadog/baseline/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/gdc_daemonset_default.yaml
@@ -1,18 +1,16 @@
----
-# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+    env.datadoghq.com/kind: gke-gdc
+    helm.sh/chart: datadog-3.98.1
   name: datadog
   namespace: datadog-agent
-  labels:
-    helm.sh/chart: "datadog-3.98.1"
-    app.kubernetes.io/name: "datadog"
-    app.kubernetes.io/instance: "datadog"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "7"
-    app.kubernetes.io/component: agent
-    env.datadoghq.com/kind: gke-gdc
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -20,46 +18,38 @@ spec:
       app: datadog
   template:
     metadata:
+      annotations:
+        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
+        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+        checksum/clusteragent_token: 22ebc3963e8d071b46e4dcf4d6c43130b1f186f40d3822402a5130c395b4269a
+        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
       labels:
-        app.kubernetes.io/name: "datadog"
-        app.kubernetes.io/instance: "datadog"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: agent
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        app.kubernetes.io/component: agent
+        app.kubernetes.io/instance: datadog
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: datadog
         env.datadoghq.com/kind: gke-gdc
       name: datadog
-      annotations:
-        checksum/clusteragent_token: 0b031290a5e81deca5e18515f7df9f20690264df092d7f181d3579b095025f4b
-        checksum/install_info: 5dc2ee139450be3da942ecdcd059c0481d4422714c642d6592cba7c2779ee0f4
-        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
-        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
     spec:
-      securityContext:
-        runAsUser: 0
+      affinity: {}
+      automountServiceAccountToken: true
       containers:
-        - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command: ["agent", "run"]
-
-          resources: {}
-          ports:
-            - containerPort: 8125
-              name: dogstatsdport
-              protocol: UDP
+        - command:
+            - agent
+            - run
           env:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-secret"
                   key: api-key
+                  name: datadog-secret
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
-
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBELET_CLIENT_CRT
@@ -80,20 +70,19 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: DD_HOSTNAME
-              value: "$(DD_NODE_NAME)-$(DD_CLUSTER_NAME)"
+              value: $(DD_NODE_NAME)-$(DD_CLUSTER_NAME)
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-
             - name: DD_LOG_LEVEL
-              value: "INFO"
+              value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
             - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
-              value: "low"
+              value: low
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -101,8 +90,8 @@ spec:
             - name: DD_CLUSTER_AGENT_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: datadog-cluster-agent
                   key: token
+                  name: datadog-cluster-agent
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -116,9 +105,9 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_EXTRA_CONFIG_PROVIDERS
-              value: "clusterchecks endpointschecks"
+              value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF
-              value: "kubernetes_state"
+              value: kubernetes_state
             - name: DD_CONTAINER_LIFECYCLE_ENABLED
               value: "true"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
@@ -131,27 +120,8 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          volumeMounts:
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
-            - name: installinfo
-              subPath: install_info
-              mountPath: /etc/datadog-agent/install_info
-              readOnly: true
-            - name: tmpdir
-              mountPath: /tmp
-              readOnly: false # Need RW to write to /tmp directory
-
-            - name: config
-              mountPath: /etc/datadog-agent
-              readOnly: false # Need RW to mount to config path
-            - name: auth-token
-              mountPath: /etc/datadog-agent/auth
-              readOnly: false # Need RW to write auth token
-
-            - name: kubelet-cert-volume
-              mountPath: /certs
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -162,6 +132,11 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          name: agent
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
           readinessProbe:
             failureThreshold: 6
             httpGet:
@@ -172,6 +147,7 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          resources: {}
           startupProbe:
             failureThreshold: 6
             httpGet:
@@ -182,41 +158,54 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
-      initContainers:
-        - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command: ["bash", "-c"]
-          args:
-            - cp -r /etc/datadog-agent /opt
           volumeMounts:
-            - name: config
-              mountPath: /opt/datadog-agent
-              readOnly: false # Need RW for config path
-          resources: {}
-        - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
+            - mountPath: /var/log/datadog
+              name: logdatadog
+              readOnly: false
+            - mountPath: /etc/datadog-agent/install_info
+              name: installinfo
+              readOnly: true
+              subPath: install_info
+            - mountPath: /tmp
+              name: tmpdir
+              readOnly: false
+            - mountPath: /etc/datadog-agent
+              name: config
+              readOnly: false
+            - mountPath: /etc/datadog-agent/auth
+              name: auth-token
+              readOnly: false
+            - mountPath: /certs
+              name: kubelet-cert-volume
+      initContainers:
+        - args:
+            - cp -r /etc/datadog-agent /opt
           command:
             - bash
             - -c
-          args:
-            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-volume
+          resources: {}
           volumeMounts:
-            - name: config
-              mountPath: /etc/datadog-agent
-              readOnly: false # Need RW for config path
+            - mountPath: /opt/datadog-agent
+              name: config
+              readOnly: false
+        - args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          command:
+            - bash
+            - -c
           env:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-secret"
                   key: api-key
+                  name: datadog-secret
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
-
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBELET_CLIENT_CRT
@@ -237,37 +226,44 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: DD_HOSTNAME
-              value: "$(DD_NODE_NAME)-$(DD_CLUSTER_NAME)"
+              value: $(DD_NODE_NAME)-$(DD_CLUSTER_NAME)
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-config
           resources: {}
-      volumes:
-        - name: auth-token
-          emptyDir: {}
-        - name: installinfo
-          configMap:
-            name: datadog-installinfo
-        - name: config
-          emptyDir: {}
-
-        - name: logdatadog
-          emptyDir: {}
-        - name: tmpdir
-          emptyDir: {}
-        - name: s6-run
-          emptyDir: {}
-        - secret:
-            secretName: datadog-kubelet-cert
-          name: kubelet-cert-volume
-      tolerations:
-      affinity: {}
-      serviceAccountName: "datadog"
-      automountServiceAccountToken: true
+          volumeMounts:
+            - mountPath: /etc/datadog-agent
+              name: config
+              readOnly: false
       nodeSelector:
         kubernetes.io/os: linux
+      securityContext:
+        runAsUser: 0
+      serviceAccountName: datadog
+      tolerations: null
+      volumes:
+        - emptyDir: {}
+          name: auth-token
+        - configMap:
+            name: datadog-installinfo
+          name: installinfo
+        - emptyDir: {}
+          name: config
+        - emptyDir: {}
+          name: logdatadog
+        - emptyDir: {}
+          name: tmpdir
+        - emptyDir: {}
+          name: s6-run
+        - name: kubelet-cert-volume
+          secret:
+            secretName: datadog-kubelet-cert
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---

--- a/test/datadog/baseline/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/gdc_daemonset_logs_collection.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
     env.datadoghq.com/kind: gke-gdc
-    helm.sh/chart: datadog-3.98.1
   name: datadog
   namespace: datadog-agent
 spec:
@@ -18,12 +17,7 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations:
-        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
-        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/clusteragent_token: 23f07fae70fc1151c11c436765c232eda1abafb17ee67922e94d95cc5b0527a4
-        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog

--- a/test/datadog/baseline/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/gdc_daemonset_logs_collection.yaml
@@ -1,18 +1,16 @@
----
-# Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+    env.datadoghq.com/kind: gke-gdc
+    helm.sh/chart: datadog-3.98.1
   name: datadog
   namespace: datadog-agent
-  labels:
-    helm.sh/chart: "datadog-3.98.1"
-    app.kubernetes.io/name: "datadog"
-    app.kubernetes.io/instance: "datadog"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "7"
-    app.kubernetes.io/component: agent
-    env.datadoghq.com/kind: gke-gdc
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -20,46 +18,38 @@ spec:
       app: datadog
   template:
     metadata:
+      annotations:
+        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
+        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+        checksum/clusteragent_token: 23f07fae70fc1151c11c436765c232eda1abafb17ee67922e94d95cc5b0527a4
+        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
       labels:
-        app.kubernetes.io/name: "datadog"
-        app.kubernetes.io/instance: "datadog"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: agent
         admission.datadoghq.com/enabled: "false"
         app: datadog
+        app.kubernetes.io/component: agent
+        app.kubernetes.io/instance: datadog
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: datadog
         env.datadoghq.com/kind: gke-gdc
       name: datadog
-      annotations:
-        checksum/clusteragent_token: 67ca9b57ce1091cf08a3a16210f0f577f88e46f63bb06bba49d72d6f310d2156
-        checksum/install_info: 5dc2ee139450be3da942ecdcd059c0481d4422714c642d6592cba7c2779ee0f4
-        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
-        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
     spec:
-      securityContext:
-        runAsUser: 0
+      affinity: {}
+      automountServiceAccountToken: true
       containers:
-        - name: agent
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command: ["agent", "run"]
-
-          resources: {}
-          ports:
-            - containerPort: 8125
-              name: dogstatsdport
-              protocol: UDP
+        - command:
+            - agent
+            - run
           env:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-secret"
                   key: api-key
+                  name: datadog-secret
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
-
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBELET_CLIENT_CRT
@@ -80,20 +70,19 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: DD_HOSTNAME
-              value: "$(DD_NODE_NAME)-$(DD_CLUSTER_NAME)"
+              value: $(DD_NODE_NAME)-$(DD_CLUSTER_NAME)
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-
             - name: DD_LOG_LEVEL
-              value: "INFO"
+              value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
             - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
-              value: "low"
+              value: low
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -101,8 +90,8 @@ spec:
             - name: DD_CLUSTER_AGENT_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: datadog-cluster-agent
                   key: token
+                  name: datadog-cluster-agent
             - name: DD_APM_ENABLED
               value: "false"
             - name: DD_LOGS_ENABLED
@@ -116,9 +105,9 @@ spec:
             - name: DD_HEALTH_PORT
               value: "5555"
             - name: DD_EXTRA_CONFIG_PROVIDERS
-              value: "clusterchecks endpointschecks"
+              value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF
-              value: "kubernetes_state"
+              value: kubernetes_state
             - name: DD_CONTAINER_LIFECYCLE_ENABLED
               value: "true"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
@@ -131,39 +120,8 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          volumeMounts:
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
-            - name: installinfo
-              subPath: install_info
-              mountPath: /etc/datadog-agent/install_info
-              readOnly: true
-            - name: tmpdir
-              mountPath: /tmp
-              readOnly: false # Need RW to write to /tmp directory
-
-            - name: config
-              mountPath: /etc/datadog-agent
-              readOnly: false # Need RW to mount to config path
-            - name: auth-token
-              mountPath: /etc/datadog-agent/auth
-              readOnly: false # Need RW to write auth token
-
-            - name: pointerdir
-              mountPath: /opt/datadog-agent/run
-              mountPropagation: None
-              readOnly: false # Need RW for logs pointer
-            - name: logpodpath
-              mountPath: /var/log/pods
-              mountPropagation: None
-              readOnly: true
-            - name: logscontainerspath
-              mountPath: /var/log/containers
-              mountPropagation: None
-              readOnly: true
-            - name: kubelet-cert-volume
-              mountPath: /certs
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -174,6 +132,11 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          name: agent
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
           readinessProbe:
             failureThreshold: 6
             httpGet:
@@ -184,6 +147,7 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          resources: {}
           startupProbe:
             failureThreshold: 6
             httpGet:
@@ -194,41 +158,66 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
-      initContainers:
-        - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
-          command: ["bash", "-c"]
-          args:
-            - cp -r /etc/datadog-agent /opt
           volumeMounts:
-            - name: config
-              mountPath: /opt/datadog-agent
-              readOnly: false # Need RW for config path
-          resources: {}
-        - name: init-config
-          image: "gcr.io/datadoghq/agent:7.63.0"
-          imagePullPolicy: IfNotPresent
+            - mountPath: /var/log/datadog
+              name: logdatadog
+              readOnly: false
+            - mountPath: /etc/datadog-agent/install_info
+              name: installinfo
+              readOnly: true
+              subPath: install_info
+            - mountPath: /tmp
+              name: tmpdir
+              readOnly: false
+            - mountPath: /etc/datadog-agent
+              name: config
+              readOnly: false
+            - mountPath: /etc/datadog-agent/auth
+              name: auth-token
+              readOnly: false
+            - mountPath: /opt/datadog-agent/run
+              mountPropagation: None
+              name: pointerdir
+              readOnly: false
+            - mountPath: /var/log/pods
+              mountPropagation: None
+              name: logpodpath
+              readOnly: true
+            - mountPath: /var/log/containers
+              mountPropagation: None
+              name: logscontainerspath
+              readOnly: true
+            - mountPath: /certs
+              name: kubelet-cert-volume
+      initContainers:
+        - args:
+            - cp -r /etc/datadog-agent /opt
           command:
             - bash
             - -c
-          args:
-            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-volume
+          resources: {}
           volumeMounts:
-            - name: config
-              mountPath: /etc/datadog-agent
-              readOnly: false # Need RW for config path
+            - mountPath: /opt/datadog-agent
+              name: config
+              readOnly: false
+        - args:
+            - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+          command:
+            - bash
+            - -c
           env:
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: "datadog-secret"
                   key: api-key
+                  name: datadog-secret
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
-
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBELET_CLIENT_CRT
@@ -249,27 +238,39 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: DD_HOSTNAME
-              value: "$(DD_NODE_NAME)-$(DD_CLUSTER_NAME)"
+              value: $(DD_NODE_NAME)-$(DD_CLUSTER_NAME)
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
+          image: gcr.io/datadoghq/agent:7.63.0
+          imagePullPolicy: IfNotPresent
+          name: init-config
           resources: {}
+          volumeMounts:
+            - mountPath: /etc/datadog-agent
+              name: config
+              readOnly: false
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsUser: 0
+      serviceAccountName: datadog
+      tolerations: null
       volumes:
-        - name: auth-token
-          emptyDir: {}
-        - name: installinfo
-          configMap:
+        - emptyDir: {}
+          name: auth-token
+        - configMap:
             name: datadog-installinfo
-        - name: config
-          emptyDir: {}
-
-        - name: logdatadog
-          emptyDir: {}
-        - name: tmpdir
-          emptyDir: {}
-        - name: s6-run
-          emptyDir: {}
+          name: installinfo
+        - emptyDir: {}
+          name: config
+        - emptyDir: {}
+          name: logdatadog
+        - emptyDir: {}
+          name: tmpdir
+        - emptyDir: {}
+          name: s6-run
         - hostPath:
             path: /var/datadog/logs
           name: pointerdir
@@ -279,16 +280,11 @@ spec:
         - hostPath:
             path: /var/log/containers
           name: logscontainerspath
-        - secret:
+        - name: kubelet-cert-volume
+          secret:
             secretName: datadog-kubelet-cert
-          name: kubelet-cert-volume
-      tolerations:
-      affinity: {}
-      serviceAccountName: "datadog"
-      automountServiceAccountToken: true
-      nodeSelector:
-        kubernetes.io/os: linux
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
+---

--- a/test/datadog/baseline/other_default.yaml
+++ b/test/datadog/baseline/other_default.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-clusterchecks
   namespace: datadog-agent
 spec:
@@ -23,7 +22,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
 spec:
@@ -42,8 +40,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    chart: datadog-3.98.1
-    helm.sh/chart: datadog-3.98.1
     heritage: Helm
     release: datadog
   name: datadog-cluster-checks
@@ -59,8 +55,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    chart: datadog-3.98.1
-    helm.sh/chart: datadog-3.98.1
     heritage: Helm
     release: datadog
   name: datadog-cluster-agent
@@ -75,13 +69,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog
   namespace: datadog-agent
 ---
 apiVersion: v1
-data:
-  token: ZjJRWVVVemlHeE5HSmx0SUU5eFZYVlY3eWVDdmdNamM=
+data: {}
 kind: Secret
 metadata:
   labels:
@@ -89,7 +81,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
 type: Opaque
@@ -137,42 +128,30 @@ data:
           {}
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+  annotations: {}
   labels:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent-confd
   namespace: datadog-agent
 ---
 apiVersion: v1
-data:
-  install_info: |
-    ---
-    install_method:
-      tool: helm
-      tool_version: Helm
-      installer_version: datadog-3.98.1
+data: {}
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+  annotations: {}
   labels:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-installinfo
   namespace: datadog-agent
 ---
 apiVersion: v1
 data:
-  install_id: 083e3522-1c60-4b40-8824-6e600021198c
-  install_time: "1740674044"
   install_type: k8s_manual
 kind: ConfigMap
 metadata:
@@ -181,7 +160,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-kpi-telemetry-configmap
   namespace: datadog-agent
 ---
@@ -193,7 +171,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
 rules:
   - apiGroups:
@@ -434,7 +411,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-ksm-core
 rules:
   - apiGroups:
@@ -528,7 +504,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog
 rules:
   - nonResourceURLs:
@@ -583,7 +558,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-checks
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -602,7 +576,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -621,7 +594,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-ksm-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -640,7 +612,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -659,7 +630,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent-main
   namespace: datadog-agent
 rules:
@@ -682,7 +652,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-dca-flare
   namespace: datadog-agent
 rules:
@@ -703,7 +672,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent-main
   namespace: datadog-agent
 roleRef:
@@ -723,7 +691,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-dca-flare
   namespace: datadog-agent
 roleRef:
@@ -743,7 +710,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
 spec:
@@ -764,8 +730,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    chart: datadog-3.98.1
-    helm.sh/chart: datadog-3.98.1
     heritage: Helm
     release: datadog
   name: datadog-cluster-agent-admission-controller
@@ -788,8 +752,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    chart: datadog-3.98.1
-    helm.sh/chart: datadog-3.98.1
     heritage: Helm
     release: datadog
   name: datadog
@@ -817,7 +779,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog
   namespace: datadog-agent
 spec:
@@ -827,12 +788,7 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations:
-        checksum/autoconf-config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
-        checksum/checksd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/clusteragent_token: 2afb21b22cd9b1aabbd81594a8d849dfd6ef642f6522541af35670dd9e4c1f88
-        checksum/confd-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
@@ -1224,7 +1180,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-clusterchecks
   namespace: datadog-agent
 spec:
@@ -1240,9 +1195,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        checksum/clusteragent_token: 9ec6cecd9fccff195795f3b3d2fceab0bcfcd6feda9a6c645053469519edb5a6
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog-clusterchecks
@@ -1406,7 +1359,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    helm.sh/chart: datadog-3.98.1
   name: datadog-cluster-agent
   namespace: datadog-agent
 spec:
@@ -1422,10 +1374,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        checksum/clusteragent-configmap: 192a72a1adcb4888ce9a7b181b10569bc24a09e8ccf6c513d524b0a115bd460b
-        checksum/clusteragent_token: d33eef7d18b9450d98fa1adfa95e732fce9b3aef3e2ca5fe6f38894adf4d2d05
-        checksum/install_info: 294ab445dd224b5cc1663ee0737da0a03d9e2d995bc77fd2d21fb358fe1b2eed
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent


### PR DESCRIPTION
#### What this PR does / why we need it:

CECO-2006

* Updates baseline test for `datadog` chart to drop dynamic fields like timestamps, checksums etc. from a preconfigured list.
* Adds a 'default' baseline which renders chart with all resources with empty yaml. 

First commit reformats existing baselines using function used for reading/writing the manifests. Second commit adds filtering to make what's getting dropped more obvious for the reviewer. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
