### PR TITLE
cloudprem: increase ts precision

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.1
+
+* Fix issue with sorting documents per timestamp
+
+## 0.1.0
+
+* Initial version

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: v0.1.0
+version: v0.1.1
 appVersion: v0.1.0
 home: https://www.datadoghq.com/
 icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: v0.1.0](https://img.shields.io/badge/Version-v0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: v0.1.1](https://img.shields.io/badge/Version-v0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/values.yaml
+++ b/charts/cloudprem/values.yaml
@@ -589,6 +589,7 @@ seed:
               - rfc3339
               - iso8601
               - unix_timestamp
+            fast_precision: milliseconds
 
           - name: message
             type: text


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
- fixes an issue where documents with less than 1s difference in their timestamp could be returned out of order

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [x] `CHANGELOG.md` has been updated 
