### PR TITLE
[ACTP] add support for passing environment variables to the PAR container

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.16.0
+
+* Add support for passing environment variables to the Datadog Private Action Runner container.
+
 ## 0.15.8
 
 * Update private action image version to `v0.1.14-beta`

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.15.8
+version: 0.16.0
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -51,6 +51,7 @@ helm repo update
 | runners[0].config.port | int | `9016` | Port for HTTP server liveness checks and App Builder mode |
 | runners[0].config.privateKey | string | `"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG"` | The runner's privateKey from the enrollment page |
 | runners[0].config.urn | string | `"CHANGE_ME_URN_FROM_CONFIG"` | The runner's URN from the enrollment page |
+| runners[0].env | list | `[]` | Environment variables to be passed to the Datadog Private Action Runner |
 | runners[0].kubernetesActions | object | `{"configMaps":[],"controllerRevisions":[],"cronJobs":[],"customObjects":[],"customResourceDefinitions":[],"daemonSets":[],"deployments":[],"endpoints":[],"events":[],"jobs":[],"limitRanges":[],"namespaces":[],"nodes":[],"persistentVolumeClaims":[],"persistentVolumes":[],"podTemplates":[],"pods":["get","list"],"replicaSets":[],"replicationControllers":[],"resourceQuotas":[],"serviceAccounts":[],"services":[],"statefulSets":[]}` | Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account |
 | runners[0].kubernetesActions.configMaps | list | `[]` | Actions related to configMaps (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runners[0].kubernetesActions.controllerRevisions | list | `[]` | Actions related to controllerRevisions (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -11,7 +11,7 @@ runners:
       port: 9016
       actionsAllowlist:
         - com.datadoghq.http.request
-    envVars:
+    env:
       - name: "ENV_VAR_NAME"
         value: "ENV_VAR_VALUE"
     # -- Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -11,6 +11,9 @@ runners:
       port: 9016
       actionsAllowlist:
         - com.datadoghq.http.request
+    envVars:
+      - name: "ENV_VAR_NAME"
+        value: "ENV_VAR_VALUE"
     # -- Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account
     kubernetesActions:
       controllerRevisions: [] # select your actions among ["get", "list", "create", "update", "patch", "delete", "deleteMultiple"]

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
           env:
             - name: MANAGED_BY
               value: "helm"
+            {{- range $key, $value := $runner.envVars }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
       volumes:
         - name: secrets
           secret:

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -45,13 +45,9 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner
-          env:
-            - name: MANAGED_BY
-              value: "helm"
-            {{- range $key, $value := $runner.envVars }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
+          {{- if $runner.env }}
+          env: {{ $runner.env | toYaml | nindent 12 }}
+          {{- end }}
       volumes:
         - name: secrets
           secret:

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -29,6 +29,8 @@ runners:
       port: 9016
       # -- List of actions that the Datadog Private Action Runner is allowed to execute
       actionsAllowlist: []
+    # -- Environment variables to be passed to the Datadog Private Action Runner
+    env: []
     # -- Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account
     kubernetesActions:
       # -- Actions related to controllerRevisions (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple")

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -19,11 +19,12 @@ import (
 )
 
 type HelmCommand struct {
-	ReleaseName string
-	ChartPath   string
-	ShowOnly    []string          // helm template `-s, --show-only` flag
-	Values      []string          // helm template `-f, --values` flag
-	Overrides   map[string]string // helm template `--set` flag
+	ReleaseName   string
+	ChartPath     string
+	ShowOnly      []string          // helm template `-s, --show-only` flag
+	Values        []string          // helm template `-f, --values` flag
+	Overrides     map[string]string // helm template `--set` flag
+	OverridesJson map[string]string // helm template `--set-json` flag
 }
 
 func Unmarshal[T any](t *testing.T, manifest string, destObj *T) {
@@ -40,6 +41,7 @@ func RenderChart(t *testing.T, cmd HelmCommand) (string, error) {
 	options := &helm.Options{
 		KubectlOptions: kubectlOptions,
 		SetValues:      cmd.Overrides,
+		SetJsonValues:  cmd.OverridesJson,
 		ValuesFiles:    cmd.Values,
 	}
 

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -90,7 +90,7 @@ spec:
         app:  "private-action-runner-default" 
         service:  "private-action-runner-default-service" 
       annotations:
-        config-hash: 901f2ec9a9fb5d777a371e54f350edd083c9c9e2b1c3bcb2b1d7f7cb68bcd201
+        config-hash: 2fa834a4c916b0d4254f354857cd894879f1a7787214ef3fe8e8159911c3d74b
     spec:
       serviceAccountName:  "private-action-runner-default-serviceaccount" 
       tolerations:
@@ -115,6 +115,11 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner
+          env: 
+            - name: FOO
+              value: foo
+            - name: BAR
+              value: bar
       volumes:
         - name: secrets
           secret:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -134,7 +134,7 @@ spec:
         app:  "private-action-runner-default" 
         service:  "private-action-runner-default-service" 
       annotations:
-        config-hash: bda02d4e95c0ab1a984e62d87be14d65768d938dc3ff2e59342961b37acf25fb
+        config-hash: 7091b9a074330e2ed57f3086a7de30e96f38467ae819e6656d164b0bc59a2da6
     spec:
       serviceAccountName:  "private-action-runner-default-serviceaccount" 
       tolerations:
@@ -159,9 +159,6 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner
-          env:
-            - name: MANAGED_BY
-              value: "helm"
       volumes:
         - name: secrets
           secret:

--- a/test/private-action-runner/baseline_test.go
+++ b/test/private-action-runner/baseline_test.go
@@ -32,17 +32,30 @@ func Test_baseline_manifests(t *testing.T) {
 				ReleaseName: "private-action-runner",
 				ChartPath:   "../../charts/private-action-runner",
 				Values:      []string{"../../charts/private-action-runner/values.yaml"},
-				Overrides: map[string]string{
-					"runners[0].kubernetesActions.controllerRevisions": "{get,list,create,update,patch,delete,deleteMultiple}",
-					"runners[0].kubernetesActions.customObjects":       "{deleteMultiple}",
-					"runners[0].kubernetesActions.deployments":         "{restart}",
-					"runners[0].kubernetesActions.endpoints":           "{patch}",
-					"runners[0].kubernetesPermissions[0].apiGroups":    "{example.com}",
-					"runners[0].kubernetesPermissions[0].resources":    "{tests}",
-					"runners[0].kubernetesPermissions[0].verbs":        "{list,get,create,patch,update,delete}",
+				OverridesJson: map[string]string{
+					"runners[0].kubernetesActions.controllerRevisions": `["get","list","create","update","patch","delete","deleteMultiple"]`,
+					"runners[0].kubernetesActions.customObjects":       `["deleteMultiple"]`,
+					"runners[0].kubernetesActions.deployments":         `["restart"]`,
+					"runners[0].kubernetesActions.endpoints":           `["patch"]`,
+					"runners[0].kubernetesPermissions[0].apiGroups":    `["example.com"]`,
+					"runners[0].kubernetesPermissions[0].resources":    `["tests"]`,
+					"runners[0].kubernetesPermissions[0].verbs":        `["list","get","create","patch","update","delete"]`,
 				},
 			},
 			snapshotName: "enable-kubernetes-actions",
+			assertions:   verifyPrivateActionRunner,
+		},
+		{
+			name: "Specify certain config overrides",
+			command: common.HelmCommand{
+				ReleaseName: "private-action-runner",
+				ChartPath:   "../../charts/private-action-runner",
+				Values:      []string{"../../charts/private-action-runner/values.yaml"},
+				OverridesJson: map[string]string{
+					"runners[0].env": `[ {"name": "FOO", "value": "foo"}, {"name": "BAR", "value": "bar"} ]`,
+				},
+			},
+			snapshotName: "config-overrides",
 			assertions:   verifyPrivateActionRunner,
 		},
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

This makes it possible to pass environment variables that will be received by the PAR container


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

