### PR TITLE
Create noop job so when files are unchanged during a merge queue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,13 @@
 stages:
   - e2e
+  - test
 
 variables:
   RUN_E2E_TEST:
     description: "set RUN_E2E_TEST to 'true' if you want to trigger the e2e test on your pipeline."
 
 noop:
-  stage: e2e
+  stage: test
   script: 
     - echo "No op job to get merge queue working"
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:95dca87f269a

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,13 @@ variables:
   RUN_E2E_TEST:
     description: "set RUN_E2E_TEST to 'true' if you want to trigger the e2e test on your pipeline."
 
+noop:
+  stage: e2e
+  script: 
+    - echo "No op job to get merge queue working"
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:95dca87f269a
+  tags: ["arch:amd64"]
+
 e2e:
   stage: e2e
   rules:


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
* Had an issue pushing this [PR](https://github.com/DataDog/helm-charts/pull/1825) using the merge queue. It kept getting skipped and the reason is because there wasn't any updates that triggered a job, so got a recommendation from @loic-mura to create a no-op job that will always run

