### PR TITLE
Add Liveness Probe and Readiness Probe to Private Action Runner

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.2.3
+
+* Add ability to include liveness probe and readiness probe configurations with option to change/assign port name.
+
 ## 1.2.2
 
 * Add customizable nodeSelector, tolerations, affinity for the private action runner deployment.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: "v1.4.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
+![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
 
 ## Overview
 
@@ -220,11 +220,11 @@ If actions requiring credentials fail:
 | image | object | `{"repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.4.0"}` | Current Datadog Private Action Runner image |
 | nameOverride | string | `""` | Override name of app |
 | runner.affinity | object | `{}` | Kubernetes affinity settings for the runner pods |
-| runner.config | object | `{"actionsAllowlist":[],"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":9016,"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
+| runner.config | object | `{"actionsAllowlist":[],"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":{"containerPort":9016,"name":"http"},"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
 | runner.config.actionsAllowlist | list | `[]` | List of actions that the Datadog Private Action Runner is allowed to execute |
 | runner.config.ddBaseURL | string | `"https://app.datadoghq.com"` | Base URL of the Datadog app |
 | runner.config.modes | list | `["workflowAutomation","appBuilder"]` | Modes that the runner can run in |
-| runner.config.port | int | `9016` | Port for HTTP server liveness checks and App Builder mode |
+| runner.config.port | object | `{"containerPort":9016,"name":"http"}` | Port for HTTP server liveness checks and App Builder mode |
 | runner.config.privateKey | string | `"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG"` | The runner's privateKey from the enrollment page |
 | runner.config.urn | string | `"CHANGE_ME_URN_FROM_CONFIG"` | The runner's URN from the enrollment page |
 | runner.credentialFiles | list | `[]` | List of credential files to be used by the Datadog Private Action Runner |
@@ -255,7 +255,9 @@ If actions requiring credentials fail:
 | runner.kubernetesActions.services | list | `[]` | Actions related to services (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runner.kubernetesActions.statefulSets | list | `[]` | Actions related to statefulSets (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runner.kubernetesPermissions | list | `[]` | Kubernetes permissions to provide in addition to the one that will be inferred from `kubernetesActions` (useful for customObjects) |
+| runner.livenessProbe | object | `{}` | LivenessProbe settings |
 | runner.nodeSelector | object | `{}` | Allow the private action runner pods to schedule on selected nodes |
+| runner.readinessProbe | object | `{}` | ReadinessProbe settings |
 | runner.replicas | int | `1` | Number of pod instances for the Datadog Private Action Runner |
 | runner.resources | object | `{"limits":{"cpu":"250m","memory":"1Gi"},"requests":{"cpu":"250m","memory":"1Gi"}}` | Resource requirements for the Datadog Private Action Runner container |
 | runner.resources.limits | object | `{"cpu":"250m","memory":"1Gi"}` | Resource limits for the runner container |

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -11,7 +11,9 @@ runner:
     modes:
       - appBuilder
       - workflowAutomation
-    port: 9016
+    port:
+      name: http
+      containerPort: 9016
     actionsAllowlist:
       - com.datadoghq.http.request
   # Use a "Role" to scope the permissions to the runner's namespace or a "ClusterRole" to give permissions to the entire cluster
@@ -19,6 +21,20 @@ runner:
   env:
     - name: "ENV_VAR_NAME"
       value: "ENV_VAR_VALUE"
+  livenessProbe:
+    httpGet:
+      path: /liveness
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /readiness
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
   # runnerIdentitySecret: "A-SECRET-WITH-THE-RUNNER-PRIVATE-KEY-AND-URN" # Reference a kubernetes secrets that contains the runner identity instead of providing it in the config section see https://github.com/DataDog/helm-charts/blob/main/charts/private-action-runner/README.md
   # -- Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account
   kubernetesActions:

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -24,8 +24,16 @@ spec:
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
           imagePullPolicy: IfNotPresent
           ports:
-            - name: http
-              containerPort: 9016
+            - name: {{ $.Values.runner.config.port.name | default "http" }}
+              containerPort: {{ $.Values.runner.config.port.containerPort | default 9016 }}
+          {{- if .Values.runner.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $.Values.runner.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.runner.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $.Values.runner.readinessProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml $.Values.runner.resources | nindent 12 }}
           volumeMounts:

--- a/charts/private-action-runner/templates/secrets.yaml
+++ b/charts/private-action-runner/templates/secrets.yaml
@@ -17,7 +17,7 @@ stringData:
       - {{ $mode }}
     {{- end }}
     {{- if $.Values.runner.config.port }}
-    port: {{ $.Values.runner.config.port }}
+    port: {{ $.Values.runner.config.port.containerPort }}
     {{- else if $.Values.runner.config.appBuilder }}
     port: {{ $.Values.runner.config.appBuilder.port }}
     {{- end }}

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -68,8 +68,18 @@
               }
             },
             "port": {
-              "type": "integer",
-              "description": "Port for HTTP server liveness checks and App Builder mode"
+              "type": "object",
+              "description": "Port configuration",
+              "properties": {
+                "containerPort": {
+                  "type": "integer",
+                  "description": "Port for HTTP server liveness checks and App Builder mode"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the Port"
+                }
+              }
             },
             "actionsAllowlist": {
               "type": "array",
@@ -103,6 +113,14 @@
           "items": {
             "type": "object"
           }
+        },
+        "livenessProbe": {
+          "type": "object",
+          "description": "Liveness Probe configuration"
+        },
+        "readinessProbe": {
+          "type": "object",
+          "description": "Readiness Probe configuration"
         },
         "runnerIdentitySecret": {
           "type": "string",

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -33,7 +33,9 @@ runner:
       - "workflowAutomation"
       - "appBuilder"
     # -- Port for HTTP server liveness checks and App Builder mode
-    port: 9016
+    port:
+      containerPort: 9016
+      name: http
     # -- List of actions that the Datadog Private Action Runner is allowed to execute
     actionsAllowlist: []
   # -- Environment variables to be passed to the Datadog Private Action Runner
@@ -44,6 +46,10 @@ runner:
   affinity: {}
   # -- Tolerations to allow scheduling runner pods on nodes with taints
   tolerations: []
+  # -- LivenessProbe settings
+  livenessProbe: {}
+  # -- ReadinessProbe settings
+  readinessProbe: {}
   # -- Reference to a kubernetes secrets that contains the runner identity
   runnerIdentitySecret: ""
   # -- Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -77,7 +77,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 5ec29c3fb96081a9962733ad682ce7a7d6c90b6607fab4f53307f89f1c69a980
+        checksum/values: d68f0b70934aab863247094ec04ac145f4859527104e6fc4ce497c30a4a65306
     spec:
       serviceAccountName: custom-full-name
       containers:
@@ -118,7 +118,7 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner
-          env: 
+          env:
             - name: FOO
               value: foo
             - name: BAR

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: efd72170c12dfc431c95c216061404eb4cf2b67bd26d6aa18d44f544022634c5
+        checksum/values: 5a3102bf91e8d2aec252fbf9b55aa95b3aa3d899bdaf752048ef8b10ba51b6b6
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: d763c657f165984896697eea8bec32e2692a667c08fc31e28d745c69dea8510e
+        checksum/values: 024c6cf5a8ee9ce47a8f4faa882f6d28b03b5eff373fdb20ee798c742f20c392
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,7 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: ab55de272f50fa621c0d1a9f460edb478560acd84e23cf2f667b9adf36d40875
+        checksum/values: 6924a7ed11741d2ec16c2700e18a42c9a6be6ffa93f39d9e262ae1fbc6205e0b
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -130,7 +130,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.4.0"
@@ -145,13 +145,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: a33b417594160b6ea96139aa9a52eb829fe55c67ad0ad09e810461a2ed06e04a
+        checksum/values: aba61cfcf36467b22e1aec22ee5f87550b1bef0081f00caaad6500f9545919ba
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,7 +211,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.4.0"
@@ -226,13 +226,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: dc3fc008bf045c62538b8bb9ceb8af81a802a92d4dda996c3e42560619c86cf4
+        checksum/values: a3fcbd06989cec24d628d04d62498cfaf34e762993ccedd94edfa87213126d86
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
@@ -242,6 +242,20 @@ spec:
           ports:
             - name: http
               containerPort: 9016
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /liveness
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readiness
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 10
           resources:
             limits:
               cpu: 250m

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,7 +75,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.4.0"
@@ -90,13 +90,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: d141312104211eac6c1f55674870d2d2e9d46291919ac1fa519f78e2f9ead5aa
+        checksum/values: fc984f4c8df76065bded8027a7dd4cae3a8cb193bc4bdb4fba79d89f821f8ac2
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:


### PR DESCRIPTION
#### What this PR does / why we need it:

Include liveness and readiness probes to use for healthchecks. Modify the `port` values configuration to be an object if needed for flexibility with the probes.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
