### PR TITLE
Fix: replicationcontrollers apiGroup

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.110.14
+
+* Fix `replicationcontrollers` apiGroup ([#1821](https://github.com/DataDog/helm-charts/pull/1821)).
+
 ## 3.110.13
 * Defaults `DD_CLOUD_PROVIDER_METADATA` to `["gcp"]` when the GKE Autopilot provider is used, to avoid polling other cloud providers for metadata.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.110.13
+version: 3.110.14
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.110.13](https://img.shields.io/badge/Version-3.110.13-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.110.14](https://img.shields.io/badge/Version-3.110.14-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -268,7 +268,10 @@ rules:
   resources: ["jobs", "cronjobs"]
   verbs: ["get"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "replicationcontrollers", "replicasets", "deployments", "daemonsets"]
+  resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["replicationcontrollers"]
   verbs: ["get"]
 {{- if and .Values.clusterAgent.admissionController.cwsInstrumentation.enabled (eq .Values.clusterAgent.admissionController.cwsInstrumentation.mode "remote_copy") }}
 - apiGroups: [""]

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -356,10 +356,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -353,10 +353,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -353,10 +353,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -353,10 +353,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -339,10 +339,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -339,10 +339,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -339,10 +339,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -339,10 +339,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -339,10 +339,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -339,10 +339,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -588,10 +588,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -588,10 +588,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -588,10 +588,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -339,10 +339,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -588,10 +588,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -362,10 +362,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -399,10 +399,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -399,10 +399,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -339,10 +339,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -588,10 +588,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -588,10 +588,15 @@ rules:
       - apps
     resources:
       - statefulsets
-      - replicationcontrollers
       - replicasets
       - deployments
       - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
     verbs:
       - get
   - apiGroups:


### PR DESCRIPTION
#### What this PR does / why we need it:

The API Group set for `replicationcontrollers` was incorrect, it is in the core api not the `apps` api.

#### Special notes for your reviewer:

Fixes #1800 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
