### PR TITLE
fix(NOTES.txt): avoid "incompatible types for comparison" error when …

### DIFF
--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -712,7 +712,7 @@ To learn more about it please refer to the following documentation:
 https://docs.datadoghq.com/agent/guide/fips-agent/
 {{- end }}
 
-{{- if (and (not .Values.datadog.csi.enabled ) (eq .Values.clusterAgent.admissionController.configMode "csi"))  }}
+{{- if (and (not .Values.datadog.csi.enabled ) .Values.clusterAgent.admissionController.configMode (eq .Values.clusterAgent.admissionController.configMode "csi")) }}
 ################################################################                                                             
 ###    WARNING: Admission Controller CSI Misconfiguration    ###                                                             
 ################################################################


### PR DESCRIPTION
#### What this PR does / why we need it:

Helm fails with a type mismatch when comparing a nil value to the string "csi" in the admission controller warning block : 

> Error: INSTALLATION FAILED: template: datadog/templates/NOTES.txt:715:48: executing "datadog/templates/NOTES.txt" at <eq .Values.clusterAgent.admissionController.configMode "csi">: error calling eq: incompatible types for comparison

#### Which issue this PR fixes

This change guards the comparison by checking if `clusterAgent.admissionController.configMode` is defined before using `eq`, avoiding the error when it is not set.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
