### PR TITLE
[ACTP] update PAR configuration file location

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.3.0
+
+* Change the configuration directory to be `/etc/dd-action-runner/config`.
+
 ## 1.2.2
 
 * Add customizable nodeSelector, tolerations, affinity for the private action runner deployment.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.2.2
+version: 1.3.0
 appVersion: "v1.4.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
 
 ## Overview
 
@@ -164,10 +164,10 @@ Reference these secrets in your values.yaml:
 ```yaml
 runner:
   credentialSecrets:
-    # Mount all files from the secret at /etc/dd-action-runner/credentials/
+    # Mount all files from the secret at /etc/dd-action-runner/config/credentials/
     - secretName: action-credentials
       directoryName: ""
-    # Mount files in a subdirectory at /etc/dd-action-runner/credentials/jenkins/
+    # Mount files in a subdirectory at /etc/dd-action-runner/config/credentials/jenkins/
     - secretName: jenkins-credentials
       directoryName: "jenkins"
 ```
@@ -204,9 +204,9 @@ If actions requiring credentials fail:
 1. Verify that your credential files are properly formatted
 2. Check that the credentials are mounted correctly in the pod:
    ```bash
-   kubectl exec <pod-name> -- ls /etc/dd-action-runner/credentials/
+   kubectl exec <pod-name> -- ls /etc/dd-action-runner/config/credentials/
    ## Depending on how you pass the credentials they might appear in a different directory
-   kubectl exec <pod-name> -- ls /etc/dd-action-runner/
+   kubectl exec <pod-name> -- ls /etc/dd-action-runner/config
    ```
 
 3. Check the pod logs for credential-related errors

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -165,10 +165,10 @@ Reference these secrets in your values.yaml:
 ```yaml
 runner:
   credentialSecrets:
-    # Mount all files from the secret at /etc/dd-action-runner/credentials/
+    # Mount all files from the secret at /etc/dd-action-runner/config/credentials/
     - secretName: action-credentials
       directoryName: ""
-    # Mount files in a subdirectory at /etc/dd-action-runner/credentials/jenkins/
+    # Mount files in a subdirectory at /etc/dd-action-runner/config/credentials/jenkins/
     - secretName: jenkins-credentials
       directoryName: "jenkins"
 ```
@@ -205,9 +205,9 @@ If actions requiring credentials fail:
 1. Verify that your credential files are properly formatted
 2. Check that the credentials are mounted correctly in the pod:
    ```bash
-   kubectl exec <pod-name> -- ls /etc/dd-action-runner/credentials/
+   kubectl exec <pod-name> -- ls /etc/dd-action-runner/config/credentials/
    ## Depending on how you pass the credentials they might appear in a different directory
-   kubectl exec <pod-name> -- ls /etc/dd-action-runner/
+   kubectl exec <pod-name> -- ls /etc/dd-action-runner/config
    ```
 
 3. Check the pod logs for credential-related errors

--- a/charts/private-action-runner/UPGRADING.md
+++ b/charts/private-action-runner/UPGRADING.md
@@ -1,3 +1,8 @@
+# Upgrade to version 1.3.0
+
+In version 1.3.0 the chart has been updated to change the default location for the runner's configuration and credentials files. The configuration file has been moved from `/etc/datadog-runner/config.yaml` to `/etc/datadog-runner/config/config.yaml`. 
+Credentials have been moved from `/etc/datadog-runner/credentials` to `/etc/datadog-runner/config/credentials` so you might need to update your connection configurations to point to the new location.
+
 # Upgrade from version 0.x to version 1.x
 
 Version 1.0.0 introduces changes to simplify the chart and better align with Helm best practices. The most significant change is the restructuring of the values.yaml file.

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -59,7 +59,7 @@ runner:
   #        - "patch"
   #        - "update"
   #        - "delete"
-  # credential files provided here will be mounted in /etc/dd-action-runner/
+  # credential files provided here will be mounted in /etc/dd-action-runner/config/
   # it is safe to remove unneeded files from this section
   credentialFiles:
     - fileName: "http_basic.json"
@@ -198,9 +198,9 @@ runner:
         }
 
   credentialSecrets:
-    # a kubernetes secret containing multiple credentials files mounted at /etc/dd-action-runner/credentials/<filename-from-secret>
+    # a kubernetes secret containing multiple credentials files mounted at /etc/dd-action-runner/config/credentials/<filename-from-secret>
     - secretName: all-secrets-at-once
       directoryName: ""
