### PR TITLE
Add otelCollector.useStandaloneImage parameter to configure `ddot-collectro`

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.121.0
+
+* Add `datadog.otelCollector.useStandaloneImage` to configure the `otel-agent` container to use the new `ddot-collector` image, defaulted to `true`.
+/!\ If `datadog.otelCollector.enabled` is set to `true`, please ensure you can pull the image `{{- agents.image.registry -}}/ddot-collector:{{- agents.image.tag}}` (i.e. `gcr.io/datadoghq/ddot-collector:7.67.0`).
+
 ## 3.120.0
 
 * `apm.instrumentation.targets` supports `valueFrom`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.120.0
+version: 3.121.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -1,6 +1,6 @@
 {{- define "container-otel-agent" -}}
 - name: otel-agent
-  image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
+  image: "{{ include "ddot-collector-image" . }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
   {{- if eq .Values.targetSystem "linux" }}
   command:

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -10,7 +10,7 @@
 {{- $version = "6.55.1" -}}
 {{- end -}}
 {{- if and (eq $length 1) (or (eq $version "7") (eq $version "latest")) -}}
-{{- $version = "7.59.0" -}}
+{{- $version = "7.67.0" -}}
 {{- end -}}
 {{- $version -}}
 {{- end -}}
@@ -381,6 +381,23 @@ Return a remote image path based on `.Values` (passed as root) and `.` (any `.im
 {{- else -}}
 {{ include "registry" .root }}/{{ .image.name }}:{{ .image.tag }}{{ $tagSuffix }}
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return a remote otel-agent based on `.Values` (passed as .)
+*/}}
+{{- define "ddot-collector-image" -}}
+{{- if .Values.datadog.otelCollector.useStandaloneImage -}}
+{{- if semverCompare "<7.67.0" (include "agent-version" .) -}}
+{{- fail "datadog.otelCollector.useStandaloneImage is only supported for agent versions 7.67.0+. Please bump the agent version to 7.67.0+ or set datadog.otelCollector.useStandaloneImage to false and set agents.image.tagSuffix to `-full`" -}}
+{{- end -}}
+{{ include "registry" . }}/ddot-collector:{{ include "agent-version" . }}
+{{- else -}}
+{{- if ne .Values.agents.image.tagSuffix "full" -}}
+{{- fail "When datadog.otelCollector.useStandaloneImage is false, agents.image.tagSuffix must be set to 'full' to use the agent image with OTel collector" -}}
+{{- end -}}
+{{ include "image-path" (dict "root" . "image" .agents.image) }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -389,15 +389,15 @@ Return a remote otel-agent based on `.Values` (passed as .)
 */}}
 {{- define "ddot-collector-image" -}}
 {{- if .Values.datadog.otelCollector.useStandaloneImage -}}
-{{- if semverCompare "<7.67.0" (include "agent-version" .) -}}
+{{- if semverCompare "<7.67.0" (include "get-agent-version" .) -}}
 {{- fail "datadog.otelCollector.useStandaloneImage is only supported for agent versions 7.67.0+. Please bump the agent version to 7.67.0+ or set datadog.otelCollector.useStandaloneImage to false and set agents.image.tagSuffix to `-full`" -}}
 {{- end -}}
-{{ include "registry" . }}/ddot-collector:{{ include "agent-version" . }}
+{{ include "registry" .Values }}/ddot-collector:{{ include "get-agent-version" . }}
 {{- else -}}
 {{- if ne .Values.agents.image.tagSuffix "full" -}}
 {{- fail "When datadog.otelCollector.useStandaloneImage is false, agents.image.tagSuffix must be set to 'full' to use the agent image with OTel collector" -}}
 {{- end -}}
-{{ include "image-path" (dict "root" . "image" .agents.image) }}
+{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -6,10 +6,10 @@
 ## ONLY SET THE VALUES YOU WANT TO OVERRIDE IN YOUR values.yaml.
 
 # nameOverride -- Override name of app
-nameOverride:  # ""
+nameOverride: # ""
 
 # fullnameOverride -- Override the full qualified app name
-fullnameOverride:  # ""
+fullnameOverride: # ""
 
 # targetSystem -- Target OS for this deployment (possible values: linux, windows)
 targetSystem: "linux"
@@ -29,29 +29,29 @@ commonLabels: {}
 ## DockerHub - use docker.io/datadog
 ## If you are on GKE Autopilot, you must use a gcr.io variant registry.
 
-registry:  # gcr.io/datadoghq
+registry: # gcr.io/datadoghq
 
 datadog:
   # datadog.apiKey -- Your Datadog API key
 
   ## ref: https://app.datadoghq.com/account/settings#agent/kubernetes
-  apiKey:  # <DATADOG_API_KEY>
+  apiKey: # <DATADOG_API_KEY>
 
   # datadog.apiKeyExistingSecret -- Use existing Secret which stores API key instead of creating a new one. The value should be set with the `api-key` key inside the secret.
 
   ## If set, this parameter takes precedence over "apiKey".
-  apiKeyExistingSecret:  # <DATADOG_API_KEY_SECRET>
+  apiKeyExistingSecret: # <DATADOG_API_KEY_SECRET>
 
   # datadog.appKey -- Datadog APP key required to use metricsProvider
 
   ## If you are using clusterAgent.metricsProvider.enabled = true, you must set
   ## a Datadog application key for read access to your metrics.
-  appKey:  # <DATADOG_APP_KEY>
+  appKey: # <DATADOG_APP_KEY>
 
   # datadog.appKeyExistingSecret -- Use existing Secret which stores APP key instead of creating a new one. The value should be set with the `app-key` key inside the secret.
 
   ## If set, this parameter takes precedence over "appKey".
-  appKeyExistingSecret:  # <DATADOG_APP_KEY_SECRET>
+  appKeyExistingSecret: # <DATADOG_APP_KEY_SECRET>
 
   # agents.secretAnnotations -- Annotations to add to the Secrets
   secretAnnotations: {}
@@ -64,16 +64,16 @@ datadog:
 
     ## Note: If the command value is "/readsecret_multiple_providers.sh", and datadog.secretBackend.enableGlobalPermissions is enabled below, the agents will have permissions to get secret objects across the cluster.
     ## Read more about "/readsecret_multiple_providers.sh": https://docs.datadoghq.com/agent/guide/secrets-management/#script-for-reading-from-multiple-secret-providers-readsecret_multiple_providerssh
-    command:  # "/readsecret.sh" or "/readsecret_multiple_providers.sh" or any custom binary path
+    command: # "/readsecret.sh" or "/readsecret_multiple_providers.sh" or any custom binary path
 
     # datadog.secretBackend.arguments -- Configure the secret backend command arguments (space-separated strings).
-    arguments:  # "/etc/secret-volume" or any other custom arguments
+    arguments: # "/etc/secret-volume" or any other custom arguments
 
     # datadog.secretBackend.timeout -- Configure the secret backend command timeout in seconds.
-    timeout:  # 30
+    timeout: # 30
 
     # datadog.secretBackend.refreshInterval -- [PREVIEW] Configure the secret backend command refresh interval in seconds.
-    refreshInterval:  # 0
+    refreshInterval: # 0
 
     # datadog.secretBackend.enableGlobalPermissions -- Whether to create a global permission allowing Datadog agents to read all secrets when `datadog.secretBackend.command` is set to `"/readsecret_multiple_providers.sh"`.
     enableGlobalPermissions: true
@@ -108,7 +108,7 @@ datadog:
   ## * Overall length should not be higher than 80 characters.
   ## Compared to the rules of GKE, dots are allowed whereas they are not allowed on GKE:
   ## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
-  clusterName:  # <CLUSTER_NAME>
+  clusterName: # <CLUSTER_NAME>
 
   # datadog.site -- The site of the Datadog intake to send Agent data to.
   # (documentation: https://docs.datadoghq.com/getting_started/site/)
@@ -119,12 +119,12 @@ datadog:
   ## Set to 'us5.datadoghq.com' to send data to the US5 site.
   ## Set to 'ddog-gov.com' to send data to the US1-FED site.
   ## Set to 'ap1.datadoghq.com' to send data to the AP1 site.
-  site:  # datadoghq.com
+  site: # datadoghq.com
 
   # datadog.dd_url -- The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL
 
   ## Overrides the site setting defined in "site".
-  dd_url:  # https://app.datadoghq.com
+  dd_url: # https://app.datadoghq.com
 
   # datadog.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, off
   logLevel: INFO
@@ -146,7 +146,7 @@ datadog:
     enabled: true
 
     rbac:
-    # datadog.kubeStateMetricsCore.rbac.create -- If true, create & use RBAC resources
+      # datadog.kubeStateMetricsCore.rbac.create -- If true, create & use RBAC resources
       create: true
 
     # datadog.kubeStateMetricsCore.ignoreLegacyKSMCheck -- Disable the auto-configuration of legacy kubernetes_state check (taken into account only when datadog.kubeStateMetricsCore.enabled is true)
@@ -313,7 +313,7 @@ datadog:
   # datadog.checksCardinality -- Sets the tag cardinality for the checks run by the Agent.
 
   ## ref: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
-  checksCardinality:  # low, orchestrator or high (not set by default to avoid overriding existing DD_CHECKS_TAG_CARDINALITY configurations, the default value in the Agent is low)
+  checksCardinality: # low, orchestrator or high (not set by default to avoid overriding existing DD_CHECKS_TAG_CARDINALITY configurations, the default value in the Agent is low)
 
   # kubelet configuration
   kubelet:
@@ -324,7 +324,7 @@ datadog:
           fieldPath: status.hostIP
     # datadog.kubelet.tlsVerify -- Toggle kubelet TLS verification
     # @default -- true
-    tlsVerify:  # false
+    tlsVerify: # false
     # datadog.kubelet.hostCAPath -- Path (on host) where the Kubelet CA certificate is stored
     # @default -- None (no mount from host)
     hostCAPath:
@@ -343,7 +343,6 @@ datadog:
     # datadog.kubelet.useApiServer -- Enable this to query the pod list from the API Server instead of the Kubelet. (Requires Agent 7.65.0+)
     # @default -- false
     useApiServer: false
-
 
   # datadog.expvarPort -- Specify the port to expose pprof and expvar to not interfere with the agent metrics port from the cluster-agent, which defaults to 5000
   expvarPort: 6000
@@ -432,10 +431,10 @@ datadog:
     unbundleEvents: false
     # datadog.kubernetesEvents.collectedEventTypes -- Event types to be collected. This requires datadog.kubernetesEvents.unbundleEvents to be set to true.
     collectedEventTypes:
-    # - kind: <kubernetes resource kind> # (optional if `source`` is provided)
-    #   source: <controller name> # (optional if `kind`` is provided)
-    #   reasons: # (optional) if empty accept all event reasons
-    #   - <kubernetes event reason>
+      # - kind: <kubernetes resource kind> # (optional if `source`` is provided)
+      #   source: <controller name> # (optional if `kind`` is provided)
+      #   reasons: # (optional) if empty accept all event reasons
+      #   - <kubernetes event reason>
       - kind: Pod
         reasons:
           - Failed
