### PR TITLE
[Documentation] Add DAP CRD explicitly to values.yaml

### DIFF
--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.11.0-dev.2
+version: 2.11.0
 appVersion: 1.16.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.11.0-dev.2](https://img.shields.io/badge/Version-2.11.0--dev.2-informational?style=flat-square) ![AppVersion: 1.16.0-rc.1](https://img.shields.io/badge/AppVersion-1.16.0--rc.1-informational?style=flat-square)
+![Version: 2.11.0](https://img.shields.io/badge/Version-2.11.0-informational?style=flat-square) ![AppVersion: 1.16.0-rc.1](https://img.shields.io/badge/AppVersion-1.16.0--rc.1-informational?style=flat-square)
 
 ## Values
 
@@ -17,6 +17,7 @@
 | containerSecurityContext | object | `{}` | A security context defines privileges and access control settings for a container. |
 | datadogAgent.enabled | bool | `true` | Enables Datadog Agent controller |
 | datadogAgentProfile.enabled | bool | `false` | If true, enables DatadogAgentProfile controller (beta). Requires v1.5.0+ |
+| datadogCRDs.crds.datadogAgentProfiles | bool | `false` | Set to true to deploy the DatadogAgentProfile CRD |
 | datadogCRDs.crds.datadogAgents | bool | `true` | Set to true to deploy the DatadogAgents CRD |
 | datadogCRDs.crds.datadogDashboards | bool | `false` | Set to true to deploy the DatadogDashboard CRD |
 | datadogCRDs.crds.datadogGenericResources | bool | `false` | Set to true to deploy the DatadogGenericResource CRD |

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -152,6 +152,8 @@ datadogCRDs:
     datadogDashboards: false
     # datadogCRDs.crds.datadogGenericResources -- Set to true to deploy the DatadogGenericResource CRD
     datadogGenericResources: false
+    # datadogCRDs.crds.datadogAgentProfiles -- Set to true to deploy the DatadogAgentProfile CRD
+    datadogAgentProfiles: false
 
 # podAnnotations -- Allows setting additional annotations for Datadog Operator PODs
 podAnnotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
* Adds `datadogCRDs.crds.datadogAgentProfiles` explicitly to `values.yaml`

#### Which issue this PR fixes
* the CRDs section depends on the `datadog/datadog-crds` chart where this is defined: https://github.com/DataDog/helm-charts/blob/246666ffc0cb7233ed1631e812ae3b71a8434c8b/charts/datadog-crds/values.yaml#L14-L15
    * We simply document it for ease of access, but it was already available before

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
