### PR TITLE
Otel Agent: add support for multi items in configmap

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.120.2
+
+* Add support for passing multiple collector configs for Otel agent (`otelCollector.configMap.items`)
+
 ## 3.120.1
 
 * Added ports for gRPC and HTTP OTLP ingest in NetworkPolicy and CiliumNetworkPolicy when `datadog.networkPolicy.create` and `datadog.networkPolicy.flavor` are configured respectively as `"kubernetes"` or `"cilium"`.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.118.4
+
+* Add support for passing multiple collector configs for Otel agent (`otelCollector.configMap.items`)
+
 ## 3.118.3
 
 * Update `process_config.run_in_core_agent.enabled` to `false` on the cluster check worker.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.118.3
+version: 3.118.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.120.1
+version: 3.120.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.120.1](https://img.shields.io/badge/Version-3.120.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.120.2](https://img.shields.io/badge/Version-3.120.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.118.3](https://img.shields.io/badge/Version-3.118.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.118.4](https://img.shields.io/badge/Version-3.118.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -833,7 +833,8 @@ helm install <RELEASE_NAME> \
 | datadog.originDetectionUnified.enabled | bool | `false` | Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+). |
 | datadog.osReleasePath | string | `"/etc/os-release"` | Specify the path to your os-release file |
 | datadog.otelCollector.config | string | `nil` | OTel collector configuration |
-| datadog.otelCollector.configMap | object | `{"key":"otel-config.yaml","name":null}` | Use an existing ConfigMap for DDOT Collector configuration |
+| datadog.otelCollector.configMap | object | `{"items":null,"key":"otel-config.yaml","name":null}` | Use an existing ConfigMap for DDOT Collector configuration |
+| datadog.otelCollector.configMap.items | string | `nil` | Items within the ConfigMap that contain DDOT Collector configuration |
 | datadog.otelCollector.configMap.key | string | `"otel-config.yaml"` | Key within the ConfigMap that contains the DDOT Collector configuration |
 | datadog.otelCollector.configMap.name | string | `nil` | Name of the existing ConfigMap that contains the DDOT Collector configuration |
 | datadog.otelCollector.enabled | bool | `false` | Enable the OTel Collector |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.120.2](https://img.shields.io/badge/Version-3.120.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.120.2](https://img.shields.io/badge/Version-3.120.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -5,7 +5,13 @@
   {{- if eq .Values.targetSystem "linux" }}
   command:
     - "otel-agent"
+    {{- if .Values.datadog.otelCollector.configMap.items }}
+    {{- range .Values.datadog.otelCollector.configMap.items }}
+    - "--config={{ template "datadog.otelconfPath" $ }}/{{ .path }}"
+    {{- end }}
+    {{- else }}
     - "--config={{ template "datadog.otelconfPath" . }}/otel-config.yaml"
+    {{- end }}
     - "--core-config={{ template "datadog.confPath" .  }}/datadog.yaml"
     - "--sync-delay=30s"
     {{- if .Values.datadog.otelCollector.featureGates }}
@@ -16,7 +22,13 @@
   command:
     - "otel-agent"
     - "-foreground"
+    {{- if .Values.datadog.otelCollector.configMap.items }}
+    {{- range .Values.datadog.otelCollector.configMap.items }}
+    - "-config={{ template "datadog.otelconfPath" $ }}/{{ .path }}"
+    {{- end }}
+    {{- else }}
     - "-config={{ template "datadog.otelconfPath" . }}/otel-config.yaml"
+    {{- end }}
     - "--core-config={{ template "datadog.confPath" .  }}/datadog.yaml"
     - "--sync-delay=30s"
     {{- if .Values.datadog.otelCollector.featureGates }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -197,14 +197,22 @@ spec:
         configMap:
           {{- if .Values.datadog.otelCollector.configMap.name }}
           name: {{ .Values.datadog.otelCollector.configMap.name }}
+          {{- if .Values.datadog.otelCollector.configMap.items }}
           items:
-          - key: {{ .Values.datadog.otelCollector.configMap.key }}
-            path: otel-config.yaml
+            {{- range .Values.datadog.otelCollector.configMap.items }}
+            - key: {{ .key }}
+              path: {{ .path }}
+            {{- end }}
+          {{- else if .Values.datadog.otelCollector.configMap.key }}
+          items:
+            - key: {{ .Values.datadog.otelCollector.configMap.key }}
+              path: otel-config.yaml
+          {{- end }}
           {{- else }}
           name: {{ include "agents-install-otel-configmap-name" . }}
           items:
-          - key: otel-config.yaml
-            path: otel-config.yaml
+            - key: otel-config.yaml
+              path: otel-config.yaml
           {{- end }}
       {{- end }}
 {{- if .Values.agents.volumes }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -659,10 +659,10 @@ datadog:
       name: null
       # datadog.otelCollector.configMap.items -- Items within the ConfigMap that contain DDOT Collector configuration
       items:
-        - key: otel-config.yaml
-          path: otel-config.yaml
-        - key: otel-config-two.yaml
-          path: otel-config-two.yaml
+      #   - key: otel-config.yaml
+      #     path: otel-config.yaml
+      #   - key: otel-config-two.yaml
+      #     path: otel-config-two.yaml
       # datadog.otelCollector.configMap.key -- Key within the ConfigMap that contains the DDOT Collector configuration
       key: otel-config.yaml
     # datadog.otelCollector.featureGates -- Feature gates to pass to OTel collector, as a comma separated list

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -657,6 +657,12 @@ datadog:
     configMap:
       # datadog.otelCollector.configMap.name -- Name of the existing ConfigMap that contains the DDOT Collector configuration
       name: null
+      # datadog.otelCollector.configMap.items -- Items within the ConfigMap that contain DDOT Collector configuration
+      items:
+        - key: otel-config.yaml
+          path: otel-config.yaml
+        - key: otel-config-two.yaml
+          path: otel-config-two.yaml
       # datadog.otelCollector.configMap.key -- Key within the ConfigMap that contains the DDOT Collector configuration
       key: otel-config.yaml
     # datadog.otelCollector.featureGates -- Feature gates to pass to OTel collector, as a comma separated list


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds support for providing multiple items in otelCollector.configMap.items. Each item is an otel config, and the appropriate volume/ volume mounts will be created. The otel agent command will also be updated to pass all configs.

#### Which issue this PR fixes
OTAGENT-352


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