@@ -462,7 +461,7 @@ datadog:
   leaderElection: true
 
   # datadog.leaderLeaseDuration -- Set the lease time for leader election in second
-  leaderLeaseDuration:  # 60
+  leaderLeaseDuration: # 60
 
   # datadog.leaderElectionResource -- Selects the default resource to use for leader election.
   # Can be:
@@ -648,8 +647,7 @@ datadog:
     enabled: false
     # datadog.otelCollector.ports -- Ports that OTel Collector is listening on
     ports:
-
-        # Default GRPC port of OTLP receiver
+      # Default GRPC port of OTLP receiver
       - containerPort: "4317"
         name: otel-grpc
         protocol: TCP
@@ -685,6 +683,12 @@ datadog:
       # If true, checks OTel Collector config for filelog receiver and mounts additional volumes to collect containers
       # and pods logs.
       enabled: false
+
+    ## datadog.otelCollector.useStandaloneImage -- If true, the OTel Collector will use the `ddot-collector` image instead of the `agent` image
+    ## The tag is retrieved from the `agents.image.tag` value.
+    ## This is only supported for agent versions 7.67.0+
+    ## If set to false, you will need to set `agents.image.tagSuffix` to `-full`
+    useStandaloneImage: true
 
   ## Continuous Profiler configuration
   ##
