### PR TITLE
Make some volume mounts readonly

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.5
+
+* Mount `apm-socket` and `dsd-socket` to CSI node server container in readonly mode.
+* Mount `plugins-dir` to node registrar container in readonly mode.
+
 ## 0.3.4
 
 * Remove `hostNetwork: true` from csi driver daemonset.

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -34,11 +34,11 @@ spec:
               mountPath: /csi
             - name: apm-socket
               mountPath: {{ (dir .Values.sockets.apmHostSocketPath) }}
-              readOnly: false
+              readOnly: true
             {{- if ne (dir .Values.sockets.dsdHostSocketPath) (dir .Values.sockets.apmHostSocketPath) }}
             - name: dsd-socket
               mountPath: {{ (dir .Values.sockets.dsdHostSocketPath) }}
-              readOnly: false
+              readOnly: true
             {{- end }}
             - mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -30,6 +30,8 @@ spec:
             - --apm-host-socket-path={{ .Values.sockets.apmHostSocketPath }}
             - --dsd-host-socket-path={{ .Values.sockets.dsdHostSocketPath }}
           volumeMounts:
+            # plugin-dir stores the socket on which CSI node server service is exposed.
+            # it is created by the node server and needs to be writeable.
             - name: plugin-dir
               mountPath: /csi
             - name: apm-socket
@@ -40,6 +42,8 @@ spec:
               mountPath: {{ (dir .Values.sockets.dsdHostSocketPath) }}
               readOnly: true
             {{- end }}
+            # write mode is required to perform a volume mount
+            # csi driver has to create a subdirectory under /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~csi/datadog/mount. 
             - mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
               name: mountpoint-dir
@@ -60,8 +64,13 @@ spec:
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/datadog.csi/driver/csi.sock
           volumeMounts:
+            # plugin-dir stores the socket created by the CSI driver node server.
+            # it is needed by the registrar to fetch the driver name from the driver contain (via the CSI GetPluginInfo() call).
             - name: plugin-dir
               mountPath: /csi # Match this to ADDRESS
+              readOnly: true
+            # registration-dir is used to store the registration information and register the driver with kubelet.
+            # it needs to be writeable
             - name: registration-dir
               mountPath: /registration # This is where the registrar writes the registration information
       volumes:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR modifies the following volume mounts to be read-only mounts:
- apm-sock and dsd-sock volume mounts on the csi node server container
- plugin-dir volume mount on the node registrar container.

#### Special notes for your reviewer:

Added comments to the daemonset to explain what each volume / volume mount does.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
