### PR TITLE
[datadog] add datadog.advancedConfd

### DIFF
--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.117.3
+version: 3.117.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.117.3](https://img.shields.io/badge/Version-3.117.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.117.4](https://img.shields.io/badge/Version-3.117.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -705,6 +705,7 @@ helm install <RELEASE_NAME> \
 | commonLabels | object | `{}` | Labels to apply to all resources |
 | datadog-crds.crds.datadogMetrics | bool | `true` | Set to true to deploy the DatadogMetrics CRD |
 | datadog-crds.crds.datadogPodAutoscalers | bool | `true` | Set to true to deploy the DatadogPodAutoscalers CRD |
+| datadog.advancedConfd | object | `{}` | Provide additional check configurations. Each key is an integration containing several config files. |
 | datadog.agentDataPlane.enabled | bool | `false` | Whether or not Agent Data Plane is enabled |
 | datadog.agentDataPlane.image.digest | string | `""` | Define Agent Data Plane image digest to use, takes precedence over tag if specified |
 | datadog.agentDataPlane.image.name | string | `"agent-data-plane"` | Agent Data Plane image name to use (relative to `registry`) |

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -29,7 +29,7 @@
     - name: config
       mountPath: /etc/datadog-agent
       readOnly: false # Need RW for config path
-    {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
+    {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf) (.Values.datadog.advancedConfd)) }}
     - name: confd
       mountPath: /conf.d
       readOnly: true

--- a/charts/datadog/templates/_containers-init-windows.yaml
+++ b/charts/datadog/templates/_containers-init-windows.yaml
@@ -34,7 +34,7 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
       readOnly: false # Need RW for config path
-    {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
+    {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf) (.Values.datadog.advancedConfd)) }}
     - name: confd
       mountPath: C:/conf.d
       readOnly: true

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -5,10 +5,25 @@
   emptyDir: {}
 - name: s6-run
   emptyDir: {}
-{{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
+{{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf) (.Values.datadog.advancedConfd)) }}
 - name: confd
   configMap:
     name: {{ include "agents.confd-configmap-name" . }}
+    items:
+{{- range $file, $configs := $.Values.datadog.autoconf }}
+      - key: {{ $file | quote }}
+        path: {{ $file | quote }}
+{{- end }}
+{{- range $file, $configs := $.Values.datadog.confd }}
+      - key: {{ $file | quote }}
+        path: {{ $file | quote }}
+{{- end }}
+{{- range $integration, $configs := $.Values.datadog.advancedConfd }}
+{{- range $name, $config := $configs }}
+      - key: {{ printf "%s--%s" $integration $name | quote }}
+        path: {{ printf "%s/%s" $integration $name | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if and (not .Values.providers.gke.gdc) (not .Values.providers.gke.autopilot) .Values.datadog.gpuMonitoring.enabled }}
 - name: pod-resources-socket

--- a/charts/datadog/templates/_daemonset-volumes-windows.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-windows.yaml
@@ -5,10 +5,24 @@
     type: Directory
   name: kubelet-ca
 {{- end }}
-{{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
+{{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf) (.Values.datadog.advancedConfd)) }}
 - name: confd
   configMap:
     name: {{ include "agents.confd-configmap-name" . }}
+{{- range $file, $configs := $.Values.datadog.autoconf }}
+      - key: {{ $file | quote }}
+        path: {{ $file | quote }}
+{{- end }}
+{{- range $file, $configs := $.Values.datadog.confd }}
+      - key: {{ $file | quote }}
+        path: {{ $file | quote }}
+{{- end }}
+{{- range $integration, $configs := $.Values.datadog.advancedConfd }}
+{{- range $name, $config := $configs }}
+      - key: {{ printf "%s--%s" $integration $name | quote }}
+        path: {{ printf "%s/%s" $integration $name | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
 - hostPath:

--- a/charts/datadog/templates/confd-configmap.yaml
+++ b/charts/datadog/templates/confd-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
+{{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf) (.Values.datadog.advancedConfd)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,6 +9,7 @@ metadata:
   annotations:
     checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
     checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}
+    checksum/advanced-confd-config: {{ tpl (toYaml .Values.datadog.advancedConfd) . | sha256sum }}
 data:
 {{/*
 Merge the legacy autoconf dict before so confd static configurations
@@ -19,5 +20,11 @@ override duplicates
 {{- end }}
 {{- if .Values.datadog.confd }}
 {{ tpl (toYaml .Values.datadog.confd) . | indent 2 }}
+{{- end }}
+{{- range $integration, $configs := $.Values.datadog.advancedConfd }}
+{{- range $name, $config := $configs }}
+  {{ printf "%s--%s: |" $integration $name }}
+    {{ tpl $config $ | indent 4 | trim }}
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -47,6 +47,7 @@ spec:
         checksum/install_info: {{ printf "%s-%s" .Chart.Name .Chart.Version | sha256sum }}
         checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}
         checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
+        checksum/advanced-confd-config: {{ tpl (toYaml .Values.datadog.advancedConfd) . | sha256sum }}
         checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
         {{- if eq (include "should-enable-otel-agent" .) "true" }}
         checksum/otel-config: {{ include "otel-agent-config-configmap-content" . | sha256sum }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -739,6 +739,22 @@ datadog:
   #     instances:
   #       - kube_state_url: http://%%host%%:8080/metrics
 
+  # datadog.advancedConfd -- Provide additional check configurations. Each key is an integration containing several config files.
+  
+  ## ref: https://docs.datadoghq.com/agent/autodiscovery/
+  advancedConfd: {}
+  #  cilium.d:
+  #    cilium-agent.yaml: |-
+  #        ad_identifiers:
+  #          - cilium-agent
+  #        instances:
+  #          - agent_endpoint: http://%%host%%:9090/metrics
+  #    cilium-operator.yaml: |-
+  #        ad_identifiers:
+  #          - cilium-operator
+  #        instances:
+  #          - operator_endpoint: http://%%host%%:6942/metrics
+
   # datadog.checksd -- Provide additional custom checks as python code
 
   ## Each key becomes a file in /checks.d

--- a/test/datadog/baseline_test.go
+++ b/test/datadog/baseline_test.go
@@ -21,6 +21,7 @@ var FilterKeys = map[string]interface{}{
 	"checksum/clusteragent-configmap": nil,
 	"checksum/install_info":           nil,
 	"checksum":                        nil,
+	"checksum/advanced-confd-config":  nil,
 	"checksum/autoconf-config":        nil,
 	"checksum/checksd-config":         nil,
 	"checksum/confd-config":           nil,


### PR DESCRIPTION
#### What this PR does / why we need it:
Signed-off-by: Nate Kaldor nate.kaldor@agilebits.com

#### Which issue this PR fixes
This enables advanced `confd` use cases with multiple configurations per check, similar to what was added earlier for cluster agent with `clusterAgent.advancedConfd`.

See this older PR: https://github.com/DataDog/helm-charts/pull/753

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

