### PR TITLE
[ACTP-462] allow to store PAR credential files outside of the helm chart

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.20.0
+
+* Add the ability to specify kubernetes secrets to store credential files.
+
 ## 0.19.0
 
 * Use a role instead of a cluster role for the runner's service account by default.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 0.19.0
+version: 0.20.0
 appVersion: "1.22.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -65,23 +65,23 @@ runners:
 If you want to store the credentials outside of the Helm chart, you can create a kubernetes secret and use it in the `values.yaml` file.
 ```bash
 # Create a secret with the credentials files
-kubectl create secret generic <secret-name> --from-literal jenkins_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "username", "tokenValue": "USERNAME"}, {"tokenName": "token", "tokenValue": "TOKEN"}, {"tokenName": "domain", "tokenValue": "DOMAIN" }]}' --from-literal gitlab_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "baseURL", "tokenValue": "GITLAB_BASE_URL"}, {"tokenName": "gitlabApiToken", "tokenValue": "GITLAB_API_TOKEN"}]}'
+kubectl create secret generic <secret-name> --from-literal jenkins_token.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "username", "tokenValue": "USERNAME"}, {"tokenName": "token", "tokenValue": "TOKEN"}, {"tokenName": "domain", "tokenValue": "DOMAIN" }]}' --from-literal gitlab_token.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "baseURL", "tokenValue": "GITLAB_BASE_URL"}, {"tokenName": "gitlabApiToken", "tokenValue": "GITLAB_API_TOKEN"}]}'
 
 # Alternatively create one secret per credentials file
-kubectl create secret generic <secret-name-jenkins> --from-literal jenkins_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "username", "tokenValue": "USERNAME"}, {"tokenName": "token", "tokenValue": "TOKEN"}, {"tokenName": "domain", "tokenValue": "DOMAIN" }]}'
-kubectl create secret generic <secret-name-gitlab> --from-literal gitlab_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "baseURL", "tokenValue": "GITLAB_BASE_URL"}, {"tokenName": "gitlabApiToken", "tokenValue": "GITLAB_API_TOKEN"}]}'
+kubectl create secret generic <secret-name-jenkins> --from-literal jenkins_token.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "username", "tokenValue": "USERNAME"}, {"tokenName": "token", "tokenValue": "TOKEN"}, {"tokenName": "domain", "tokenValue": "DOMAIN" }]}'
+kubectl create secret generic <secret-name-gitlab> --from-literal gitlab_token.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "baseURL", "tokenValue": "GITLAB_BASE_URL"}, {"tokenName": "gitlabApiToken", "tokenValue": "GITLAB_API_TOKEN"}]}'
 ```
 
 Update the `values.yaml` file with the secrets names and the directory names
 ```yaml
 credentialSecrets:
-  # your credentials files will be located at /etc/dd-action-runner/credentials/jenkins_sample.json and /etc/dd-action-runner/credentials/gitlab_sample.json
+  # your credentials files will be located at /etc/dd-action-runner/credentials/jenkins_token.json and /etc/dd-action-runner/credentials/gitlab_token.json
   - secretName: <secret-name>
     directoryName: ""
-  # your credentials file will be located at /etc/dd-action-runner/credentials/jenkins/jenkins_sample.json
+  # your credentials file will be located at /etc/dd-action-runner/credentials/jenkins/jenkins_token.json
   - secretName: <secret-name-jenkins>
     directoryName: "jenkins"
-  # your credentials file will be located at /etc/dd-action-runner/credentials/gitlab/gitlab.json
+  # your credentials file will be located at /etc/dd-action-runner/credentials/gitlab/gitlab_token.json
   - secretName: <secret-name-gitlab>
     directoryName: "gitlab"
 ```

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
 
 This Helm Chart deploys the Datadog Private Action runner inside a Kubernetes cluster. It allows you to use private actions from the Datadog Workflow and Datadog App Builder products. When deploying this chart, you can give permissions to the runner in order to be able to run Kubernetes actions.
 
