### PR TITLE
[ACTP-745] update PAR configuration file location

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.3.0
+
+* Change the configuration directory to be `/etc/dd-action-runner/config`.
+
 ## 1.2.3
 
 * Add ability to include livenessProbe and readinessProbe configurations.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.2.3
+version: 1.3.0
 appVersion: "v1.4.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
 
 ## Overview
 
@@ -164,10 +164,10 @@ Reference these secrets in your values.yaml:
 ```yaml
 runner:
   credentialSecrets:
-    # Mount all files from the secret at /etc/dd-action-runner/credentials/
+    # Mount all files from the secret at /etc/dd-action-runner/config/credentials/
     - secretName: action-credentials
       directoryName: ""
-    # Mount files in a subdirectory at /etc/dd-action-runner/credentials/jenkins/
+    # Mount files in a subdirectory at /etc/dd-action-runner/config/credentials/jenkins/
     - secretName: jenkins-credentials
       directoryName: "jenkins"
 ```
@@ -204,9 +204,9 @@ If actions requiring credentials fail:
 1. Verify that your credential files are properly formatted
 2. Check that the credentials are mounted correctly in the pod:
    ```bash
-   kubectl exec <pod-name> -- ls /etc/dd-action-runner/credentials/
+   kubectl exec <pod-name> -- ls /etc/dd-action-runner/config/credentials/
    ## Depending on how you pass the credentials they might appear in a different directory
-   kubectl exec <pod-name> -- ls /etc/dd-action-runner/
+   kubectl exec <pod-name> -- ls /etc/dd-action-runner/config
    ```
 
 3. Check the pod logs for credential-related errors
@@ -229,7 +229,7 @@ If actions requiring credentials fail:
 | runner.config.urn | string | `"CHANGE_ME_URN_FROM_CONFIG"` | The runner's URN from the enrollment page |
 | runner.credentialFiles | list | `[]` | List of credential files to be used by the Datadog Private Action Runner |
 | runner.credentialSecrets | list | `[]` | References to kubernetes secrets that contain credentials to be used by the Datadog Private Action Runner |
