### PR TITLE
Enable local fallback when workload autoscaling enabled

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.118.0
+
+* Enable local fallback by default when workload autoscaling is enabled.
+
 ## 3.117.2
 
 * Do not mount `/etc/passwd` from host on `agent` container if running unprivileged to prevent incorrect user running the Agent.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.117.2
+version: 3.118.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.117.2](https://img.shields.io/badge/Version-3.117.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.118.0](https://img.shields.io/badge/Version-3.118.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -237,9 +237,9 @@
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.datadog.autoscaling.workload.enabled }}
+    {{- if (((.Values.datadog.autoscaling).workload).enabled) }}
     - name: DD_AUTOSCALING_FAILOVER_ENABLED
-      value: "true"
+      value: {{ (((.Values.datadog.autoscaling).workload).enabled) | quote }}
     - name: DD_AUTOSCALING_FAILOVER_METRICS
       value: "container.memory.usage container.cpu.usage"
     {{- end }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -237,6 +237,12 @@
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.datadog.autoscaling.workload.enabled }}
+    - name: DD_AUTOSCALING_FAILOVER_ENABLED
+      value: "true"
+    - name: DD_AUTOSCALING_FAILOVER_METRICS
+      value: "container.memory.usage container.cpu.usage"
+    {{- end }}
     {{- include "additional-env-entries" .Values.agents.containers.agent.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.agent.envDict | indent 4 }}
   volumeMounts:

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -397,6 +397,8 @@ spec:
           {{- if (((.Values.datadog.autoscaling).workload).enabled) }}
           - name: DD_AUTOSCALING_WORKLOAD_ENABLED
             value: {{ (((.Values.datadog.autoscaling).workload).enabled) | quote }}
+          - name: DD_AUTOSCALING_FAILOVER_ENABLED
+            value: {{ (((.Values.datadog.autoscaling).workload).enabled) | quote }}
           {{- end }}
           - name: DD_INSTRUMENTATION_INSTALL_TIME
             valueFrom:


### PR DESCRIPTION
#### What this PR does / why we need it:

Ensure local fallback is enabled by default when workload autoscaling is enabled

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