@@ -59,5 +59,32 @@ runners:
       # urn: "STORED_IN_A_SECRET"
       # privateKey: "STORED_IN_A_SECRET"
 ```
+
+### Use kubernetes secrets to store credentials
+
+If you want to store the credentials outside of the Helm chart, you can create a kubernetes secret and use it in the `values.yaml` file.
+```bash
+# Create a secret with the credentials files
+kubectl create secret generic <secret-name> --from-literal jenkins_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "username", "tokenValue": "USERNAME"}, {"tokenName": "token", "tokenValue": "TOKEN"}, {"tokenName": "domain", "tokenValue": "DOMAIN" }]}' --from-literal gitlab_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "baseURL", "tokenValue": "GITLAB_BASE_URL"}, {"tokenName": "gitlabApiToken", "tokenValue": "GITLAB_API_TOKEN"}]}'
+
+# Alternatively create one secret per credentials file
+kubectl create secret generic <secret-name-jenkins> --from-literal jenkins_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "username", "tokenValue": "USERNAME"}, {"tokenName": "token", "tokenValue": "TOKEN"}, {"tokenName": "domain", "tokenValue": "DOMAIN" }]}'
+kubectl create secret generic <secret-name-gitlab> --from-literal gitlab_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "baseURL", "tokenValue": "GITLAB_BASE_URL"}, {"tokenName": "gitlabApiToken", "tokenValue": "GITLAB_API_TOKEN"}]}'
+```
+
+Update the `values.yaml` file with the secrets names and the directory names
+```yaml
+credentialSecrets:
+  # your credentials files will be located at /etc/dd-action-runner/credentials/jenkins_sample.json and /etc/dd-action-runner/credentials/gitlab_sample.json
+  - secretName: <secret-name>
+    directoryName: ""
+  # your credentials file will be located at /etc/dd-action-runner/credentials/jenkins/jenkins_sample.json
+  - secretName: <secret-name-jenkins>
+    directoryName: "jenkins"
+  # your credentials file will be located at /etc/dd-action-runner/credentials/gitlab/gitlab.json
+  - secretName: <secret-name-gitlab>
+    directoryName: "gitlab"
+```
+
 
 {{ template "chart.valuesSection" . }}

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -65,23 +65,23 @@ runners:
 If you want to store the credentials outside of the Helm chart, you can create a kubernetes secret and use it in the `values.yaml` file.
 ```bash
 # Create a secret with the credentials files
-kubectl create secret generic <secret-name> --from-literal jenkins_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "username", "tokenValue": "USERNAME"}, {"tokenName": "token", "tokenValue": "TOKEN"}, {"tokenName": "domain", "tokenValue": "DOMAIN" }]}' --from-literal gitlab_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "baseURL", "tokenValue": "GITLAB_BASE_URL"}, {"tokenName": "gitlabApiToken", "tokenValue": "GITLAB_API_TOKEN"}]}'
+kubectl create secret generic <secret-name> --from-literal jenkins_token.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "username", "tokenValue": "USERNAME"}, {"tokenName": "token", "tokenValue": "TOKEN"}, {"tokenName": "domain", "tokenValue": "DOMAIN" }]}' --from-literal gitlab_token.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "baseURL", "tokenValue": "GITLAB_BASE_URL"}, {"tokenName": "gitlabApiToken", "tokenValue": "GITLAB_API_TOKEN"}]}'
 
 # Alternatively create one secret per credentials file
-kubectl create secret generic <secret-name-jenkins> --from-literal jenkins_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "username", "tokenValue": "USERNAME"}, {"tokenName": "token", "tokenValue": "TOKEN"}, {"tokenName": "domain", "tokenValue": "DOMAIN" }]}'
-kubectl create secret generic <secret-name-gitlab> --from-literal gitlab_sample.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "baseURL", "tokenValue": "GITLAB_BASE_URL"}, {"tokenName": "gitlabApiToken", "tokenValue": "GITLAB_API_TOKEN"}]}'
+kubectl create secret generic <secret-name-jenkins> --from-literal jenkins_token.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "username", "tokenValue": "USERNAME"}, {"tokenName": "token", "tokenValue": "TOKEN"}, {"tokenName": "domain", "tokenValue": "DOMAIN" }]}'
+kubectl create secret generic <secret-name-gitlab> --from-literal gitlab_token.json='{"auth_type": "Token Auth", "credentials": [{"tokenName": "baseURL", "tokenValue": "GITLAB_BASE_URL"}, {"tokenName": "gitlabApiToken", "tokenValue": "GITLAB_API_TOKEN"}]}'
 ```
 
 Update the `values.yaml` file with the secrets names and the directory names
 ```yaml
 credentialSecrets:
