### PR TITLE
Update DCA CNP for kube-apiserver egress

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.117.5
+
+* Upgrade Cluster Agent CiliumNetworkPolicy to be valid for Kube API server egress.
+
 ## 3.117.4
 
 * Upgrade default Agent version to `7.66.1` (compatible with Kubernetes 1.33+).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.117.4
+version: 3.117.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.117.4](https://img.shields.io/badge/Version-3.117.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.117.5](https://img.shields.io/badge/Version-3.117.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-cilium-network-policy.yaml
+++ b/charts/datadog/templates/cluster-agent-cilium-network-policy.yaml
@@ -72,23 +72,8 @@ specs:
         {{ toYaml .Values.clusterAgent.podLabels | indent 8 }}
         {{- end }}
     egress:
-      # toServices works only for endpoints outside of the cluster
-      # This section handles the case where the control plane is outside
-      # of the cluster.
-      - toServices:
-          - k8sService:
-              namespace: default
-              serviceName: kubernetes
-      # When the control plane is on the same cluster, we must allow connections
-      # to the node entity.
       - toEntities:
           - kube-apiserver
-          - host
-          - remote-node
-        toPorts:
-          - ports:
-              - port: "443"
-                protocol: TCP
   - description: Ingress from cluster agent
     endpointSelector:
       matchLabels:


### PR DESCRIPTION
#### What this PR does / why we need it:
* Updates CNP for Cluster Agent for kube-apiserver egress by removing `toServices` and solely relying on `toEntities` for `kube-apiserver`

#### Which issue this PR fixes
* > combining ToEntities and ToServices is not supported yet
* Same as https://github.com/DataDog/datadog-operator/issues/1930, more details in https://github.com/DataDog/datadog-operator/pull/1948

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
