### PR TITLE
fix seccomp/apparmor for agent container

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.118.2
+
+* fix seccomp/apparmor for agent container ([#1901](https://github.com/DataDog/helm-charts/pull/1901)).
+
 ## 3.118.1
 
 * Update `datadog-crds` dependency to `2.8.0`

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.118.1
+version: 3.118.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.118.1](https://img.shields.io/badge/Version-3.118.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.118.2](https://img.shields.io/badge/Version-3.118.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -27,6 +27,7 @@ type HelmCommand struct {
 	Overrides     map[string]string // helm template `--set` flag
 	OverridesJson map[string]string // helm template `--set-json` flag
 	Logger        *logger.Logger    // logger to use for helm output. Set to logger.Discard by default.
+	ExtraArgs     []string
 }
 
 func Unmarshal[T any](t *testing.T, manifest string, destObj *T) {
@@ -51,7 +52,7 @@ func RenderChart(t *testing.T, cmd HelmCommand) (string, error) {
 		options.Logger = logger.Discard
 	}
 
-	output, err := helm.RenderTemplateE(t, options, chartPath, cmd.ReleaseName, cmd.ShowOnly /*, "--debug"*/)
+	output, err := helm.RenderTemplateE(t, options, chartPath, cmd.ReleaseName, cmd.ShowOnly, cmd.ExtraArgs...)
 
 	return output, err
 }

--- a/test/datadog/apparmor_test.go
+++ b/test/datadog/apparmor_test.go
@@ -1,0 +1,77 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/helm-charts/test/common"
+)
+
+func TestApparmor(t *testing.T) {
+	t.Run("<1.30", func(t *testing.T) {
+		manifest, err := common.RenderChart(t, common.HelmCommand{
+			ReleaseName: "datadog",
+			ChartPath:   "../../charts/datadog",
+			ShowOnly:    []string{"templates/daemonset.yaml"},
+			Values:      []string{"../../charts/datadog/values.yaml"},
+			Overrides: map[string]string{
+				"datadog.apiKeyExistingSecret":        "datadog-secret",
+				"datadog.appKeyExistingSecret":        "datadog-secret",
+				"datadog.sbom.containerImage.enabled": "true",
+				"datadog.networkMonitoring.enabled":   "true",
+			},
+			ExtraArgs: []string{"--kube-version=1.29.8"},
+		})
+		require.NoError(t, err)
+		var deployment appsv1.DaemonSet
+		common.Unmarshal(t, manifest, &deployment)
+		coreAgentContainer, ok := getContainer(t, deployment.Spec.Template.Spec.Containers, "agent")
+		if assert.True(t, ok, "has agent container") {
+			assert.Nil(t, coreAgentContainer.SecurityContext.AppArmorProfile, "agent apparmor profile")
+		}
+		systemProbeContainer, ok := getContainer(t, deployment.Spec.Template.Spec.Containers, "system-probe")
+		if assert.True(t, ok, "has system-probe container") {
+			assert.Nil(t, systemProbeContainer.SecurityContext.AppArmorProfile, "system-probe apparmor profile")
+		}
+		assert.Contains(t, deployment.Spec.Template.Annotations, "container.apparmor.security.beta.kubernetes.io/agent")
+		assert.Contains(t, deployment.Spec.Template.Annotations, "container.apparmor.security.beta.kubernetes.io/system-probe")
+	})
+	t.Run("1.30+", func(t *testing.T) {
+		manifest, err := common.RenderChart(t, common.HelmCommand{
+			ReleaseName: "datadog",
+			ChartPath:   "../../charts/datadog",
+			ShowOnly:    []string{"templates/daemonset.yaml"},
+			Values:      []string{"../../charts/datadog/values.yaml"},
+			Overrides: map[string]string{
+				"datadog.apiKeyExistingSecret":        "datadog-secret",
+				"datadog.appKeyExistingSecret":        "datadog-secret",
+				"datadog.sbom.containerImage.enabled": "true",
+				"datadog.networkMonitoring.enabled":   "true",
+			},
+			ExtraArgs: []string{"--kube-version=1.30.4"},
+		})
+		require.NoError(t, err)
+		var deployment appsv1.DaemonSet
+		common.Unmarshal(t, manifest, &deployment)
+		coreAgentContainer, ok := getContainer(t, deployment.Spec.Template.Spec.Containers, "agent")
+		if assert.True(t, ok, "has agent container") {
+			profile := coreAgentContainer.SecurityContext.AppArmorProfile
+			if assert.NotNil(t, profile, "agent apparmor profile") {
+				assert.Equal(t, v1.AppArmorProfileTypeUnconfined, profile.Type, "agent apparmor profile type")
+			}
+		}
+		systemProbeContainer, ok := getContainer(t, deployment.Spec.Template.Spec.Containers, "system-probe")
+		if assert.True(t, ok, "has system-probe container") {
+			profile := systemProbeContainer.SecurityContext.AppArmorProfile
+			if assert.NotNil(t, profile, "system-probe apparmor profile") {
+				assert.Equal(t, v1.AppArmorProfileTypeUnconfined, profile.Type, "system-probe apparmor profile type")
+			}
+		}
+		assert.NotContains(t, deployment.Spec.Template.Annotations, "container.apparmor.security.beta.kubernetes.io/agent")
+		assert.NotContains(t, deployment.Spec.Template.Annotations, "container.apparmor.security.beta.kubernetes.io/system-probe")
+	})
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

If no custom/default `securityContext` was provided, then the seccomp/apparmor sections of the `securityContext` were not generated

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
