### PR TITLE
[PAR] ensure runner config dir is always specified

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.5.1
+
+* Ensure that the `DD_PRIVATE_RUNNER_CONFIG_DIR` environment variable is set even when custom env variables are passed. 
+
 ## 1.5.0
 
 * Bump runner version to `v1.5.1`

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: "v1.5.1"
 keywords:
 - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![AppVersion: v1.5.1](https://img.shields.io/badge/AppVersion-v1.5.1-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![AppVersion: v1.5.1](https://img.shields.io/badge/AppVersion-v1.5.1-informational?style=flat-square)
 
 ## Overview
 
@@ -239,9 +239,10 @@ If actions requiring credentials fail:
 | runner.config.port | int | `9016` | Port for HTTP server liveness checks and App Builder mode |
 | runner.config.privateKey | string | `"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG"` | The runner's privateKey from the enrollment page |
 | runner.config.urn | string | `"CHANGE_ME_URN_FROM_CONFIG"` | The runner's URN from the enrollment page |
+| runner.configDirectory | string | `"/etc/dd-action-runner/config"` | The directory containing the Datadog Private Action Runner configuration |
 | runner.credentialFiles | list | `[]` | List of credential files to be used by the Datadog Private Action Runner |
 | runner.credentialSecrets | list | `[]` | References to kubernetes secrets that contain credentials to be used by the Datadog Private Action Runner |
-| runner.env | list | `[{"name":"DD_PRIVATE_RUNNER_CONFIG_DIR","value":"/etc/dd-action-runner/config"}]` | Environment variables to be passed to the Datadog Private Action Runner |
+| runner.env | list | `[]` | Environment variables to be passed to the Datadog Private Action Runner |
 | runner.kubernetesActions | object | `{"configMaps":[],"controllerRevisions":[],"cronJobs":[],"customObjects":[],"customResourceDefinitions":[],"daemonSets":[],"deployments":[],"endpoints":[],"events":[],"jobs":[],"limitRanges":[],"namespaces":[],"nodes":[],"persistentVolumeClaims":[],"persistentVolumes":[],"podTemplates":[],"pods":["get","list"],"replicaSets":[],"replicationControllers":[],"resourceQuotas":[],"serviceAccounts":[],"services":[],"statefulSets":[]}` | Add Kubernetes actions to the `config.actionsAllowlist` and corresponding permissions for the service account |
 | runner.kubernetesActions.configMaps | list | `[]` | Actions related to configMaps (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |
 | runner.kubernetesActions.controllerRevisions | list | `[]` | Actions related to controllerRevisions (options: "get", "list", "create", "update", "patch", "delete", "deleteMultiple") |

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -17,9 +17,7 @@ runner:
       - com.datadoghq.http.request
   # Use a "Role" to scope the permissions to the runner's namespace or a "ClusterRole" to give permissions to the entire cluster
   roleType: "Role"
-  env:
-    - name: DD_PRIVATE_RUNNER_CONFIG_DIR
-      value: /etc/dd-action-runner/config
+  env: []
   livenessProbe:
     httpGet:
       path: /liveness

--- a/charts/private-action-runner/templates/deployment.yaml
+++ b/charts/private-action-runner/templates/deployment.yaml
@@ -43,9 +43,10 @@ spec:
             - name: {{ $credentialSecret.secretName }}
               mountPath: /etc/dd-action-runner/config/credentials/{{ $credentialSecret.directoryName }}
             {{- end }}
-          {{- if $.Values.runner.env }}
-          env: {{ $.Values.runner.env | toYaml | nindent 12 }}
-          {{- end }}
+          env:
+            - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+              value: {{ $.Values.runner.configDirectory }}
+          {{- if $.Values.runner.env }}{{ $.Values.runner.env | toYaml | nindent 12 }}{{- end }}
           {{- if $.Values.runner.runnerIdentitySecret }}
           envFrom:
             - secretRef:

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -47,6 +47,10 @@
           "type": "integer",
           "description": "Number of pod instances for the Datadog Private Action Runner"
         },
+        "configDirectory": {
+          "type": "string",
+          "description": "The directory containing the Datadog Private Action Runner configuration"
+        },
         "config": {
           "type": "object",
           "description": "Configuration for the Datadog Private Action Runner",
@@ -94,7 +98,17 @@
           "type": "array",
           "description": "Environment variables to be passed to the Datadog Private Action Runner",
           "items": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the environment variable"
+              },
+              "value": {
+                "type": "string",
+                "description": "Value of the environment variable"
+              }
+            }
           }
         },
         "nodeSelector": {

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -21,6 +21,8 @@ runner:
   roleType: "Role"
   # -- Number of pod instances for the Datadog Private Action Runner
   replicas: 1
+  # -- The directory containing the Datadog Private Action Runner configuration
+  configDirectory: "/etc/dd-action-runner/config"
   # -- Configuration for the Datadog Private Action Runner
   config:
     # -- Base URL of the Datadog app
@@ -40,9 +42,7 @@ runner:
     # -- List of actions that the Datadog Private Action Runner is allowed to execute
     actionsAllowlist: []
   # -- Environment variables to be passed to the Datadog Private Action Runner
-  env:
-    - name: DD_PRIVATE_RUNNER_CONFIG_DIR
-      value: /etc/dd-action-runner/config
+  env: []
   # -- Allow the private action runner pods to schedule on selected nodes
   nodeSelector: {}
   # -- Kubernetes affinity settings for the runner pods

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -78,7 +78,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.5.0
+    helm.sh/chart: private-action-runner-1.5.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.5.1"
@@ -93,13 +93,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.5.0
+        helm.sh/chart: private-action-runner-1.5.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 4868e85788e07f463f821a0cda493b8f48a1d8d99117a4b1f57f6967a81171c6
+        checksum/values: 152463cba819d9b1af3569984807127a9c970085f4f3d37077713bfac1a60468
     spec:
       serviceAccountName: custom-full-name
       containers:
@@ -119,7 +119,9 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner/config
-          env: 
+          env:
+            - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+              value: /etc/dd-action-runner/config
             - name: FOO
               value: foo
             - name: BAR

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.5.0
+    helm.sh/chart: private-action-runner-1.5.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.5.1"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.5.0
+        helm.sh/chart: private-action-runner-1.5.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 414b787698840132284d14463a383a324e45c8b5393eb1252e2ad8ecc10f68e0
+        checksum/values: 0ff74852179c7adff32274bf71d4938a402bb76ed83824aa51b2bf46b10396e6
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
@@ -118,7 +118,7 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner/config
-          env: 
+          env:
             - name: DD_PRIVATE_RUNNER_CONFIG_DIR
               value: /etc/dd-action-runner/config
       nodeSelector:

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.5.0
+    helm.sh/chart: private-action-runner-1.5.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.5.1"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.5.0
+        helm.sh/chart: private-action-runner-1.5.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 5928d65555089a0b0a69f9cef344eb306f8a36dcba18d2d047494ac7a4441ef1
+        checksum/values: fdb3fa4d146168daca0f325cfd59a901645bd9131f39515073ddb2bde6818e0b
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
@@ -118,7 +118,7 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner/config
-          env: 
+          env:
             - name: DD_PRIVATE_RUNNER_CONFIG_DIR
               value: /etc/dd-action-runner/config
       volumes:

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,7 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.5.0
+    helm.sh/chart: private-action-runner-1.5.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.5.1"
@@ -92,13 +92,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.5.0
+        helm.sh/chart: private-action-runner-1.5.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: c9d4f1ec27514afb9731c4eabda89ff8f8f277d73336e8efa27cc44c45d299a3
+        checksum/values: 4254154bdeab176862be07e0a94da2bf4670d3813bf05c7950b9ff8bf1ce7e61
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
@@ -118,7 +118,7 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner/config
-          env: 
+          env:
             - name: DD_PRIVATE_RUNNER_CONFIG_DIR
               value: /etc/dd-action-runner/config
       volumes:

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -130,7 +130,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.5.0
+    helm.sh/chart: private-action-runner-1.5.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.5.1"
@@ -145,13 +145,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.5.0
+        helm.sh/chart: private-action-runner-1.5.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 4a587fd8e085cb71c4817ed012cced5f548e0f56ae5f423fadad226957c04f08
+        checksum/values: a064a57166471403ef890ec03c688e0adbdbaab2e60058527ee7e9886aa79b9a
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
@@ -171,7 +171,7 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner/config
-          env: 
+          env:
             - name: DD_PRIVATE_RUNNER_CONFIG_DIR
               value: /etc/dd-action-runner/config
       volumes:

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -211,7 +211,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.5.0
+    helm.sh/chart: private-action-runner-1.5.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.5.1"
@@ -226,13 +226,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.5.0
+        helm.sh/chart: private-action-runner-1.5.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 2868f600f5e302f23589692ee1efa4b11a8b3c2b46ab7af07889e68ed1601c1e
+        checksum/values: 068d4f4be3a64f7e4cfcac858145c72ed5a99aa34af7956efcea3ace8679c95a
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
@@ -266,7 +266,7 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: /etc/dd-action-runner/config
-          env: 
+          env:
             - name: DD_PRIVATE_RUNNER_CONFIG_DIR
               value: /etc/dd-action-runner/config
       volumes:

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,7 +75,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.5.0
+    helm.sh/chart: private-action-runner-1.5.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.5.1"
@@ -90,13 +90,13 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.5.0
+        helm.sh/chart: private-action-runner-1.5.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.5.1"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 263919834ec2f84477860730acaebbc516fb69830c35b63ceb4dbe3f1527a564
+        checksum/values: 8d538bb15a35d42e68b88d8f6c406443855a8384d90c6bf46a596b4f77957719
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
@@ -120,9 +120,11 @@ spec:
               mountPath: /etc/dd-action-runner/config/credentials/
             - name: second-secret
               mountPath: /etc/dd-action-runner/config/credentials/second-secret-directory
-          env: 
+          env:
             - name: DD_PRIVATE_RUNNER_CONFIG_DIR
               value: /etc/dd-action-runner/config
+            - name: FOO
+              value: foo
           envFrom:
             - secretRef:
                 name: the-name-of-the-secret

--- a/test/private-action-runner/baseline_test.go
+++ b/test/private-action-runner/baseline_test.go
@@ -83,6 +83,7 @@ func Test_baseline_manifests(t *testing.T) {
 					"runner.runnerIdentitySecret": `"the-name-of-the-secret"`,
 					"runner.config.urn":           ``,
 					"runner.config.privateKey":    ``,
+					"runner.env":                  `[{"name": "FOO", "value": "foo"}]`,
 					"runner.credentialSecrets":    `[{"secretName": "first-secret"}, {"secretName": "second-secret", "directoryName": "second-secret-directory"}]`,
 				},
 			},


### PR DESCRIPTION
#### What this PR does / why we need it:

This ensure that the PAR will always have the `DD_PRIVATE_RUNNER_CONFIG_DIR` env variable specified. 
Previously if customers were overriding `runner.env` property the `DD_PRIVATE_RUNNER_CONFIG_DIR` would be absent and the runner would fail at startup 

#### Which issue this PR fixes


#### Special notes for your reviewer:

Tested in local setup

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
