### PR TITLE
Obs Pipelines: Enable API, add liveness and readiness probes

### DIFF
--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -32,10 +32,11 @@ datadog:
   dataDir: "/var/lib/observability-pipelines-worker"
   workerAPI:
     # datadog.workerAPI.enabled -- Whether to enable the Worker's API.
-    enabled: false
+    enabled: true
     # datadog.workerAPI.playground -- Whether to enable the Worker's API GraphQL playground.
-    playground: true
+    playground: false
     # datadog.workerAPI.address -- Local address to bind the Worker's API to.
+    # if you change this port, you'll need to update the livenessProbe and readinessProbe
     address: "127.0.0.1:8686"
 
 image:
@@ -301,8 +302,28 @@ dnsConfig: {}
 
 # livenessProbe -- Specify the livenessProbe
 # [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).
-livenessProbe: {}
+livenessProbe:
+  failureThreshold: 5
+  httpGet:
+    path: /health
+    # if you modify datadog.workerAPI.address to a different port you'll need to update here as well
+    port: 8686
+    scheme: HTTP
+  initialDelaySeconds: 15
+  timeoutSeconds: 15
+  periodSeconds: 10
+  successThreshold: 1
 
 # readinessProbe -- Specify the readinessProbe
 # [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).
-readinessProbe: {}
+readinessProbe:
+  failureThreshold: 3
+  httpGet:
+    path: /health
+    # if you modify datadog.workerAPI.address to a different port you'll need to update here as well
+    port: 8686
+    scheme: HTTP
+  initialDelaySeconds: 15
+  timeoutSeconds: 15
+  periodSeconds: 10
+  successThreshold: 1


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds liveness and readiness probes to Observability Pipelines helm chart.
Customers have asked why we don't have liveness and readiness probes for OP in k8s.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