-| runner.env | list | `[]` | Environment variables to be passed to the Datadog Private Action Runner |
+| runner.env | list | `[{"name":"DD_PRIVATE_RUNNER_CONFIG_DIR","value":"/etc/dd-action-runner/config"}]` | Environment variables to be passed to the Datadog Private Action Runner |
 | runner.kubernetesActions | object | `{"configMaps":[],"controllerRevisions":[],"cronJobs":[],"customObjects":[],"customResourceDefinitions":[],"daemonSets":[],"deployments":[],"endpoints":[],"events":[],"jobs":[],"limitRanges":[],"namespaces":[],"nodes":[],"persistentVolumeClaims":[],"persistentVolumes":[],"podTemplates":[],"pods":["get","list"],"replicaSets":[],"replicationControllers":[],"resourceQuotas":[],"serviceAccounts":[],"services":[],"statefulSets":[]}` | Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account |
 | runner.kubernetesActions.configMaps | list | `[]` | Actions related to configMaps (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runner.kubernetesActions.controllerRevisions | list | `[]` | Actions related to controllerRevisions (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |

--- a/charts/private-action-runner/README.md.gotmpl
+++ b/charts/private-action-runner/README.md.gotmpl
@@ -165,10 +165,10 @@ Reference these secrets in your values.yaml:
 ```yaml
 runner:
   credentialSecrets:
-    # Mount all files from the secret at /etc/dd-action-runner/credentials/
+    # Mount all files from the secret at /etc/dd-action-runner/config/credentials/
     - secretName: action-credentials
       directoryName: ""
-    # Mount files in a subdirectory at /etc/dd-action-runner/credentials/jenkins/
+    # Mount files in a subdirectory at /etc/dd-action-runner/config/credentials/jenkins/
     - secretName: jenkins-credentials
       directoryName: "jenkins"
 ```
@@ -205,9 +205,9 @@ If actions requiring credentials fail:
 1. Verify that your credential files are properly formatted
 2. Check that the credentials are mounted correctly in the pod:
    ```bash
-   kubectl exec <pod-name> -- ls /etc/dd-action-runner/credentials/
+   kubectl exec <pod-name> -- ls /etc/dd-action-runner/config/credentials/
    ## Depending on how you pass the credentials they might appear in a different directory
-   kubectl exec <pod-name> -- ls /etc/dd-action-runner/
+   kubectl exec <pod-name> -- ls /etc/dd-action-runner/config
    ```
 
 3. Check the pod logs for credential-related errors

--- a/charts/private-action-runner/UPGRADING.md
+++ b/charts/private-action-runner/UPGRADING.md
@@ -1,3 +1,8 @@
+# Upgrade to version 1.3.0
+
+In version 1.3.0 the chart has been updated to change the default location for the runner's configuration and credentials files. The configuration file has been moved from `/etc/datadog-runner/config.yaml` to `/etc/datadog-runner/config/config.yaml`. 
+Credentials have been moved from `/etc/datadog-runner/credentials` to `/etc/datadog-runner/config/credentials` so you might need to update your connection configurations to point to the new location.
+
 # Upgrade from version 0.x to version 1.x
 
 Version 1.0.0 introduces changes to simplify the chart and better align with Helm best practices. The most significant change is the restructuring of the values.yaml file.

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -17,8 +17,8 @@ runner:
   # Use a "Role" to scope the permissions to the runner's namespace or a "ClusterRole" to give permissions to the entire cluster
   roleType: "Role"
   env:
-    - name: "ENV_VAR_NAME"
-      value: "ENV_VAR_VALUE"
+    - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+      value: /etc/dd-action-runner/config
   livenessProbe:
     httpGet:
       path: /liveness
@@ -73,7 +73,7 @@ runner:
   #        - "patch"
   #        - "update"
   #        - "delete"
-  # credential files provided here will be mounted in /etc/dd-action-runner/
+  # credential files provided here will be mounted in /etc/dd-action-runner/config/
   # it is safe to remove unneeded files from this section
   credentialFiles:
     - fileName: "http_basic.json"
@@ -212,9 +212,9 @@ runner:
         }
 
   credentialSecrets: []
-    # a kubernetes secret containing multiple credentials files mounted at /etc/dd-action-runner/credentials/<filename-from-secret> see https://github.com/DataDog/helm-charts/blob/main/charts/private-action-runner/README.md
+    # a kubernetes secret containing multiple credentials files mounted at /etc/dd-action-runner/config/credentials/<filename-from-secret> see https://github.com/DataDog/helm-charts/blob/main/charts/private-action-runner/README.md
     # - secretName: all-secrets-at-once
     #   directoryName: ""
-    # a kubernetes secret containing a single credentials file mounted at /etc/dd-action-runner/credentials/jenkins/<filename-from-secret> see https://github.com/DataDog/helm-charts/blob/main/charts/private-action-runner/README.md
+    # a kubernetes secret containing a single credentials file mounted at /etc/dd-action-runner/config/credentials/jenkins/<filename-from-secret> see https://github.com/DataDog/helm-charts/blob/main/charts/private-action-runner/README.md
     # - secretName: jenkins-secret
     #   directoryName: jenkins

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -38,10 +38,10 @@ spec:
             {{- toYaml $.Values.runner.resources | nindent 12 }}
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
             {{- range $_, $credentialSecret := $.Values.runner.credentialSecrets }}
             - name: {{ $credentialSecret.secretName }}
-              mountPath: /etc/dd-action-runner/credentials/{{ $credentialSecret.directoryName }}
+              mountPath: /etc/dd-action-runner/config/credentials/{{ $credentialSecret.directoryName }}
             {{- end }}
           {{- if $.Values.runner.env }}
           env: {{ $.Values.runner.env | toYaml | nindent 12 }}

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -37,7 +37,9 @@ runner:
     # -- List of actions that the Datadog Private Action Runner is allowed to execute
     actionsAllowlist: []
   # -- Environment variables to be passed to the Datadog Private Action Runner
-  env: []
+  env:
+    - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+      value: /etc/dd-action-runner/config
   # -- Allow the private action runner pods to schedule on selected nodes
   nodeSelector: {}
   # -- Kubernetes affinity settings for the runner pods
@@ -113,8 +115,8 @@ runner:
   # -- List of credential files to be used by the Datadog Private Action Runner
   credentialFiles: []
   # see examples/values.yaml for examples on how to specify secrets
-  # credential files provided here will be mounted in /etc/dd-action-runner/
+  # credential files provided here will be mounted in /etc/dd-action-runner/config/
   # -- References to kubernetes secrets that contain credentials to be used by the Datadog Private Action Runner
   credentialSecrets: []
-  # credential files provided here will be mounted in /etc/dd-action-runner/credentials/
+  # credential files provided here will be mounted in /etc/dd-action-runner/config/credentials/
   # see examples/values.yaml for examples on how to specify secrets

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -77,7 +77,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.3
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.3
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.4.0"
@@ -117,7 +117,7 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
           env: 
             - name: FOO
               value: foo

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.3
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.3
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: f42d26f7e0b678aa3235b43bcd592b9e213fbe2dbb95009c20262347abc6f70f
+        checksum/values: 80cf8a4e558b434efcb5ed7013d2495a6ecdf4d5dbba496f0971b7d023f02497
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
@@ -117,7 +117,10 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
+          env: 
+            - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+              value: /etc/dd-action-runner/config
       nodeSelector:
         kubernetes.io/os: linux
       affinity:

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.3
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.3
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 559352e3a2c1ff22e4700e103fb0efd2038aa8094b8faa21627dfa134f384a37
+        checksum/values: cbdedb8fe0d0f91309dbe6099357aa3a72c116d034b663c881481820ab266f4d
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
@@ -117,7 +117,10 @@ spec:
               memory: 512Mi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
+          env: 
+            - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+              value: /etc/dd-action-runner/config
       volumes:
         - name: secrets
           secret:

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,7 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.3
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.3
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 7e5eb4232e930e290cf9b92ebf272d62657b61c45bf899a86a7423d1e568f011
+        checksum/values: 66c2eaafe50c120cbaeac86b62a882507132240e723678edd55fdaa86270537d
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
@@ -117,7 +117,10 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
+          env: 
+            - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+              value: /etc/dd-action-runner/config
       volumes:
         - name: secrets
           secret:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -130,7 +130,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.3
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.4.0"
@@ -145,13 +145,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.3
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: f4f90da3d2bfbbd0e2687d4510f7a514de0fd5050be81346a24407a7fe766f9d
+        checksum/values: f673cce7d82ab74161452aba49e1f8828cc3dcd50c4b16ed3218de605011213d
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
@@ -170,7 +170,10 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
+          env: 
+            - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+              value: /etc/dd-action-runner/config
       volumes:
         - name: secrets
           secret:

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,7 +211,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.3
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.4.0"
@@ -226,13 +226,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.3
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 3b75798f4bb7b59d37785b8e41a17b4d01ae2b2b48dda58807cf1e697d7917b3
+        checksum/values: fe8a7c5d8265721edb6aa41d28e0e3851956c0f44afa636db8d96e7cf4445cab
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
@@ -265,10 +265,10 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
           env: 
-            - name: ENV_VAR_NAME
-              value: ENV_VAR_VALUE
+            - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+              value: /etc/dd-action-runner/config
       volumes:
         - name: secrets
           secret:

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,7 +75,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.3
+    helm.sh/chart: private-action-runner-1.3.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.4.0"
@@ -90,13 +90,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.3
+        helm.sh/chart: private-action-runner-1.3.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 534fcff6317a03906d20a1d34a8de4aa7fb919ff6f6952554df30118af336e40
+        checksum/values: d952c293bbea5e7cb58517878e92c814a3d612589f852d3b9a6bae88ac6aa59a
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
@@ -115,11 +115,14 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: secrets
-              mountPath: /etc/dd-action-runner
+              mountPath: /etc/dd-action-runner/config
             - name: first-secret
-              mountPath: /etc/dd-action-runner/credentials/
+              mountPath: /etc/dd-action-runner/config/credentials/
             - name: second-secret
-              mountPath: /etc/dd-action-runner/credentials/second-secret-directory
+              mountPath: /etc/dd-action-runner/config/credentials/second-secret-directory
+          env: 
+            - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+              value: /etc/dd-action-runner/config
           envFrom:
             - secretRef:
                 name: the-name-of-the-secret

--- a/test/private-action-runner/data/old-values-file.yaml
+++ b/test/private-action-runner/data/old-values-file.yaml
@@ -56,7 +56,7 @@ runners:
 #          - "patch"
 #          - "update"
 #          - "delete"
-# credential files provided here will be mounted in /etc/dd-action-runner/
+# credential files provided here will be mounted in /etc/dd-action-runner/config/
 # it is safe to remove unneeded files from this section
 credentialFiles:
   - fileName: "http_basic_creds.json"
@@ -195,9 +195,9 @@ credentialFiles:
       }
 
 credentialSecrets:
-  # a kubernetes secret containing multiple credentials files mounted at /etc/dd-action-runner/credentials/<filename-from-secret>
+  # a kubernetes secret containing multiple credentials files mounted at /etc/dd-action-runner/config/credentials/<filename-from-secret>
   - secretName: all-secrets-at-once
     directoryName: ""
-  # a kubernetes secret containing a single credentials file mounted at /etc/dd-action-runner/credentials/jenkins/<filename-from-secret>
+  # a kubernetes secret containing a single credentials file mounted at /etc/dd-action-runner/config/credentials/jenkins/<filename-from-secret>
   - secretName: jenkins-secret
     directoryName: jenkins


### PR DESCRIPTION
#### What this PR does / why we need it:

We want to change the location used by runner configuration files from `/etc/dd-action-runner` to `/etc/dd-action-runner/config` so we're updating all places where we specify the value. This PR change the configuration for the helm chart.

#### Which issue this PR fixes
ACTP-745

#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
