### PR TITLE
[ACTP][PAR] Add $schema for completion support in IDEs

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.1.0
+
+* Add the `$schema` key to the `values.yaml` file to enable schema validation in IDEs.
+
 ## 1.0.3
 
 * Allow a `global` object in values so this chart can be used in a subchart.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.0.3
+version: 1.1.0
 appVersion: "v1.2.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
 
 ## Overview
 
@@ -215,6 +215,7 @@ If actions requiring credentials fail:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| $schema | string | `"./values.schema.json"` | Schema for the values file, enables support in IDEs |
 | fullnameOverride | string | `""` | Override the full qualified app name |
 | image | object | `{"repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.2.0"}` | Current Datadog Private Action Runner image |
 | nameOverride | string | `""` | Override name of app |

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -215,7 +215,7 @@ If actions requiring credentials fail:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| $schema | string | `"./values.schema.json"` | Schema for the values file, enables support in IDEs |
+| $schema | string | `"./values.schema.json"` | Schema for the values file, enables support in Jetbrains IDEs. You should probably use https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json. |
 | fullnameOverride | string | `""` | Override the full qualified app name |
 | image | object | `{"repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.2.0"}` | Current Datadog Private Action Runner image |
 | nameOverride | string | `""` | Override name of app |

--- a/charts/private-action-runner/ci/kubeconform-values.yaml
+++ b/charts/private-action-runner/ci/kubeconform-values.yaml
@@ -1,5 +1,4 @@
 runner:
-  name: "default"
   config:
     # -- Base URL of the Datadog app
     ddBaseURL: "https://app.datadoghq.com"
@@ -7,3 +6,4 @@ runner:
     urn: "urn:dd:apps:on-prem-runner:us1:2:runner-CI_TEST_ONLY"
     # -- The runner's privateKey from the enrollment page
     privateKey: "eyJ1c2UiOiJzaWciLCJrdHkiOiJFQyIsImtpZCI6IkxXbl9LLU9qbXQ4TFJ6TWdjbFY4dTRMYUVsdF9mZGpCN2RXdlJ2TkVhN2ciLCJjcnYiOiJQLTI1NiIsImFsZyI6IkVTMjU2IiwieCI6Imd3MVFKNVBQQXJmZk56XzdmWmZxX0xMYjhTV0MyaXhJUDFBbDh2SjJmVTgiLCJ5IjoiRjQ4VGRWZVhIRnpack05N1BwbnFMZFRUOG9iWDdKa2N5d3RzQ2RhLXRpayIsImQiOiJaczdDQ0MzMkRJQkpuaUZ5S1hFV0VvWThrZ1ZXMTVZbGdTYU9ISm5uX1drIn0"
+    modes: ["workflowAutomation", "appBuilder"]

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -1,3 +1,6 @@
+# This is for the https://marketplace.visualstudio.com/items/?itemName=redhat.vscode-yaml VSCode extension
+# yaml-language-server: $schema=https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json
+# This is for jetbrains IDEs
 $schema: https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json
 runner:
   # Replace this section with the output of the private action runner enrollment process with the `--enroll-and-print-config` flag

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -1,3 +1,4 @@
+$schema: https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json
 runner:
   # Replace this section with the output of the private action runner enrollment process with the `--enroll-and-print-config` flag
   config:

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -3,57 +3,77 @@
   "title": "Values",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema definition for the values file"