@@ -753,10 +757,10 @@ datadog:
   #   service.py: |-
 
   # datadog.dockerSocketPath -- Path to the docker socket
-  dockerSocketPath:  # /var/run/docker.sock
+  dockerSocketPath: # /var/run/docker.sock
 
   # datadog.criSocketPath -- Path to the container runtime socket (if different from Docker)
-  criSocketPath:  # /var/run/containerd/containerd.sock
+  criSocketPath: # /var/run/containerd/containerd.sock
 
   # Configure how the agent interact with the host's container runtime
   containerRuntimeSupport:
@@ -784,10 +788,11 @@ datadog:
 
     # datadog.processAgent.runInCoreAgent -- Set this to true to run the following features in the core agent: Live Processes, Live Containers, Process Discovery.
     ## This requires Agent 7.60.0+ and Linux.
-    runInCoreAgent: true
+    runInCoreAgent:
+      true
 
-     # datadog.processAgent.containerCollection -- Set this to true to enable container collection
-     ## ref: https://docs.datadoghq.com/infrastructure/containers/?tab=helm
+      # datadog.processAgent.containerCollection -- Set this to true to enable container collection
+      ## ref: https://docs.datadoghq.com/infrastructure/containers/?tab=helm
     containerCollection: true
 
   # datadog.disableDefaultOsReleasePaths -- Set this to true to disable mounting datadog.osReleasePath in all containers
