### PR TITLE
[tooling] Do not mark pre-release version as latest in Github

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'charts/**'
+      - '!charts/datadog-csi-driver/**'
+
 
 permissions: {}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - 'charts/**'
-      - '!charts/datadog-csi-driver/**'
 
 permissions: {}
 
@@ -29,8 +28,23 @@ jobs:
         run: |
           helm repo add datadog https://helm.datadoghq.com
           helm repo add kube-state-metrics https://prometheus-community.github.io/helm-charts
+      - name: Extract chart version
+        id: chart_version
+        run: |
+          version=$(yq e '.version' charts/datadog-operator/Chart.yaml)
+          echo "chart_version=$version" >> "$GITHUB_OUTPUT"
+      - name: Set mark_as_latest flag
+        id: is_prerelease
+        run: |
+          if [[ "${{ steps.chart_version.outputs.chart_version }}" == *-* ]]; then
+            echo "mark_as_latest=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "mark_as_latest=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
+        with:
+          skip_existing: true # Ignore chart changes when version was not updated (documentation)
+          mark_as_latest: ${{ steps.is_prerelease.outputs.mark_as_latest }}
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          CR_SKIP_EXISTING: true # Ignore chart changes when version was not updated (documentation)


### PR DESCRIPTION
#### What this PR does / why we need it:

Update releaser action to not mark pre-release versions like `X.Y.Z-*` as latest in Github.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
