### PR TITLE
[ACTP-695] Make PAR Helm chart configurable to limit runner resources

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.1.2
+
+* Add customizable resource limits and requests for the private action runner container
+
 ## 1.1.1
 
 * Bump runner version to `v1.3.0`

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: "v1.3.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 ## Overview
 
@@ -255,5 +255,8 @@ If actions requiring credentials fail:
 | runner.kubernetesActions.statefulSets | list | `[]` | Actions related to statefulSets (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runner.kubernetesPermissions | list | `[]` | Kubernetes permissions to provide in addition to the one that will be inferred from `kubernetesActions` (useful for customObjects) |
 | runner.replicas | int | `1` | Number of pod instances for the Datadog Private Action Runner |
+| runner.resources | object | `{"limits":{"cpu":"250m","memory":"1Gi"},"requests":{"cpu":"250m","memory":"1Gi"}}` | Resource requirements for the Datadog Private Action Runner container |
+| runner.resources.limits | object | `{"cpu":"250m","memory":"1Gi"}` | Resource limits for the runner container |
+| runner.resources.requests | object | `{"cpu":"250m","memory":"1Gi"}` | Resource requests for the runner container |
 | runner.roleType | string | `"Role"` | Type of kubernetes role to create (either "Role" or "ClusterRole") |
 | runner.runnerIdentitySecret | string | `""` | Reference to a kubernetes secrets that contains the runner identity |

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -27,12 +27,7 @@ spec:
             - name: http
               containerPort: 9016
           resources:
-            limits:
-              cpu: 250m
-              memory: 1Gi
-            requests:
-              cpu: 250m
-              memory: 1Gi
+            {{- toYaml $.Values.runner.resources | nindent 12 }}
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -267,6 +267,42 @@
             "type": "object"
           }
         },
