### PR TITLE
[tooling] fix CRDs and Operator releaser

### DIFF
--- a/.github/workflows/release-crds.yaml
+++ b/.github/workflows/release-crds.yaml
@@ -44,7 +44,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
-          charts_dir: charts/datadog-crds
           skip_existing: true # Ignore chart changes when version was not updated (documentation)
           mark_as_latest: ${{ steps.is_prerelease.outputs.mark_as_latest }}
         env:

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -44,7 +44,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
-          charts_dir: charts/datadog-operator
           skip_existing: true # Ignore chart changes when version was not updated (documentation)
           mark_as_latest: ${{ steps.is_prerelease.outputs.mark_as_latest }}
         env:


### PR DESCRIPTION
#### What this PR does / why we need it:

Run the Operator and CRDs releaser workflow on default `charts` dir. Chart releaser action doesn't work with  `charts_dir: charts/somechart` - it expect a directory which contain chart directories with `Chart.yaml` files; otherwise it skips.

There is a slight risk of race condition which may result in release not marked as `latest` in Github when Operator/CRDs workflow tries to also release other chart while release pre-release version. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
