### PR TITLE
Allow setting automountServiceAccountToken in the synthetics-private-location chart

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.17.8
+
+* Add `automountServiceAccountToken` to control whether to automatically mount the service account token in the pod. 
+
 ## 0.17.7
 
 * Update private location image version to `1.55.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.17.7
+version: 0.17.8
 appVersion: 1.55.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.17.7](https://img.shields.io/badge/Version-0.17.7-informational?style=flat-square) ![AppVersion: 1.55.0](https://img.shields.io/badge/AppVersion-1.55.0-informational?style=flat-square)
+![Version: 0.17.8](https://img.shields.io/badge/Version-0.17.8-informational?style=flat-square) ![AppVersion: 1.55.0](https://img.shields.io/badge/AppVersion-1.55.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations/?tab=helmchart).
 
@@ -26,6 +26,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Allows to specify affinity for Datadog Synthetics Private Location PODs |
+| automountServiceAccountToken | bool | `true` | If true, automatically mount the ServiceAccount's API credentials |
 | commonLabels | object | `{}` | Labels to apply to all resources |
 | configConfigMap | string | `""` | Config Map that stores the configuration of the private location worker for the deployment |
 | configFile | string | `"{}"` | JSON string containing the configuration of the private location worker |

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "synthetics-private-location.serviceAccountName" . }}
+      {{- if .Values.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       hostAliases:
         {{- .Values.hostAliases | toYaml | nindent 8 }}
       containers:

--- a/charts/synthetics-private-location/templates/deployment.yaml
+++ b/charts/synthetics-private-location/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "synthetics-private-location.serviceAccountName" . }}
-      {{- if .Values.automountServiceAccountToken }}
+      {{- if not (eq .Values.automountServiceAccountToken nil) }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- end }}
       hostAliases:

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -37,6 +37,9 @@ serviceAccount:
   # serviceAccount.annotations -- Annotations for the service account
   annotations: {}
 
+# automountServiceAccountToken -- If true, automatically mount the ServiceAccount's API credentials
+automountServiceAccountToken: true
+
 # Create a ConfigMap containing the PEM files of your custom CA Root certificate
 # Then add it as an extra volume mounted on /etc/datadog/certs/
 # extraVolumes -- Optionally specify extra list of additional volumes to mount into the pod


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `automountServiceAccountToken` to the synthetics-private-location chart to control whether to automatically mount the service account token in the pod. 

This is needed in some cases where automounting the token is prevented by a policy.

#### Which issue this PR fixes

Fixes #1790

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
