### PR TITLE
Enable dogstatsd in clusterchecks when jmx image is used for cluster check runners

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 3.118.5
+* Enable `DD_USE_DOGSTATSD` when JMX image is used for the cluster check runners.
+
 ## 3.118.4
 
 * Update `fips.image.tag` to `1.1.12` fixing CVEs and updating packages.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.118.4
+version: 3.118.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.118.4](https://img.shields.io/badge/Version-3.118.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.118.5](https://img.shields.io/badge/Version-3.118.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -172,9 +172,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          # Remove unused features
+          {{- if eq .Values.clusterChecksRunner.image.tagSuffix "jmx" }}
+          - name: DD_USE_DOGSTATSD
+            value: "true"
+          {{- else }}
           - name: DD_USE_DOGSTATSD
             value: "false"
+          {{- end }}
+          # Remove unused features
           - name: DD_PROCESS_AGENT_ENABLED
             value: "false"
           - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED


### PR DESCRIPTION
#### What this PR does / why we need it:
Enable `DD_USE_DOGSTATSD` fo the cluster checks runner whenever a user uses the `-jmx` Datadog Agent image so that JMX based checks can run properly.

#### Which issue this PR fixes
CONS-7381


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
