### PR TITLE
[tooling] discard Go helm test outputs; update chart deps in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,32 +45,38 @@ vet:
 	go vet -C test ./...
 
 .PHONY: unit-test
-unit-test:
-	go test -C test ./... -count=1
+unit-test: unit-test-datadog unit-test-operator unit-test-private-action-runner
 
 .PHONY: unit-test-datadog
 unit-test-datadog:
+	helm dependency update ./charts/datadog
 	go test -C test ./datadog -count=1
 
 .PHONY: unit-test-operator
 unit-test-operator:
+	helm dependency update ./charts/datadog-operator
 	go test -C test ./datadog-operator -count=1
 
 .PHONY: unit-test-private-action-runner
 unit-test-private-action-runner:
 	go test -C test ./private-action-runner -count=1
 
+.PHONY: update-test-baselines
+update-test-baselines: update-test-baselines-datadog-agent update-test-baselines-operator update-test-baselines-private-action-runner
+
 .PHONY: update-test-baselines-private-action-runner
 update-test-baselines-private-action-runner:
 	go test -C test ./private-action-runner -count=1 -args -updateBaselines=true
 
-.PHONY: update-test-baselines
-update-test-baselines:
-	go test -C test ./... -count=1 -args -updateBaselines=true
-
 .PHONY: update-test-baselines-operator
-update-test-baselines-operator:
+update-test-baselines-operator: 
+	helm dependency update ./charts/datadog-operator
 	go test -C test ./datadog-operator -count=1 -args -updateBaselines=true
+
+.PHONY: update-test-baselines-datadog-agent
+update-test-baselines-datadog-agent: 
+	helm dependency update ./charts/datadog
+	go test -C test ./datadog -count=1 -args -updateBaselines=true
 
 .PHONY: integration-test
 integration-test:

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v3"
@@ -25,6 +26,7 @@ type HelmCommand struct {
 	Values        []string          // helm template `-f, --values` flag
 	Overrides     map[string]string // helm template `--set` flag
 	OverridesJson map[string]string // helm template `--set-json` flag
+	Logger        *logger.Logger    // logger to use for helm output. Set to logger.Discard by default.
 }
 
 func Unmarshal[T any](t *testing.T, manifest string, destObj *T) {
@@ -45,7 +47,11 @@ func RenderChart(t *testing.T, cmd HelmCommand) (string, error) {
 		ValuesFiles:    cmd.Values,
 	}
 
-	output, err := helm.RenderTemplateE(t, options, chartPath, cmd.ReleaseName, cmd.ShowOnly, "--debug")
+	if cmd.Logger == nil {
+		options.Logger = logger.Discard
+	}
+
+	output, err := helm.RenderTemplateE(t, options, chartPath, cmd.ReleaseName, cmd.ShowOnly /*, "--debug"*/)
 
 	return output, err
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

* Makefile change to run helm dependency update before tests.
* Discard `helm template` outputs. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
