### PR TITLE
Fix operator semverCompare to work with pre-release versions

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.10.1-dev
+
+* Fix semverCompare to work with pre-release versions.
+
 ## 2.10.0-dev
 
 * Update Datadog Operator chart for 1.15.0-rc.1.

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.10.1
+## 2.10.0-dev.1
 
 * Fix semverCompare to work with pre-release versions.
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.10.1-dev
+## 2.10.1
 
 * Fix semverCompare to work with pre-release versions.
 

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.10.0-dev.1
+version: 2.10.1
 appVersion: 1.15.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.10.0-dev
+version: 2.10.1-dev
 appVersion: 1.15.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.10.1
+version: 2.10.0-dev.1
 appVersion: 1.15.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.10.1-dev
+version: 2.10.0-dev.1
 appVersion: 1.15.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.10.1-dev](https://img.shields.io/badge/Version-2.10.1--dev-informational?style=flat-square) ![AppVersion: 1.15.0-rc.1](https://img.shields.io/badge/AppVersion-1.15.0--rc.1-informational?style=flat-square)
+![Version: 2.10.1](https://img.shields.io/badge/Version-2.10.1-informational?style=flat-square) ![AppVersion: 1.15.0-rc.1](https://img.shields.io/badge/AppVersion-1.15.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.10.1](https://img.shields.io/badge/Version-2.10.1-informational?style=flat-square) ![AppVersion: 1.15.0-rc.1](https://img.shields.io/badge/AppVersion-1.15.0--rc.1-informational?style=flat-square)
+![Version: 2.10.0-dev.1](https://img.shields.io/badge/Version-2.10.0--dev.1-informational?style=flat-square) ![AppVersion: 1.15.0-rc.1](https://img.shields.io/badge/AppVersion-1.15.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.10.0-dev](https://img.shields.io/badge/Version-2.10.0--dev-informational?style=flat-square) ![AppVersion: 1.15.0-rc.1](https://img.shields.io/badge/AppVersion-1.15.0--rc.1-informational?style=flat-square)
+![Version: 2.10.1-dev](https://img.shields.io/badge/Version-2.10.1--dev-informational?style=flat-square) ![AppVersion: 1.15.0-rc.1](https://img.shields.io/badge/AppVersion-1.15.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -132,26 +132,26 @@ spec:
           {{- if and .Values.maximumGoroutines (semverCompare ">=1.0.0-rc.13" $version) }}
             - "-maximumGoroutines={{ .Values.maximumGoroutines }}"
           {{- end }}
-          {{- if (semverCompare ">=1.4.0" $version) }}
+          {{- if (semverCompare ">=1.4.0-0" $version) }}
             - "-introspectionEnabled={{ .Values.introspection.enabled }}"
           {{- end }}
-          {{- if (semverCompare ">=1.5.0" $version) }}
+          {{- if (semverCompare ">=1.5.0-0" $version) }}
             - "-datadogAgentProfileEnabled={{ .Values.datadogAgentProfile.enabled }}"
           {{- end }}
             - "-datadogMonitorEnabled={{ .Values.datadogMonitor.enabled }}"
           {{- if (semverCompare ">=1.0.0-rc.13" $version) }}
             - "-datadogAgentEnabled={{ .Values.datadogAgent.enabled }}"
           {{- end }}
-          {{- if (semverCompare ">=1.3.0" $version) }}
+          {{- if (semverCompare ">=1.3.0-0" $version) }}
             - "-datadogSLOEnabled={{ .Values.datadogSLO.enabled }}"
           {{- end }}
           {{- if (semverCompare ">=1.9.0-0" $version) }}
             - "-datadogDashboardEnabled={{ .Values.datadogDashboard.enabled }}"
           {{- end }}
-          {{- if (semverCompare ">=1.12.0" $version) }}
+          {{- if (semverCompare ">=1.12.0-0" $version) }}
             - "-datadogGenericResourceEnabled={{ .Values.datadogGenericResource.enabled }}"
           {{- end }}
-          {{- if (semverCompare ">=1.7.0" $version) }}
+          {{- if (semverCompare ">=1.7.0-0" $version) }}
             - "-remoteConfigEnabled={{ .Values.remoteConfiguration.enabled }}"
           {{- end }}
           ports:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.10.0-dev
+    helm.sh/chart: datadog-operator-2.10.0-dev.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.15.0-rc.1"
     app.kubernetes.io/managed-by: Helm
@@ -54,9 +54,14 @@ spec:
             - "-metrics-addr=:8383"
             - "-loglevel=info"
             - "-operatorMetricsEnabled=true"
+            - "-introspectionEnabled=false"
+            - "-datadogAgentProfileEnabled=false"
             - "-datadogMonitorEnabled=false"
             - "-datadogAgentEnabled=true"
+            - "-datadogSLOEnabled=false"
             - "-datadogDashboardEnabled=false"
+            - "-datadogGenericResourceEnabled=false"
+            - "-remoteConfigEnabled=false"
           ports:
             - name: metrics
               containerPort: 8383


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix semverCompare versions to compare properly with pre-release operator versions. 

I encountered this issue while installing the `dev` chart version with `datadogSLO.enabled=true`. The previous `semverCompare >=x.y.z .Values.foo.bar` was only comparing stable release versions. This fix changes the comparator version to `x.y.z-0` so that pre-release operator versions are included for comparisons. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
