### PR TITLE
[feat] Automatically restart agent pods on roles change

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.110.2
+
+* Restart Datadog pods after a change has been made to `datadog.secretBackend.roles`.
+
 ## 3.110.1
 
 * Mount the pod-resources socket only when `datadog.gpuMonitoring.enabled` is set to `true`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.110.1
+version: 3.110.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -64,6 +64,9 @@ spec:
         {{- if .Values.clusterAgent.confd }}
         checksum/confd-config: {{ tpl (toYaml .Values.clusterAgent.confd) . | sha256sum }}
         {{- end }}
+        {{- if .Values.datadog.secretBackend.roles }}
+        checksum/secret-backend-roles: {{ tpl (toYaml .Values.datadog.secretBackend.roles) . | sha256sum }}
+        {{- end }}
       {{- if .Values.clusterAgent.podAnnotations }}
 {{ tpl (toYaml .Values.clusterAgent.podAnnotations) . | indent 8 }}
       {{- end }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -54,6 +54,9 @@ spec:
         {{- if .Values.agents.customAgentConfig }}
         checksum/agent-config: {{ tpl (toYaml .Values.agents.customAgentConfig) . | sha256sum }}
         {{- end }}
+        {{- if .Values.datadog.secretBackend.roles }}
+        checksum/secret-backend-roles: {{ tpl (toYaml .Values.datadog.secretBackend.roles) . | sha256sum }}
+        {{- end }}
         {{- if eq  (include "should-enable-system-probe" .) "true" }}
         {{- if and (.Values.agents.podSecurity.apparmor.enabled) }}
         container.apparmor.security.beta.kubernetes.io/system-probe: {{ .Values.datadog.systemProbe.apparmor }}

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -173,6 +173,8 @@ kind: Role
 metadata:
   name: {{ template "datadog.fullname" $ }}-secret-reader-{{ $role.namespace }}
   namespace: {{ $role.namespace }}
+  annotations:
+    checksum/secret-backend-roles: {{ tpl (toYaml $.Values.datadog.secretBackend.roles) . | sha256sum }}
   labels:
 {{ include "datadog.labels" $ | indent 4 }}
 rules:
@@ -191,6 +193,8 @@ kind: RoleBinding
 metadata:
   name: {{ template "datadog.fullname" $ }}-read-secrets-{{ $role.namespace }}
   namespace: {{ $role.namespace }}
+  annotations:
+    checksum/secret-backend-roles: {{ tpl (toYaml $.Values.datadog.secretBackend.roles) . | sha256sum }}
   labels:
 {{ include "datadog.labels" $ | indent 4 }}
 subjects:


### PR DESCRIPTION
#### What this PR does / why we need it:

When we add new Roles and RoleBindings to Datadog, we need to manually restart pods in order for the new Roles to be picked up. 

By adding a checksum of the roles values as an annotation to Datadog agent, the pods will get rolled automatically. Removing the need for us to manually restart them.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

fixes #1759

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
