### PR TITLE
Deprecated Kubernetes 1.18 from the ci install-chart job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,8 +123,6 @@ jobs:
     strategy:
       matrix:
         versions:
-          - k8s: v1.18.20
-            kind: v0.17.0
           - k8s: v1.22.17
             kind: v0.22.0
           - k8s: v1.24.17


### PR DESCRIPTION
#### What this PR does / why we need it:
with the deprecation of ubuntu-20, it is not possible to run the kind create cluster with kubernetes 1.18

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated
- [ ] Variables are documented in the `README.md`
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
