### PR TITLE
Update agent to 7.63.2

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.99.0
+
+* Upgrade default Agent version to `7.63.2`.
+
 ## 3.98.1
 
 * Fixes bug that causes `DD_KUBERNETES_ANNOTATIONS_AS_TAGS` env var to be incorrectly set to the merged value of `.Values.datadog.kubernetesResourcesLabelsAsTags` and `.Values.datadog.kubernetesResourcesAnnotationsAsTags`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.98.1
+version: 3.99.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.98.1](https://img.shields.io/badge/Version-3.98.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.99.0](https://img.shields.io/badge/Version-3.99.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -525,7 +525,7 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.63.0"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.63.2"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
 | agents.localService.overrideName | string | `""` | Name of the internal traffic service to target the agent running on the local node |
@@ -608,7 +608,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"7.63.0"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"7.63.2"` | Cluster Agent image tag to use |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
@@ -664,7 +664,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
-| clusterChecksRunner.image.tag | string | `"7.63.0"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.63.2"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1042,7 +1042,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 7.63.0
+    tag: 7.63.2
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -1566,7 +1566,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.63.0
+    tag: 7.63.2
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2075,7 +2075,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.63.0
+    tag: 7.63.2
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""

--- a/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/agent-clusterchecks-deployment_default.yaml
@@ -97,7 +97,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -146,7 +146,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -159,7 +159,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}

--- a/test/datadog/baseline/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default.yaml
@@ -150,7 +150,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          image: gcr.io/datadoghq/cluster-agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -223,7 +223,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          image: gcr.io/datadoghq/cluster-agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -164,7 +164,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          image: gcr.io/datadoghq/cluster-agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -237,7 +237,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          image: gcr.io/datadoghq/cluster-agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -97,7 +97,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
               value: agent
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-              value: 7.63.0
+              value: 7.63.2
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -160,7 +160,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          image: gcr.io/datadoghq/cluster-agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -233,7 +233,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          image: gcr.io/datadoghq/cluster-agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/daemonset_default.yaml
+++ b/test/datadog/baseline/daemonset_default.yaml
@@ -111,7 +111,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -248,7 +248,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -297,7 +297,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -332,7 +332,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}

--- a/test/datadog/baseline/default_all.yaml
+++ b/test/datadog/baseline/default_all.yaml
@@ -816,7 +816,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -953,7 +953,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1002,7 +1002,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1037,7 +1037,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1256,7 +1256,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          image: gcr.io/datadoghq/cluster-agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1329,7 +1329,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          image: gcr.io/datadoghq/cluster-agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/gdc_daemonset_default.yaml
@@ -114,7 +114,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -177,7 +177,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -225,7 +225,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}

--- a/test/datadog/baseline/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/gdc_daemonset_logs_collection.yaml
@@ -114,7 +114,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -189,7 +189,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -237,7 +237,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}

--- a/test/datadog/baseline/other_default.yaml
+++ b/test/datadog/baseline/other_default.yaml
@@ -883,7 +883,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1020,7 +1020,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1069,7 +1069,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1104,7 +1104,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1270,7 +1270,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1319,7 +1319,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1332,7 +1332,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.0
+          image: gcr.io/datadoghq/agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1504,7 +1504,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          image: gcr.io/datadoghq/cluster-agent:7.63.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1577,7 +1577,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.0
+          image: gcr.io/datadoghq/cluster-agent:7.63.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates default agent to 7.63.2

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For Datadog Operator chart or value changes update the test baselines (run: `make update-test-baselines`)