@@ -801,7 +806,6 @@ datadog:
 
   ## Enable systemProbe agent and provide custom configs
   systemProbe:
-
     # datadog.systemProbe.debugPort -- Specify the port to expose pprof and expvar for system-probe agent
     debugPort: 0
 
@@ -852,7 +856,7 @@ datadog:
     maxTrackedConnections: 131072
 
     # datadog.systemProbe.conntrackMaxStateSize -- the maximum size of the userspace conntrack cache
-    conntrackMaxStateSize: 131072  # 2 * maxTrackedConnections by default, per  https://github.com/DataDog/datadog-agent/blob/d1c5de31e1bba72dfac459aed5ff9562c3fdcc20/pkg/process/config/config.go#L229
+    conntrackMaxStateSize: 131072 # 2 * maxTrackedConnections by default, per  https://github.com/DataDog/datadog-agent/blob/d1c5de31e1bba72dfac459aed5ff9562c3fdcc20/pkg/process/config/config.go#L229
 
     # datadog.systemProbe.conntrackInitTimeout -- the time to wait for conntrack to initialize before failing
     conntrackInitTimeout: 10s
@@ -863,7 +867,6 @@ datadog:
 
     # datadog.systemProbe.enableDefaultKernelHeadersPaths -- Enable mount of default paths where kernel headers are stored
     enableDefaultKernelHeadersPaths: true
-
 
   containerImageCollection:
     # datadog.containerImageCollection.enabled -- Enable collection of container image metadata
@@ -906,7 +909,8 @@ datadog:
 
     # datadog.helmCheck.valuesAsTags -- Collects Helm values from a release and uses them as tags (Requires Agent and Cluster Agent 7.40.0+).
     # This requires datadog.HelmCheck.enabled to be set to true
-    valuesAsTags: {}
+    valuesAsTags:
+      {}
       #   <HELM_VALUE>: <LABEL_NAME>
 
   networkMonitoring:
@@ -943,7 +947,7 @@ datadog:
 
   discovery:
     # datadog.discovery.enabled -- (bool) Enable Service Discovery
