### PR TITLE
Update CODEOWNERS - remove Docs team from courtesy reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 *  @DataDog/container-helm-chart-maintainers
 
 # Documentation
-*.md             @DataDog/documentation @DataDog/container-helm-chart-maintainers
+*.md             @DataDog/container-helm-chart-maintainers
 
 # Charts
 charts/datadog-crds                                    @DataDog/container-ecosystems


### PR DESCRIPTION
#### What this PR does / why we need it:

The Datadog docs team has in the past offered to do courtesy reviews on engineering-owned content. However, we are refining our scope and removing courtesy reviews.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
