### PR TITLE
[datadog] Upgrade default agent and cluster-agent versions to 7.65.2

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.114.4
+
+* Upgrade default Agent version to `7.65.2`.
+
 ## 3.114.3
 
 * Show ERROR log if the chart is installed with different values for `datadog.dogstatsd.hostSocketPath` and `datadog.apm.hostSocketPath` while having same parent directories for `datadog.dogstatsd.socketPath` and `datadog.apm.socketPath`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.114.3
+version: 3.114.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.114.3](https://img.shields.io/badge/Version-3.114.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.114.4](https://img.shields.io/badge/Version-3.114.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -526,7 +526,7 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.65.1"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.65.2"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
 | agents.localService.overrideName | string | `""` | Name of the internal traffic service to target the agent running on the local node |
@@ -610,7 +610,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"7.65.1"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"7.65.2"` | Cluster Agent image tag to use |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
@@ -666,7 +666,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
-| clusterChecksRunner.image.tag | string | `"7.65.1"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.65.2"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1124,7 +1124,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 7.65.1
+    tag: 7.65.2
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -1666,7 +1666,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.65.1
+    tag: 7.65.2
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2182,7 +2182,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.65.1
+    tag: 7.65.2
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -890,7 +890,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1029,7 +1029,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1078,7 +1078,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1115,7 +1115,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1281,7 +1281,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1330,7 +1330,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1343,7 +1343,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1515,7 +1515,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1588,7 +1588,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -883,7 +883,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -956,7 +956,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -897,7 +897,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -970,7 +970,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -830,7 +830,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
               value: agent
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-              value: 7.65.1
+              value: 7.65.2
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -893,7 +893,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -966,7 +966,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -855,7 +855,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -994,7 +994,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1043,7 +1043,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1080,7 +1080,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1299,7 +1299,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1372,7 +1372,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -855,7 +855,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -994,7 +994,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1043,7 +1043,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1080,7 +1080,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1299,7 +1299,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1372,7 +1372,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -832,7 +832,7 @@ spec:
               value: /var/lib/kubelet/pod-resources/kubelet.sock
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -935,7 +935,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -961,7 +961,7 @@ spec:
           command:
             - pwsh
             - -Command
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1001,7 +1001,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1194,7 +1194,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1267,7 +1267,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -835,7 +835,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -898,7 +898,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -948,7 +948,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1142,7 +1142,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1215,7 +1215,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -835,7 +835,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -910,7 +910,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -960,7 +960,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1163,7 +1163,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1236,7 +1236,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -876,7 +876,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -999,7 +999,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1040,7 +1040,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1089,7 +1089,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1256,7 +1256,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1311,7 +1311,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1330,7 +1330,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1512,7 +1512,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1591,7 +1591,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -848,7 +848,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -969,7 +969,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1010,7 +1010,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1057,7 +1057,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1275,7 +1275,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1354,7 +1354,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1095,7 +1095,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1233,7 +1233,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1313,7 +1313,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1375,7 +1375,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1424,7 +1424,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1457,7 +1457,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1682,7 +1682,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1761,7 +1761,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1095,7 +1095,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1233,7 +1233,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1313,7 +1313,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1407,7 +1407,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1456,7 +1456,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1489,7 +1489,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1746,7 +1746,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1825,7 +1825,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1091,7 +1091,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1202,7 +1202,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1292,7 +1292,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1341,7 +1341,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1374,7 +1374,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1628,7 +1628,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1707,7 +1707,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -874,7 +874,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -946,7 +946,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -995,7 +995,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1162,7 +1162,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1217,7 +1217,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1236,7 +1236,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1418,7 +1418,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1497,7 +1497,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1109,7 +1109,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1255,7 +1255,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1353,7 +1353,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1427,7 +1427,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1502,7 +1502,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1539,7 +1539,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1566,7 +1566,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1807,7 +1807,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1880,7 +1880,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -869,7 +869,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1008,7 +1008,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1096,7 +1096,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1145,7 +1145,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1182,7 +1182,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1407,7 +1407,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1480,7 +1480,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -892,7 +892,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1031,7 +1031,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1119,7 +1119,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1180,7 +1180,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1217,7 +1217,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1454,7 +1454,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1527,7 +1527,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -929,7 +929,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1068,7 +1068,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1156,7 +1156,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1208,7 +1208,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1245,7 +1245,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1473,7 +1473,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1546,7 +1546,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -929,7 +929,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1068,7 +1068,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1156,7 +1156,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1205,7 +1205,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1242,7 +1242,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1467,7 +1467,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1540,7 +1540,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -855,7 +855,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -994,7 +994,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1043,7 +1043,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1080,7 +1080,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1299,7 +1299,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1372,7 +1372,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1109,7 +1109,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1255,7 +1255,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1353,7 +1353,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1429,7 +1429,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1588,7 +1588,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -1629,7 +1629,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1666,7 +1666,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1693,7 +1693,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1974,7 +1974,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2047,7 +2047,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1109,7 +1109,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1255,7 +1255,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1353,7 +1353,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1427,7 +1427,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1582,7 +1582,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -1623,7 +1623,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1660,7 +1660,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1687,7 +1687,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.65.1
+          image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1965,7 +1965,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2038,7 +2038,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.65.1
+          image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrade default agent and cluster-agent versions to 7.65.2.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [X] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated 
- [X] Variables are documented in the `README.md`
