### PR TITLE
[ACTP-461] allow to store the runner's identity in a kubernetes secret

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Datadog changelog
 
+## 0.18.0
+
+* Add the ability to specify a kubernetes secret to store the runner's identity.
+
 ## 0.17.2
 
 * Update postgresql credentials file example
-  
+
 ## 0.17.1
 
 * Update private action image version to `v1.1.1`

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.17.2
+version: 0.18.0
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.17.1](https://img.shields.io/badge/Version-0.17.1-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 
@@ -37,6 +37,28 @@ helm repo update
 * Learn more about [Kubernetes RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac).
 * Deploy several runners with different permissions or create different connections according to your needs.
 * Learn more about [Private actions](https://docs.datadoghq.com/service_management/app_builder/private_actions).
+
+### Use a kubernetes secret to store the runner's identity
+
+If you want to store the runner's identity outside of the Helm chart, you can create a kubernetes secret and use it in the `values.yaml` file.
+```bash
+# Create a secret with runner's private key and urn
+kubectl create secret generic <secret-name> --from-literal RUNNER_URN=<CHANGE_ME_URN_FROM_CONFIG> --from-literal RUNNER_PRIVATE_KEY=<CHANGE_ME_PRIVATE_KEY_FROM_CONFIG>
+# Alternatively you can only store the private key in the secret and keep the URN in the values.yaml
+kubectl create secret generic <secret-name>  --from-literal RUNNER_PRIVATE_KEY=<CHANGE_ME_PRIVATE_KEY_FROM_CONFIG>
+```
+Update the `values.yaml` file with the secret name
+```yaml
+runners:
+  -
+  # ... other fields
+    runnerIdentitySecret: <secret-name>
+  # ... other fields
+    config:
+      # you can get rid of the values in `config`, the secret will take precedence
+      # urn: "STORED_IN_A_SECRET"
+      # privateKey: "STORED_IN_A_SECRET"
+```
 
 ## Values
 
@@ -79,3 +101,4 @@ helm repo update
 | runners[0].kubernetesPermissions | list | `[]` | Kubernetes permissions to provide in addition to the one that will be inferred from `kubernetesActions` (useful for customObjects) |
 | runners[0].name | string | `"default"` | Name of the Datadog Private Action Runner |
 | runners[0].replicas | int | `1` | Number of pod instances for the Datadog Private Action Runner |
+| runners[0].runnerIdentitySecret | string | `""` | Reference to a kubernetes secrets that contains the runner identity |

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.17.1](https://img.shields.io/badge/Version-0.17.1-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 
@@ -37,5 +37,27 @@ helm repo update
 * Learn more about [Kubernetes RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac).
 * Deploy several runners with different permissions or create different connections according to your needs.
 * Learn more about [Private actions](https://docs.datadoghq.com/service_management/app_builder/private_actions).
+
+### Use a kubernetes secret to store the runner's identity
+
+If you want to store the runner's identity outside of the Helm chart, you can create a kubernetes secret and use it in the `values.yaml` file.
+```bash
+# Create a secret with runner's private key and urn
+kubectl create secret generic <secret-name> --from-literal RUNNER_URN=<CHANGE_ME_URN_FROM_CONFIG> --from-literal RUNNER_PRIVATE_KEY=<CHANGE_ME_PRIVATE_KEY_FROM_CONFIG>
+# Alternatively you can only store the private key in the secret and keep the URN in the values.yaml
+kubectl create secret generic <secret-name>  --from-literal RUNNER_PRIVATE_KEY=<CHANGE_ME_PRIVATE_KEY_FROM_CONFIG>
+```
+Update the `values.yaml` file with the secret name
+```yaml
+runners:
+  -
+  # ... other fields
+    runnerIdentitySecret: <secret-name>
+  # ... other fields
+    config:
+      # you can get rid of the values in `config`, the secret will take precedence
+      # urn: "STORED_IN_A_SECRET"
+      # privateKey: "STORED_IN_A_SECRET"
+```
 
 {{ template "chart.valuesSection" . }}

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -14,6 +14,7 @@ runners:
     env:
       - name: "ENV_VAR_NAME"
         value: "ENV_VAR_VALUE"
+    runnerIdentitySecret: "A-SECRET-WITH-THE-RUNNER-PRIVATE-KEY-AND-URN"
     # -- Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account
     kubernetesActions:
       controllerRevisions: [] # select your actions among ["get", "list", "create", "update", "patch", "delete", "deleteMultiple"]

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -48,6 +48,11 @@ spec:
           {{- if $runner.env }}
           env: {{ $runner.env | toYaml | nindent 12 }}
           {{- end }}
+          {{- if $runner.runnerIdentitySecret }}
+          envFrom:
+            - secretRef:
+                name: {{ $runner.runnerIdentitySecret }}
+          {{- end }}
       volumes:
         - name: secrets
           secret:

--- a/charts/private-action-runner/templates/secrets.yaml
+++ b/charts/private-action-runner/templates/secrets.yaml
@@ -8,8 +8,12 @@ metadata:
 stringData:
   config.yaml: |
     ddBaseURL: {{ $runner.config.ddBaseURL }}
+    {{- if $runner.config.urn }}
     urn: {{ $runner.config.urn }}
+    {{- end }}
+    {{- if $runner.config.privateKey }}
     privateKey: {{ $runner.config.privateKey }}
+    {{- end }}
     modes:
     {{- range $mode := $runner.config.modes }}
       - {{ $mode }}

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -31,6 +31,8 @@ runners:
       actionsAllowlist: []
     # -- Environment variables to be passed to the Datadog Private Action Runner
     env: []
+    # -- Reference to a kubernetes secrets that contains the runner identity
+    runnerIdentitySecret: ""
     # -- Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account
     kubernetesActions:
       # -- Actions related to controllerRevisions (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple")

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -90,7 +90,7 @@ spec:
         app:  "private-action-runner-default" 
         service:  "private-action-runner-default-service" 
       annotations:
-        config-hash: 2fa834a4c916b0d4254f354857cd894879f1a7787214ef3fe8e8159911c3d74b
+        config-hash: 8328d30c1b1f9da3685601122ee752cf6a14a5cc7fa1a0c1426ba91d6a314566
     spec:
       serviceAccountName:  "private-action-runner-default-serviceaccount" 
       tolerations:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -134,7 +134,7 @@ spec:
         app:  "private-action-runner-default" 
         service:  "private-action-runner-default-service" 
       annotations:
-        config-hash: 7091b9a074330e2ed57f3086a7de30e96f38467ae819e6656d164b0bc59a2da6
+        config-hash: 3004ab3b807a95e07086b81865f54afc43025d477bb182ab8d6b868c5c502409
     spec:
       serviceAccountName:  "private-action-runner-default-serviceaccount" 
       tolerations:

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -15,8 +15,6 @@ metadata:
 stringData:
   config.yaml: |
     ddBaseURL: https://app.datadoghq.com
-    urn: CHANGE_ME_URN_FROM_CONFIG
-    privateKey: CHANGE_ME_PRIVATE_KEY_FROM_CONFIG
     modes:
       - workflowAutomation
       - appBuilder
@@ -90,7 +88,7 @@ spec:
         app:  "private-action-runner-default" 
         service:  "private-action-runner-default-service" 
       annotations:
-        config-hash: cf100db02beb8cd31d40cb5534d61050a658aecdd4518e64695b477296a8a48f
+        config-hash: 953013b9c7209ac5f1cfceb30a9c883c55a50f077fa7065be4e11e71d94dfd7b
     spec:
       serviceAccountName:  "private-action-runner-default-serviceaccount" 
       tolerations:
@@ -115,6 +113,9 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner
+          envFrom:
+            - secretRef:
+                name: the-name-of-the-secret
       volumes:
         - name: secrets
           secret:

--- a/test/private-action-runner/baseline_test.go
+++ b/test/private-action-runner/baseline_test.go
@@ -58,6 +58,21 @@ func Test_baseline_manifests(t *testing.T) {
 			snapshotName: "config-overrides",
 			assertions:   verifyPrivateActionRunner,
 		},
+		{
+			name: "Specify secrets externally",
+			command: common.HelmCommand{
+				ReleaseName: "private-action-runner",
+				ChartPath:   "../../charts/private-action-runner",
+				Values:      []string{"../../charts/private-action-runner/values.yaml"},
+				OverridesJson: map[string]string{
+					"runners[0].runnerIdentitySecret": `"the-name-of-the-secret"`,
+					"runners[0].config.urn":           ``,
+					"runners[0].config.privateKey":    ``,
+				},
+			},
+			snapshotName: "external-secrets",
+			assertions:   verifyPrivateActionRunner,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What this PR does / why we need it:

This allows to retrieve the runner's URN and private key from a kubernetes secret instead of having to store it in the `values.yaml`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
