### PR TITLE
[ACTP] Allow global object in values

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.0.3
+
+* Allow a `global` object in values so this chart can be used in a subchart.
+
 ## 1.0.2
 
 * Update private action runner version to `v1.2.0`

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "v1.2.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
 
 ## Overview
 

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -254,8 +254,12 @@
         }
       },
       "required": ["config"]
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": true
     }
   },
   "required": ["runner"],
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -257,5 +257,5 @@
     }
   },
   "required": ["runner"],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -77,7 +77,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.0.2
+    helm.sh/chart: private-action-runner-1.0.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.2.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.0.2
+        helm.sh/chart: private-action-runner-1.0.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.2.0"

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,7 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.0.2
+    helm.sh/chart: private-action-runner-1.0.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.2.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.0.2
+        helm.sh/chart: private-action-runner-1.0.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.2.0"

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -121,7 +121,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.0.2
+    helm.sh/chart: private-action-runner-1.0.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.2.0"
@@ -136,7 +136,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.0.2
+        helm.sh/chart: private-action-runner-1.0.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.2.0"

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,7 +211,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.0.2
+    helm.sh/chart: private-action-runner-1.0.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.2.0"
@@ -226,7 +226,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.0.2
+        helm.sh/chart: private-action-runner-1.0.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.2.0"

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,7 +75,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.0.2
+    helm.sh/chart: private-action-runner-1.0.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.2.0"
@@ -90,7 +90,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.0.2
+        helm.sh/chart: private-action-runner-1.0.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.2.0"


### PR DESCRIPTION
#### What this PR does / why we need it:
A customer requested this so they can use the PAR as a subchart. This requires that a `global` object is allowed in the values. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
