### PR TITLE
Set OTel agent config to args rather than command

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.123.3
+
+* Add otel config to args rather than command
+
 ## 3.123.2
 
 * add support for enabling csi driver globally and as admission controller config mode.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.123.2
+version: 3.123.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.123.2](https://img.shields.io/badge/Version-3.123.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.123.3](https://img.shields.io/badge/Version-3.123.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -9,17 +9,18 @@
   {{- if eq .Values.targetSystem "linux" }}
   command:
     - "otel-agent"
+    - "--core-config={{ template "datadog.confPath" .  }}/datadog.yaml"
+    - "--sync-delay=30s"
+    {{- if .Values.datadog.otelCollector.featureGates }}
+    - "--feature-gates={{ .Values.datadog.otelCollector.featureGates }}"
+    {{- end }}
+  args:
     {{- if .Values.datadog.otelCollector.configMap.items }}
     {{- range .Values.datadog.otelCollector.configMap.items }}
     - "--config={{ template "datadog.otelconfPath" $ }}/{{ .path }}"
     {{- end }}
     {{- else }}
     - "--config={{ template "datadog.otelconfPath" . }}/otel-config.yaml"
-    {{- end }}
-    - "--core-config={{ template "datadog.confPath" .  }}/datadog.yaml"
-    - "--sync-delay=30s"
-    {{- if .Values.datadog.otelCollector.featureGates }}
-    - "--feature-gates={{ .Values.datadog.otelCollector.featureGates }}"
     {{- end }}
   {{- end -}}
   {{- if eq .Values.targetSystem "windows" }}

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -11,9 +11,6 @@
     - "otel-agent"
     - "--core-config={{ template "datadog.confPath" .  }}/datadog.yaml"
     - "--sync-delay=30s"
-    {{- if .Values.datadog.otelCollector.featureGates }}
-    - "--feature-gates={{ .Values.datadog.otelCollector.featureGates }}"
-    {{- end }}
   args:
     {{- if .Values.datadog.otelCollector.configMap.items }}
     {{- range .Values.datadog.otelCollector.configMap.items }}
@@ -21,6 +18,9 @@
     {{- end }}
     {{- else }}
     - "--config={{ template "datadog.otelconfPath" . }}/otel-config.yaml"
+    {{- end }}
+    {{- if .Values.datadog.otelCollector.featureGates }}
+    - "--feature-gates={{ .Values.datadog.otelCollector.featureGates }}"
     {{- end }}
   {{- end -}}
   {{- if eq .Values.targetSystem "windows" }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR sets the otel agent config and feature gates in args rather than command. In GKE autopilot allowlist, the command field only allows exact matches, but the args field allows for regex matching. This is necessary because:
- The otel config file name can be anything.
- There can be multiple otel config files.

#### Which issue this PR fixes
OTAGENT-448

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
