### PR TITLE
[OTAGENT-391] Update _container-otel-agent.yaml

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.110.15
+## 3.110.16
 
 * Fix otel-agent container template to respect configs `otelCollector.enabled` and `otelCollector.converter.enabled` in values.yaml
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 3.110.15
+
+* Fix otel-agent container template to respect configs `otelCollector.enabled` and `otelCollector.converter.enabled` in values.yaml
 
 ## 3.110.15
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.111.0
+## 3.110.16
 
 * Fix otel-agent container template to respect config `otelCollector.enabled` in values.yaml
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.110.16
 
-* Fix otel-agent container template to respect configs `otelCollector.enabled` and `otelCollector.converter.enabled` in values.yaml
+* Fix otel-agent container template to respect config `otelCollector.enabled` in values.yaml
 
 ## 3.110.15
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.110.16
+## 3.111.0
 
 * Fix otel-agent container template to respect config `otelCollector.enabled` in values.yaml
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.110.16
+version: 3.111.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.111.0
+version: 3.110.16
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.110.15
+version: 3.110.16
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.110.15](https://img.shields.io/badge/Version-3.110.15-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.110.16](https://img.shields.io/badge/Version-3.110.16-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.110.16](https://img.shields.io/badge/Version-3.110.16-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.111.0](https://img.shields.io/badge/Version-3.111.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.111.0](https://img.shields.io/badge/Version-3.111.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.110.16](https://img.shields.io/badge/Version-3.110.16-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -51,8 +51,10 @@
       value: "5009"
     - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
       value: "60"
+    {{- if .Values.datadog.otelCollector.enabled }}
     - name: DD_OTELCOLLECTOR_ENABLED
-      value: {{ .Values.datadog.otelCollector.enabled | default "false" }}
+      value: "true"
+    {{- end }}
     {{- include "fips-envvar" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.otelAgent.logLevel | default .Values.datadog.logLevel | quote }}

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -51,6 +51,8 @@
       value: "5009"
     - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
       value: "60"
+    - name: DD_OTELCOLLECTOR_ENABLED
+      value: {{ .Values.datadog.otelCollector.enabled }}
     {{- include "fips-envvar" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.otelAgent.logLevel | default .Values.datadog.logLevel | quote }}

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -52,7 +52,7 @@
     - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
       value: "60"
     - name: DD_OTELCOLLECTOR_ENABLED
-      value: {{ .Values.datadog.otelCollector.enabled }}
+      value: {{ .Values.datadog.otelCollector.enabled | default "false" }}
     {{- include "fips-envvar" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.otelAgent.logLevel | default .Values.datadog.logLevel | quote }}

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -53,8 +53,6 @@
       value: "60"
     - name: DD_OTELCOLLECTOR_ENABLED
       value: {{ .Values.datadog.otelCollector.enabled }}
-    - name: DD_OTELCOLLECTOR_CONVERTER_ENABLED
-      value: {{ .Values.datadog.otelCollector.converter.enabled }}
     {{- include "fips-envvar" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.otelAgent.logLevel | default .Values.datadog.logLevel | quote }}

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -53,6 +53,8 @@
       value: "60"
     - name: DD_OTELCOLLECTOR_ENABLED
       value: {{ .Values.datadog.otelCollector.enabled }}
+    - name: DD_OTELCOLLECTOR_CONVERTER_ENABLED
+      value: {{ .Values.datadog.otelCollector.converter.enabled }}
     {{- include "fips-envvar" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.otelAgent.logLevel | default .Values.datadog.logLevel | quote }}

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.9.1
+    helm.sh/chart: datadog-operator-2.9.2
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1109,6 +1109,8 @@ spec:
               value: "5009"
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
+            - name: DD_OTELCOLLECTOR_ENABLED
+              value: true
             - name: DD_LOG_LEVEL
               value: INFO
           image: gcr.io/datadoghq/agent:7.64.3

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1110,7 +1110,7 @@ spec:
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
             - name: DD_OTELCOLLECTOR_ENABLED
-              value: true
+              value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
           image: gcr.io/datadoghq/agent:7.64.3

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -1147,7 +1147,7 @@ spec:
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
             - name: DD_OTELCOLLECTOR_ENABLED
-              value: true
+              value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
           image: gcr.io/datadoghq/agent:7.64.3

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -1146,6 +1146,8 @@ spec:
               value: "5009"
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
+            - name: DD_OTELCOLLECTOR_ENABLED
+              value: true
             - name: DD_LOG_LEVEL
               value: INFO
           image: gcr.io/datadoghq/agent:7.64.3

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -1147,7 +1147,7 @@ spec:
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
             - name: DD_OTELCOLLECTOR_ENABLED
-              value: true
+              value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
           image: gcr.io/datadoghq/agent:7.64.3

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -1146,6 +1146,8 @@ spec:
               value: "5009"
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
+            - name: DD_OTELCOLLECTOR_ENABLED
+              value: true
             - name: DD_LOG_LEVEL
               value: INFO
           image: gcr.io/datadoghq/agent:7.64.3


### PR DESCRIPTION
#### What this PR does / why we need it:
Set `DD_OTELCOLLECTOR_ENABLED` from `datadog.otelCollector.enabled` in values.yaml

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
