### PR TITLE
feat(instrumentation): support valueFrom

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.120.0
+
+* `apm.instrumentation.targets` supports `valueFrom`.
+
 ## 3.118.7
 
 * Upgrade default Agent version to `7.67.0`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.119.0
+version: 3.120.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.119.0](https://img.shields.io/badge/Version-3.119.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.120.0](https://img.shields.io/badge/Version-3.120.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -723,7 +723,7 @@ helm install <RELEASE_NAME> \
 | datadog.apm.instrumentation.language_detection.enabled | bool | `true` | Run language detection to automatically detect languages of user workloads (preview). |
 | datadog.apm.instrumentation.libVersions | object | `{}` | Inject specific version of tracing libraries with Single Step Instrumentation. |
 | datadog.apm.instrumentation.skipKPITelemetry | bool | `false` | Disable generating Configmap for APM Instrumentation KPIs |
-| datadog.apm.instrumentation.targets | list | `[]` | Enable target based workload selection. Requires Cluster Agent 7.64.0+ |
+| datadog.apm.instrumentation.targets | list | `[]` | Enable target based workload selection. Requires Cluster Agent 7.64.0+.  ddTraceConfigs[]valueFrom Requires Cluster Agent 7.66.0+. |
 | datadog.apm.port | int | `8126` | Override the trace Agent port |
 | datadog.apm.portEnabled | bool | `false` | Enable APM over TCP communication (hostPort 8126 by default) |
 | datadog.apm.socketEnabled | bool | `true` | Enable APM over Socket (Unix Socket or windows named pipe) |

--- a/charts/datadog/values.schema.json
+++ b/charts/datadog/values.schema.json
@@ -23,8 +23,12 @@
                 "enabled": {
                   "type": "boolean"
                 },
-                "enabledNamespaces": { "$ref": "#/$defs/stringArray" },
-                "disabledNamespaces": { "$ref": "#/$defs/stringArray" },
+                "enabledNamespaces": {
+                  "$ref": "#/$defs/stringArray"
+                },
+                "disabledNamespaces": {
+                  "$ref": "#/$defs/stringArray"
+                },
                 "libVersions": {
                   "type": "object",
                   "additionalProperties": {
@@ -42,17 +46,27 @@
                       "podSelector": {
                         "type": "object",
                         "properties": {
-                          "matchLabels": { "$ref": "#/$defs/matchLabels" },
-                          "matchExpressions": { "$ref": "#/$defs/matchExpressions" }
+                          "matchLabels": {
+                            "$ref": "#/$defs/matchLabels"
+                          },
+                          "matchExpressions": {
+                            "$ref": "#/$defs/matchExpressions"
+                          }
                         },
                         "additionalProperties": false
                       },
                       "namespaceSelector": {
                         "type": "object",
                         "properties": {
-                          "matchNames": { "$ref": "#/$defs/stringArray" },
-                          "matchLabels": { "$ref": "#/$defs/matchLabels" },
-                          "matchExpressions": { "$ref": "#/$defs/matchExpressions" }
+                          "matchNames": {
+                            "$ref": "#/$defs/stringArray"
+                          },
+                          "matchLabels": {
+                            "$ref": "#/$defs/matchLabels"
+                          },
+                          "matchExpressions": {
+                            "$ref": "#/$defs/matchExpressions"
+                          }
                         },
                         "anyOf": [
                           {
@@ -134,12 +148,17 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name", "value"],
+                          "required": [
+                            "name",
+                            "value"
+                          ],
                           "additionalProperties": false
                         }
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "additionalProperties": false
                   }
                 },
@@ -229,44 +248,49 @@
     }
   },
   "$defs": {
-      "stringArray": {
-          "type": "array",
-          "items": {
-              "type": "string"
-          }
-      },
-      "matchLabels": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
-        }
-      },
-      "matchExpressions": {
-          "type": "array",
-          "items": {
-              "type": "object",
-              "properties": {
-                  "key": {
-                      "type": "string"
-                  },
-                  "operator": {
-                      "type": "string",
-                      "enum": [
-                          "In",
-                          "NotIn",
-                          "Exists",
-                          "DoesNotExist"
-                      ]
-                  },
-                  "values": {
-                      "type": "array",
-                      "items": { "type": "string" },
-                      "minItems": 1
-                  }
-              },
-              "required": ["key", "operator"],
-              "additionalProperties": false
-          }
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "type": "string"
       }
