### PR TITLE
[ACTP-459] deploy the PAR with a role instead of a cluster role by default

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.19.0
+
+* Use a role instead of a cluster role for the runner's service account by default.
+
 ## 0.18.0
 
 * Add the ability to specify a kubernetes secret to store the runner's identity.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.18.0
+version: 0.19.0
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 
@@ -101,4 +101,5 @@ runners:
 | runners[0].kubernetesPermissions | list | `[]` | Kubernetes permissions to provide in addition to the one that will be inferred from `kubernetesActions` (useful for customObjects) |
 | runners[0].name | string | `"default"` | Name of the Datadog Private Action Runner |
 | runners[0].replicas | int | `1` | Number of pod instances for the Datadog Private Action Runner |
+| runners[0].roleType | string | `"Role"` | Type of kubernetes role to create (either "Role" or "ClusterRole") |
 | runners[0].runnerIdentitySecret | string | `""` | Reference to a kubernetes secrets that contains the runner identity |

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -11,6 +11,8 @@ runners:
       port: 9016
       actionsAllowlist:
         - com.datadoghq.http.request
+    # Use a "Role" to scope the permissions to the runner's namespace or a "ClusterRole" to give permissions to the entire cluster
+    roleType: "Role"
     env:
       - name: "ENV_VAR_NAME"
         value: "ENV_VAR_VALUE"

--- a/charts/private-action-runner/templates/NOTES.txt
+++ b/charts/private-action-runner/templates/NOTES.txt
@@ -1,0 +1,8 @@
+{{- if .Values.runners }}
+{{- range .Values.runners }}
+{{- if not .roleType }}
+ℹ️ No roleType specified. The default value is "Role" which provides namespace-scoped permissions.
+{{- end }}
+{{- end }}
+{{- end }}
+

--- a/charts/private-action-runner/templates/role.yaml
+++ b/charts/private-action-runner/templates/role.yaml
@@ -1,7 +1,7 @@
 {{- range $_, $runner := $.Values.runners }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ $runner.roleType | default "Role" }}
 metadata:
   namespace: {{ $.Release.Namespace }}
   name: {{ include "chart.roleName" $runner.name }}

--- a/charts/private-action-runner/templates/rolebinding.yaml
+++ b/charts/private-action-runner/templates/rolebinding.yaml
@@ -1,13 +1,13 @@
 {{- range $_, $runner := $.Values.runners }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ $runner.roleType | default "Role" }}Binding
 metadata:
   name: {{ include "chart.roleBindingName" $runner.name }}
   namespace: {{ $.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ $runner.roleType | default "Role"}}
   name: {{ include "chart.roleName" $runner.name }}
 subjects:
   - kind: ServiceAccount

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -11,6 +11,8 @@ common:
 runners:
   # runners[0].name -- Name of the Datadog Private Action Runner
   - name: "default"
+    # -- Type of kubernetes role to create (either "Role" or "ClusterRole")
+    roleType: "Role"
     # -- Number of pod instances for the Datadog Private Action Runner
     replicas: 1
     # -- Configuration for the Datadog Private Action Runner

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -27,7 +27,7 @@ stringData:
 ---
 # Source: private-action-runner/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   namespace: datadog-agent
   name:  "private-action-runner-default-role" 
@@ -42,13 +42,13 @@ rules:
 ---
 # Source: private-action-runner/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name:  "private-action-runner-default-rolebinding" 
   namespace: datadog-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name:  "private-action-runner-default-role" 
 subjects:
   - kind: ServiceAccount
@@ -90,7 +90,7 @@ spec:
         app:  "private-action-runner-default" 
         service:  "private-action-runner-default-service" 
       annotations:
-        config-hash: 8328d30c1b1f9da3685601122ee752cf6a14a5cc7fa1a0c1426ba91d6a314566
+        config-hash: abcf3b71b184f776de80c25782022af554aeff4e918a55084e8add5cda537b79
     spec:
       serviceAccountName:  "private-action-runner-default-serviceaccount" 
       tolerations:

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -27,7 +27,7 @@ stringData:
 ---
 # Source: private-action-runner/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   namespace: datadog-agent
   name:  "private-action-runner-default-role" 
