### PR TITLE
[ACTP-757] add script action support

### DIFF
--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -220,8 +220,9 @@ If actions requiring credentials fail:
 | image | object | `{"repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.4.0"}` | Current Datadog Private Action Runner image |
 | nameOverride | string | `""` | Override name of app |
 | runner.affinity | object | `{}` | Kubernetes affinity settings for the runner pods |
-| runner.config | object | `{"actionsAllowlist":[],"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":9016,"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
+| runner.config | object | `{"actionsAllowlist":[],"bundles":{},"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":9016,"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |
 | runner.config.actionsAllowlist | list | `[]` | List of actions that the Datadog Private Action Runner is allowed to execute |
+| runner.config.bundles | object | `{}` | Bundles specific configuration |
 | runner.config.ddBaseURL | string | `"https://app.datadoghq.com"` | Base URL of the Datadog app |
 | runner.config.modes | list | `["workflowAutomation","appBuilder"]` | Modes that the runner can run in |
 | runner.config.port | int | `9016` | Port for HTTP server liveness checks and App Builder mode |

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -14,6 +14,15 @@ runner:
     port: 9016
     actionsAllowlist:
       - com.datadoghq.http.request
+    bundles:
+      "com.datadoghq.script":
+        runPredefinedScript:
+          echo-parametrized:
+            command: [ "echo", "{{ parameters.echoValue }}" ]
+          echo-nested-parametrized:
+            command: [ "echo", "{{ parameters.nested.echoValue }}" ]
+          echo-multiple-parametrized:
+            command: [ "echo", "{{ parameters.echoValue1 }} {{ parameters.echoValue2 }}" ]
   # Use a "Role" to scope the permissions to the runner's namespace or a "ClusterRole" to give permissions to the entire cluster
   roleType: "Role"
   env:

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -1,7 +1,7 @@
 # This is for the https://marketplace.visualstudio.com/items/?itemName=redhat.vscode-yaml VSCode extension
-# yaml-language-server: $schema=https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/gabriel.plassard/ACTP-757/add-support-for-script-action/charts/private-action-runner/values.schema.json
 # This is for jetbrains IDEs
-$schema: https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json
+$schema: https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/gabriel.plassard/ACTP-757/add-support-for-script-action/charts/private-action-runner/values.schema.json
 runner:
   # Replace this section with the output of the private action runner enrollment process with the `--enroll-and-print-config` flag
   config:

--- a/charts/private-action-runner/templates/secrets.yaml
+++ b/charts/private-action-runner/templates/secrets.yaml
@@ -45,7 +45,9 @@ stringData:
         {{- end }}
       {{- end}}
     {{- end}}
-    {{- if $.Values.runner.config.bundles }}
-    bundles: {{ $.Values.runner.config.bundles | toYaml | nindent 6 }}
-    {{- end }}
   {{- include "chart.credentialFiles" $ | indent 2 }}
+  {{- if $.Values.runner.config.bundles }}
+  script.yaml: |
+    schemaId: script-credentials-v1
+     {{ index $.Values.runner.config.bundles "com.datadoghq.script" | toYaml | nindent 4}}
+  {{- end }}

--- a/charts/private-action-runner/templates/secrets.yaml
+++ b/charts/private-action-runner/templates/secrets.yaml
@@ -42,4 +42,7 @@ stringData:
         {{- end }}
       {{- end}}
     {{- end}}
+    {{- if $.Values.runner.config.bundles }}
+    bundles: {{ $.Values.runner.config.bundles | toYaml | nindent 6 }}
+    {{- end }}
   {{- include "chart.credentialFiles" $ | indent 2 }}

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -77,6 +77,13 @@
               "items": {
                 "type": "string"
               }
+            },
+            "bundles": {
+              "type": "object",
+              "description": "Bundles specific configurations",
+              "items": {
+                "type": "object"
+              }
             }
           },
           "required": ["ddBaseURL", "modes"],

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -7,8 +7,8 @@ $schema: ./values.schema.json
 
 # -- Current Datadog Private Action Runner image
 image:
-  repository: gcr.io/datadoghq/private-action-runner
-  tag: v1.4.0
+  repository: datadog/private-action-runner-dev
+  tag: latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8
   pullPolicy: Always
 
 # nameOverride -- Override name of app

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -8,7 +8,7 @@ $schema: ./values.schema.json
 # -- Current Datadog Private Action Runner image
 image:
   repository: datadog/private-action-runner-dev
-  tag: latest@sha256:b47bb268f9123c2cb907f81a059ad62d35e2175d20f2f21a6ec8e0d5d5ed2b02
+  tag: latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145
   pullPolicy: Always
 
 # nameOverride -- Override name of app

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -8,7 +8,7 @@ $schema: ./values.schema.json
 # -- Current Datadog Private Action Runner image
 image:
   repository: datadog/private-action-runner-dev
