### PR TITLE
[ACTP] add support for kubernetes deployments actions

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.2.0
+
+* Add support for kubernetes scaleDeployment and rollbackDeployment actions
+
 ## 1.1.2
 
 * Add customizable resource limits and requests for the private action runner container

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.1.2
+version: 1.2.0
 appVersion: "v1.3.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 ## Overview
 
@@ -236,7 +236,7 @@ If actions requiring credentials fail:
 | runner.kubernetesActions.customObjects | list | `[]` | Actions related to customObjects (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple"). You also need to add appropriate `kubernetesPermissions`. |
 | runner.kubernetesActions.customResourceDefinitions | list | `[]` | Actions related to customResourceDefinitions (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runner.kubernetesActions.daemonSets | list | `[]` | Actions related to daemonSets (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
-| runner.kubernetesActions.deployments | list | `[]` | Actions related to deployments (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple", "restart") |
+| runner.kubernetesActions.deployments | list | `[]` | Actions related to deployments (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple", "restart", "rollback", "scale") |
 | runner.kubernetesActions.endpoints | list | `[]` | Actions related to endpoints (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runner.kubernetesActions.events | list | `[]` | Actions related to events (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runner.kubernetesActions.jobs | list | `[]` | Actions related to jobs (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -24,7 +24,7 @@ runner:
   kubernetesActions:
     controllerRevisions: [] # select your actions among ["get", "list", "create", "update", "patch", "delete", "deleteMultiple"]
     daemonSets: [] # select your actions among ["get", "list", "create", "update", "patch", "delete", "deleteMultiple"]
-    deployments: [] # select your actions among ["get", "list", "create", "update", "patch", "delete", "deleteMultiple", "restart"]
+    deployments: [] # select your actions among ["get", "list", "create", "update", "patch", "delete", "deleteMultiple", "restart", "rollback", "scale"]
     replicaSets: [] # select your actions among ["get", "list", "create", "update", "patch", "delete", "deleteMultiple"]
     statefulSets: [] # select your actions among ["get", "list", "create", "update", "patch", "delete", "deleteMultiple"]
     cronJobs: [] # select your actions among ["get", "list", "create", "update", "patch", "delete", "deleteMultiple"]

--- a/charts/private-action-runner/templates/_helpers.tpl
+++ b/charts/private-action-runner/templates/_helpers.tpl
@@ -152,3 +152,12 @@ Transform a list of actions into the list of k8s verbs that are required to perf
 {{- end -}}
 {{- $allVerbs | toJson -}}
 {{- end -}}
+
+{{/*
+Generates additional RBAC rules for special cases.
+*/}}
+{{- define "chart.additionalK8sPermissions" -}}
+  {{- if and (eq .verb "rollback") (eq .resource "deployment") }}
+    {{- include "rbacRule" (dict "apiGroup" "apps" "resource" "replicasets" "verbs" (list "list")) }}
+  {{- end }}
+{{- end }}

--- a/charts/private-action-runner/templates/_helpers.tpl
+++ b/charts/private-action-runner/templates/_helpers.tpl
@@ -142,6 +142,10 @@ Transform a list of actions into the list of k8s verbs that are required to perf
     {{- $allVerbs = concat $allVerbs (list "delete" "list") -}}
   {{- else if eq $action "restart" -}}
     {{- $allVerbs = append $allVerbs "patch" -}}
+  {{- else if eq $action "rollback" -}}
+    {{- $allVerbs = concat $allVerbs (list "get" "patch") -}}
+  {{- else if eq $action "scale" -}}
+    {{- $allVerbs = append $allVerbs "patch" -}}
   {{- else -}}
     {{- $allVerbs = append $allVerbs $action -}}
   {{- end -}}

--- a/charts/private-action-runner/templates/role.yaml
+++ b/charts/private-action-runner/templates/role.yaml
@@ -13,4 +13,9 @@ rules:
         {{- include "rbacRule" (dict "apiGroup" (include "chart.k8sApiGroup" $bundle) "resource" (lower $resourceType) "verbs"  (fromJsonArray (include "chart.k8sVerbs" (index $.Values.runner.kubernetesActions $resourceType))))}}
     {{- end }}
   {{- end }}
+  {{- range $resourceType, $verbs := .Values.runner.kubernetesActions }}
+    {{- range $i, $verb := $verbs }}
+      {{- include "chart.additionalK8sPermissions" (dict "resource" (include "chart.k8sResourceSingular" $resourceType) "verb" $verb) }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -113,7 +113,7 @@
             },
             "deployments": {
               "type": "array",
-              "description": "Actions related to deployments (options: get, list, create, update, patch, delete, deleteMultiple, restart)",
+              "description": "Actions related to deployments (options: get, list, create, update, patch, delete, deleteMultiple, restart, rollback, scale)",
               "items": {
                 "type": "string"
               }

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -46,7 +46,7 @@ runner:
     controllerRevisions: []
     # -- Actions related to daemonSets (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple")
     daemonSets: []
-    # -- Actions related to deployments (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple", "restart")
+    # -- Actions related to deployments (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple", "restart", "rollback", "scale")
     deployments: []
     # -- Actions related to replicaSets (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple")
     replicaSets: []

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -77,7 +77,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.1.2
+    helm.sh/chart: private-action-runner-1.2.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.3.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.1.2
+        helm.sh/chart: private-action-runner-1.2.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.3.0"

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.1.2
+    helm.sh/chart: private-action-runner-1.2.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.3.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.1.2
+        helm.sh/chart: private-action-runner-1.2.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.3.0"

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,7 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.1.2
+    helm.sh/chart: private-action-runner-1.2.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.3.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.1.2
+        helm.sh/chart: private-action-runner-1.2.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.3.0"

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -86,6 +86,12 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - list
 ---
 # Source: private-action-runner/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -30,6 +30,8 @@ stringData:
       - com.datadoghq.kubernetes.apps.deleteControllerRevision
       - com.datadoghq.kubernetes.apps.deleteMultipleControllerRevisions
       - com.datadoghq.kubernetes.apps.restartDeployment
+      - com.datadoghq.kubernetes.apps.rollbackDeployment
+      - com.datadoghq.kubernetes.apps.scaleDeployment
       - com.datadoghq.kubernetes.core.patchEndpoints
       - com.datadoghq.kubernetes.core.getPod
       - com.datadoghq.kubernetes.core.listPod
@@ -70,6 +72,7 @@ rules:
   - deployments
   verbs:
   - patch
+  - get
 - apiGroups:
   - ""
   resources:
@@ -121,7 +124,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.1.2
+    helm.sh/chart: private-action-runner-1.2.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.3.0"
@@ -136,13 +139,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.1.2
+        helm.sh/chart: private-action-runner-1.2.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.3.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: bc9653cc3fcc293b677fb19450d6d14ab5a8fa5288f8f605a457f57ffa8d876e
+        checksum/values: 5901f670e03cd3023bf5efe0089c9551aaa54f7cdf6c537a0db1f73968573733
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,7 +211,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.1.2
+    helm.sh/chart: private-action-runner-1.2.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.3.0"
@@ -226,7 +226,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.1.2
+        helm.sh/chart: private-action-runner-1.2.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.3.0"

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,7 +75,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.1.2
+    helm.sh/chart: private-action-runner-1.2.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.3.0"
@@ -90,7 +90,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.1.2
+        helm.sh/chart: private-action-runner-1.2.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.3.0"

--- a/test/private-action-runner/baseline_test.go
+++ b/test/private-action-runner/baseline_test.go
@@ -47,7 +47,7 @@ func Test_baseline_manifests(t *testing.T) {
 					"runner.roleType": `"ClusterRole"`,
 					"runner.kubernetesActions.controllerRevisions": `["get","list","create","update","patch","delete","deleteMultiple"]`,
 					"runner.kubernetesActions.customObjects":       `["deleteMultiple"]`,
-					"runner.kubernetesActions.deployments":         `["restart"]`,
+					"runner.kubernetesActions.deployments":         `["restart", "rollback", "scale"]`,
 					"runner.kubernetesActions.endpoints":           `["patch"]`,
 					"runner.kubernetesPermissions[0].apiGroups":    `["example.com"]`,
 					"runner.kubernetesPermissions[0].resources":    `["tests"]`,


### PR DESCRIPTION
#### What this PR does / why we need it:

Add new kubernetes deployment actions support in the helm chart


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
