### PR TITLE
add extra kubernetes manifests

### DIFF
--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -926,6 +926,7 @@ helm install <RELEASE_NAME> \
 | existingClusterAgent.join | bool | `false` | set this to true if you want the agents deployed by this chart to connect to a Cluster Agent deployed independently |
 | existingClusterAgent.serviceName | string | `nil` | Existing service name to use for reaching the external Cluster Agent |
 | existingClusterAgent.tokenSecretName | string | `nil` | Existing secret name to use for external Cluster Agent token |
+| extraObjects | list | `[]` | Extra Kubernetes objects to deploy with the helm chart |
 | fips.customFipsConfig | object | `{}` | Configure a custom configMap to provide the FIPS configuration. Specify custom contents for the FIPS proxy sidecar container config (/etc/datadog-fips-proxy/datadog-fips-proxy.cfg). If empty, the default FIPS proxy sidecar container config is used. |
 | fips.enabled | bool | `false` | Enable fips proxy sidecar. The fips-proxy method is getting phased out in favor of FIPS-compliant images (refer to the `useFIPSAgent` setting). |
 | fips.image.digest | string | `""` | Define the FIPS sidecar image digest to use, takes precedence over `fips.image.tag` if specified. |

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -1238,3 +1238,14 @@ false
     true
   {{- end -}}
 {{- end -}}
+
+{{/*
+Renders a complete tree, even values that contains template.
+*/}}
+{{- define "datadog.render" -}}
+  {{- if typeIs "string" .value }}
+    {{- tpl .value .context }}
+  {{ else }}
+    {{- tpl (.value | toYaml) .context }}
+  {{- end }}
+{{- end -}}

--- a/charts/datadog/templates/extra-manifests.yaml
+++ b/charts/datadog/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ include "datadog.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2590,3 +2590,6 @@ remoteConfiguration:
   # Can be overridden if `datadog.remoteConfiguration.enabled`
   # Preferred way to enable Remote Configuration.
   enabled: true
+
+# extraObjects -- Extra Kubernetes objects to deploy with the helm chart
+extraObjects: []


### PR DESCRIPTION
#### What this PR does / why we need it:

I would like to deploy additional kubernetes objects in the same helm values.yaml file. Like this:
- https://github.com/external-secrets/external-secrets/pull/3421
- https://github.com/cert-manager/cert-manager/pull/6424
- https://github.com/kubernetes/k8s.io/blob/main/kubernetes/gke-utility/helm/cert-manager.yaml

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