-  tag: latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145
+  tag: latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d
   pullPolicy: Always
 
 # nameOverride -- Override name of app

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -7,8 +7,8 @@ $schema: ./values.schema.json
 
 # -- Current Datadog Private Action Runner image
 image:
-  repository: gcr.io/datadoghq/private-action-runner
-  tag: v1.4.0
+  repository: datadog/private-action-runner-dev
+  tag: latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8
 
 # nameOverride -- Override name of app
 nameOverride: ""

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -36,6 +36,8 @@ runner:
     port: 9016
     # -- List of actions that the Datadog Private Action Runner is allowed to execute
     actionsAllowlist: []
+    # -- Bundles specific configuration
+    bundles: {}
   # -- Environment variables to be passed to the Datadog Private Action Runner
   env:
     - name: DD_PRIVATE_RUNNER_CONFIG_DIR

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -99,12 +99,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 1b25944a20457f088dc32c19134e2b941a4e7bc0029cdf3c224703800cf1af36
+        checksum/values: f3b596273224c7cd5fb25609fb87856a6db09221fa6b7bf95de6a3a876d5d4df
     spec:
       serviceAccountName: custom-full-name
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -99,12 +99,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 5f2e760018247bed9426a52f638c961851352f9431ac23686b394cb6c871d31c
+        checksum/values: 1b25944a20457f088dc32c19134e2b941a4e7bc0029cdf3c224703800cf1af36
     spec:
       serviceAccountName: custom-full-name
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:b47bb268f9123c2cb907f81a059ad62d35e2175d20f2f21a6ec8e0d5d5ed2b02"
+          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -98,7 +98,7 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 7d3e9ebc39f014d37ff1cbc7a8a8b0e3d4d60f707e5906d23a60895a452789b4
+        checksum/values: 0db53883c86e483633008d8ee006c1da8513f80861b9d020934ee32f0c62e158
     spec:
       serviceAccountName: custom-full-name
       containers:

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: fd11ee9c922530b40cbef4ebb9fd7b8e7605a8d8fd8bafe66545611dc7dd6b71
+        checksum/values: 07a25da96fdb272be4198ccd1b18ca43b3a945d98dd47ab3fdc809890a1c18d7
     spec:
       serviceAccountName: custom-full-name
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 0db53883c86e483633008d8ee006c1da8513f80861b9d020934ee32f0c62e158
+        checksum/values: 7724b6b65035a08b03817c36f1d3de3f1d4a4cd1f08672e0970a38c74cc190bf
     spec:
       serviceAccountName: custom-full-name
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -98,7 +98,7 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 80cf8a4e558b434efcb5ed7013d2495a6ecdf4d5dbba496f0971b7d023f02497
+        checksum/values: 81459ddbce671cf961a73545090a6ce911e78e82f21914ba02091918d0a55a3a
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 81459ddbce671cf961a73545090a6ce911e78e82f21914ba02091918d0a55a3a
+        checksum/values: ccce58d750c27cd4f4977f83609d9db1aba3d84d6ff1a4f6987130d596e5e7d0
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 7144f80c204d2369c4a2710f410f6e7d9d03826db80a240100b235e081b599a6
+        checksum/values: 597b857feda8741b5244585a343b71c31e7c557c3d4151c8cbf74d66c967b69f
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:b47bb268f9123c2cb907f81a059ad62d35e2175d20f2f21a6ec8e0d5d5ed2b02"
+          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 597b857feda8741b5244585a343b71c31e7c557c3d4151c8cbf74d66c967b69f
+        checksum/values: 6a02aea7e1fca6e02afd74c5a26d34b0a3b4df7ce694a664f926edee75f2703f
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 09fdf8e64ced4d1dcc5f66e49d0eaf660bd313e473a73815c2d196fedda2d767
+        checksum/values: aebc2a650f9957f1335964eea27291643f21ab6d7ab6680aa33352959f5124d4
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: e2297d0610a7b2d9273eef4cfbd5590a5fc194361a16dd1f659fbc8d74914a5f
+        checksum/values: a8d90a3eb793c663e0fce4920467878c076df1163d28b83813110d8f7a0f20d5
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:b47bb268f9123c2cb907f81a059ad62d35e2175d20f2f21a6ec8e0d5d5ed2b02"
+          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: b5e43106bcb0a22f02b1eb0478aad5fb57d5f8f056ca5a098fb61ba2034c264e
+        checksum/values: 05a8715ea5012db3bdd17d8c418f1e94f43f1a8100f3715a095052f468219401
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: b8af2ee1e1c88329a48ecaf9dd61b52d93fc13329e8db5a7bae74da93ab07457
+        checksum/values: 2eab8135d10977f85858ba04f28a8739f653edc5ec7b01b6f6c7d93009f4157e
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -98,7 +98,7 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: cbdedb8fe0d0f91309dbe6099357aa3a72c116d034b663c881481820ab266f4d
+        checksum/values: b5e43106bcb0a22f02b1eb0478aad5fb57d5f8f056ca5a098fb61ba2034c264e
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: a8d90a3eb793c663e0fce4920467878c076df1163d28b83813110d8f7a0f20d5
+        checksum/values: 22e6ee9ab8f7c30a2d6d786b10506da88e7096f79fce6a0df62ea1c2256547bf
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 12108142908cedfc10cca556dfb05d1028d47925ef61bd0fd327cde77e4b487b
+        checksum/values: d8ff3ab17d1df850573cce39f4f4c185b0691f61d4ff341900d4caf134baf235
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: b01684f56fe4a93caae1823f109266a84a74583b800a954223b488394660ffc5
+        checksum/values: 3043984426c692928163da9d762bf7c1642f950ae69e5e3a01aff328a5579203
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 3b89ad82325f82162c9526ce24658028df365986016608f7412937fd5b6d38fd
+        checksum/values: b01684f56fe4a93caae1823f109266a84a74583b800a954223b488394660ffc5
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:b47bb268f9123c2cb907f81a059ad62d35e2175d20f2f21a6ec8e0d5d5ed2b02"
+          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -98,7 +98,7 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 66c2eaafe50c120cbaeac86b62a882507132240e723678edd55fdaa86270537d
+        checksum/values: bbfc924b29021cc3ad79aafc6ae633e68876a4ec3436e67971d19baf4648cce5
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: bbfc924b29021cc3ad79aafc6ae633e68876a4ec3436e67971d19baf4648cce5
+        checksum/values: 748a4c3f4ae4c634678ba54f8601d488d42e89dc0760dd2b88d82890f3490ebc
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -151,12 +151,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: a3bd559cb9599647e90f7167869c949221cb1dd19348272cf1074a1cd54e4a1b
+        checksum/values: e817507124d28e74bfde89be9e696e55d6f7a3b522076d7807e8070cc5d55d52
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -151,12 +151,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 3593975d1c013636143981b0f6de2d5a4e57ab40084d7ae090fc9a7321e40c67
+        checksum/values: 50454dc0dd89b4a85c62ac60070fa4dc593a453f8541b4d7f4fda5b5ee3347a4
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -151,12 +151,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 6104d28b1d69574d8c615e4d8909fb4ab81824d4efd160de5933f0bdc9b15df1
+        checksum/values: 9cce466839a1928863d6c07cb0a5c358e0bb49df68c82c4c7c1b693de62d7a66
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -151,7 +151,7 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: f673cce7d82ab74161452aba49e1f8828cc3dcd50c4b16ed3218de605011213d
+        checksum/values: 6104d28b1d69574d8c615e4d8909fb4ab81824d4efd160de5933f0bdc9b15df1
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -151,12 +151,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: f52f357b346dfbc4747ea73d6d904844bd152626f26c9af8299c45fdd643af7b
+        checksum/values: a3bd559cb9599647e90f7167869c949221cb1dd19348272cf1074a1cd54e4a1b
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:b47bb268f9123c2cb907f81a059ad62d35e2175d20f2f21a6ec8e0d5d5ed2b02"
+          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -247,12 +247,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 88ae59e507c5188f08dd5655ea801a24185759ef747fde3f4aca406345dff9a3
+        checksum/values: a5e2fcdc91ae3a20313e36b7380c73fee7c2e63c139c9afec2c358817f96fca0
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -24,22 +24,7 @@ stringData:
     actionsAllowlist:
       - com.datadoghq.http.request
       - com.datadoghq.kubernetes.core.getPod
