### PR TITLE
[PoC] Create and supply a Deployment-generated IPC root CA

### DIFF
--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -410,6 +410,9 @@
     - name: kubelet-cert-volume
       mountPath: /certs
     {{- end }}
+    - name: agent-cluster-ca
+      mountPath: /etc/datadog-agent/agent-cluster-ca
+      readOnly: true
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}
 {{- end }}

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -110,6 +110,9 @@
     {{- if .Values.datadog.kubelet.hostCAPath }}
 {{ include "datadog.kubelet.volumeMount" . | indent 4 }}
     {{- end }}
+    - name: agent-cluster-ca
+      mountPath: /etc/datadog-agent/agent-cluster-ca
+      readOnly: true
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}
 {{- end }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -107,6 +107,9 @@
     {{- if .Values.datadog.kubelet.hostCAPath }}
 {{ include "datadog.kubelet.volumeMount" . | indent 4 }}
     {{- end }}
+    - name: agent-cluster-ca
+      mountPath: /etc/datadog-agent/agent-cluster-ca
+      readOnly: true
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}
 {{- end }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -129,6 +129,9 @@
       readOnly: true
     {{- end }}
     {{- end }}
+    - name: agent-cluster-ca
+      mountPath: /etc/datadog-agent/agent-cluster-ca
+      readOnly: true
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}
 {{- end }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -171,6 +171,9 @@
       mountPath: {{ .Values.datadog.systemProbe.btfPath }}
       readOnly: true
 {{- end }}
+    - name: agent-cluster-ca
+      mountPath: /etc/datadog-agent/agent-cluster-ca
+      readOnly: true
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}
 {{- end }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -117,6 +117,9 @@
       readOnly: false # Need RW for UDS APM socket
     {{- end }}
     {{- end }}
+    - name: agent-cluster-ca
+      mountPath: /etc/datadog-agent/agent-cluster-ca
+      readOnly: true
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- end }}
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -213,6 +213,9 @@ spec:
           - name: config
             mountPath: {{ template "datadog.confPath" . }}
             readOnly: false # Need RW for config path
+          - name: agent-cluster-ca
+            mountPath: /etc/datadog-agent/agent-cluster-ca
+            readOnly: true
 {{- if eq (include "should-mount-fips-configmap" .) "true" }}
 {{- include "linux-container-fips-proxy-cfg-volumemount" . | indent 10 }}
 {{- end }}
@@ -229,6 +232,9 @@ spec:
 {{- $startup := .Values.clusterChecksRunner.startupProbe }}
 {{ include "probe.http" (dict "settings" $startup "path" "/startup" "port" $healthPort) | indent 10 }}
       volumes:
+        - name: agent-cluster-ca
+          secret:
+            secretName: datadog-agent-cluster-ca-secret
         - name: installinfo
           configMap:
             name: {{ include "agents-install-info-configmap-name" . }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -439,6 +439,9 @@ spec:
           - name: tmpdir
             mountPath: /tmp
             readOnly: false
+          - name: agent-cluster-ca
+            mountPath: /etc/datadog-agent/agent-cluster-ca
+            readOnly: true
           - name: installinfo
             subPath: install_info
             {{- if eq .Values.targetSystem "windows" }}
@@ -471,6 +474,9 @@ spec:
           - name: config
             mountPath: /etc/datadog-agent
       volumes:
+        - name: agent-cluster-ca
+          secret:
+            secretName: datadog-agent-cluster-ca-secret
         - name: datadogrun
           emptyDir: {}
         - name: varlog

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -151,6 +151,9 @@ spec:
           {{ include "system-probe-init" . | nindent 6 }}
         {{- end }}
       volumes:
+      - name: agent-cluster-ca
+        secret:
+          secretName: datadog-agent-cluster-ca-secret
       {{- if (not .Values.providers.gke.autopilot) }}
       - name: auth-token
         emptyDir: {}

--- a/charts/datadog/templates/secret-ipc-ca.yaml
+++ b/charts/datadog/templates/secret-ipc-ca.yaml
@@ -1,0 +1,13 @@
+{{- $cn := printf "%s-root-ca" .Release.Name -}}
+{{- $ca := genCA $cn 3650 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: datadog-agent-cluster-ca-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "datadog.labels" . | indent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.key: {{ $ca.Key | b64enc | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR demonstrate how HelmChart built-ins allow to create and supply a self-signed root CA to all Datadog Agent containers.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