-    enabled:  # false
+    enabled: # false
 
     # datadog.discovery.networkStats.enabled -- (bool) Enable Service Discovery Network Stats
     networkStats:
@@ -958,7 +962,6 @@ datadog:
 
     # datadog.gpuMonitoring.runtimeClassName -- Runtime class name for the agent pods to get access to NVIDIA resources. Can be left empty to use the default runtime class.
     runtimeClassName: "nvidia"
-
 
   # Software Bill of Materials configuration
   sbom:
@@ -1081,7 +1084,8 @@ datadog:
     # datadog.prometheusScrape.serviceEndpoints -- Enable generating dedicated checks for service endpoints.
     serviceEndpoints: false
     # datadog.prometheusScrape.additionalConfigs -- Allows adding advanced openmetrics check configurations with custom discovery rules. (Requires Agent version 7.27+)
-    additionalConfigs: []
+    additionalConfigs:
+      []
       # -
       #   autodiscovery:
       #     kubernetes_annotations:
@@ -1110,7 +1114,7 @@ datadog:
   # datadog.containerExclude -- Exclude containers from Agent Autodiscovery, as a space-separated list
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
-  containerExclude:  # "image:datadog/agent"
+  containerExclude: # "image:datadog/agent"
 
   # datadog.containerInclude -- Include containers in Agent Autodiscovery, as a space-separated list.
   # If a container matches an include rule, it’s always included in Autodiscovery
@@ -1201,7 +1205,7 @@ clusterAgent:
     ## This boolean permits completely skipping this check.
     ## This is useful, for example, for custom tags that are not
     ## respecting semantic versioning.
-    doNotCheckTag:  # false
+    doNotCheckTag: # false
 
   # clusterAgent.securityContext -- Allows you to overwrite the default PodSecurityContext on the cluster-agent pods.
   securityContext: {}
@@ -1301,7 +1305,7 @@ clusterAgent:
       port: 8443
 
     # clusterAgent.metricsProvider.endpoint -- Override the external metrics provider endpoint. If not set, the cluster-agent defaults to `datadog.site`
-    endpoint:  # https://api.datadoghq.com
+    endpoint: # https://api.datadoghq.com
 
   # clusterAgent.env -- Set environment variables specific to Cluster Agent
 
@@ -1352,7 +1356,7 @@ clusterAgent:
     ##   * Otherwise, the Admission Controller defaults to hostip.
     ## Note: "service" mode relies on the internal traffic service to target the agent running on the local node (requires Kubernetes v1.22+).
     ## ref: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/#configure-apm-and-dogstatsd-communication-mode
-    configMode:  # "hostip", "socket" or "service"
+    configMode: # "hostip", "socket" or "service"
 
     # clusterAgent.admissionController.failurePolicy -- Set the failure policy for dynamic admission control.'
 
@@ -1412,7 +1416,8 @@ clusterAgent:
       imageTag:
 
       # clusterAgent.admissionController.agentSidecarInjection.selectors -- Defines the pod selector for sidecar injection, currently only one rule is supported.
-      selectors: []
+      selectors:
+        []
         # - objectSelector:
         #   matchLabels:
         #       "podlabelKey1": podlabelValue1
@@ -1425,7 +1430,8 @@ clusterAgent:
       # clusterAgent.admissionController.agentSidecarInjection.profiles -- Defines the sidecar configuration override, currently only one profile is supported.
 
       ## This setting allows overriding the sidecar Agent configuration by adding environment variables and providing resource settings.
-      profiles: []
+      profiles:
+        []
         # - env:
         #     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
         #       value: "true"
@@ -1484,7 +1490,7 @@ clusterAgent:
   #   memory: 256Mi
 
   # clusterAgent.priorityClassName -- Name of the priorityClass to apply to the Cluster Agent
-  priorityClassName:  # system-cluster-critical
+  priorityClassName: # system-cluster-critical
 
   # clusterAgent.nodeSelector -- Allow the Cluster Agent Deployment to be scheduled on selected nodes
 