+    },
+    "matchLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "matchExpressions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string",
+            "enum": [
+              "In",
+              "NotIn",
+              "Exists",
+              "DoesNotExist"
+            ]
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "key",
+          "operator"
+        ],
+        "additionalProperties": false
+      }
+    }
   }
 }

--- a/charts/datadog/values.schema.json
+++ b/charts/datadog/values.schema.json
@@ -145,12 +145,17 @@
                               "type": "string"
                             },
                             "value": {
-                              "type": "string"
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "valueFrom": {
+                              "$ref": "#/$defs/k8s.api.envVarSource"
                             }
                           },
                           "required": [
-                            "name",
-                            "value"
+                            "name"
                           ],
                           "additionalProperties": false
                         }
@@ -290,6 +295,108 @@
           "operator"
         ],
         "additionalProperties": false
+      }
+    },
+    "k8s.api.envVarSource": {
+      "description": "EnvVarSource represents a source for the value of an EnvVar.",
+      "properties": {
+        "secretKeyRef": {
+          "required": [
+            "key"
+          ],
+          "description": "SecretKeySelector selects a key of a Secret.",
+          "properties": {
+            "optional": {
+              "type": "boolean",
+              "description": "Specify whether the Secret or it's key must be defined"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+            },
+            "key": {
+              "type": "string",
+              "description": "The key of the secret to select from.  Must be a valid secret key."
+            }
+          }
+        },
+        "fieldRef": {
+          "required": [
+            "fieldPath"
+          ],
+          "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+          "properties": {
+            "fieldPath": {
+              "type": "string",
+              "description": "Path of the field to select in the specified API version."
+            },
+            "apiVersion": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\"."
+            }
+          }
+        },
+        "configMapKeyRef": {
+          "required": [
+            "key"
+          ],
+          "description": "Selects a key from a ConfigMap.",
+          "properties": {
+            "optional": {
+              "type": "boolean",
+              "description": "Specify whether the ConfigMap or it's key must be defined"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+            },
+            "key": {
+              "type": "string",
+              "description": "The key to select."
+            }
+          }
+        },
+        "resourceFieldRef": {
+          "required": [
+            "resource"
+          ],
+          "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+          "properties": {
+            "containerName": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Container name: required for volumes, optional for env vars"
+            },
+            "resource": {
+              "type": "string",
+              "description": "Required: resource to select"
+            },
+            "divisor": {
+              "oneOf": [
+                {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            }
+          }
+        }
       }
     }
   }

--- a/charts/datadog/values.schema.json
+++ b/charts/datadog/values.schema.json
@@ -23,18 +23,8 @@
                 "enabled": {
                   "type": "boolean"
                 },
-                "enabledNamespaces": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "disabledNamespaces": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
+                "enabledNamespaces": { "$ref": "#/$defs/stringArray" },
+                "disabledNamespaces": { "$ref": "#/$defs/stringArray" },
                 "libVersions": {
                   "type": "object",
                   "additionalProperties": {
@@ -52,84 +42,17 @@
                       "podSelector": {
                         "type": "object",
                         "properties": {
-                          "matchLabels": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "string"
-                            }
-                          },
-                          "matchExpressions": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "key": {
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "type": "string",
-                                  "enum": [
-                                    "In",
-                                    "NotIn",
-                                    "Exists",
-                                    "DoesNotExist"
-                                  ]
-                                },
-                                "values": {
-                                  "type": "array",
-                                  "items": { "type": "string" },
-                                  "minItems": 1
-                                }
-                              },
-                              "required": ["key", "operator"],
-                              "additionalProperties": false
-                            }
-                          }
+                          "matchLabels": { "$ref": "#/$defs/matchLabels" },
+                          "matchExpressions": { "$ref": "#/$defs/matchExpressions" }
                         },
                         "additionalProperties": false
                       },
                       "namespaceSelector": {
                         "type": "object",
                         "properties": {
-                          "matchNames": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          "matchLabels": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "string"
-                            }
-                          },
-                          "matchExpressions": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "key": {
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "type": "string",
-                                  "enum": [
-                                    "In",
-                                    "NotIn",
-                                    "Exists",
-                                    "DoesNotExist"
-                                  ]
-                                },
-                                "values": {
-                                  "type": "array",
-                                  "items": { "type": "string" },
-                                  "minItems": 1
-                                }
-                              },
-                              "required": ["key", "operator"],
-                              "additionalProperties": false
-                            }
-                          }
+                          "matchNames": { "$ref": "#/$defs/stringArray" },
+                          "matchLabels": { "$ref": "#/$defs/matchLabels" },
+                          "matchExpressions": { "$ref": "#/$defs/matchExpressions" }
                         },
                         "anyOf": [
                           {
@@ -304,5 +227,46 @@
         }
       }
     }
