### PR TITLE
add option to configure csi registrar image

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2
+
+* Add option to configure CSI registrar image
+
 ## 0.3.1
 
 * Fix image pull secrets of the CSI driver daemonset.

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 
@@ -20,6 +20,9 @@ Datadog CSI Driver helm chart
 | image.repository | string | `nil` | Override default registry + image.name for CSI driver TODO: change to official repository when available |
 | image.tag | string | `"latest"` | CSI driver image tag to use TODO: change to a static stable version |
 | nameOverride | string | `""` | Allows overriding the name of the chart. If set, this value replaces the default chart name. |
+| registrar.image.pullPolicy | string | `"IfNotPresent"` | CSI registrar image pullPolicy |
+| registrar.image.repository | string | `"k8s.gcr.io/sig-storage/csi-node-driver-registrar"` | Override default registry + image.name for the registrar |
+| registrar.image.tag | string | `"v2.0.1"` | CSI registrar image tag to use |
 | sockets.apmHostSocketPath | string | `"/var/run/datadog/apm.socket"` |  |
 | sockets.dsdHostSocketPath | string | `"/var/run/datadog/dsd.socket"` |  |
 

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -51,7 +51,8 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
+          image: "{{ .Values.registrar.image.repository }}:{{ .Values.registrar.image.tag }}"
+          imagePullPolicy: {{ .Values.registrar.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/charts/datadog-csi-driver/values.yaml
+++ b/charts/datadog-csi-driver/values.yaml
@@ -29,6 +29,20 @@ image:
   pullSecrets: []
   #   - name: "<REG_SECRET>"
 
+## Configure the CSI registrar to use as a sidecar container
+registrar:
+
+  # Define the CSI registrar image to work with
+  image:
+    # registrar.image.tag -- CSI registrar image tag to use
+    tag: v2.0.1
+
+    # registrar.image.repository -- Override default registry + image.name for the registrar
+    repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+
+    # registrar.image.pullPolicy -- CSI registrar image pullPolicy
+    pullPolicy: IfNotPresent
+
 sockets:
   # apmHostSocketPath -- Host path of the apm socket.
   # Should correspond to `datadog.apm.hostSocketPath`


### PR DESCRIPTION
#### What this PR does / why we need it:

See title

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