+    },
     "image": {
       "type": "object",
+      "description": "Configuration for the Datadog Private Action Runner image",
       "properties": {
         "repository": {
-          "type": "string"
+          "type": "string",
+          "description": "Repository for the Datadog Private Action Runner image"
         },
         "tag": {
-          "type": "string"
+          "type": "string",
+          "description": "Tag for the Datadog Private Action Runner image"
         }
       },
       "required": ["repository", "tag"]
     },
     "nameOverride": {
-      "type": "string"
+      "type": "string",
+      "description": "Override the name of the chart"
     },
     "fullnameOverride": {
-      "type": "string"
+      "type": "string",
+      "description": "Override the full name of the chart"
     },
     "runner": {
       "type": "object",
+      "description": "Configuration for the Datadog Private Action Runner",
       "properties": {
         "roleType": {
           "type": "string",
-          "enum": ["Role", "ClusterRole"]
+          "enum": ["Role", "ClusterRole"],
+          "description": "Type of role to create. Role for namespace-scoped permissions, ClusterRole for cluster-wide permissions"
         },
         "replicas": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Number of pod instances for the Datadog Private Action Runner"
         },
         "config": {
           "type": "object",
+          "description": "Configuration for the Datadog Private Action Runner",
           "properties": {
             "ddBaseURL": {
-              "type": "string"
+              "type": "string",
+              "description": "Base URL of the Datadog app"
             },
             "urn": {
-              "type": "string"
+              "type": "string",
+              "description": "The runner's URN from the enrollment page"
             },
             "privateKey": {
-              "type": "string"
+              "type": "string",
+              "description": "The runner's privateKey from the enrollment page"
             },
             "modes": {
               "type": "array",
+              "description": "Modes that the runner can run in",
               "items": {
-                "type": "string"
+                "type": "string",
+                "enum": ["appBuilder", "workflowAutomation"]
               }
             },
             "port": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Port for HTTP server liveness checks and App Builder mode"
             },
             "actionsAllowlist": {
               "type": "array",
+              "description": "List of actions that the Datadog Private Action Runner is allowed to execute",
               "items": {
                 "type": "string"
               }
@@ -64,150 +84,176 @@
         },
         "env": {
           "type": "array",
+          "description": "Environment variables to be passed to the Datadog Private Action Runner",
           "items": {
             "type": "object"
           }
         },
         "runnerIdentitySecret": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the secret containing the runner's identity"
         },
         "kubernetesActions": {
           "type": "object",
+          "description": "Kubernetes actions configuration for the runner",
           "properties": {
             "controllerRevisions": {
               "type": "array",
+              "description": "Actions related to controllerRevisions (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "daemonSets": {
               "type": "array",
+              "description": "Actions related to daemonSets (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "deployments": {
               "type": "array",
+              "description": "Actions related to deployments (options: get, list, create, update, patch, delete, deleteMultiple, restart)",
               "items": {
                 "type": "string"
               }
             },
             "replicaSets": {
               "type": "array",
+              "description": "Actions related to replicaSets (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "statefulSets": {
               "type": "array",
+              "description": "Actions related to statefulSets (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "cronJobs": {
               "type": "array",
+              "description": "Actions related to cronJobs (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "configMaps": {
               "type": "array",
+              "description": "Actions related to configMaps (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "endpoints": {
               "type": "array",
+              "description": "Actions related to endpoints (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "events": {
               "type": "array",
+              "description": "Actions related to events (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "limitRanges": {
               "type": "array",
+              "description": "Actions related to limitRanges (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "namespaces": {
               "type": "array",
+              "description": "Actions related to namespaces (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "nodes": {
               "type": "array",
+              "description": "Actions related to nodes (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "persistentVolumes": {
               "type": "array",
+              "description": "Actions related to persistentVolumes (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "persistentVolumeClaims": {
               "type": "array",
+              "description": "Actions related to persistentVolumeClaims (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "pods": {
               "type": "array",
+              "description": "Actions related to pods (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "podTemplates": {
               "type": "array",
+              "description": "Actions related to podTemplates (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "replicationControllers": {
               "type": "array",
+              "description": "Actions related to replicationControllers (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "resourceQuotas": {
               "type": "array",
+              "description": "Actions related to resourceQuotas (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "services": {
               "type": "array",
+              "description": "Actions related to services (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "serviceAccounts": {
               "type": "array",
+              "description": "Actions related to serviceAccounts (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "customResourceDefinitions": {
               "type": "array",
+              "description": "Actions related to customResourceDefinitions (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "jobs": {
               "type": "array",
+              "description": "Actions related to jobs (options: get, list, create, update, patch, delete, deleteMultiple)",
               "items": {
                 "type": "string"
               }
             },
             "customObjects": {
               "type": "array",
+              "description": "Actions related to customObjects (options: get, list, create, update, patch, delete, deleteMultiple). You also need to add appropriate kubernetesPermissions.",
               "items": {
                 "type": "string"
               }
@@ -216,20 +262,24 @@
         },
         "kubernetesPermissions": {
           "type": "array",
+          "description": "Kubernetes permissions to provide in addition to the ones that will be inferred from kubernetesActions (useful for customObjects)",
           "items": {
             "type": "object"
           }
         },
         "credentialFiles": {
           "type": "array",
+          "description": "List of credential files to be used by the Datadog Private Action Runner",
           "items": {
             "type": "object",
             "properties": {
               "fileName": {
-                "type": "string"
+                "type": "string",
+                "description": "Name of the credential file"
               },
               "data": {
-                "type": "string"
+                "type": "string",
+                "description": "Content of the credential file"
               }
             },
             "required": ["fileName", "data"],
@@ -238,22 +288,26 @@
         },
         "credentialSecrets": {
           "type": "array",
+          "description": "List of secrets containing credentials to be used by the Datadog Private Action Runner",
           "items": {
             "type": "object",
             "properties": {
               "secretName": {
-                "type": "string"
+                "type": "string",
+                "description": "Name of the secret containing the credentials"
               },
               "directoryName": {
-                "type": "string"
+                "type": "string",
+                "description": "Name of the directory where the credentials will be mounted"
               }
             },
-            "required": ["secretName"],
+            "required": ["secretName", "directoryName"],
             "additionalProperties": false
           }
         }
       },
-      "required": ["config"]
+      "required": ["config"],
+      "additionalProperties": false
     },
     "global": {
       "type": "object",

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -301,7 +301,7 @@
                 "description": "Name of the directory where the credentials will be mounted"
               }
             },
-            "required": ["secretName", "directoryName"],
+            "required": ["secretName"],
             "additionalProperties": false
           }
         }

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -1,4 +1,5 @@
-# $schema: ./values.schema.json
+# $schema -- Schema for the values file, enables support in IDEs. You should probably use https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json.
+$schema: ./values.schema.json
 # Default values for private-action-runner.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -1,4 +1,5 @@