@@ -1599,14 +1605,15 @@ clusterAgent:
     create: false
 
   # clusterAgent.additionalLabels -- Adds labels to the Cluster Agent deployment and pods
-  additionalLabels: {}
+  additionalLabels:
+    {}
     # key: "value"
 
   # clusterAgent.containerExclude -- Exclude containers from the Cluster Agent
   # Autodiscovery, as a space-separated list. (Requires Agent/Cluster Agent 7.50.0+)
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
-  containerExclude:  # "image:datadog/agent"
+  containerExclude: # "image:datadog/agent"
 
   # clusterAgent.containerInclude -- Include containers in the Cluster Agent Autodiscovery,
   # as a space-separated list.  If a container matches an include rule, it’s
@@ -1623,10 +1630,10 @@ existingClusterAgent:
   join: false
 
   # existingClusterAgent.tokenSecretName -- Existing secret name to use for external Cluster Agent token
-  tokenSecretName:  # <EXISTING_DCA_SECRET_NAME>
+  tokenSecretName: # <EXISTING_DCA_SECRET_NAME>
 
   # existingClusterAgent.serviceName -- Existing service name to use for reaching the external Cluster Agent
-  serviceName:  # <EXISTING_DCA_SERVICE_NAME>
+  serviceName: # <EXISTING_DCA_SERVICE_NAME>
 
   # existingClusterAgent.clusterchecksEnabled -- set this to false if you don’t want the agents to run the cluster checks of the joined external cluster agent
   clusterchecksEnabled: true
@@ -1658,7 +1665,8 @@ fips:
 
   # fips.resources -- Resource requests and limits for the FIPS sidecar container.
   # This setting is only used for the fips-proxy sidecar.
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 256Mi
@@ -1691,7 +1699,7 @@ fips:
 
   ## Note: Use `|` to declare multi-line configuration.
   ## ref: https://docs.datadoghq.com/agent/guide/agent-fips-proxy
-  customFipsConfig: {}  # |
+  customFipsConfig: {} # |
   #  foobar
   #     foo bar baz
 
@@ -1729,6 +1737,7 @@ agents:
     ## Ex:
     ##  jmx        to enable jmx fetch collection
     ##  servercore to get Windows images based on servercore
+    ## full        to get the full image (includes ddot-collector)
     tagSuffix: ""
 
     # agents.image.repository -- Override default registry + image.name for Agent
@@ -1741,7 +1750,7 @@ agents:
     ## This boolean permits to completely skip this check.
     ## This is useful, for example, for custom tags that are not
     ## respecting semantic versioning
-    doNotCheckTag:  # false
+    doNotCheckTag: # false
 
     # agents.image.pullPolicy -- Datadog Agent image pull policy
     pullPolicy: IfNotPresent
@@ -1856,7 +1865,7 @@ agents:
 
       # agents.containers.agent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.agent.resources -- Resource requests and limits for the agent container.
       resources: {}
@@ -1920,7 +1929,7 @@ agents:
 
       # agents.containers.processAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.processAgent.resources -- Resource requests and limits for the process-agent container
       resources: {}
@@ -1989,7 +1998,7 @@ agents:
       #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
 
       # agents.containers.traceAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.traceAgent.resources -- Resource requests and limits for the trace-agent container
       resources: {}
@@ -2030,7 +2039,7 @@ agents:
 
       # agents.containers.systemProbe.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.systemProbe.resources -- Resource requests and limits for the system-probe container
       resources: {}
@@ -2047,7 +2056,18 @@ agents:
       securityContext:
         privileged: false
         capabilities:
-          add: ["SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN", "DAC_READ_SEARCH"]
+          add:
+            [
+              "SYS_ADMIN",
+              "SYS_RESOURCE",
+              "SYS_PTRACE",
+              "NET_ADMIN",
+              "NET_BROADCAST",
+              "NET_RAW",
+              "IPC_LOCK",
+              "CHOWN",
+              "DAC_READ_SEARCH",
+            ]
 
       # agents.containers.systemProbe.ports -- Allows to specify extra ports (hostPorts for instance) for this container
       ports: []
