### PR TITLE
Fix stuck jobs on `bump-chart-version` workflow

### DIFF
--- a/.github/workflows/bump-chart-version.yaml
+++ b/.github/workflows/bump-chart-version.yaml
@@ -17,10 +17,17 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.DD_GITHUB_TOKEN_APP_ID }}
+          private-key: ${{ secrets.DD_GITHUB_TOKEN_PRIVATE_KEY }}
+
       - name: Extract all chart label information and update Chart.yaml and CHANGELOG.md
         id: update_charts
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             // Based on script from: https://github.com/DataDog/k8s-datadog-agent-ops/blob/main/.github/workflows/automatically-bump.yaml
 
@@ -228,7 +235,7 @@ jobs:
               
               // If the changelog has not been modified, add a new entry.
               const prLink = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${pr.number}`;
-              const newEntry = `## ${desiredVersion} \n\n* ${pr.title} ([#${pr.number}](${prLink})).\n\n`;
+              const newEntry = `## ${desiredVersion}\n\n* ${pr.title} ([#${pr.number}](${prLink})).\n\n`;
               
               if (versionHeaderIdx !== -1) {
                 const headerSection = lines.slice(0, versionHeaderIdx).join('\n').trimEnd();


### PR DESCRIPTION
#### What this PR does / why we need it:

Use robot app token for the `bump-chart-version` workflow so that its commits will properly trigger GH jobs. Previously, the GH status checks would get "stuck" on the required `pr-validated` job. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
