### PR TITLE
fail installation if apm and dogstatsd have different hostpath but same mount path

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.114.3
+
+* Show ERROR log if the chart is installed with different values for `datadog.dogstatsd.hostSocketPath` and `datadog.apm.hostSocketPath` while having same parent directories for `datadog.dogstatsd.socketPath` and `datadog.apm.socketPath`.
+
 ## 3.114.2
 
 * Upgrade default Agent version to `7.65.1`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.114.2
+version: 3.114.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.114.2](https://img.shields.io/badge/Version-3.114.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.114.3](https://img.shields.io/badge/Version-3.114.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -570,6 +570,23 @@ However, the `datadog.disableDefaultOsReleasePaths` option set to `true` and `da
 {{- fail "OS Release information is required  when system-probe is enabled." }}
 {{- end }}
 
+{{- if (and (eq  (dir .Values.datadog.dogstatsd.socketPath) (dir .Values.datadog.apm.socketPath) ) (ne .Values.datadog.dogstatsd.hostSocketPath .Values.datadog.apm.hostSocketPath)) }}
+#################################################################
+####            ERROR: Conflicting socket host path          ####
+#################################################################
+
+Dogstatsd and APM sockets are configured with different paths on the host (datadog.dogstatsd.hostSocketPath and datadog.apm.hostSocketPath).
+However, they have the same parent directory in the mount (datadog.dogstatsd.socketPath and datadog.apm.socketPath).
+
+It is not possible to mount two different host paths at the same mount path. 
+
+To resolve this:
+- use the same value for datadog.dogstatsd.hostSocketPath and datadog.apm.hostSocketPath
+- or use different parent directories for datadog.dogstatsd.socketPath and datadog.apm.socketPath
+
+{{- end }}
+
+
 
 {{- $hasContainerIncludeEnv := false }}
 {{- range $key := .Values.datadog.env }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes issue where `datadog.apm.hostSocketPath` is not respected by the agent in case apm and dogstatsd sockets are configured with the different host paths but same mount path.

This PR adds an ERROR that shows upon installation of the chart if the configuration results in conflicting hostpath for apm and dogstatsd.

Trying to install the chart with conflicting hostpaths will show the following error:

```
#################################################################
####            ERROR: Conflicting socket host path          ####
#################################################################

Dogstatsd and APM sockets are configured with different paths on the host (datadog.dogstatsd.hostSocketPath and datadog.apm.hostSocketPath).
However, they have the same parent directory in the mount (datadog.dogstatsd.socketPath and datadog.apm.socketPath).

It is not possible to mount two different host paths at the same mount path. 

To resolve this:
- use the same value for datadog.dogstatsd.hostSocketPath and datadog.apm.hostSocketPath
- or use different values for datadog.dogstatsd.socketPath and datadog.apm.socketPath
```

#### Special notes for your reviewer:

This issue doesn't cause problems in the agent, but rather silently disrespects the user configuration when it is not possible to achieve. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
