### PR TITLE
Bump datadog chart datadog-crds dependency version to 2.8.0

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.118.1
+
+* Update `datadog-crds` dependency to `2.8.0`
+
 ## 3.118.0
 
 * Enable local fallback by default when workload autoscaling is enabled.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.118.0
+version: 3.118.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.118.0](https://img.shields.io/badge/Version-3.118.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.118.1](https://img.shields.io/badge/Version-3.118.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -28,7 +28,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://helm.datadoghq.com | datadog-crds | 2.5.1 |
+| https://helm.datadoghq.com | datadog-crds | 2.8.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 
 ## Quick start

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.5.1
+  version: 2.8.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
-digest: sha256:c7e8021305c6cfadc26022a18d2374d5854ce95b7d4d9bd72eeecda140761229
-generated: "2025-03-24T15:15:23.958775+01:00"
+digest: sha256:15f05b44b105c4e1a08082ef0b12b1e7da076ef5db04ca880474c1e4a58dd36f
+generated: "2025-06-10T12:39:11.353853-04:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: datadog-crds
-    version: 2.5.1
+    version: 2.8.0
     repository: https://helm.datadoghq.com
     condition: datadog.autoscaling.workload.enabled,clusterAgent.metricsProvider.useDatadogMetrics
     tags:


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump datadog chart datadog-crds dependency version to 2.8.0

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
