### PR TITLE
[datadog] Update Agent components to `7.63.3`

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.103.0
+
+* Upgrade default Agent version to `7.63.3`.
+
 ## 3.102.0
 
 * Add a mount for the Kubernetes PodResources socket.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.102.0
+version: 3.103.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.102.0](https://img.shields.io/badge/Version-3.102.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.103.0](https://img.shields.io/badge/Version-3.103.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -525,7 +525,7 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.63.2"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.63.3"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
 | agents.localService.overrideName | string | `""` | Name of the internal traffic service to target the agent running on the local node |
@@ -608,7 +608,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"7.63.2"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"7.63.3"` | Cluster Agent image tag to use |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
@@ -664,7 +664,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
-| clusterChecksRunner.image.tag | string | `"7.63.2"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.63.3"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1066,7 +1066,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 7.63.2
+    tag: 7.63.3
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -1590,7 +1590,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.63.2
+    tag: 7.63.3
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2099,7 +2099,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.63.2
+    tag: 7.63.3
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -853,7 +853,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -993,7 +993,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1042,7 +1042,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1077,7 +1077,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1246,7 +1246,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1295,7 +1295,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1308,7 +1308,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1480,7 +1480,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1553,7 +1553,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -869,7 +869,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -942,7 +942,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -883,7 +883,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -956,7 +956,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -816,7 +816,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
               value: agent
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-              value: 7.63.2
+              value: 7.63.3
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -879,7 +879,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -952,7 +952,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -818,7 +818,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -958,7 +958,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1007,7 +1007,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1042,7 +1042,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1264,7 +1264,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1337,7 +1337,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -818,7 +818,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -958,7 +958,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1007,7 +1007,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1042,7 +1042,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1264,7 +1264,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1337,7 +1337,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -814,7 +814,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -915,7 +915,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -938,7 +938,7 @@ spec:
           command:
             - pwsh
             - -Command
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -976,7 +976,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1169,7 +1169,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1242,7 +1242,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -819,7 +819,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -882,7 +882,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -930,7 +930,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1124,7 +1124,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1197,7 +1197,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -819,7 +819,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -894,7 +894,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -942,7 +942,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1145,7 +1145,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1218,7 +1218,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -166,7 +166,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    checksum/otel-config: 7442a7b9ad409386207bbf9d49106e0a931ebd258432e9c551f0c32e28dc9d85
+    checksum/otel-config: 0c5563c5e9a82132926709c072b925fd278450344419379d6d0738853d82e315
   labels:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
@@ -894,7 +894,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1034,7 +1034,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1118,7 +1118,7 @@ spec:
               value: "60"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1167,7 +1167,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1202,7 +1202,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1430,7 +1430,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1503,7 +1503,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -818,7 +818,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -958,7 +958,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1007,7 +1007,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1042,7 +1042,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.63.2
+          image: gcr.io/datadoghq/agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1264,7 +1264,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1337,7 +1337,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.63.2
+          image: gcr.io/datadoghq/cluster-agent:7.63.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:

Update Agent/cluster Agent images to `7.63.3` by default

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