-      - com.datadoghq.kubernetes.core.listPod
-    bundles: 
-      com.datadoghq.script:
-        runPredefinedScript:
-          echo-multiple-parametrized:
-            command:
-            - echo
-            - '{{ parameters.echoValue1 }} {{ parameters.echoValue2 }}'
-          echo-nested-parametrized:
-            command:
-            - echo
-            - '{{ parameters.nested.echoValue }}'
-          echo-parametrized:
-            command:
-            - echo
-            - '{{ parameters.echoValue }}'  
+      - com.datadoghq.kubernetes.core.listPod  
   http_basic.json: |
     {
       "auth_type": "Basic Auth",
@@ -173,6 +158,23 @@ stringData:
         }
       ]
     }
+    
+  script.yaml: |
+    schemaId: script-credentials-v1
+     
+    runPredefinedScript:
+      echo-multiple-parametrized:
+        command:
+        - echo
+        - '{{ parameters.echoValue1 }} {{ parameters.echoValue2 }}'
+      echo-nested-parametrized:
+        command:
+        - echo
+        - '{{ parameters.nested.echoValue }}'
+      echo-parametrized:
+        command:
+        - echo
+        - '{{ parameters.echoValue }}'
 ---
 # Source: private-action-runner/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -247,12 +249,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 3a98c291ca5aee521cf55e65528e9b23e1badeb9a5ee51f1b44ab0870f56141d
