### PR TITLE
[SYN]: Update Private Location to 1.56.1

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.17.9
+
+* Update private location image version to `1.56.1`.
+
 ## 0.17.8
 
 * Update private location image version to `1.56.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.17.8
-appVersion: 1.56.0
+version: 0.17.9
+appVersion: 1.56.1
 description: Datadog Synthetics Private Location
 keywords:
 - monitoring

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.17.8](https://img.shields.io/badge/Version-0.17.8-informational?style=flat-square) ![AppVersion: 1.56.0](https://img.shields.io/badge/AppVersion-1.56.0-informational?style=flat-square)
+![Version: 0.17.9](https://img.shields.io/badge/Version-0.17.9-informational?style=flat-square) ![AppVersion: 1.56.1](https://img.shields.io/badge/AppVersion-1.56.1-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations/?tab=helmchart).
 
@@ -41,7 +41,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | hostAliases | list | `[]` | Add entries to Datadog Synthetics Private Location PODs' /etc/hosts |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Synthetics Private Location image |
 | image.repository | string | `"gcr.io/datadoghq/synthetics-private-location-worker"` | Repository to use for Datadog Synthetics Private Location image |
-| image.tag | string | `"1.56.0"` | Define the Datadog Synthetics Private Location version to use |
+| image.tag | string | `"1.56.1"` | Define the Datadog Synthetics Private Location version to use |
 | imagePullSecrets | list | `[]` | Datadog Synthetics Private Location repository pullSecret (ex: specify docker registry credentials) |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Synthetics Private Location on specific nodes |

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -15,7 +15,7 @@ image:
   # image.pullPolicy -- Define the pullPolicy for Datadog Synthetics Private Location image
   pullPolicy: IfNotPresent
   # image.tag -- Define the Datadog Synthetics Private Location version to use
-  tag: 1.56.0
+  tag: 1.56.1
 
 # dnsPolicy -- DNS Policy to set to the Datadog Synthetics Private Location PODs
 dnsPolicy: ClusterFirst


### PR DESCRIPTION
#### What this PR does / why we need it:

Releases a new chart for Synthetics Private Location Worker latest 1.56.1 version.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