+  },
+  "$defs": {
+      "stringArray": {
+          "type": "array",
+          "items": {
+              "type": "string"
+          }
+      },
+      "matchLabels": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "matchExpressions": {
+          "type": "array",
+          "items": {
+              "type": "object",
+              "properties": {
+                  "key": {
+                      "type": "string"
+                  },
+                  "operator": {
+                      "type": "string",
+                      "enum": [
+                          "In",
+                          "NotIn",
+                          "Exists",
+                          "DoesNotExist"
+                      ]
+                  },
+                  "values": {
+                      "type": "array",
+                      "items": { "type": "string" },
+                      "minItems": 1
+                  }
+              },
+              "required": ["key", "operator"],
+              "additionalProperties": false
+          }
+      }
   }
 }

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -564,6 +564,8 @@ datadog:
 
       # datadog.apm.instrumentation.targets -- Enable target based workload selection.
       # Requires Cluster Agent 7.64.0+
+      #
+      # ddTraceConfigs[..]valueFrom requires agent 7.66.0+.
       targets: []
       #  - name: "example"
       #    podSelector:
@@ -577,6 +579,10 @@ datadog:
       #    ddTraceConfigs:
       #      - name: "DD_PROFILING_ENABLED"
       #        value: "true"
+      #      - name: "DD_SERVICE"
+      #        valueFrom:
+      #          fieldRef:
+      #            fieldPath: metadata.labels[my-label]
 
       # datadog.apm.instrumentation.skipKPITelemetry -- Disable generating Configmap for APM Instrumentation KPIs
       skipKPITelemetry: false

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -563,9 +563,9 @@ datadog:
       libVersions: {}
 
       # datadog.apm.instrumentation.targets -- Enable target based workload selection.
-      # Requires Cluster Agent 7.64.0+
+      # Requires Cluster Agent 7.64.0+.
       #
-      # ddTraceConfigs[..]valueFrom requires agent 7.66.0+.
+      # ddTraceConfigs[]valueFrom Requires Cluster Agent 7.66.0+.
       targets: []
       #  - name: "example"
       #    podSelector:

