### PR TITLE
Add default resource limits for system-probe on gke autopilot

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.117.1
+
+* Add default resource limits for system-probe container on GKE Autopilot
+
 ## 3.117.0
 
 * Add support for Agent Data Plane.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.117.0
+version: 3.117.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.117.0](https://img.shields.io/badge/Version-3.117.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.117.1](https://img.shields.io/badge/Version-3.117.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-resources.yaml
+++ b/charts/datadog/templates/_container-resources.yaml
@@ -7,6 +7,15 @@ limits:
   memory: 256Mi
 {{- end }}
 
+{{- define "default-system-probe-container-resources" }}
+requests:
+  cpu: 100m
+  memory: 400Mi
+limits:
+  cpu: 100m
+  memory: 400Mi
+{{- end }}
+
 {{- define "default-container-resources" }}
 requests:
   cpu: 100m

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -33,7 +33,11 @@
     {{- include "additional-env-entries" .Values.agents.containers.systemProbe.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.systemProbe.envDict | indent 4 }}
   resources:
+{{- if and (empty .Values.agents.containers.systemProbe.resources) .Values.providers.gke.autopilot -}}
+{{ include "default-system-probe-container-resources" . | indent 4 }}
+{{- else }}
 {{ toYaml .Values.agents.containers.systemProbe.resources | indent 4 }}
+{{- end }}
   volumeMounts:
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1315,7 +1315,13 @@ spec:
           image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: system-probe
-          resources: {}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 400Mi
+            requests:
+              cpu: 100m
+              memory: 400Mi
           securityContext:
             appArmorProfile:
               type: Unconfined

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1315,7 +1315,13 @@ spec:
           image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: system-probe
-          resources: {}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 400Mi
+            requests:
+              cpu: 100m
+              memory: 400Mi
           securityContext:
             appArmorProfile:
               type: Unconfined

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1204,7 +1204,13 @@ spec:
           image: gcr.io/datadoghq/agent:7.65.2
           imagePullPolicy: IfNotPresent
           name: system-probe
-          resources: {}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 400Mi
+            requests:
+              cpu: 100m
+              memory: 400Mi
           securityContext:
             appArmorProfile:
               type: Unconfined


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds defaults for resource limits for the system-probe container on GKE Autopilot.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
