### PR TITLE
Update DPA storage version to v1alpha2

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.1
+
+* Update DatadogPodAutoscaler CRD to have `storage` set to `v1alpha2`.
+
 # 2.5.0
 
 * Update CRDs from Datadog Operator v1.13.0 tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.5.0
+version: 2.5.1
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.5.1](https://img.shields.io/badge/Version-2.5.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
@@ -568,7 +568,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -1115,7 +1115,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
 {{- end }}

--- a/crds/datadoghq.com_datadogpodautoscalers.yaml
+++ b/crds/datadoghq.com_datadogpodautoscalers.yaml
@@ -562,7 +562,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -1109,6 +1109,6 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Update DPA storage version to v1alpha2

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
