### PR TITLE
Add pdb rbac to dca

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.110.6
+
+* Add `podisruptionbudgets` RBAC to the Cluster Agent for orchestrator explorer.
+
 ## 3.110.5
 
 * Update `fips.image.tag` to `1.1.9` fixing CVEs

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.110.5
+version: 3.110.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.110.5](https://img.shields.io/badge/Version-3.110.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.110.6](https://img.shields.io/badge/Version-3.110.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -336,6 +336,14 @@ rules:
   verbs: ["get"]
 {{- end }}
 {{- if .Values.datadog.orchestratorExplorer.enabled }}
+- apiGroups:
+  - "policy"
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
 {{- include "orchestratorExplorer-config-crs" . }}
 {{- end }}
 ---

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -370,6 +370,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -367,6 +367,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -367,6 +367,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -367,6 +367,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -353,6 +353,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -353,6 +353,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -353,6 +353,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -353,6 +353,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -353,6 +353,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_daemonset_default.yaml
@@ -353,6 +353,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -598,6 +598,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -376,6 +376,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -413,6 +413,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -413,6 +413,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -353,6 +353,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -598,6 +598,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -598,6 +598,14 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
#### What this PR does / why we need it:

```
2025-03-31 18:12:51 UTC | CLUSTER | WARN | (client-go@v0.31.3/tools/cache/reflector.go:362 in ListAndWatch) | pkg/mod/k8s.io/client-go@v0.31.3/tools/cache/reflector.go:243: failed to list *v1.PodDisruptionBudget: poddisruptionbudgets.policy is forbidden: User "system:serviceaccount:default:dd-datadog-cluster-agent" cannot list resource "poddisruptionbudgets" in API group "policy" at the cluster scope
```

Orchestrator explorer added automatic PDB collection but only added the associated RBAC to the DCA when [securityAgent.compliance is enabled](https://github.com/DataDog/helm-charts/blob/8c459c636bb910a866194740fb993bf70a6067c5/charts/datadog/templates/cluster-agent-rbac.yaml#L280). This only shows up when KSM core uses cluster check runners since orchestrator explorer will continue to be run on the DCA.

#### Which issue this PR fixes

https://datadoghq.atlassian.net/browse/CONS-7185

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