@@ -2069,7 +2089,7 @@ agents:
 
       # agents.containers.securityAgent.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.securityAgent.resources -- Resource requests and limits for the security-agent container
       resources: {}
@@ -2100,7 +2120,7 @@ agents:
 
       # agents.containers.agentDataPlane.logLevel -- Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off.
       # If not set, fall back to the value of datadog.logLevel.
-      logLevel:  # INFO
+      logLevel: # INFO
 
       # agents.containers.agentDataPlane.resources -- Resource requests and limits for the agent-data-plane container
       resources: {}
@@ -2236,11 +2256,12 @@ agents:
   podLabels: {}
 
   # agents.additionalLabels -- Adds labels to the Agent daemonset and pods
-  additionalLabels: {}
+  additionalLabels:
+    {}
     # key: "value"
 
   # agents.useConfigMap -- Configures a configmap to provide the agent configuration. Use this in combination with the `agents.customAgentConfig` parameter.
-  useConfigMap:  # false
+  useConfigMap: # false
 
   # agents.customAgentConfig -- Specify custom contents for the datadog agent config (datadog.yaml)
 
@@ -2336,7 +2357,6 @@ clusterChecksRunner:
     # clusterChecksRunner.rbac.serviceAccountAdditionalLabels -- Labels to add to the ServiceAccount if clusterChecksRunner.rbac.dedicated is true
     serviceAccountAdditionalLabels: {}
 
-
     # clusterChecksRunner.rbac.automountServiceAccountToken -- If true, automatically mount the ServiceAccount's API credentials if clusterChecksRunner.rbac.create is true
     automountServiceAccountToken: true
 
@@ -2391,7 +2411,7 @@ clusterChecksRunner:
   #    value: "1"
 
   # clusterChecksRunner.priorityClassName -- Name of the priorityClass to apply to the Cluster checks runners
-  priorityClassName:  # system-cluster-critical
+  priorityClassName: # system-cluster-critical
 
   # clusterChecksRunner.nodeSelector -- Allow the ClusterChecks Deployment to schedule on selected nodes
 
@@ -2504,7 +2524,8 @@ clusterChecksRunner:
     create: false
 
   # clusterChecksRunner.additionalLabels -- Adds labels to the cluster checks runner deployment and pods
-  additionalLabels: {}
+  additionalLabels:
+    {}
     # key: "value"
 
   # clusterChecksRunner.securityContext -- Allows you to overwrite the default PodSecurityContext on the clusterchecks pods.

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -1160,7 +1160,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.67.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1580,3 +1580,4 @@ spec:
         - emptyDir: {}
           name: config
 ---
+

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -1096,7 +1096,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.67.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1510,3 +1510,4 @@ spec:
         - emptyDir: {}
           name: config
 ---
+

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -1156,7 +1156,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.67.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1574,3 +1574,4 @@ spec:
         - emptyDir: {}
           name: config
 ---
+

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1119,7 +1119,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.67.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1557,3 +1557,4 @@ spec:
         - emptyDir: {}
           name: config
 ---
+

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -1156,7 +1156,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.67.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1576,3 +1576,4 @@ spec:
         - emptyDir: {}
           name: config
 ---
+

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -1156,7 +1156,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.67.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1570,3 +1570,4 @@ spec:
         - emptyDir: {}
           name: config
 ---
+

--- a/test/datadog/otel_agent_test.go
+++ b/test/datadog/otel_agent_test.go
@@ -73,3 +73,175 @@ func verifyOtelAgentEnvVars(t *testing.T, manifest string, expectedIpcEnv Expect
 	assert.Equal(t, expectedIpcEnv.ipcPort, coreEnvs[DDAgentIpcPort])
 	assert.Equal(t, expectedIpcEnv.ipcConfigRefreshInterval, coreEnvs[DDAgentIpcConfigRefreshInterval])
 }
