### PR TITLE
Remove baseline test codeowners 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,18 +23,3 @@ charts/private-action-runner                           @DataDog/action-platform
 
 # Tests
 test/private-action-runner                             @DataDog/action-platform
-
-test/datadog/baseline/values/npm_daemonset_default.yaml    @DataDog/Networks @DataDog/container-helm-chart-maintainers
-test/datadog/baseline/values/gke_autopilot_npm.yaml        @DataDog/Networks @DataDog/container-helm-chart-maintainers
-test/datadog/baseline/manifests/npm_daemonset_default.yaml @DataDog/Networks @DataDog/container-helm-chart-maintainers
-test/datadog/baseline/manifests/gke_autopilot_npm.yaml     @DataDog/Networks @DataDog/container-helm-chart-maintainers
-
-test/datadog/baseline/values/system_probe_daemonset_default.yaml    @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
-test/datadog/baseline/values/gke_autopilot_system_probe.yaml.yaml   @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
-test/datadog/baseline/manifests/system_probe_daemonset_default.yaml @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
-test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml     @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
-
-test/datadog/baseline/values/usm_daemonset_default.yaml    @DataDog/universal-service-monitoring @DataDog/container-helm-chart-maintainers
-test/datadog/baseline/values/gke_autopilot_usm.yaml        @DataDog/universal-service-monitoring @DataDog/container-helm-chart-maintainers
-test/datadog/baseline/manifests/usm_daemonset_default.yaml @DataDog/universal-service-monitoring @DataDog/container-helm-chart-maintainers
-test/datadog/baseline/manifests/gke_autopilot_usm.yaml     @DataDog/universal-service-monitoring @DataDog/container-helm-chart-maintainers


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove baseline test codeowners (temporarily) to reduce excessive noise from irrelevant changes to the baseline manifests while we establish a proper codeowners system. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
