### PR TITLE
[datadog-operator] Update chart for 1.14.0 release

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.9.0-dev
+## 2.9.0
 
 * Update Datadog Operator version to 1.14.0.
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.9.0-dev
 
+* Update Datadog Operator version to 1.14.0.
+
+## 2.9.0-dev
+
 * Update Datadog Operator version to 1.14.0-rc.3.
 
 ## 2.8.0

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.6.0-dev
-digest: sha256:67e33aa895c3c7bebea38db9af567f88c1bbfed0be2edd4ac62bba2bbe4b79e4
-generated: "2025-04-22T15:18:22.240743-04:00"
+  version: 2.6.0
+digest: sha256:31bc818d9f7c4c375e680af9121a1abcc51e0c689e9868ed5aab428882560489
+generated: "2025-04-23T16:18:43.111315-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.9.0
+version: 2.9.1
 appVersion: 1.14.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.9.1-dev
-appVersion: 1.14.0-rc.3
+version: 2.9.0
+appVersion: 1.14.0
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "=2.6.0-dev"
+  version: "=2.6.0"
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.9.1-dev](https://img.shields.io/badge/Version-2.9.1--dev-informational?style=flat-square) ![AppVersion: 1.14.0-rc.3](https://img.shields.io/badge/AppVersion-1.14.0--rc.3-informational?style=flat-square)
+![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=flat-square)
 
 ## Values
 
@@ -35,7 +35,7 @@
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.14.0-rc.3"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.14.0"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=flat-square)
+![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/_helpers.tpl
+++ b/charts/datadog-operator/templates/_helpers.tpl
@@ -85,6 +85,6 @@ Check operator image tag version.
 {{- if not .Values.image.doNotCheckTag -}}
 {{- .Values.image.tag -}}
 {{- else -}}
-{{ "1.14.0-rc.3" }}
+{{ "1.14.0" }}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.14.0-rc.3
+  tag: 1.14.0
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
   # image.doNotCheckTag -- Permit skipping operator image tag compatibility with the chart.

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-2.6.0-dev'
+    helm.sh/chart: 'datadogCRDs-2.6.0'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.9.0-dev
+    helm.sh/chart: datadog-operator-2.9.0
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.14.0-rc.3"
+    app.kubernetes.io/version: "1.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.14.0-rc.3"
+          image: "gcr.io/datadoghq/operator:1.14.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -54,9 +54,14 @@ spec:
             - "-metrics-addr=:8383"
             - "-loglevel=info"
             - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
             - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
           ports:
             - name: metrics
               containerPort: 8383

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -121,7 +121,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "gcr.io/datadoghq/operator:1.14.0-rc.3", operatorContainer.Image)
+	assert.Equal(t, "gcr.io/datadoghq/operator:1.14.0", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

[datadog-operator] Update chart for 1.14.0 release

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
