### PR TITLE
[PAR] Add a makefile entry to update the private-action-runner snapshot tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ unit-test-operator:
 unit-test-private-action-runner:
 	go test -C test ./private-action-runner -count=1
 
+.PHONY: update-test-baselines-private-action-runner
+update-test-baselines-private-action-runner:
+	go test -C test ./private-action-runner -count=1 -args -updateBaselines=true
+
 .PHONY: update-test-baselines
 update-test-baselines:
 	go test -C test ./... -count=1 -args -updateBaselines=true


### PR DESCRIPTION
#### What this PR does / why we need it:

Create a make command to update the private action runner snapshot tests to facilitate the upgrade process

