### PR TITLE
Enable pod-resources socket only with GPU monitoring enabled

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.110.1
+
+* Mount the pod-resources socket only when `datadog.gpuMonitoring.enabled` is set to `true`.
+
 ## 3.110.0
 
 * Validation has been added for values under `datadog.apm.instrumentation`. Additional or incorrect values will fail a helm install or upgrade operation.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.110.0
+version: 3.110.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.110.0](https://img.shields.io/badge/Version-3.110.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.110.1](https://img.shields.io/badge/Version-3.110.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -254,7 +254,7 @@
       readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
-    {{- if and (not .Values.providers.gke.gdc) (not .Values.providers.gke.autopilot) }}
+    {{- if and (not .Values.providers.gke.gdc) (not .Values.providers.gke.autopilot) .Values.datadog.gpuMonitoring.enabled }}
     - name: pod-resources-socket
       mountPath: {{ .Values.datadog.kubelet.podResourcesSocketDir }}
       readOnly: false

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -10,7 +10,7 @@
   configMap:
     name: {{ include "agents.confd-configmap-name" . }}
 {{- end }}
-{{- if and (not .Values.providers.gke.gdc) (not .Values.providers.gke.autopilot) }}
+{{- if and (not .Values.providers.gke.gdc) (not .Values.providers.gke.autopilot) .Values.datadog.gpuMonitoring.enabled }}
 - name: pod-resources-socket
   hostPath:
     path: {{ .Values.datadog.kubelet.podResourcesSocketDir }}

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -915,9 +915,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/lib/kubelet/pod-resources
-              name: pod-resources-socket
-              readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1116,9 +1113,6 @@ spec:
           name: tmpdir
         - emptyDir: {}
           name: s6-run
-        - hostPath:
-            path: /var/lib/kubelet/pod-resources
-          name: pod-resources-socket
         - hostPath:
             path: /proc
           name: procdir

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -880,9 +880,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/lib/kubelet/pod-resources
-              name: pod-resources-socket
-              readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1081,9 +1078,6 @@ spec:
           name: tmpdir
         - emptyDir: {}
           name: s6-run
-        - hostPath:
-            path: /var/lib/kubelet/pod-resources
-          name: pod-resources-socket
         - hostPath:
             path: /proc
           name: procdir

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -880,9 +880,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/lib/kubelet/pod-resources
-              name: pod-resources-socket
-              readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1081,9 +1078,6 @@ spec:
           name: tmpdir
         - emptyDir: {}
           name: s6-run
-        - hostPath:
-            path: /var/lib/kubelet/pod-resources
-          name: pod-resources-socket
         - hostPath:
             path: /proc
           name: procdir

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1126,9 +1126,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/lib/kubelet/pod-resources
-              name: pod-resources-socket
-              readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1548,9 +1545,6 @@ spec:
           name: tmpdir
         - emptyDir: {}
           name: s6-run
-        - hostPath:
-            path: /var/lib/kubelet/pod-resources
-          name: pod-resources-socket
         - hostPath:
             path: /proc
           name: procdir

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -917,9 +917,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/lib/kubelet/pod-resources
-              name: pod-resources-socket
-              readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1214,9 +1211,6 @@ spec:
           name: tmpdir
         - emptyDir: {}
           name: s6-run
-        - hostPath:
-            path: /var/lib/kubelet/pod-resources
-          name: pod-resources-socket
         - hostPath:
             path: /proc
           name: procdir

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -954,9 +954,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/lib/kubelet/pod-resources
-              name: pod-resources-socket
-              readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1242,9 +1239,6 @@ spec:
           name: tmpdir
         - emptyDir: {}
           name: s6-run
-        - hostPath:
-            path: /var/lib/kubelet/pod-resources
-          name: pod-resources-socket
         - hostPath:
             path: /proc
           name: procdir

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -954,9 +954,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/lib/kubelet/pod-resources
-              name: pod-resources-socket
-              readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1239,9 +1236,6 @@ spec:
           name: tmpdir
         - emptyDir: {}
           name: s6-run
-        - hostPath:
-            path: /var/lib/kubelet/pod-resources
-          name: pod-resources-socket
         - hostPath:
             path: /proc
           name: procdir

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -880,9 +880,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/lib/kubelet/pod-resources
-              name: pod-resources-socket
-              readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1081,9 +1078,6 @@ spec:
           name: tmpdir
         - emptyDir: {}
           name: s6-run
-        - hostPath:
-            path: /var/lib/kubelet/pod-resources
-          name: pod-resources-socket
         - hostPath:
             path: /proc
           name: procdir

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1126,9 +1126,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/lib/kubelet/pod-resources
-              name: pod-resources-socket
-              readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1673,9 +1670,6 @@ spec:
           name: tmpdir
         - emptyDir: {}
           name: s6-run
-        - hostPath:
-            path: /var/lib/kubelet/pod-resources
-          name: pod-resources-socket
         - hostPath:
             path: /proc
           name: procdir

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1126,9 +1126,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/lib/kubelet/pod-resources
-              name: pod-resources-socket
-              readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1667,9 +1664,6 @@ spec:
           name: tmpdir
         - emptyDir: {}
           name: s6-run
-        - hostPath:
-            path: /var/lib/kubelet/pod-resources
-          name: pod-resources-socket
         - hostPath:
             path: /proc
           name: procdir


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR puts the `podResources` socket mount behind the GPU monitoring flag, as it's the only product currently using it.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
