### PR TITLE
[datadog] Upgrade default agent and cluster-agent versions to 7.65.0

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.112.0
+
+* Upgrade default Agent version to `7.65.0`.
+
 ## 3.111.1
 
 * Update `fips.image.tag` to `1.1.10` fixing CVEs and updating packages.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.111.1
+version: 3.112.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.111.1](https://img.shields.io/badge/Version-3.111.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.112.0](https://img.shields.io/badge/Version-3.112.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -526,7 +526,7 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.64.3"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.65.0"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
 | agents.localService.overrideName | string | `""` | Name of the internal traffic service to target the agent running on the local node |
@@ -610,7 +610,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"7.64.3"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"7.65.0"` | Cluster Agent image tag to use |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
@@ -666,7 +666,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
-| clusterChecksRunner.image.tag | string | `"7.64.3"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.65.0"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1121,7 +1121,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 7.64.3
+    tag: 7.65.0
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -1653,7 +1653,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.64.3
+    tag: 7.65.0
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2169,7 +2169,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.64.3
+    tag: 7.65.0
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -888,7 +888,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1025,7 +1025,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1074,7 +1074,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1109,7 +1109,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1275,7 +1275,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1324,7 +1324,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1337,7 +1337,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1509,7 +1509,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1582,7 +1582,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -883,7 +883,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -956,7 +956,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -897,7 +897,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -970,7 +970,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -830,7 +830,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
               value: agent
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-              value: 7.64.3
+              value: 7.65.0
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -893,7 +893,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -966,7 +966,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -853,7 +853,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -990,7 +990,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1039,7 +1039,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1074,7 +1074,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1293,7 +1293,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1366,7 +1366,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -853,7 +853,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -990,7 +990,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1039,7 +1039,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1074,7 +1074,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1293,7 +1293,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1366,7 +1366,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -830,7 +830,7 @@ spec:
               value: /var/lib/kubelet/pod-resources/kubelet.sock
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -931,7 +931,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -957,7 +957,7 @@ spec:
           command:
             - pwsh
             - -Command
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -995,7 +995,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1188,7 +1188,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1261,7 +1261,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -833,7 +833,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -896,7 +896,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -944,7 +944,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1138,7 +1138,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1211,7 +1211,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -833,7 +833,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -908,7 +908,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -956,7 +956,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1159,7 +1159,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1232,7 +1232,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -841,7 +841,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -962,7 +962,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1003,7 +1003,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1050,7 +1050,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1268,7 +1268,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1347,7 +1347,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1093,7 +1093,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1229,7 +1229,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1307,7 +1307,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1369,7 +1369,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1416,7 +1416,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1449,7 +1449,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1674,7 +1674,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1753,7 +1753,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1093,7 +1093,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1229,7 +1229,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1307,7 +1307,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1401,7 +1401,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1448,7 +1448,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1481,7 +1481,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1738,7 +1738,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1817,7 +1817,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1089,7 +1089,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1198,7 +1198,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1288,7 +1288,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1335,7 +1335,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1368,7 +1368,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1622,7 +1622,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1701,7 +1701,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -839,7 +839,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -911,7 +911,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -958,7 +958,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1176,7 +1176,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1255,7 +1255,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1107,7 +1107,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1251,7 +1251,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1347,7 +1347,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1419,7 +1419,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1494,7 +1494,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1529,7 +1529,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1556,7 +1556,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1797,7 +1797,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1870,7 +1870,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -867,7 +867,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1004,7 +1004,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1090,7 +1090,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1139,7 +1139,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1174,7 +1174,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1399,7 +1399,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1472,7 +1472,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -890,7 +890,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1027,7 +1027,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1113,7 +1113,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1174,7 +1174,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1209,7 +1209,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1446,7 +1446,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1519,7 +1519,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -927,7 +927,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1064,7 +1064,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1150,7 +1150,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1202,7 +1202,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1237,7 +1237,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1465,7 +1465,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1538,7 +1538,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -927,7 +927,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1064,7 +1064,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1150,7 +1150,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1199,7 +1199,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1234,7 +1234,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1459,7 +1459,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1532,7 +1532,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -853,7 +853,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -990,7 +990,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1039,7 +1039,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1074,7 +1074,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1293,7 +1293,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1366,7 +1366,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1107,7 +1107,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1251,7 +1251,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1347,7 +1347,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1421,7 +1421,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1578,7 +1578,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -1619,7 +1619,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1654,7 +1654,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1681,7 +1681,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1962,7 +1962,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2035,7 +2035,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1107,7 +1107,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1251,7 +1251,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1347,7 +1347,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1419,7 +1419,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1572,7 +1572,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -1613,7 +1613,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1648,7 +1648,7 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1675,7 +1675,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.64.3
+          image: gcr.io/datadoghq/agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1953,7 +1953,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2026,7 +2026,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.64.3
+          image: gcr.io/datadoghq/cluster-agent:7.65.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrade default agent and cluster-agent versions to 7.65.0.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [X] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated 
- [X] Variables are documented in the `README.md`
