### PR TITLE
[ACTP] Bump private actions runner version to v1.4.0

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.2.1
+
+* Bump runner version to `v1.4.0`
+
 ## 1.2.0
 
 * Add support for kubernetes scaleDeployment and rollbackDeployment actions

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,8 +3,8 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.2.0
-appVersion: "v1.3.0"
+version: 1.2.1
+appVersion: "v1.4.0"
 keywords:
 - app builder
 - workflow automation

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
 
 ## Overview
 
@@ -217,7 +217,7 @@ If actions requiring credentials fail:
 |-----|------|---------|-------------|
 | $schema | string | `"./values.schema.json"` | Schema for the values file, enables support in Jetbrains IDEs. You should probably use https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json. |
 | fullnameOverride | string | `""` | Override the full qualified app name |
-| image | object | `{"repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.3.0"}` | Current Datadog Private Action Runner image |
+| image | object | `{"repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.4.0"}` | Current Datadog Private Action Runner image |
 | nameOverride | string | `""` | Override name of app |
 | runner.config | object | `{"actionsAllowlist":[],"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":9016,"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
 | runner.config.actionsAllowlist | list | `[]` | List of actions that the Datadog Private Action Runner is allowed to execute |

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -8,7 +8,7 @@ $schema: ./values.schema.json
 # -- Current Datadog Private Action Runner image
 image:
   repository: gcr.io/datadoghq/private-action-runner
-  tag: v1.3.0
+  tag: v1.4.0
 
 # nameOverride -- Override name of app
 nameOverride: ""

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -32,13 +32,13 @@ metadata:
   namespace: datadog-agent
   name: custom-full-name
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
 ---
 # Source: private-action-runner/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -63,8 +63,8 @@ metadata:
   namespace: datadog-agent
 spec:
   selector:
-      app.kubernetes.io/name: private-action-runner
-      app.kubernetes.io/instance: override-test
+    app.kubernetes.io/name: private-action-runner
+    app.kubernetes.io/instance: override-test
   ports:
     - name: http
       port: 9016
@@ -77,10 +77,10 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.0
+    helm.sh/chart: private-action-runner-1.2.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
-    app.kubernetes.io/version: "v1.3.0"
+    app.kubernetes.io/version: "v1.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -92,18 +92,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.0
+        helm.sh/chart: private-action-runner-1.2.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
-        app.kubernetes.io/version: "v1.3.0"
+        app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 682dbfc13e707fe2f2f2268f2c96f14e9f8d6c33fdacf72351c89ce729ec7ec9
+        checksum/values: dd6e972057ae5e597c61d1a115df6901a507699723425bd1749c8bb766f96e59
     spec:
       serviceAccountName: custom-full-name
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.3.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -118,7 +118,7 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner
-          env: 
+          env:
             - name: FOO
               value: foo
             - name: BAR

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -32,13 +32,13 @@ metadata:
   namespace: datadog-agent
   name: custom-full-name
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
 ---
 # Source: private-action-runner/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -63,8 +63,8 @@ metadata:
   namespace: datadog-agent
 spec:
   selector:
-    app.kubernetes.io/name: private-action-runner
-    app.kubernetes.io/instance: override-test
+      app.kubernetes.io/name: private-action-runner
+      app.kubernetes.io/instance: override-test
   ports:
     - name: http
       port: 9016
@@ -118,7 +118,7 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner
-          env:
+          env: 
             - name: FOO
               value: foo
             - name: BAR

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,11 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-<<<<<<< HEAD
-    helm.sh/chart: private-action-runner-1.2.0
-=======
-    helm.sh/chart: private-action-runner-1.1.3
->>>>>>> f7e91ee2 ([ACTP] Bump private actions runner version to v1.4.0)
+    helm.sh/chart: private-action-runner-1.2.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.4.0"

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,10 +77,14 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
+<<<<<<< HEAD
     helm.sh/chart: private-action-runner-1.2.0
+=======
+    helm.sh/chart: private-action-runner-1.1.3
+>>>>>>> f7e91ee2 ([ACTP] Bump private actions runner version to v1.4.0)
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
-    app.kubernetes.io/version: "v1.3.0"
+    app.kubernetes.io/version: "v1.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -92,18 +96,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.0
+        helm.sh/chart: private-action-runner-1.2.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
-        app.kubernetes.io/version: "v1.3.0"
+        app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: ac8a95d8feb0ebf0c9638eda2b0071685c4429327d4242172750e28f75f325a8
+        checksum/values: 3eaa0c28d5d5b6c90c67730d4e75c84f6aa0835da7ce33819e191dfb0c90472b
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.3.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,10 +77,14 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
+<<<<<<< HEAD
     helm.sh/chart: private-action-runner-1.2.0
+=======
+    helm.sh/chart: private-action-runner-1.1.3
+>>>>>>> f7e91ee2 ([ACTP] Bump private actions runner version to v1.4.0)
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
-    app.kubernetes.io/version: "v1.3.0"
+    app.kubernetes.io/version: "v1.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -92,18 +96,22 @@ spec:
   template:
     metadata:
       labels:
+<<<<<<< HEAD
         helm.sh/chart: private-action-runner-1.2.0
+=======
+        helm.sh/chart: private-action-runner-1.1.3
+>>>>>>> f7e91ee2 ([ACTP] Bump private actions runner version to v1.4.0)
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
-        app.kubernetes.io/version: "v1.3.0"
+        app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 1286a3dfad299cbac32f8547f200b367377da827659e341b809a72d6592dd41d
+        checksum/values: d770b7f99297eb2e3301c6e4ee385d951571b948da009dacff8d23cefb4099b5
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.3.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,11 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-<<<<<<< HEAD
-    helm.sh/chart: private-action-runner-1.2.0
-=======
-    helm.sh/chart: private-action-runner-1.1.3
->>>>>>> f7e91ee2 ([ACTP] Bump private actions runner version to v1.4.0)
+    helm.sh/chart: private-action-runner-1.2.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.4.0"
@@ -96,11 +92,7 @@ spec:
   template:
     metadata:
       labels:
-<<<<<<< HEAD
-        helm.sh/chart: private-action-runner-1.2.0
-=======
-        helm.sh/chart: private-action-runner-1.1.3
->>>>>>> f7e91ee2 ([ACTP] Bump private actions runner version to v1.4.0)
+        helm.sh/chart: private-action-runner-1.2.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.4.0"

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -151,7 +151,7 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 7a7f7f524be204bc3f45cc44a0006404c912a62ec557e17261d22a77868d4265
+        checksum/values: 4c4d2095b29522d3889aeb0c0b63ec242979f69f6bbf8edd7acec519f77d2794
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -130,10 +130,10 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.0
+    helm.sh/chart: private-action-runner-1.2.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
-    app.kubernetes.io/version: "v1.3.0"
+    app.kubernetes.io/version: "v1.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -145,18 +145,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.0
+        helm.sh/chart: private-action-runner-1.2.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
-        app.kubernetes.io/version: "v1.3.0"
+        app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 5901f670e03cd3023bf5efe0089c9551aaa54f7cdf6c537a0db1f73968573733
+        checksum/values: 7a7f7f524be204bc3f45cc44a0006404c912a62ec557e17261d22a77868d4265
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.3.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,11 +211,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-<<<<<<< HEAD
-    helm.sh/chart: private-action-runner-1.2.0
-=======
-    helm.sh/chart: private-action-runner-1.1.3
->>>>>>> f7e91ee2 ([ACTP] Bump private actions runner version to v1.4.0)
+    helm.sh/chart: private-action-runner-1.2.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.4.0"

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,10 +211,14 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
+<<<<<<< HEAD
     helm.sh/chart: private-action-runner-1.2.0
+=======
+    helm.sh/chart: private-action-runner-1.1.3
+>>>>>>> f7e91ee2 ([ACTP] Bump private actions runner version to v1.4.0)
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
-    app.kubernetes.io/version: "v1.3.0"
+    app.kubernetes.io/version: "v1.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -226,18 +230,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.0
+        helm.sh/chart: private-action-runner-1.2.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
-        app.kubernetes.io/version: "v1.3.0"
+        app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: fb688436760d2258344d27e977bfbba94c6342defab873e029bf9e8019612cf0
+        checksum/values: f4b7669e56883fe9ae5cf1ec811201b44cd9c553042ecfa5cd4c2e4f048077a3
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.3.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,10 +75,10 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.0
+    helm.sh/chart: private-action-runner-1.2.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
-    app.kubernetes.io/version: "v1.3.0"
+    app.kubernetes.io/version: "v1.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -90,18 +90,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.0
+        helm.sh/chart: private-action-runner-1.2.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
-        app.kubernetes.io/version: "v1.3.0"
+        app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 24e13ea746d7c0e7f4d0600dff5e4cf4aae33bc85dfa9741d45d15dab67f026c
+        checksum/values: 582ca74e3f1b531d39c5e2cae9384b772d9aad7be45093ca8682e7e3a7ec426f
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.3.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump the private actions runner version to `v1.4.0`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
