### PR TITLE
Update datadog-crds for operator v1.16.0 tag

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.0
+
+* Update CRDs from Datadog Operator v1.16.0 tag.
+
 ## 2.9.0-dev.1
 
 * Update CRDs from Datadog Operator v1.16.0-rc.1 release candidate tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.9.0-dev.1
+version: 2.9.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.9.0-dev.1](https://img.shields.io/badge/Version-2.9.0--dev.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