+
+func Test_ddotCollectorImage(t *testing.T) {
+	tests := []struct {
+		name         string
+		command      common.HelmCommand
+		expectError  bool
+		errorMessage string
+		assertion    func(t *testing.T, manifest string)
+	}{
+		{
+			name: "useStandaloneImage true with agent version 7.67.0",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7.67.0",
+				},
+			},
+			expectError: false,
+			assertion:   verifyStandaloneOtelImage,
+		},
+		{
+			name: "useStandaloneImage true with agent version 7.68.0",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7.68.0",
+				},
+			},
+			expectError: false,
+			assertion:   verifyStandaloneOtelImage,
+		},
+		{
+			name: "useStandaloneImage true with agent version 7.66.0 should fail",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7.66.0",
+				},
+			},
+			expectError:  true,
+			errorMessage: "datadog.otelCollector.useStandaloneImage is only supported for agent versions 7.67.0+",
+		},
+		{
+			name: "useStandaloneImage false with tagSuffix full",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "false",
+					"agents.image.tagSuffix":                   "full",
+					"agents.image.tag":                         "7.66.0",
+				},
+			},
+			expectError: false,
+			assertion:   verifyFullTagSuffixOtelImage,
+		},
+		{
+			name: "useStandaloneImage false without tagSuffix full should fail",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "false",
+					"agents.image.tag":                         "7.67.0",
+				},
+			},
+			expectError:  true,
+			errorMessage: "When datadog.otelCollector.useStandaloneImage is false, agents.image.tagSuffix must be set to 'full'",
+		},
+		{
+			name: "useStandaloneImage false with incorrect tagSuffix should fail",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "false",
+					"agents.image.tagSuffix":                   "jmx",
+					"agents.image.tag":                         "7.66.0",
+				},
+			},
+			expectError:  true,
+			errorMessage: "When datadog.otelCollector.useStandaloneImage is false, agents.image.tagSuffix must be set to 'full'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := common.RenderChart(t, tt.command)
+
+			if tt.expectError {
+				assert.Error(t, err, "expected an error but got none")
+				if err != nil {
+					assert.Contains(t, err.Error(), tt.errorMessage, "error message should contain expected text")
+				}
+			} else {
+				assert.NoError(t, err, "expected no error but got: %v", err)
+				if err == nil && tt.assertion != nil {
+					tt.assertion(t, manifest)
+				}
+			}
+		})
+	}
+}
+
+func verifyStandaloneOtelImage(t *testing.T, manifest string) {
+	var deployment appsv1.DaemonSet
+	common.Unmarshal(t, manifest, &deployment)
+
+	// Get the otel-agent container
+	otelAgentContainer, ok := getContainer(t, deployment.Spec.Template.Spec.Containers, "otel-agent")
+	assert.True(t, ok, "should find otel-agent container")
+
+	// Check that it uses the standalone ddot-collector image
+	assert.Contains(t, otelAgentContainer.Image, "gcr.io/datadoghq/ddot-collector:", "should use standalone ddot-collector image")
+
+	// Verify the image doesn't have -full suffix since it's standalone
+	assert.NotContains(t, otelAgentContainer.Image, "-full", "standalone image should not have -full suffix")
+}
+
+func verifyFullTagSuffixOtelImage(t *testing.T, manifest string) {
+	var deployment appsv1.DaemonSet
+	common.Unmarshal(t, manifest, &deployment)
+
+	// Get the otel-agent container
+	otelAgentContainer, ok := getContainer(t, deployment.Spec.Template.Spec.Containers, "otel-agent")
+	assert.True(t, ok, "should find otel-agent container")
+
+	// Check that it uses the agent image with -full suffix
+	assert.Contains(t, otelAgentContainer.Image, "-full", "should use agent image with -full suffix when useStandaloneImage is false")
+
+	// Verify it's not using the standalone ddot-collector image
+	assert.NotContains(t, otelAgentContainer.Image, "ddot-collector", "should not use ddot-collector when useStandaloneImage is false")
+
+	// Verify it's using the regular agent image
+	assert.Contains(t, otelAgentContainer.Image, "gcr.io/datadoghq/agent:", "should use regular agent image when useStandaloneImage is false")
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows users to use the standalone image instead of the `full` image.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
