### PR TITLE
[errortracking] fix error tracking standalone config

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.110.2
+
+* Fix bug preventing using the `datadog.apm.errorTrackingStandalone.enabled` configuration.
+
 ## 3.110.1
 
 * Mount the pod-resources socket only when `datadog.gpuMonitoring.enabled` is set to `true`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.110.1
+version: 3.110.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.110.1](https://img.shields.io/badge/Version-3.110.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.110.2](https://img.shields.io/badge/Version-3.110.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -209,6 +209,10 @@
     - name: DD_OTELCOLLECTOR_ENABLED
       value: "true"
     {{- end }}
+    {{- if .Values.datadog.apm.errorTrackingStandalone.enabled }}
+    - name: DD_APM_ERROR_TRACKING_STANDALONE_ENABLED
+      value: "true"
+    {{- end }}
     {{- if and (not .Values.providers.gke.gdc) (not .Values.providers.gke.autopilot) }}
     - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
       value: {{ printf "%s/kubelet.sock" .Values.datadog.kubelet.podResourcesSocketDir | quote }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -73,7 +73,7 @@
     {{- include "additional-env-dict-entries" .Values.agents.containers.traceAgent.envDict | indent 4 }}
     {{- if .Values.datadog.apm.errorTrackingStandalone.enabled }}
     - name: DD_APM_ERROR_TRACKING_STANDALONE_ENABLED
-      value: true
+      value: "true"
     {{- end }}
   volumeMounts:
     - name: config

--- a/charts/datadog/values.schema.json
+++ b/charts/datadog/values.schema.json
@@ -9,6 +9,14 @@
         "apm": {
           "type": "object",
           "properties": {
+            "errorTrackingStandalone": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            },
             "instrumentation": {
               "type": "object",
               "properties": {


### PR DESCRIPTION
#### What this PR does / why we need it:

It's not possible to use `datadog.apm.errorTrackingStandalone.enabled` without running into this error

`json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string`

This is because the value of the var is `true` where it should've been `"true"`

It also introduces the `errorTrackingStandalone` object into the schema for validation

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