-  # your credentials files will be located at /etc/dd-action-runner/credentials/jenkins_sample.json and /etc/dd-action-runner/credentials/gitlab_sample.json
+  # your credentials files will be located at /etc/dd-action-runner/credentials/jenkins_token.json and /etc/dd-action-runner/credentials/gitlab_token.json
   - secretName: <secret-name>
     directoryName: ""
-  # your credentials file will be located at /etc/dd-action-runner/credentials/jenkins/jenkins_sample.json
+  # your credentials file will be located at /etc/dd-action-runner/credentials/jenkins/jenkins_token.json
   - secretName: <secret-name-jenkins>
     directoryName: "jenkins"
-  # your credentials file will be located at /etc/dd-action-runner/credentials/gitlab/gitlab.json
+  # your credentials file will be located at /etc/dd-action-runner/credentials/gitlab/gitlab_token.json
   - secretName: <secret-name-gitlab>
     directoryName: "gitlab"
 ```

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -194,3 +194,10 @@ credentialFiles:
         ]
       }
 
+credentialSecrets:
+  # a kubernetes secret containing multiple credentials files mounted at /etc/dd-action-runner/credentials/<filename-from-secret>
+  - secretName: all-secrets-at-once
+    directoryName: ""
+  # a kubernetes secret containing a single credentials file mounted at /etc/dd-action-runner/credentials/jenkins/<filename-from-secret>
+  - secretName: jenkins-secret
+    directoryName: jenkins

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner
+            {{- range $_, $credentialSecret := $.Values.credentialSecrets }}
+            - name: {{ $credentialSecret.secretName }}
+              mountPath: /etc/dd-action-runner/credentials/{{ $credentialSecret.directoryName }}
+            {{- end }}
           {{- if $runner.env }}
           env: {{ $runner.env | toYaml | nindent 12 }}
           {{- end }}
@@ -57,4 +61,9 @@ spec:
         - name: secrets
           secret:
             secretName: {{ include "chart.secretName" $runner.name }}
+        {{- range $_, $credentialSecret := $.Values.credentialSecrets }}
+        - name: {{ $credentialSecret.secretName }}
+          secret:
+            secretName: {{ $credentialSecret.secretName }}
+        {{- end }}
 {{- end }}

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -90,3 +90,7 @@ runners:
 credentialFiles: []
 # see examples/values.yaml for examples on how to specify secrets
 # credential files provided here will be mounted in /etc/dd-action-runner/
+# -- References to kubernetes secrets that contain credentials to be used by the Datadog Private Action Runner
+credentialSecrets: []
+# credential files provided here will be mounted in /etc/dd-action-runner/credentials/
+# see examples/values.yaml for examples on how to specify secrets

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -113,10 +113,20 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner
+            - name: first-secret
+              mountPath: /etc/dd-action-runner/credentials/
+            - name: second-secret
+              mountPath: /etc/dd-action-runner/credentials/second-secret-directory
           envFrom:
             - secretRef:
                 name: the-name-of-the-secret
       volumes:
         - name: secrets
           secret:
-            secretName:  "private-action-runner-default-secrets"
+            secretName:  "private-action-runner-default-secrets" 
+        - name: first-secret
+          secret:
+            secretName: first-secret
+        - name: second-secret
+          secret:
+            secretName: second-secret

--- a/test/private-action-runner/baseline_test.go
+++ b/test/private-action-runner/baseline_test.go
@@ -70,6 +70,7 @@ func Test_baseline_manifests(t *testing.T) {
 					"runners[0].runnerIdentitySecret": `"the-name-of-the-secret"`,
 					"runners[0].config.urn":           ``,
 					"runners[0].config.privateKey":    ``,
+					"credentialSecrets":               `[{"secretName": "first-secret"}, {"secretName": "second-secret", "directoryName": "second-secret-directory"}]`,
 				},
 			},
 			snapshotName: "external-secrets",


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow to retrieve credentials files from existing kubernetes secrets in order to be able to manage them outside of the chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
