### PR TITLE
Bump the default ADP version to v0.1.16.

### DIFF
--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1161,7 +1161,7 @@ datadog:
       name: agent-data-plane
 
       # datadog.agentDataPlane.image.tag -- Define the Agent Data Plane version to use
-      tag: 0.1.11
+      tag: 0.1.16
 
       # datadog.agentDataPlane.image.digest -- Define Agent Data Plane image digest to use, takes precedence over tag if specified
       digest: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

As stated in the PR title.

We've fixed a ton of stuff between v0.1.16 and the current default version of v0.1.11, so we want to bring that forward.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
