### PR TITLE
Add livenessProbe and readinessProbe to Private Action Runner chart

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.2.3
+
+* Add ability to include livenessProbe and readinessProbe configurations.
+
 ## 1.2.2
 
 * Add customizable nodeSelector, tolerations, affinity for the private action runner deployment.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: "v1.4.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
+![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
 
 ## Overview
 
@@ -255,7 +255,9 @@ If actions requiring credentials fail:
 | runner.kubernetesActions.services | list | `[]` | Actions related to services (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runner.kubernetesActions.statefulSets | list | `[]` | Actions related to statefulSets (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runner.kubernetesPermissions | list | `[]` | Kubernetes permissions to provide in addition to the one that will be inferred from `kubernetesActions` (useful for customObjects) |
+| runner.livenessProbe | object | `{}` | LivenessProbe settings |
 | runner.nodeSelector | object | `{}` | Allow the private action runner pods to schedule on selected nodes |
+| runner.readinessProbe | object | `{}` | ReadinessProbe settings |
 | runner.replicas | int | `1` | Number of pod instances for the Datadog Private Action Runner |
 | runner.resources | object | `{"limits":{"cpu":"250m","memory":"1Gi"},"requests":{"cpu":"250m","memory":"1Gi"}}` | Resource requirements for the Datadog Private Action Runner container |
 | runner.resources.limits | object | `{"cpu":"250m","memory":"1Gi"}` | Resource limits for the runner container |

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -19,6 +19,20 @@ runner:
   env:
     - name: "ENV_VAR_NAME"
       value: "ENV_VAR_VALUE"
+  livenessProbe:
+    httpGet:
+      path: /liveness
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /readiness
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
   # runnerIdentitySecret: "A-SECRET-WITH-THE-RUNNER-PRIVATE-KEY-AND-URN" # Reference a kubernetes secrets that contains the runner identity instead of providing it in the config section see https://github.com/DataDog/helm-charts/blob/main/charts/private-action-runner/README.md
   # -- Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account
   kubernetesActions:

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -26,6 +26,14 @@ spec:
           ports:
             - name: http
               containerPort: 9016
+                    {{- if .Values.runner.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $.Values.runner.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.runner.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $.Values.runner.readinessProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml $.Values.runner.resources | nindent 12 }}
           volumeMounts:

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -104,6 +104,14 @@
             "type": "object"
           }
         },
+        "livenessProbe": {
+          "type": "object",
+          "description": "Liveness Probe configuration"
+        },
+        "readinessProbe": {
+          "type": "object",
+          "description": "Readiness Probe configuration"
+        },
         "runnerIdentitySecret": {
           "type": "string",
           "description": "Name of the secret containing the runner's identity"

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -44,6 +44,10 @@ runner:
   affinity: {}
   # -- Tolerations to allow scheduling runner pods on nodes with taints
   tolerations: []
+    # -- LivenessProbe settings
+  livenessProbe: {}
+  # -- ReadinessProbe settings
+  readinessProbe: {}
   # -- Reference to a kubernetes secrets that contains the runner identity
   runnerIdentitySecret: ""
   # -- Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -77,7 +77,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 5ec29c3fb96081a9962733ad682ce7a7d6c90b6607fab4f53307f89f1c69a980
+        checksum/values: 7d3e9ebc39f014d37ff1cbc7a8a8b0e3d4d60f707e5906d23a60895a452789b4
     spec:
       serviceAccountName: custom-full-name
       containers:

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: efd72170c12dfc431c95c216061404eb4cf2b67bd26d6aa18d44f544022634c5
+        checksum/values: f42d26f7e0b678aa3235b43bcd592b9e213fbe2dbb95009c20262347abc6f70f
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: d763c657f165984896697eea8bec32e2692a667c08fc31e28d745c69dea8510e
+        checksum/values: 559352e3a2c1ff22e4700e103fb0efd2038aa8094b8faa21627dfa134f384a37
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,7 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.4.0"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: ab55de272f50fa621c0d1a9f460edb478560acd84e23cf2f667b9adf36d40875
+        checksum/values: 7e5eb4232e930e290cf9b92ebf272d62657b61c45bf899a86a7423d1e568f011
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -130,7 +130,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.4.0"
@@ -145,13 +145,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: a33b417594160b6ea96139aa9a52eb829fe55c67ad0ad09e810461a2ed06e04a
+        checksum/values: f4f90da3d2bfbbd0e2687d4510f7a514de0fd5050be81346a24407a7fe766f9d
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,7 +211,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.4.0"
@@ -226,13 +226,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: dc3fc008bf045c62538b8bb9ceb8af81a802a92d4dda996c3e42560619c86cf4
+        checksum/values: 3b75798f4bb7b59d37785b8e41a17b4d01ae2b2b48dda58807cf1e697d7917b3
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
@@ -242,6 +242,20 @@ spec:
           ports:
             - name: http
               containerPort: 9016
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /liveness
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readiness
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 10
           resources:
             limits:
               cpu: 250m

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,7 +75,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.2.2
+    helm.sh/chart: private-action-runner-1.2.3
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.4.0"
@@ -90,13 +90,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.2.2
+        helm.sh/chart: private-action-runner-1.2.3
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: d141312104211eac6c1f55674870d2d2e9d46291919ac1fa519f78e2f9ead5aa
+        checksum/values: 534fcff6317a03906d20a1d34a8de4aa7fb919ff6f6952554df30118af336e40
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
Include liveness and readiness probes to use for healthchecks. Modify the port values configuration to be an object if needed for flexibility with the probes.

#### Special notes for your reviewer:

#### Checklist
GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
