### PR TITLE
Allow MQ for logs-cloudprem

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -10,6 +10,7 @@ github_teams_restrictions:
   - container-helm-chart-maintainers
   - container-integrations
   - container-t2
+  - logs-cloudprem
   - synthetics
   - documentation
   - observability-pipelines


### PR DESCRIPTION
#### What this PR does / why we need it:
Give access to MQ for @DataDog/logs-cloudprem team that owns the CloudPrem chart

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