-# $schema -- Schema for the values file, enables support in IDEs. You should probably use https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json.
+# yaml-language-server: $schema=./values.schema.json
+# $schema -- Schema for the values file, enables support in Jetbrains IDEs. You should probably use https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json.
 $schema: ./values.schema.json
 # Default values for private-action-runner.
 # This is a YAML-formatted file.

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -77,7 +77,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.0.3
+    helm.sh/chart: private-action-runner-1.1.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.2.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.0.3
+        helm.sh/chart: private-action-runner-1.1.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.2.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 924f6f688abee0339e98dd817c3e320ca18d9398028360ebda57685a3535d3ee
+        checksum/values: 41135fee34f657a30b985a3deb5d7ace42696135a2f9721d1c563a869ace32ef
     spec:
       serviceAccountName: custom-full-name
       containers:

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,7 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.0.3
+    helm.sh/chart: private-action-runner-1.1.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.2.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.0.3
+        helm.sh/chart: private-action-runner-1.1.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.2.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 0d61b652c7ce8420f0bfa194bb4ed3df8cabd64e34a17631499890c61a11b9cd
+        checksum/values: d8287d0d6cb829e320c7b0eb32d7766201431fd523859ab1483e3d6b50fcd55b
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -121,7 +121,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.0.3
+    helm.sh/chart: private-action-runner-1.1.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.2.0"
@@ -136,13 +136,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.0.3
+        helm.sh/chart: private-action-runner-1.1.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.2.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 77b66397edbb68cd5d6d09b7996d02121f8d1667995f7ff4a8e417a9149fe150
+        checksum/values: 7da55a6d0a1034dd862c86f8e62bb88119950d02c83761fe487fce7ac53f7c62
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,7 +211,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.0.3
+    helm.sh/chart: private-action-runner-1.1.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.2.0"
@@ -226,13 +226,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.0.3
+        helm.sh/chart: private-action-runner-1.1.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.2.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 42a49a9fd22cb303ee0b54c6777005d88cb04978b8ca5fc4dbdbbe2dc8c8c213
+        checksum/values: 0de9d1a8a01422fefd373d18fa4c8a558b3e2c486eaebf9087c420f92dc24ae8
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,7 +75,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.0.3
+    helm.sh/chart: private-action-runner-1.1.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.2.0"
@@ -90,13 +90,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.0.3
+        helm.sh/chart: private-action-runner-1.1.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.2.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: d316460e6a67fcff03d99936ba0c0cfe8b1bdc29957bd054ea705e159fdd2c5b
+        checksum/values: 30829ffd5d0dc47f2811866fba6f622a4a28e9ea62772c89baba4ef60f22bf60
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds special comments / instructions for JSON schema based support in IDEs when using the PAR helm chart.

#### Special notes for your reviewer:

I get native support in goland 
<img width="1121" alt="image" src="https://github.com/user-attachments/assets/41eb435d-fa40-47c0-b8a3-36f65b6f2a08" />
For VSCode i had to install [this extension](https://marketplace.visualstudio.com/items/?itemName=redhat.vscode-yaml)
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/c6118c2d-00ca-484a-8080-65393d61a7c6" />


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
