### PR TITLE
fix bug in csi driver chart

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.3
+
+* Fix bug that caused to pass the socket's parent directory to the start command arguments instead of the full socket path.
+
 ## 0.3.2
 
 * Add option to configure CSI registrar image

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -28,9 +28,8 @@ spec:
             - containerPort: 5000
               protocol: TCP 
           args:
-            - /dd-csi-driver
-            - -apm-host-socket-path="{{ dir .Values.sockets.apmHostSocketPath }}"
-            - -dsd-host-socket-path="{{ dir .Values.sockets.dsdHostSocketPath }}"
+            - --apm-host-socket-path={{ .Values.sockets.apmHostSocketPath }}
+            - --dsd-host-socket-path={{ .Values.sockets.dsdHostSocketPath }}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes bugs in datadog csi driver: the dsd and apm socket paths were not passed correctly in the flags to the entrypoint.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