+        "resources": {
+          "type": "object",
+          "description": "Resource requirements for the Datadog Private Action Runner container",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "description": "Resource limits for the runner container",
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "description": "CPU limit for the runner container"
+                },
+                "memory": {
+                  "type": "string",
+                  "description": "Memory limit for the runner container"
+                }
+              },
+              "additionalProperties": false
+            },
+            "requests": {
+              "type": "object",
+              "description": "Resource requests for the runner container",
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "description": "CPU request for the runner container"
+                },
+                "memory": {
+                  "type": "string",
+                  "description": "Memory request for the runner container"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
         "credentialFiles": {
           "type": "array",
           "description": "List of credential files to be used by the Datadog Private Action Runner",

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -90,7 +90,16 @@ runner:
     customObjects: []
   # -- Kubernetes permissions to provide in addition to the one that will be inferred from `kubernetesActions` (useful for customObjects)
   kubernetesPermissions: []
-
+  # -- Resource requirements for the Datadog Private Action Runner container
+  resources:
+    # -- Resource limits for the runner container
+    limits:
+      cpu: 250m
+      memory: 1Gi
+    # -- Resource requests for the runner container
+    requests:
+      cpu: 250m
+      memory: 1Gi
   # -- List of credential files to be used by the Datadog Private Action Runner
   credentialFiles: []
   # see examples/values.yaml for examples on how to specify secrets

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -77,7 +77,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.1.1
+    helm.sh/chart: private-action-runner-1.1.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.3.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.1.1
+        helm.sh/chart: private-action-runner-1.1.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.3.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 7be6af7ae3c2d8f09e8216a19df37b8ff64cddd22cd37a4492c5159d6f665833
+        checksum/values: 682dbfc13e707fe2f2f2268f2c96f14e9f8d6c33fdacf72351c89ce729ec7ec9
     spec:
       serviceAccountName: custom-full-name
       containers:

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -3,14 +3,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubernetes-test-private-action-runner
+  name: resources-test-private-action-runner
   namespace: datadog-agent
 ---
 # Source: private-action-runner/templates/secrets.yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kubernetes-test-private-action-runner
+  name: resources-test-private-action-runner
   namespace: datadog-agent
 stringData:
   config.yaml: |
@@ -22,60 +22,16 @@ stringData:
       - appBuilder
     port: 9016
     actionsAllowlist:
-      - com.datadoghq.kubernetes.apps.getControllerRevision
-      - com.datadoghq.kubernetes.apps.listControllerRevision
-      - com.datadoghq.kubernetes.apps.createControllerRevision
-      - com.datadoghq.kubernetes.apps.updateControllerRevision
-      - com.datadoghq.kubernetes.apps.patchControllerRevision
-      - com.datadoghq.kubernetes.apps.deleteControllerRevision
-      - com.datadoghq.kubernetes.apps.deleteMultipleControllerRevisions
-      - com.datadoghq.kubernetes.apps.restartDeployment
-      - com.datadoghq.kubernetes.core.patchEndpoints
       - com.datadoghq.kubernetes.core.getPod
       - com.datadoghq.kubernetes.core.listPod
-      - com.datadoghq.kubernetes.customresources.deleteMultipleCustomObjects
 ---
 # Source: private-action-runner/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   namespace: datadog-agent
-  name: kubernetes-test-private-action-runner
+  name: resources-test-private-action-runner
 rules:
-- apiGroups:
-  - example.com
-  resources:
-  - tests
-  verbs:
-  - list
-  - get
-  - create
-  - patch
-  - update
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - controllerrevisions
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - patch
 - apiGroups:
   - ""
   resources:
@@ -86,29 +42,29 @@ rules:
 ---
 # Source: private-action-runner/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: kubernetes-test-private-action-runner
+  name: resources-test-private-action-runner
   namespace: datadog-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubernetes-test-private-action-runner
+  kind: Role
+  name: resources-test-private-action-runner
 subjects:
   - kind: ServiceAccount
-    name: kubernetes-test-private-action-runner
+    name: resources-test-private-action-runner
     namespace: datadog-agent
 ---
 # Source: private-action-runner/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: kubernetes-test-private-action-runner
+  name: resources-test-private-action-runner
   namespace: datadog-agent
 spec:
   selector:
       app.kubernetes.io/name: private-action-runner
-      app.kubernetes.io/instance: kubernetes-test
+      app.kubernetes.io/instance: resources-test
   ports:
     - name: http
       port: 9016
@@ -118,12 +74,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kubernetes-test-private-action-runner
+  name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
     helm.sh/chart: private-action-runner-1.1.2
     app.kubernetes.io/name: private-action-runner
-    app.kubernetes.io/instance: kubernetes-test
+    app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.3.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -132,19 +88,19 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: private-action-runner
-      app.kubernetes.io/instance: kubernetes-test
+      app.kubernetes.io/instance: resources-test
   template:
     metadata:
       labels:
         helm.sh/chart: private-action-runner-1.1.2
         app.kubernetes.io/name: private-action-runner
-        app.kubernetes.io/instance: kubernetes-test
+        app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.3.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: bc9653cc3fcc293b677fb19450d6d14ab5a8fa5288f8f605a457f57ffa8d876e
+        checksum/values: ac8a95d8feb0ebf0c9638eda2b0071685c4429327d4242172750e28f75f325a8
     spec:
-      serviceAccountName: kubernetes-test-private-action-runner
+      serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
           image: "gcr.io/datadoghq/private-action-runner:v1.3.0"
@@ -154,15 +110,15 @@ spec:
               containerPort: 9016
           resources:
             limits:
-              cpu: 250m
-              memory: 1Gi
+              cpu: 500m
+              memory: 2Gi
             requests:
-              cpu: 250m
-              memory: 1Gi
+              cpu: 100m
+              memory: 512Mi
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner
       volumes:
         - name: secrets
           secret:
-            secretName: kubernetes-test-private-action-runner
+            secretName: resources-test-private-action-runner

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,7 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.1.1
+    helm.sh/chart: private-action-runner-1.1.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.3.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.1.1
+        helm.sh/chart: private-action-runner-1.1.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.3.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 5eb8fd79b8c1216b814f519cc52b635621aa4db89f6a66240b5975f67a8fab6c
+        checksum/values: 1286a3dfad299cbac32f8547f200b367377da827659e341b809a72d6592dd41d
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,7 +211,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.1.1
+    helm.sh/chart: private-action-runner-1.1.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.3.0"
@@ -226,13 +226,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.1.1
+        helm.sh/chart: private-action-runner-1.1.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.3.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: edb14a6af08eb644f379510028ca0694bb17cf2d4d85a29fe3647fb305fc8fd4
+        checksum/values: fb688436760d2258344d27e977bfbba94c6342defab873e029bf9e8019612cf0
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,7 +75,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.1.1
+    helm.sh/chart: private-action-runner-1.1.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.3.0"
@@ -90,13 +90,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.1.1
+        helm.sh/chart: private-action-runner-1.1.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.3.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 64e39cc3a57c24e6af7c4bae85c7b1e2803401d310b9fc2e2900e000a7cefd52
+        checksum/values: 24e13ea746d7c0e7f4d0600dff5e4cf4aae33bc85dfa9741d45d15dab67f026c
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:

--- a/test/private-action-runner/baseline_test.go
+++ b/test/private-action-runner/baseline_test.go
@@ -1,8 +1,9 @@
 package private_action_runner
 
 import (
-	"github.com/gruntwork-io/terratest/modules/helm"
 	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
 
 	"github.com/DataDog/helm-charts/test/common"
 	"github.com/stretchr/testify/assert"
@@ -84,6 +85,22 @@ func Test_baseline_manifests(t *testing.T) {
 				},
 			},
 			snapshotName: "external-secrets",
+			assertions:   verifyPrivateActionRunner,
+		},
+		{
+			name: "Custom resource requirements",
+			command: common.HelmCommand{
+				ReleaseName: "resources-test",
+				ChartPath:   "../../charts/private-action-runner",
+				Values:      []string{"../../charts/private-action-runner/values.yaml"},
+				OverridesJson: map[string]string{
+					"runner.resources.limits.cpu":      `"500m"`,
+					"runner.resources.limits.memory":   `"2Gi"`,
+					"runner.resources.requests.cpu":    `"100m"`,
+					"runner.resources.requests.memory": `"512Mi"`,
+				},
+			},
+			snapshotName: "custom-resources",
 			assertions:   verifyPrivateActionRunner,
 		},
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support for configurable resource limits and requests in the private-action-runner Helm chart. This allows users to set custom CPU and memory requirements based on their environment needs. Previously, these values were hardcoded in the deployment template.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
This change maintains backward compatibility by keeping the default resource values the same as the previously hardcoded values (CPU: 250m, Memory: 1Gi).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
