### PR TITLE
Update CloudPrem Helm chart

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.2
+
+* Add pipelinesConfig property to values.yaml https://github.com/DataDog/pomsky-helm-charts/pull/4
+* Fix sort order for same-second documents
+* Indexing pomsky's traces in pomsky by default
+
 ## 0.1.1
 
 * Load index config from file instead of inline definition

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: v0.1.1
-appVersion: v0.1.1
+version: 0.1.2
+appVersion: v0.1.2
 home: https://www.datadoghq.com/
 icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
 maintainers:

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: v0.1.1](https://img.shields.io/badge/Version-v0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1](https://img.shields.io/badge/AppVersion-v0.1.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.2](https://img.shields.io/badge/AppVersion-v0.1.2-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/datadog.yaml
+++ b/charts/cloudprem/datadog.yaml
@@ -14,6 +14,7 @@ doc_mapping:
         - rfc3339
         - iso8601
         - unix_timestamp
+      fast_precision: milliseconds
     - name: discovery_timestamp
       type: datetime
       fast: false

--- a/charts/cloudprem/templates/_helpers.tpl
+++ b/charts/cloudprem/templates/_helpers.tpl
@@ -155,8 +155,19 @@ Quickwit environment
   value: "$(POD_IP)"
 - name: QW_CLUSTER_ENDPOINT
   value: http://{{ include "quickwit.fullname" $ }}-metastore.{{ $.Release.Namespace }}.svc.{{ .Values.clusterDomain }}:7280
+{{- if .Values.tracingEnabled }}
+- name: QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER
+  value: "true"
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: http://{{ include "quickwit.fullname" $ }}-indexer:7281
+- name: OTEL_EXPORTER_OTLP_PROTOCOL
+  value: "grpc"
+- name: OTEL_EXPORTER_OTLP_TIMEOUT
+  value: "10"
+{{- end}}
 {{- range $key, $value := .Values.environment }}
 - name: "{{ $key }}"
   value: "{{ $value }}"
 {{- end }}
 {{- end }}
+

--- a/charts/cloudprem/templates/configmap.yaml
+++ b/charts/cloudprem/templates/configmap.yaml
@@ -7,3 +7,7 @@ metadata:
 data:
   node.yaml: |-
     {{- toYaml .Values.config | nindent 4 }}
+  {{- if .Values.pipelinesConfig }}
+  pipelines_config.json: |-
+    {{ .Values.pipelinesConfig }}
+  {{- end }}

--- a/charts/cloudprem/templates/indexer-statefulset.yaml
+++ b/charts/cloudprem/templates/indexer-statefulset.yaml
@@ -63,6 +63,10 @@ spec:
           {{- end }}
           env:
             {{- include "quickwit.environment" . | nindent 12 }}
+            {{- if .Values.pipelinesConfig }}
+            - name: "QW_PIPELINE_CONFIG_PATH"
+              value: "/quickwit/pipelines_config.json"
+            {{- end }}
             {{- range $key, $value := .Values.indexer.extraEnv }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
@@ -86,8 +90,7 @@ spec:
             {{- toYaml .Values.indexer.readinessProbe | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /quickwit/node.yaml
-              subPath: node.yaml
+              mountPath: /quickwit/
             - name: data
               mountPath: /quickwit/qwdata
             {{- range .Values.configMaps }}
@@ -108,9 +111,6 @@ spec:
         - name: config
           configMap:
             name: {{ template "quickwit.fullname" . }}
-            items:
-              - key: node.yaml
-                path: node.yaml
         {{- if ne .Values.indexer.persistentVolume.enabled true }}
         - name: data
           emptyDir: {}

--- a/charts/cloudprem/values.yaml
+++ b/charts/cloudprem/values.yaml
@@ -8,7 +8,7 @@ image:
   # The CloudPrem image is also available on DockerHub:
   # https://hub.docker.com/r/datadog/cloudprem
   repository: public.ecr.aws/datadog/cloudprem
-  tag: v0.1.1
+  tag: v0.1.4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -56,14 +56,13 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1005
 
+# If enabled, we index Cloudprem (well, pomsky/quickwit) traces within Cloudprem
+tracingEnabled: true
+
 # Additional global env
 environment:
   QW_DISABLE_TELEMETRY: true
-  QW_ENABLE_OPENTELEMETRY_OTLP_EXPORTER: true
   NO_COLOR: true
-  OTEL_EXPORTER_OTLP_ENDPOINT: http://$(HOST_IP):4317
-  OTEL_EXPORTER_OTLP_PROTOCOL: grpc
-  OTEL_EXPORTER_OTLP_TIMEOUT: 10
 
 environmentFrom: []
   # - secretRef:
@@ -658,3 +657,7 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+# List of pipeline of processors in JSON format.
+# If unset, no pipeline will be created.
+pipelinesConfig: null


### PR DESCRIPTION
## 0.1.2

* Add pipelinesConfig property to values.yaml https://github.com/DataDog/pomsky-helm-charts/pull/4
* Fix sort order for same-second documents
* Indexing pomsky's traces in pomsky by default

#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`