-    # a kubernetes secret containing a single credentials file mounted at /etc/dd-action-runner/credentials/jenkins/<filename-from-secret>
+    # a kubernetes secret containing a single credentials file mounted at /etc/dd-action-runner/config/credentials/jenkins/<filename-from-secret>
     - secretName: jenkins-secret
       directoryName: jenkins

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -30,10 +30,10 @@ spec:
             {{- toYaml $.Values.runner.resources | nindent 12 }}
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
             {{- range $_, $credentialSecret := $.Values.runner.credentialSecrets }}
             - name: {{ $credentialSecret.secretName }}
-              mountPath: /etc/dd-action-runner/credentials/{{ $credentialSecret.directoryName }}
+              mountPath: /etc/dd-action-runner/config/credentials/{{ $credentialSecret.directoryName }}
             {{- end }}
           {{- if $.Values.runner.env }}
           env: {{ $.Values.runner.env | toYaml | nindent 12 }}

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -109,8 +109,8 @@ runner:
   # -- List of credential files to be used by the Datadog Private Action Runner
   credentialFiles: []
   # see examples/values.yaml for examples on how to specify secrets
-  # credential files provided here will be mounted in /etc/dd-action-runner/
+  # credential files provided here will be mounted in /etc/dd-action-runner/config/
   # -- References to kubernetes secrets that contain credentials to be used by the Datadog Private Action Runner
   credentialSecrets: []
-  # credential files provided here will be mounted in /etc/dd-action-runner/credentials/
+  # credential files provided here will be mounted in /etc/dd-action-runner/config/credentials/
   # see examples/values.yaml for examples on how to specify secrets

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -77,7 +77,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.4.0"
@@ -117,8 +117,8 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
-          env:
+              mountPath: /etc/dd-action-runner/config
+          env: 
             - name: FOO
               value: foo
             - name: BAR

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.4.0"
@@ -117,7 +117,7 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
       nodeSelector:
         kubernetes.io/os: linux
       affinity:

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.4.0"
@@ -117,7 +117,7 @@ spec:
               memory: 512Mi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
       volumes:
         - name: secrets
           secret:

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,7 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.4.0"
@@ -117,7 +117,7 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
       volumes:
         - name: secrets
           secret:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -130,7 +130,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.4.0"
@@ -145,7 +145,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.4.0"
@@ -170,7 +170,7 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
       volumes:
         - name: secrets
           secret:

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,7 +211,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.4.0"
@@ -226,7 +226,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.4.0"
@@ -251,11 +251,11 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
             - name: all-secrets-at-once
-              mountPath: /etc/dd-action-runner/credentials/
+              mountPath: /etc/dd-action-runner/config/credentials/
             - name: jenkins-secret
-              mountPath: /etc/dd-action-runner/credentials/jenkins
+              mountPath: /etc/dd-action-runner/config/credentials/jenkins
           env: 
             - name: ENV_VAR_NAME
               value: ENV_VAR_VALUE

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,7 +75,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.4.0"
@@ -90,7 +90,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.4.0"
@@ -115,11 +115,11 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
             - name: first-secret
-              mountPath: /etc/dd-action-runner/credentials/
+              mountPath: /etc/dd-action-runner/config/credentials/
             - name: second-secret
-              mountPath: /etc/dd-action-runner/credentials/second-secret-directory
+              mountPath: /etc/dd-action-runner/config/credentials/second-secret-directory
           envFrom:
             - secretRef:
                 name: the-name-of-the-secret

--- a/test/private-action-runner/data/old-values-file.yaml
+++ b/test/private-action-runner/data/old-values-file.yaml
@@ -56,7 +56,7 @@ runners:
 #          - "patch"
 #          - "update"
 #          - "delete"
-# credential files provided here will be mounted in /etc/dd-action-runner/
+# credential files provided here will be mounted in /etc/dd-action-runner/config/
 # it is safe to remove unneeded files from this section
 credentialFiles:
   - fileName: "http_basic_creds.json"
@@ -195,9 +195,9 @@ credentialFiles:
       }
 
 credentialSecrets:
-  # a kubernetes secret containing multiple credentials files mounted at /etc/dd-action-runner/credentials/<filename-from-secret>
+  # a kubernetes secret containing multiple credentials files mounted at /etc/dd-action-runner/config/credentials/<filename-from-secret>
   - secretName: all-secrets-at-once
     directoryName: ""
-  # a kubernetes secret containing a single credentials file mounted at /etc/dd-action-runner/credentials/jenkins/<filename-from-secret>
+  # a kubernetes secret containing a single credentials file mounted at /etc/dd-action-runner/config/credentials/jenkins/<filename-from-secret>
   - secretName: jenkins-secret
     directoryName: jenkins


### PR DESCRIPTION
#### What this PR does / why we need it:

We want to change the location used by runner configuration files from `/etc/dd-action-runner` to `/etc/dd-action-runner/config` so we're updating all places where we specify the value. This PR change the configuration for the helm chart.

#### Which issue this PR fixes
See internal ADR : ADRAP-6

#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
