### PR TITLE
Do not release datadog-csi-driver chart

### DIFF
--- a/.github/workflows/bump-chart-version.yaml
+++ b/.github/workflows/bump-chart-version.yaml
@@ -107,7 +107,7 @@ jobs:
                   ref: mergeBaseSHA
                 });
               } catch (error) {
-                core.setFailed(`Could not get base Chart.yaml for ${chartName}: ${error.message}`);
+                core.warning(`Could not get base Chart.yaml for ${chartName}: ${error.message}. Skipping...`);
                 return;
               }
               const baseContent = Buffer.from(baseChartFile.data.content, baseChartFile.data.encoding).toString();

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,6 @@ on:
       - main
     paths:
       - 'charts/**'
-      - '!charts/datadog-csi-driver/**'
-
 
 permissions: {}
 

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -1,9 +1,0 @@
-apiVersion: v2
-name: datadog-csi-driver
-description: Datadog CSI Driver helm chart
-type: application
-version: 0.3.0
-appVersion: "0.1.0"
-maintainers:
-  - name: Datadog
-    email: support@datadoghq.com


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove the `Chart.yaml` as a workaround to prevent releasing the `datadog-csi-driver` chart as it is still in development. 

The `helm/chart-release-action` currently releases all changed charts in the `/charts` directory. Despite configuring the `datadog-csi-driver` chart path to be ignored in the release workflow, this only works when a commit has changes in the `datadog-csi-driver` chart path. The chart still gets released when the workflow runs for other chart releases. 

Options:
* Remove the `Chart.yaml` file from the chart, in which case the chart will get safely skipped by the chart-release-action (this PR)
  * We can still continue to document changes in the changelog, but the version should not increment until a public release
  * Caveats: chart lint job will fail and chart install jobs will be skipped for future `datadog-csi-driver` PRs
* Configure the repo with a new release workflow to publish pre-releases for the `datadog-csi-driver` chart. See new workflow: https://github.com/DataDog/helm-charts/blob/main/.github/workflows/release-operator.yaml
* Move the `datadog-csi-driver` chart outside of the `/charts` directory: https://github.com/DataDog/helm-charts/pull/1830


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
