### PR TITLE
Update CRDs for operator 1.15.0-rc.1

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.0-dev
+
+* Update CRDs from Datadog Operator v1.15.0-rc.1 release candidate tag.
+
 ## 2.7.0
 
 * Clean up `apiextensions.k8s.io/v1beta1` CRD versions. Kubernetes cluster v1.21 and earlier will be updated to `apiextensions.k8s.io/v1` CRD version.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.7.0
+version: 2.8.0-dev
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.8.0-dev](https://img.shields.io/badge/Version-2.8.0--dev-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -1541,6 +1541,8 @@ spec:
                         type: string
                       type: array
                       x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
                   type: object
                 override:
                   additionalProperties:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
@@ -825,6 +825,32 @@ spec:
                   required:
                     - maxReplicas
                   type: object
+                fallback:
+                  default: {}
+                  description: Fallback defines how recommendations should be applied when in fallback mode.
+                  properties:
+                    horizontal:
+                      default: {}
+                      description: Horizontal configures the behavior during horizontal fallback mode.
+                      properties:
+                        enabled:
+                          default: true
+                          description: 'Enabled determines whether recommendations should be applied by the controller:'
+                          type: boolean
+                        triggers:
+                          default: {}
+                          description: Triggers defines the triggers that will generate recommendations.
+                          properties:
+                            staleRecommendationThresholdSeconds:
+                              default: 600
+                              description: StaleRecommendationThresholdSeconds defines the time window the controller will wait after detecting an error before applying recommendations.
+                              format: int32
+                              maximum: 1200
+                              minimum: 100
+                              type: integer
+                          type: object
+                      type: object
+                  type: object
                 objectives:
                   description: |-
                     Objectives are the objectives to reach and maintain for the target resource.

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -1535,6 +1535,8 @@ spec:
                         type: string
                       type: array
                       x-kubernetes-list-type: set
+                    useFIPSAgent:
+                      type: boolean
                   type: object
                 override:
                   additionalProperties:

--- a/crds/datadoghq.com_datadogpodautoscalers.yaml
+++ b/crds/datadoghq.com_datadogpodautoscalers.yaml
@@ -819,6 +819,32 @@ spec:
                   required:
                     - maxReplicas
                   type: object
+                fallback:
+                  default: {}
+                  description: Fallback defines how recommendations should be applied when in fallback mode.
+                  properties:
+                    horizontal:
+                      default: {}
+                      description: Horizontal configures the behavior during horizontal fallback mode.
+                      properties:
+                        enabled:
+                          default: true
+                          description: 'Enabled determines whether recommendations should be applied by the controller:'
+                          type: boolean
+                        triggers:
+                          default: {}
+                          description: Triggers defines the triggers that will generate recommendations.
+                          properties:
+                            staleRecommendationThresholdSeconds:
+                              default: 600
+                              description: StaleRecommendationThresholdSeconds defines the time window the controller will wait after detecting an error before applying recommendations.
+                              format: int32
+                              maximum: 1200
+                              minimum: 100
+                              type: integer
+                          type: object
+                      type: object
+                  type: object
                 objectives:
                   description: |-
                     Objectives are the objectives to reach and maintain for the target resource.


### PR DESCRIPTION
#### What this PR does / why we need it:

Update CRDs for operator `1.15.0-rc.1`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