+        checksum/values: 01e235c8a8f451ff275ba030e5d51b1ec5296b2911549f8d9aa276f70e686263
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -247,12 +247,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 2d7020d3dcfb611c20f2ede1a5a801cbcf53741a2d8414a10392764db77fe06b
+        checksum/values: 3acd341401b4e5666050f5b63f9b1fda0fa3e0cdb829bf3b0824dccab94f67da
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -247,12 +247,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 96dbc345b9da1b9aa3c2260d81b11e0ca1cba4c70898c415f44b7b4cd311b2b6
+        checksum/values: 3a98c291ca5aee521cf55e65528e9b23e1badeb9a5ee51f1b44ab0870f56141d
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:b47bb268f9123c2cb907f81a059ad62d35e2175d20f2f21a6ec8e0d5d5ed2b02"
+          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -24,7 +24,22 @@ stringData:
     actionsAllowlist:
       - com.datadoghq.http.request
       - com.datadoghq.kubernetes.core.getPod
-      - com.datadoghq.kubernetes.core.listPod  
+      - com.datadoghq.kubernetes.core.listPod
+    bundles: 
+      com.datadoghq.script:
+        runPredefinedScript:
+          echo-multiple-parametrized:
+            command:
+            - echo
+            - '{{ parameters.echoValue1 }} {{ parameters.echoValue2 }}'
+          echo-nested-parametrized:
+            command:
+            - echo
+            - '{{ parameters.nested.echoValue }}'
+          echo-parametrized:
+            command:
+            - echo
+            - '{{ parameters.echoValue }}'  
   http_basic.json: |
     {
       "auth_type": "Basic Auth",
@@ -232,7 +247,7 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: fe8a7c5d8265721edb6aa41d28e0e3851956c0f44afa636db8d96e7cf4445cab
+        checksum/values: 88ae59e507c5188f08dd5655ea801a24185759ef747fde3f4aca406345dff9a3
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -96,12 +96,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 753abd14cbaaa9377194007b200bcf8f16fe2f572ea846f0b21e05438bbcbb94
+        checksum/values: 97402a84b440d716045e721d586a4f018dd6d1e91dfce0baa68d4531b153173c
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -96,7 +96,7 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: d952c293bbea5e7cb58517878e92c814a3d612589f852d3b9a6bae88ac6aa59a
+        checksum/values: 753abd14cbaaa9377194007b200bcf8f16fe2f572ea846f0b21e05438bbcbb94
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -96,12 +96,12 @@ spec:
         app.kubernetes.io/version: "v1.4.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 0f422519709220501d5fc3e993e9a72cd8879eed9760994e0cad3e754fa0ed51
+        checksum/values: f6da789c2609179c10f1a78714740c05fde0494a4c3c6ebaf98028ddc8b268ea
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.4.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:4e990e496b79d02514c19a633042d27be1ba8e7a4b9018efd0e942ed1a070ad8"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -96,12 +96,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: e61677c19ffce7d0edff6327be00cceaa65c3f7fc197d52e4b502059be44857f
+        checksum/values: f74a02b58d87368a79d462726fbcba61aeb906848a3d3d83d51daaa21e683431
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -96,12 +96,12 @@ spec:
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 47575afa064fb00b0b610fc052896db49e82bfb04fef8cafedfcb12f8ffe83d9
+        checksum/values: e61677c19ffce7d0edff6327be00cceaa65c3f7fc197d52e4b502059be44857f
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:b47bb268f9123c2cb907f81a059ad62d35e2175d20f2f21a6ec8e0d5d5ed2b02"
+          image: "datadog/private-action-runner-dev:latest@sha256:7cb533bf1f59051bc4ad36d34c2a161ddaf5a8cd0a2dc62998397eb623070145"
           imagePullPolicy: Always
           ports:
             - name: http


### PR DESCRIPTION
#### What this PR does / why we need it:

Add minimal support for the script action

#### Special notes for your reviewer:

Don't merge yet, we might make changes before release

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