@@ -42,13 +42,13 @@ rules:
 ---
 # Source: private-action-runner/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name:  "private-action-runner-default-rolebinding" 
   namespace: datadog-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name:  "private-action-runner-default-role" 
 subjects:
   - kind: ServiceAccount
@@ -90,7 +90,7 @@ spec:
         app:  "private-action-runner-default" 
         service:  "private-action-runner-default-service" 
       annotations:
-        config-hash: cf100db02beb8cd31d40cb5534d61050a658aecdd4518e64695b477296a8a48f
+        config-hash: 8ea3803f8339a8340f5a96e220f479428af819615a18ceae1d2472a1f23c8233
     spec:
       serviceAccountName:  "private-action-runner-default-serviceaccount" 
       tolerations:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -134,7 +134,7 @@ spec:
         app:  "private-action-runner-default" 
         service:  "private-action-runner-default-service" 
       annotations:
-        config-hash: 3004ab3b807a95e07086b81865f54afc43025d477bb182ab8d6b868c5c502409
+        config-hash: 701ae52311b4bbd4b7b78c8b2467034920f02f59e6b16ec5ad6171e99a12bca4
     spec:
       serviceAccountName:  "private-action-runner-default-serviceaccount" 
       tolerations:

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -25,7 +25,7 @@ stringData:
 ---
 # Source: private-action-runner/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   namespace: datadog-agent
   name:  "private-action-runner-default-role" 
@@ -40,13 +40,13 @@ rules:
 ---
 # Source: private-action-runner/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name:  "private-action-runner-default-rolebinding" 
   namespace: datadog-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name:  "private-action-runner-default-role" 
 subjects:
   - kind: ServiceAccount
@@ -88,7 +88,7 @@ spec:
         app:  "private-action-runner-default" 
         service:  "private-action-runner-default-service" 
       annotations:
-        config-hash: 953013b9c7209ac5f1cfceb30a9c883c55a50f077fa7065be4e11e71d94dfd7b
+        config-hash: 8330cf14669cdaa3803f1bb498edec99e33c8f970a3e24f3e3220acba5dbb0e7
     spec:
       serviceAccountName:  "private-action-runner-default-serviceaccount" 
       tolerations:

--- a/test/private-action-runner/baseline_test.go
+++ b/test/private-action-runner/baseline_test.go
@@ -33,6 +33,7 @@ func Test_baseline_manifests(t *testing.T) {
 				ChartPath:   "../../charts/private-action-runner",
 				Values:      []string{"../../charts/private-action-runner/values.yaml"},
 				OverridesJson: map[string]string{
+					"runners[0].roleType":                              `"ClusterRole"`,
 					"runners[0].kubernetesActions.controllerRevisions": `["get","list","create","update","patch","delete","deleteMultiple"]`,
 					"runners[0].kubernetesActions.customObjects":       `["deleteMultiple"]`,
 					"runners[0].kubernetesActions.deployments":         `["restart"]`,
@@ -52,7 +53,8 @@ func Test_baseline_manifests(t *testing.T) {
 				ChartPath:   "../../charts/private-action-runner",
 				Values:      []string{"../../charts/private-action-runner/values.yaml"},
 				OverridesJson: map[string]string{
-					"runners[0].env": `[ {"name": "FOO", "value": "foo"}, {"name": "BAR", "value": "bar"} ]`,
+					"runners[0].env":      `[ {"name": "FOO", "value": "foo"}, {"name": "BAR", "value": "bar"} ]`,
+					"runners[0].roleType": `""`,
 				},
 			},
 			snapshotName: "config-overrides",


### PR DESCRIPTION
#### What this PR does / why we need it:

Make the PAR less powerful by default and allow for least privileged permissions


#### Checklist
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