--- a/test/datadog/apm_instrumentation_test.go
+++ b/test/datadog/apm_instrumentation_test.go
@@ -10,158 +10,89 @@ import (
 func TestAPMConfigValidation(t *testing.T) {
 	tests := []struct {
 		name    string
-		command common.HelmCommand
+		values  string
 		isValid bool
 	}{
 		{
-			name: "valid enabled configuration",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/valid_enabled.yaml",
-				},
-			},
+			name:    "valid enabled configuration",
+			values:  "valid_enabled.yaml",
 			isValid: true,
 		},
 		{
-			name: "valid target configuration",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/valid_targets.yaml",
-				},
-			},
+			name:    "valid target configuration",
+			values:  "valid_targets.yaml",
 			isValid: true,
 		},
 		{
-			name: "valid namespace configuration",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/valid_namespace.yaml",
-				},
-			},
+			name:    "valid namespace configuration",
+			values:  "valid_namespace.yaml",
 			isValid: true,
 		},
 		{
-			name: "both namespaces and targets",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/namespaces_and_targets.yaml",
-				},
-			},
+			name:    "both namespaces and targets",
+			values:  "namespaces_and_targets.yaml",
 			isValid: false,
 		},
 		{
-			name: "both libversions and targets",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/libversions_and_targets.yaml",
-				},
-			},
+			name:    "both libversions and targets",
+			values:  "libversions_and_targets.yaml",
 			isValid: false,
 		},
 		{
-			name: "both enabled and disabled namespaces",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/enabled_and_disabled_namespaces.yaml",
-				},
-			},
+			name:    "both enabled and disabled namespaces",
+			values:  "enabled_and_disabled_namespaces.yaml",
 			isValid: false,
 		},
 		{
-			name: "both matchLabels and matchNames for namespace selector",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/namespace_labels_and_names.yaml",
-				},
-			},
+			name:    "both matchLabels and matchNames for namespace selector",
+			values:  "namespace_labels_and_names.yaml",
 			isValid: false,
 		},
 		{
-			name: "both matchExpressions and matchNames for namespace selector",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/namespace_exprs_and_names.yaml",
-				},
-			},
+			name:    "both matchExpressions and matchNames for namespace selector",
+			values:  "namespace_exprs_and_names.yaml",
 			isValid: false,
 		},
 		{
-			name: "extraneous instrumentation key",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/extra_instrumentation_key.yaml",
-				},
-			},
+			name:    "extraneous instrumentation key",
+			values:  "extra_instrumentation_key.yaml",
 			isValid: false,
 		},
 		{
-			name: "extraneous target key",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/extra_target_key.yaml",
-				},
-			},
+			name:    "extraneous target key",
+			values:  "extra_target_key.yaml",
 			isValid: false,
 		},
 		{
-			name: "extraneous pod selector key",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/extra_podselector_key.yaml",
-				},
-			},
+			name:    "extraneous pod selector key",
+			values:  "extra_podselector_key.yaml",
 			isValid: false,
 		},
 		{
-			name: "extraneous namespace selector key",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				Values: []string{
-					"../../charts/datadog/values.yaml",
-					"values/instrumentation/extra_namespaceselector_key.yaml",
-				},
-			},
+			name:    "extraneous namespace selector key",
+			values:  "extra_namespaceselector_key.yaml",
+			isValid: false,
+		},
+		{
+			name:    "ddTraceConfigs and valueFrom",
+			values:  "values_from.yaml",
+			isValid: true,
+		},
+		{
+			name:    "ddTraceConfigs and valueFrom invalid",
+			values:  "values_from_invalid.yaml",
 			isValid: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := common.RenderChart(t, tt.command)
+			helm := common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				Values:      []string{"../../charts/datadog/values.yaml", "values/instrumentation/" + tt.values},
+			}
+			_, err := common.RenderChart(t, helm)
 			if tt.isValid {
 				assert.Nil(t, err, "expected no error, got %v", err)
 			} else {

--- a/test/datadog/values/instrumentation/values_from.yaml
+++ b/test/datadog/values/instrumentation/values_from.yaml
@@ -1,0 +1,20 @@
+---
+datadog:
+  apm:
+    instrumentation:
+      enabled: true
+      targets:
+        - name: "billing-service"
+          namespaceSelector:
+            matchNames:
+              - "foo"
+              - "bar"
+          ddTraceVersions:
+            python: "v2"
+          ddTraceConfigs:
+            - name: "DD_A"
+              value: "A"
+            - name: "DD_B"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.labels['label']"

--- a/test/datadog/values/instrumentation/values_from_invalid.yaml
+++ b/test/datadog/values/instrumentation/values_from_invalid.yaml
@@ -1,0 +1,20 @@
+---
+datadog:
+  apm:
+    instrumentation:
+      enabled: true
+      targets:
+        - name: "billing-service"
+          namespaceSelector:
+            matchNames:
+              - "foo"
+              - "bar"
+          ddTraceVersions:
+            python: "v2"
+          ddTraceConfigs:
+            - name: "DD_A"
+              value: "A"
+            - name: "DD_B"
+              valueFrom:
+                fieldRef:
+                  fieldPathNotAThing: "metadata.labels['label']"


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds support for `valueFrom` for `apm.instrumentation`.

- https://github.com/DataDog/datadog-agent/pull/35487

#### Which issue this PR fixes

This is a combination of a few changes that can be split out if needed:
- refactoring `values.json.schema` to use [`$defs` for common components](https://github.com/DataDog/datadog-agent/pull/35487)
- adding support for `valueFrom` 
- adding tests for `valueFrom` (and cleaning up existing APM tests)

This will be shipped in agent `7.66` so I'm not sure when we want to land this specifically the helm charts.

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
