### PR TITLE
Operator Go test matrix update, add 1.33

### DIFF
--- a/.github/workflows/go-test-operator.yaml
+++ b/.github/workflows/go-test-operator.yaml
@@ -60,9 +60,13 @@ jobs:
             kind: v0.22.0
           - k8s: v1.29.8
             kind: v0.22.0
-          - k8s: v1.30.4
+          - k8s: v1.30.13
             kind: v0.22.0
-          - k8s: v1.31.1
+          - k8s: v1.31.9
+            kind: v0.22.0
+          - k8s: v1.32.5
+            kind: v0.22.0
+          - k8s: v1.33.1
             kind: v0.22.0
     steps:
       - name: Checkout


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
