### PR TITLE
[CONTP-812] remove hostnetwork true from csi driver nodeserver daemonset

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.4
+
+* Remove `hostNetwork: true` from csi driver daemonset.
+
 ## 0.3.3
 
 * Fix bug that caused to pass the socket's parent directory to the start command arguments instead of the full socket path.

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -13,7 +13,6 @@ spec:
         app: {{ include "datadog-csi-driver.daemonsetName" . }}
         admission.datadoghq.com/enabled: "false"
     spec:
-      hostNetwork: true
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
     {{ toYaml .Values.image.pullSecrets | indent 8 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Removes `hostNetwork: true` from CSI driver nodeserver daemonset.

This option is not needed for the driver to operate as expected.

Validation done using e2e:

* clone [csi driver repo](https://github.com/DataDog/datadog-csi-driver)
* update [this](https://github.com/DataDog/datadog-csi-driver/blob/b005d4de4f69d3a08a751715233047f33c0ece61/test/e2e/setup-env.sh#L36) line to reference the patched helm chart branch
* run `make e2e`
 
#### Special notes for your reviewer:
- Related to [this](https://github.com/DataDog/datadog-gke-workload-allowlist/pull/4#discussion_r2136257946).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
