### PR TITLE
Add support for Agent Data Plane.

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.117.0
+
+* Add support for Agent Data Plane.
+
 ## 3.116.1
 
 * (chore) Clean up CI values files for datadog chart ([#1878](https://github.com/DataDog/helm-charts/pull/1878)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.116.1
+version: 3.117.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.116.1](https://img.shields.io/badge/Version-3.116.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.117.0](https://img.shields.io/badge/Version-3.117.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -478,6 +478,15 @@ helm install <RELEASE_NAME> \
 | agents.containers.agent.resources | object | `{}` | Resource requests and limits for the agent container. |
 | agents.containers.agent.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the agent container. |
 | agents.containers.agent.startupProbe | object | Every 15s / 6 KO / 1 OK | Override default agent startup probe settings |
+| agents.containers.agentDataPlane.env | list | `[]` | Additional environment variables for the agent-data-plane container |
+| agents.containers.agentDataPlane.envDict | object | `{}` | Set environment variables specific to agent-data-plane container defined in a dict |
+| agents.containers.agentDataPlane.envFrom | list | `[]` | Set environment variables specific to agent-data-plane container from configMaps and/or secrets |
+| agents.containers.agentDataPlane.livenessProbe | object | Every 5s / 12 KO / 1 OK | Override default agent-data-plane liveness probe settings |
+| agents.containers.agentDataPlane.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off. If not set, fall back to the value of datadog.logLevel. |
+| agents.containers.agentDataPlane.privilegedApiPort | int | `5101` | Port for privileged API server, used for lower-level operations that can alter the state of the ADP process or expose internal information |
+| agents.containers.agentDataPlane.readinessProbe | object | Every 5s / 12 KO / 1 OK | Override default agent-data-plane readiness probe settings |
+| agents.containers.agentDataPlane.resources | object | `{}` | Resource requests and limits for the agent-data-plane container |
+| agents.containers.agentDataPlane.unprivilegedApiPort | int | `5100` | Port for unprivileged API server, used primarily for health checks |
 | agents.containers.initContainers.resources | object | `{}` | Resource requests and limits for the init containers |
 | agents.containers.initContainers.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the init containers. |
 | agents.containers.initContainers.volumeMounts | list | `[]` | Specify additional volumes to mount for the init containers |
@@ -694,6 +703,13 @@ helm install <RELEASE_NAME> \
 | commonLabels | object | `{}` | Labels to apply to all resources |
 | datadog-crds.crds.datadogMetrics | bool | `true` | Set to true to deploy the DatadogMetrics CRD |
 | datadog-crds.crds.datadogPodAutoscalers | bool | `true` | Set to true to deploy the DatadogPodAutoscalers CRD |
+| datadog.agentDataPlane.enabled | bool | `false` | Whether or not Agent Data Plane is enabled |
+| datadog.agentDataPlane.image.digest | string | `""` | Define Agent image digest to use, takes precedence over tag if specified |
+| datadog.agentDataPlane.image.name | string | `"agent-data-plane"` | Datadog Agent image name to use (relative to `registry`) |
+| datadog.agentDataPlane.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
+| datadog.agentDataPlane.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
+| datadog.agentDataPlane.image.repository | string | `nil` | Override default registry + image.name for Agent |
+| datadog.agentDataPlane.image.tag | string | `"0.1.8"` | Define the Agent version to use |
 | datadog.apiKey | string | `nil` | Your Datadog API key |
 | datadog.apiKeyExistingSecret | string | `nil` | Use existing Secret which stores API key instead of creating a new one. The value should be set with the `api-key` key inside the secret. |
 | datadog.apm.enabled | bool | `false` | Enable this to enable APM and tracing, on port 8126 DEPRECATED. Use datadog.apm.portEnabled instead |

--- a/charts/datadog/templates/_container-agent-data-plane.yaml
+++ b/charts/datadog/templates/_container-agent-data-plane.yaml
@@ -1,0 +1,92 @@
+{{- define "container-agent-data-plane" -}}
+- name: agent-data-plane
+  image: "{{ include "image-path" (dict "root" .Values "image" .Values.datadog.agentDataPlane.image) }}"
+  imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
+  command: ["agent-data-plane", "run", "--config={{ template "datadog.confPath" . }}/datadog.yaml"]
+  resources:
+{{- if and (empty .Values.agents.containers.agentDataPlane.resources) .Values.providers.gke.autopilot -}}
+{{ include "default-container-resources" . | indent 4 }}
+{{- else }}
+{{ toYaml .Values.agents.containers.agentDataPlane.resources | indent 4 }}
+{{- end }}
+  ports:
+  - containerPort: {{ .Values.datadog.dogstatsd.port }}
+    {{- if .Values.datadog.dogstatsd.useHostPort }}
+    hostPort: {{ .Values.datadog.dogstatsd.port }}
+    {{- end }}
+    name: dogstatsdport
+    protocol: UDP
+
+{{- if .Values.agents.containers.agentDataPlane.ports }}
+{{ toYaml .Values.agents.containers.agentDataPlane.ports | indent 2 }}
+{{- end }}
+{{- if or .Values.datadog.envFrom .Values.agents.containers.agentDataPlane.envFrom }}
+  envFrom:
+{{- if .Values.datadog.envFrom }}
+{{ .Values.datadog.envFrom | toYaml | indent 4 }}
+{{- end }}
+{{- if .Values.agents.containers.agentDataPlane.envFrom }}
+{{ .Values.agents.containers.agentDataPlane.envFrom | toYaml | indent 4 }}
+{{- end }}
+{{- end }}
+  env:
+    {{- include "containers-common-env" . | nindent 4 }}
+    {{- include "containers-dogstatsd-env" . | nindent 4 }}
+    {{- if .Values.datadog.logLevel }}
+    - name: DD_LOG_LEVEL
+      value: {{ .Values.agents.containers.agentDataPlane.logLevel | default .Values.datadog.logLevel | quote }}
+    {{- end }}
+    - name: DD_API_LISTEN_ADDRESS
+    {{- $unprivilegedApiPort := .Values.agents.containers.agentDataPlane.unprivilegedApiPort }}
+      value: "tcp://0.0.0.0:{{ $unprivilegedApiPort }}"
+    - name: DD_SECURE_API_LISTEN_ADDRESS
+    {{- $privilegedApiPort := .Values.agents.containers.agentDataPlane.privilegedApiPort }}
+      value: "tcp://0.0.0.0:{{ $privilegedApiPort }}"
+    {{- include "additional-env-entries" .Values.agents.containers.agentDataPlane.env | indent 4 }}
+    {{- include "additional-env-dict-entries" .Values.agents.containers.agentDataPlane.envDict | indent 4 }}
+  volumeMounts:
+    {{- if eq .Values.targetSystem "linux" }}
+    - name: tmpdir
+      mountPath: /tmp
+      readOnly: false # Need RW to write to /tmp directory
+    {{- end }}
+    - name: config
+      mountPath: {{ template "datadog.confPath" . }}
+      readOnly: false # Need RW to mount to config path
+    {{- if (not .Values.providers.gke.autopilot) }}
+    - name: auth-token
+      mountPath: {{ template "datadog.confPath" . }}/auth
+      readOnly: false # Need RW to write auth token
+    {{- end }}
+    {{- include "container-crisocket-volumemounts" . | nindent 4 }}
+    {{- if and .Values.agents.useConfigMap (eq .Values.targetSystem "linux")}}
+    - name: datadog-yaml
+      mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
+      subPath: datadog.yaml
+      readOnly: true
+    {{- end }}
+    {{- if eq .Values.targetSystem "linux" }}
+    {{- if not .Values.providers.gke.gdc }}
+    - name: dsdsocket
+      mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
+      readOnly: false
+    - name: procdir
+      mountPath: /host/proc
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
+    - name: cgroups
+      mountPath: /host/sys/fs/cgroup
+      mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
+      readOnly: true
+    {{- end }}
+    {{- end }}
+{{- if .Values.agents.volumeMounts }}
+{{ toYaml .Values.agents.volumeMounts | indent 4 }}
+{{- end }}
+  livenessProbe:
+{{- $live := .Values.agents.containers.agentDataPlane.livenessProbe }}
+{{ include "probe.http" (dict "path" "/live" "port" $unprivilegedApiPort "settings" $live) | indent 4 }}
+  readinessProbe:
+{{- $ready := .Values.agents.containers.agentDataPlane.readinessProbe }}
+{{ include "probe.http" (dict "path" "/ready" "port" $unprivilegedApiPort "settings" $ready) | indent 4 }}
+{{- end -}}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -11,12 +11,14 @@
 {{ toYaml .Values.agents.containers.agent.resources | indent 4 }}
 {{- end }}
   ports:
+  {{- if eq (include "should-enable-agent-data-plane" .) "false" }}
   - containerPort: {{ .Values.datadog.dogstatsd.port }}
     {{- if .Values.datadog.dogstatsd.useHostPort }}
     hostPort: {{ .Values.datadog.dogstatsd.port }}
     {{- end }}
     name: dogstatsdport
     protocol: UDP
+  {{- end }}
   {{- if .Values.datadog.otlp }}
   {{- if .Values.datadog.otlp.receiver }}
   {{- if .Values.datadog.otlp.receiver.protocols }}
@@ -74,31 +76,11 @@
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}
     {{- end }}
-    {{- if .Values.datadog.dogstatsd.port }}
-    - name: DD_DOGSTATSD_PORT
-      value: {{ .Values.datadog.dogstatsd.port | quote }}
-    {{- end }}
-    {{- if .Values.datadog.dogstatsd.nonLocalTraffic }}
-    - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
-      value: {{ .Values.datadog.dogstatsd.nonLocalTraffic | quote }}
-    {{- end }}
-    {{- if .Values.datadog.dogstatsd.originDetection }}
-    - name: DD_DOGSTATSD_ORIGIN_DETECTION
-      value: {{ .Values.datadog.dogstatsd.originDetection | quote }}
-    - name: DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT
-      value: {{ .Values.datadog.dogstatsd.originDetection | quote }}
-    {{- end }}
-    {{- if .Values.datadog.originDetectionUnified.enabled }}
-    - name: DD_ORIGIN_DETECTION_UNIFIED
-      value: {{ .Values.datadog.originDetectionUnified.enabled | quote }}
-    {{- end }}
-    {{- if .Values.datadog.dogstatsd.tagCardinality }}
-    - name: DD_DOGSTATSD_TAG_CARDINALITY
-      value: {{ .Values.datadog.dogstatsd.tagCardinality | quote }}
-    {{- end }}
-    {{- if .Values.datadog.dogstatsd.tags }}
-    - name: DD_DOGSTATSD_TAGS
-      value: {{ tpl (.Values.datadog.dogstatsd.tags | join " " | quote) . }}
+    {{- if eq (include "should-enable-agent-data-plane" .) "true" }}
+    - name: DD_USE_DOGSTATSD
+      value: "false"
+    {{- else }}
+    {{- include "containers-dogstatsd-env" . | nindent 4 }}
     {{- end }}
     {{- if eq (include "cluster-agent-enabled" .) "false" }}
     {{- if .Values.datadog.leaderElection }}
@@ -156,10 +138,6 @@
     - name: DD_HEALTH_PORT
     {{- $healthPort := .Values.agents.containers.agent.healthPort }}
       value: {{ $healthPort | quote }}
-    {{- if and (eq .Values.targetSystem "linux") (not .Values.providers.gke.gdc) }}
-    - name: DD_DOGSTATSD_SOCKET
-      value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
-    {{- end }}
     {{- if and (eq (include "cluster-agent-enabled" .) "true") .Values.datadog.clusterChecks.enabled }}
     {{- if or (and (not .Values.existingClusterAgent.join) .Values.clusterChecksRunner.enabled) (and .Values.existingClusterAgent.join (not .Values.existingClusterAgent.clusterchecksEnabled)) }}
     - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -172,3 +172,36 @@ Return a list of env-vars if the cluster-agent is enabled
         key: token
 {{- end }}
 {{- end -}}
+
+{{- define "containers-dogstatsd-env" -}}
+{{- if .Values.datadog.dogstatsd.port }}
+- name: DD_DOGSTATSD_PORT
+  value: {{ .Values.datadog.dogstatsd.port | quote }}
+{{- end }}
+{{- if .Values.datadog.dogstatsd.nonLocalTraffic }}
+- name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+  value: {{ .Values.datadog.dogstatsd.nonLocalTraffic | quote }}
+{{- end }}
+{{- if .Values.datadog.dogstatsd.originDetection }}
+- name: DD_DOGSTATSD_ORIGIN_DETECTION
+  value: {{ .Values.datadog.dogstatsd.originDetection | quote }}
+- name: DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT
+  value: {{ .Values.datadog.dogstatsd.originDetection | quote }}
+{{- end }}
+{{- if .Values.datadog.originDetectionUnified.enabled }}
+- name: DD_ORIGIN_DETECTION_UNIFIED
+  value: {{ .Values.datadog.originDetectionUnified.enabled | quote }}
+{{- end }}
+{{- if .Values.datadog.dogstatsd.tagCardinality }}
+- name: DD_DOGSTATSD_TAG_CARDINALITY
+  value: {{ .Values.datadog.dogstatsd.tagCardinality | quote }}
+{{- end }}
+{{- if .Values.datadog.dogstatsd.tags }}
+- name: DD_DOGSTATSD_TAGS
+  value: {{ tpl (.Values.datadog.dogstatsd.tags | join " " | quote) . }}
+{{- end }}
+{{- if and (eq .Values.targetSystem "linux") (not .Values.providers.gke.gdc) }}
+- name: DD_DOGSTATSD_SOCKET
+  value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -133,6 +133,17 @@ false
 {{- end -}}
 
 {{/*
+Return true if Agent Data Plane needs to be deployed
+*/}}
+{{- define "should-enable-agent-data-plane" -}}
+{{- if and .Values.datadog.agentDataPlane.enabled  (not .Values.providers.gke.gdc) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return true if k8sattributes RBAC rules should be added to the OTel Agent ClusterRole
 */}}
 {{- define "should-add-otel-agent-k8sattributes-rules" -}}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -140,6 +140,9 @@ spec:
         {{- if eq (include "should-enable-otel-agent" .) "true" }}
           {{- include "container-otel-agent" . | nindent 6 }}
         {{- end }}
+        {{- if eq (include "should-enable-agent-data-plane" .) "true" }}
+          {{- include "container-agent-data-plane" . | nindent 6 }}
+        {{- end }}
       initContainers:
         {{- if eq .Values.targetSystem "windows" }}
           {{ include "containers-init-windows" . | nindent 6 }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1112,6 +1112,32 @@ datadog:
     # datadog.containerLifecycle.enabled -- Enable container lifecycle events collection
     enabled: true
 
+  ## Agent Data Plane is currently in preview. Please reach out to your Datadog representative for more information.
+  agentDataPlane:
+    # datadog.agentDataPlane.enabled -- Whether or not Agent Data Plane is enabled
+    enabled: false
+
+    image:
+      # datadog.agentDataPlane.image.name -- Datadog Agent image name to use (relative to `registry`)
+      name: agent-data-plane
+
+      # datadog.agentDataPlane.image.tag -- Define the Agent version to use
+      tag: 0.1.8
+
+      # datadog.agentDataPlane.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
+      digest: ""
+
+      # datadog.agentDataPlane.image.repository -- Override default registry + image.name for Agent
+      repository:
+
+      # datadog.agentDataPlane.image.pullPolicy -- Datadog Agent image pull policy
+      pullPolicy: IfNotPresent
+
+      # datadog.agentDataPlane.image.pullSecrets -- Datadog Agent repository pullSecret (ex: specify docker registry credentials)
+
+      ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+      pullSecrets: []
+
 ## This is the Datadog Cluster Agent implementation that handles cluster-wide
 ## metrics more cleanly, separates concerns for better rbac, and implements
 ## the external metrics API so you can autoscale HPAs based on datadog metrics
@@ -2034,6 +2060,59 @@ agents:
 
       # agents.containers.securityAgent.ports -- Allows to specify extra ports (hostPorts for instance) for this container
       ports: []
+
+    agentDataPlane:
+      # agents.containers.agentDataPlane.env -- Additional environment variables for the agent-data-plane container
+      env: []
+
+      # agents.containers.agentDataPlane.envFrom -- Set environment variables specific to agent-data-plane container from configMaps and/or secrets
+      envFrom: []
+      #   - configMapRef:
+      #       name: <CONFIGMAP_NAME>
+      #   - secretRef:
+      #       name: <SECRET_NAME>
+
+      # agents.containers.agentDataPlane.envDict -- Set environment variables specific to agent-data-plane container defined in a dict
+      envDict: {}
+      #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
+
+      # agents.containers.agentDataPlane.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
+      # If not set, fall back to the value of datadog.logLevel.
+      logLevel:  # INFO
+
+      # agents.containers.agentDataPlane.resources -- Resource requests and limits for the agent-data-plane container
+      resources: {}
+      #  requests:
+      #    cpu: 100m
+      #    memory: 200Mi
+      #  limits:
+      #    cpu: 100m
+      #    memory: 200Mi
+
+      # agents.containers.agentDataPlane.unprivilegedApiPort -- Port for unprivileged API server, used primarily for health checks
+      unprivilegedApiPort: 5100
+
+      # agents.containers.agentDataPlane.privilegedApiPort -- Port for privileged API server, used for lower-level operations that
+      # can alter the state of the ADP process or expose internal information
+      privilegedApiPort: 5101
+
+      # agents.containers.agentDataPlane.livenessProbe -- Override default agent-data-plane liveness probe settings
+      # @default -- Every 5s / 12 KO / 1 OK
+      livenessProbe:
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+        successThreshold: 1
+        failureThreshold: 12
+
+      # agents.containers.agentDataPlane.readinessProbe -- Override default agent-data-plane readiness probe settings
+      # @default -- Every 5s / 12 KO / 1 OK
+      readinessProbe:
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+        successThreshold: 1
+        failureThreshold: 12
 
     initContainers:
       # agents.containers.initContainers.resources -- Resource requests and limits for the init containers

--- a/test/datadog/baseline/manifests/adp_enabled.yaml
+++ b/test/datadog/baseline/manifests/adp_enabled.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-  name: datadog-agent
+  name: datadog
   namespace: datadog-agent
 ---
 apiVersion: v1
@@ -98,7 +98,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-  name: datadog-agent-installinfo
+  name: datadog-installinfo
   namespace: datadog-agent
 ---
 apiVersion: v1
@@ -488,13 +488,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - ""
-    resources:
       - endpoints
     verbs:
       - get
@@ -573,7 +566,7 @@ roleRef:
   name: datadog
 subjects:
   - kind: ServiceAccount
-    name: datadog-agent
+    name: datadog
     namespace: datadog-agent
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -733,7 +726,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    env.datadoghq.com/kind: gke-autopilot
   name: datadog
   namespace: datadog-agent
 spec:
@@ -743,8 +735,7 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations:
-        autopilot.gke.io/no-connect: "true"
+      annotations: {}
       labels:
         admission.datadoghq.com/enabled: "false"
         app: datadog
@@ -752,7 +743,6 @@ spec:
         app.kubernetes.io/instance: datadog
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: datadog
-        env.datadoghq.com/kind: gke-autopilot
       name: datadog
     spec:
       affinity: {}
@@ -769,10 +759,10 @@ spec:
                   name: datadog-secret
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
-            - name: DD_CLOUD_PROVIDER_METADATA
-              value: '["gcp"]'
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -782,13 +772,9 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: DD_KUBELET_USE_API_SERVER
-              value: "true"
-            - name: HELM_FORCE_RENDER
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-            - name: DD_PROVIDER_KIND
-              value: gke-autopilot
             - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
               value: "false"
             - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
@@ -798,17 +784,11 @@ spec:
             - name: DD_STRIP_PROCESS_ARGS
               value: "false"
             - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-            - name: DD_DOGSTATSD_PORT
-              value: "8125"
-            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
-              value: "true"
-            - name: DD_DOGSTATSD_TAG_CARDINALITY
-              value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
+            - name: DD_USE_DOGSTATSD
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -819,7 +799,28 @@ spec:
                   key: token
                   name: datadog-cluster-agent
             - name: DD_APM_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  key: install_time
+                  name: datadog-kpi-telemetry-configmap
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: install_id
+                  name: datadog-kpi-telemetry-configmap
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  key: install_type
+                  name: datadog-kpi-telemetry-configmap
             - name: DD_LOGS_ENABLED
               value: "false"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -846,8 +847,8 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-            - name: DD_SYSTEM_PROBE_ENABLED
-              value: "false"
+            - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
+              value: /var/lib/kubelet/pod-resources/kubelet.sock
           image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -861,10 +862,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
           name: agent
-          ports:
-            - containerPort: 8125
-              name: dogstatsdport
-              protocol: UDP
+          ports: null
           readinessProbe:
             failureThreshold: 6
             httpGet:
@@ -875,13 +873,17 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
-          resources:
-            limits:
-              cpu: 200m
-              memory: 256Mi
-            requests:
-              cpu: 200m
-              memory: 256Mi
+          resources: {}
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
           volumeMounts:
             - mountPath: /var/log/datadog
               name: logdatadog
@@ -893,10 +895,16 @@ spec:
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
+            - mountPath: /host/etc/os-release
+              name: os-release-file
+              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
-            - mountPath: /host/var/run/containerd
+            - mountPath: /etc/datadog-agent/auth
+              name: auth-token
+              readOnly: false
+            - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
@@ -911,8 +919,11 @@ spec:
               mountPropagation: None
               name: cgroups
               readOnly: true
+            - mountPath: /etc/passwd
+              name: passwd
+              readOnly: true
         - command:
-            - process-agent
+            - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
           env:
             - name: DD_API_KEY
@@ -922,10 +933,10 @@ spec:
                   name: datadog-secret
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
-            - name: DD_CLOUD_PROVIDER_METADATA
-              value: '["gcp"]'
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -935,13 +946,9 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: DD_KUBELET_USE_API_SERVER
-              value: "true"
-            - name: HELM_FORCE_RENDER
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-            - name: DD_PROVIDER_KIND
-              value: gke-autopilot
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -951,34 +958,47 @@ spec:
                 secretKeyRef:
                   key: token
                   name: datadog-cluster-agent
-            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
-              value: "false"
-            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
-              value: "true"
-            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
-              value: "true"
-            - name: DD_STRIP_PROCESS_ARGS
-              value: "false"
-            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
-              value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-            - name: DD_SYSTEM_PROBE_ENABLED
-              value: "false"
+            - name: DD_APM_ENABLED
+              value: "true"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_APM_RECEIVER_PORT
+              value: "8126"
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-              value: "true"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  key: install_time
+                  name: datadog-kpi-telemetry-configmap
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: install_id
+                  name: datadog-kpi-telemetry-configmap
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  key: install_type
+                  name: datadog-kpi-telemetry-configmap
           image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
-          name: process-agent
-          resources:
-            limits:
-              cpu: 100m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 200Mi
+          livenessProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            tcpSocket:
+              port: 8126
+            timeoutSeconds: 5
+          name: trace-agent
+          ports:
+            - containerPort: 8126
+              name: traceport
+              protocol: TCP
+          resources: {}
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
@@ -986,24 +1006,123 @@ spec:
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
-            - mountPath: /tmp
-              name: tmpdir
-              readOnly: false
-            - mountPath: /host/var/run/containerd
-              mountPropagation: None
-              name: runtimesocketdir
-              readOnly: true
-            - mountPath: /host/sys/fs/cgroup
-              mountPropagation: None
-              name: cgroups
-              readOnly: true
-            - mountPath: /etc/passwd
-              name: passwd
+            - mountPath: /etc/datadog-agent/auth
+              name: auth-token
               readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
               readOnly: true
+            - mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              name: cgroups
+              readOnly: true
+            - mountPath: /tmp
+              name: tmpdir
+              readOnly: false
+            - mountPath: /var/run/datadog
+              name: dsdsocket
+              readOnly: false
+            - mountPath: /host/var/run
+              mountPropagation: None
+              name: runtimesocketdir
+              readOnly: true
+        - command:
+            - agent-data-plane
+            - run
+            - --config=/etc/datadog-agent/datadog.yaml
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: datadog-secret
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_KUBELET_USE_API_SERVER
+              value: "false"
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_DOGSTATSD_TAG_CARDINALITY
+              value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
+            - name: DD_LOG_LEVEL
+              value: INFO
+            - name: DD_API_LISTEN_ADDRESS
+              value: tcp://0.0.0.0:5100
+            - name: DD_SECURE_API_LISTEN_ADDRESS
+              value: tcp://0.0.0.0:5101
+          image: gcr.io/datadoghq/agent-data-plane:0.1.8
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 12
+            httpGet:
+              path: /live
+              port: 5100
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: agent-data-plane
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
+          readinessProbe:
+            failureThreshold: 12
+            httpGet:
+              path: /ready
+              port: 5100
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmpdir
+              readOnly: false
+            - mountPath: /etc/datadog-agent
+              name: config
+              readOnly: false
+            - mountPath: /etc/datadog-agent/auth
+              name: auth-token
+              readOnly: false
+            - mountPath: /host/var/run
+              mountPropagation: None
+              name: runtimesocketdir
+              readOnly: true
+            - mountPath: /var/run/datadog
+              name: dsdsocket
+              readOnly: false
+            - mountPath: /host/proc
+              mountPropagation: None
+              name: procdir
+              readOnly: true
+            - mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              name: cgroups
+              readOnly: true
+      hostPID: true
       initContainers:
         - args:
             - cp -r /etc/datadog-agent /opt
@@ -1013,13 +1132,7 @@ spec:
           image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
-          resources:
-            limits:
-              cpu: 100m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 200Mi
+          resources: {}
           volumeMounts:
             - mountPath: /opt/datadog-agent
               name: config
@@ -1037,10 +1150,10 @@ spec:
                   name: datadog-secret
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
             - name: KUBERNETES
               value: "yes"
-            - name: DD_CLOUD_PROVIDER_METADATA
-              value: '["gcp"]'
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -1050,23 +1163,13 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: DD_KUBELET_USE_API_SERVER
-              value: "true"
-            - name: HELM_FORCE_RENDER
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-            - name: DD_PROVIDER_KIND
-              value: gke-autopilot
           image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-config
-          resources:
-            limits:
-              cpu: 100m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 200Mi
+          resources: {}
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
@@ -1078,7 +1181,7 @@ spec:
               mountPropagation: None
               name: procdir
               readOnly: true
-            - mountPath: /host/var/run/containerd
+            - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
@@ -1086,11 +1189,13 @@ spec:
         kubernetes.io/os: linux
       securityContext:
         runAsUser: 0
-      serviceAccountName: datadog-agent
+      serviceAccountName: datadog
       tolerations: null
       volumes:
+        - emptyDir: {}
+          name: auth-token
         - configMap:
-            name: datadog-agent-installinfo
+            name: datadog-installinfo
           name: installinfo
         - emptyDir: {}
           name: config
@@ -1106,13 +1211,22 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - emptyDir: {}
+        - hostPath:
+            path: /etc/os-release
+          name: os-release-file
+        - hostPath:
+            path: /var/run/datadog/
+            type: DirectoryOrCreate
           name: dsdsocket
+        - hostPath:
+            path: /var/run/datadog/
+            type: DirectoryOrCreate
+          name: apmsocket
         - hostPath:
             path: /etc/passwd
           name: passwd
         - hostPath:
-            path: /var/run/containerd
+            path: /var/run
           name: runtimesocketdir
   updateStrategy:
     rollingUpdate:
@@ -1128,7 +1242,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
-    env.datadoghq.com/kind: gke-autopilot
   name: datadog-cluster-agent
   namespace: datadog-agent
 spec:
@@ -1152,7 +1265,6 @@ spec:
         app.kubernetes.io/instance: datadog
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: datadog
-        env.datadoghq.com/kind: gke-autopilot
       name: datadog-cluster-agent
     spec:
       affinity:
@@ -1185,8 +1297,6 @@ spec:
                   optional: true
             - name: KUBERNETES
               value: "yes"
-            - name: DD_CLOUD_PROVIDER_METADATA
-              value: '["gcp"]'
             - name: DD_LANGUAGE_DETECTION_ENABLED
               value: "false"
             - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
@@ -1204,7 +1314,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
               value: datadog-cluster-agent-admission-controller
             - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_MODE
-              value: hostip
+              value: socket
             - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_LOCAL_SERVICE_NAME
               value: datadog
             - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
@@ -1308,13 +1418,7 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
-          resources:
-            limits:
-              cpu: 200m
-              memory: 256Mi
-            requests:
-              cpu: 200m
-              memory: 256Mi
+          resources: {}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -1357,13 +1461,6 @@ spec:
           image: gcr.io/datadoghq/cluster-agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: init-volume
-          resources:
-            limits:
-              cpu: 100m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 200Mi
           volumeMounts:
             - mountPath: /opt/datadog-agent
               name: config
@@ -1378,7 +1475,7 @@ spec:
         - emptyDir: {}
           name: tmpdir
         - configMap:
-            name: datadog-agent-installinfo
+            name: datadog-installinfo
           name: installinfo
         - configMap:
             items:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -828,6 +828,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -870,8 +872,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -793,6 +793,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -835,8 +837,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -793,6 +793,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -835,8 +837,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -835,6 +835,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -856,8 +858,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1051,6 +1051,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1072,8 +1074,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1051,6 +1051,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1072,8 +1074,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1051,6 +1051,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1072,8 +1074,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -835,6 +835,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -856,8 +858,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1042,6 +1042,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1084,8 +1086,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -869,6 +869,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -911,8 +913,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -805,6 +805,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -847,8 +849,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -865,6 +865,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -907,8 +909,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -828,6 +828,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -870,8 +872,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -865,6 +865,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -907,8 +909,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -865,6 +865,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -907,8 +909,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -793,6 +793,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -835,8 +837,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1042,6 +1042,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1084,8 +1086,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1042,6 +1042,8 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
+            - name: DD_DOGSTATSD_SOCKET
+              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1084,8 +1086,6 @@ spec:
               value: "false"
             - name: DD_HEALTH_PORT
               value: "5555"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: clusterchecks endpointschecks
             - name: DD_IGNORE_AUTOCONF
@@ -1431,8 +1431,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/values/adp_enabled.yaml
+++ b/test/datadog/baseline/values/adp_enabled.yaml
@@ -1,0 +1,6 @@
+datadog:
+  apiKeyExistingSecret: datadog-secret
+  appKeyExistingSecret: datadog-secret
+
+  agentDataPlane:
+    enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for Agent Data Plane to the `datadog` chart. This will allow customers to begin experimenting with running Agent Data Plane in their own infrastructure.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
