### PR TITLE
Update RBAC for CRDs metric collection

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.123.0
+
+* Update RBAC for CRDs metric collection ([#1949](https://github.com/DataDog/helm-charts/pull/1949)).
+
 ## 3.122.0
 
 * Support a lifecycle handler for the agent via `agents.lifecycle`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.122.0
+version: 3.123.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.122.0](https://img.shields.io/badge/Version-3.122.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.123.0](https://img.shields.io/badge/Version-3.123.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/kube-state-metrics-core-rbac.yaml
+++ b/charts/datadog/templates/kube-state-metrics-core-rbac.yaml
@@ -105,7 +105,11 @@ rules:
 - apiGroups:
     - {{ .groupVersionKind.group }}
   resources:
-    - {{ .groupVersionKind.kind | lower }}s
+    - {{ if .groupVersionKind.resource }}
+        {{ .groupVersionKind.resource | lower }}
+      {{ else }}
+        {{ .groupVersionKind.kind | lower }}s
+      {{ end }}
   verbs:
     - list
     - watch

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -185,6 +185,7 @@ datadog:
     #     group: myteam.io
     #     kind: "Foo"
     #     version: "v1"
+    #     resource: "foos" # optional, if not set, the resource will be pluralized from the kind by adding "s" to the end
     #   metrics:
     #     - name: "uptime"
     #       help: "Foo uptime"

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -106,6 +106,7 @@ data:
                 groupVersionKind:
                   group: vpcresources.k8s.aws
                   kind: CNINode
+                  resource: cninode-pluralized
                   version: v1alpha1
                 labelsFromPath:
                   crd_name:
@@ -520,7 +521,7 @@ rules:
   - apiGroups:
       - vpcresources.k8s.aws
     resources:
-      - cninodes
+      - cninode-pluralized
     verbs:
       - list
       - watch
@@ -1466,3 +1467,4 @@ spec:
         - emptyDir: {}
           name: config
 ---
+

--- a/test/datadog/baseline/values/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/values/kube-state-metrics-custom-resources.yaml
@@ -29,6 +29,7 @@ datadog:
           group: "vpcresources.k8s.aws"
           kind: "CNINode"
           version: "v1alpha1"
+          resource: "cninode-pluralized"
         commonLabels:
           crd_type: "cninode"
         labelsFromPath:


### PR DESCRIPTION
#### What this PR does / why we need it:

RBACs for the KSM custom resources metric collection need to be updated to properly use the entity "resource" type instead of "kind + "s".

We will expose the option for the user to provide the **_resource_** type of the CRD so that RBACs can be generated using the specified resource name.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

CONS-7448

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
