### PR TITLE
[datadog-crds] Update CRDs for Operator 1.14.0-rc.X

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.0-dev
+
+* Update CRDs from Datadog Operator v1.14.0 release candidate tag.
+
 ## 2.5.1
 
 * Update DatadogPodAutoscaler CRD to have `storage` set to `v1alpha2`.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.5.1
+version: 2.6.0-dev
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.5.1](https://img.shields.io/badge/Version-2.5.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.6.0-dev](https://img.shields.io/badge/Version-2.6.0--dev-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -184,6 +184,78 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         type: object
                                     type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
                                 type: object
                               type: array
                               x-kubernetes-list-type: atomic
@@ -1020,6 +1092,11 @@ spec:
                       properties:
                         enabled:
                           type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                       type: object
                     tcpQueueLength:
                       properties:
@@ -3887,6 +3964,78 @@ spec:
                                               x-kubernetes-int-or-string: true
                                             type: object
                                         type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
                                     type: object
                                   type: array
                                   x-kubernetes-list-type: atomic
@@ -4723,6 +4872,11 @@ spec:
                           properties:
                             enabled:
                               type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
                           type: object
                         tcpQueueLength:
                           properties:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogdashboards_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogdashboards_v1.yaml
@@ -62,6 +62,9 @@ spec:
                   type: string
                 layoutType:
                   description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
                   type: string
                 notifyList:
                   description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
@@ -148,10 +151,14 @@ spec:
                   x-kubernetes-list-type: map
                 title:
                   description: Title is the title of the dashboard.
+                  minLength: 1
                   type: string
                 widgets:
                   description: Widgets is a JSON string representation of a list of Datadog API Widgets
                   type: string
+              required:
+                - layoutType
+                - title
               type: object
             status:
               description: DatadogDashboardStatus defines the observed state of DatadogDashboard

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -74,9 +74,11 @@ spec:
                   type: object
                 message:
                   description: Message is a message to include with notifications for this monitor
+                  minLength: 1
                   type: string
                 name:
                   description: Name is the monitor name
+                  minLength: 1
                   type: string
                 options:
                   description: Options are the optional parameters associated with your monitor
@@ -166,6 +168,27 @@ spec:
                         A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
                         recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
                       type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
                     thresholdWindows:
                       description: A struct of the alerting time window options.
                       properties:
@@ -209,6 +232,7 @@ spec:
                   type: integer
                 query:
                   description: Query is the Datadog monitor query
+                  minLength: 1
                   type: string
                 restrictedRoles:
                   description: |-
@@ -227,7 +251,25 @@ spec:
                   x-kubernetes-list-type: set
                 type:
                   description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
                   type: string
+              required:
+                - message
+                - name
+                - query
+                - type
               type: object
             status:
               description: DatadogMonitorStatus defines the observed state of DatadogMonitor

--- a/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
@@ -899,6 +899,7 @@ spec:
                     required:
                       - type
                     type: object
+                  minItems: 1
                   type: array
                   x-kubernetes-list-type: atomic
                 owner:

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -178,6 +178,78 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         type: object
                                     type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                          - type
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
                                 type: object
                               type: array
                               x-kubernetes-list-type: atomic
@@ -1014,6 +1086,11 @@ spec:
                       properties:
                         enabled:
                           type: boolean
+                        networkStats:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                       type: object
                     tcpQueueLength:
                       properties:
@@ -3881,6 +3958,78 @@ spec:
                                               x-kubernetes-int-or-string: true
                                             type: object
                                         type: object
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
                                     type: object
                                   type: array
                                   x-kubernetes-list-type: atomic
@@ -4717,6 +4866,11 @@ spec:
                           properties:
                             enabled:
                               type: boolean
+                            networkStats:
+                              properties:
+                                enabled:
+                                  type: boolean
+                              type: object
                           type: object
                         tcpQueueLength:
                           properties:

--- a/crds/datadoghq.com_datadogdashboards.yaml
+++ b/crds/datadoghq.com_datadogdashboards.yaml
@@ -56,6 +56,9 @@ spec:
                   type: string
                 layoutType:
                   description: LayoutType is the layout type of the dashboard.
+                  enum:
+                    - ordered
+                    - free
                   type: string
                 notifyList:
                   description: NotifyList is the list of handles of users to notify when changes are made to this dashboard.
@@ -142,10 +145,14 @@ spec:
                   x-kubernetes-list-type: map
                 title:
                   description: Title is the title of the dashboard.
+                  minLength: 1
                   type: string
                 widgets:
                   description: Widgets is a JSON string representation of a list of Datadog API Widgets
                   type: string
+              required:
+                - layoutType
+                - title
               type: object
             status:
               description: DatadogDashboardStatus defines the observed state of DatadogDashboard

--- a/crds/datadoghq.com_datadogmonitors.yaml
+++ b/crds/datadoghq.com_datadogmonitors.yaml
@@ -68,9 +68,11 @@ spec:
                   type: object
                 message:
                   description: Message is a message to include with notifications for this monitor
+                  minLength: 1
                   type: string
                 name:
                   description: Name is the monitor name
+                  minLength: 1
                   type: string
                 options:
                   description: Options are the optional parameters associated with your monitor
@@ -160,6 +162,27 @@ spec:
                         A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
                         recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
                       type: boolean
+                    schedulingOptions:
+                      description: Configuration options for scheduling.
+                      properties:
+                        evaluationWindow:
+                          description: |-
+                            Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                            Otherwise, day_starts and month_starts must be set together.
+                          properties:
+                            dayStarts:
+                              description: The time of the day at which a one day cumulative evaluation window starts. Must be defined in UTC time in HH:mm format.
+                              type: string
+                            hourStarts:
+                              description: The minute of the hour at which a one hour cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                            monthStarts:
+                              description: The day of the month at which a one month cumulative evaluation window starts.
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
                     thresholdWindows:
                       description: A struct of the alerting time window options.
                       properties:
@@ -203,6 +226,7 @@ spec:
                   type: integer
                 query:
                   description: Query is the Datadog monitor query
+                  minLength: 1
                   type: string
                 restrictedRoles:
                   description: |-
@@ -221,7 +245,25 @@ spec:
                   x-kubernetes-list-type: set
                 type:
                   description: Type is the monitor type
+                  enum:
+                    - metric alert
+                    - query alert
+                    - service check
+                    - event alert
+                    - log alert
+                    - process alert
+                    - rum alert
+                    - trace-analytics alert
+                    - slo alert
+                    - event-v2 alert
+                    - audit alert
+                    - composite
                   type: string
+              required:
+                - message
+                - name
+                - query
+                - type
               type: object
             status:
               description: DatadogMonitorStatus defines the observed state of DatadogMonitor

--- a/crds/datadoghq.com_datadogpodautoscalers.yaml
+++ b/crds/datadoghq.com_datadogpodautoscalers.yaml
@@ -893,6 +893,7 @@ spec:
                     required:
                       - type
                     type: object
+                  minItems: 1
                   type: array
                   x-kubernetes-list-type: atomic
                 owner:


### PR DESCRIPTION
#### What this PR does / why we need it:

Update datadog-crds chart for Datadog Operator 1.14.0 Release Candidate release.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
