### PR TITLE
Update helm chart to enable advanced dispatching by default

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 3.123.3
+* Enable cluster agent advanced dispatching for cluster check by default 
+
 ## 3.123.2
 
 * add support for enabling csi driver globally and as admission controller config mode.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.123.2
+version: 3.123.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.123.2](https://img.shields.io/badge/Version-3.123.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.123.3](https://img.shields.io/badge/Version-3.123.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -601,6 +601,8 @@ helm install <RELEASE_NAME> \
 | clusterAgent.admissionController.webhookName | string | `"datadog-webhook"` | Name of the validatingwebhookconfiguration and mutatingwebhookconfiguration created by the cluster-agent |
 | clusterAgent.advancedConfd | object | `{}` | Provide additional cluster check configurations. Each key is an integration containing several config files. |
 | clusterAgent.affinity | object | `{}` | Allow the Cluster Agent Deployment to schedule using affinity rules |
+| clusterAgent.clusterChecks | object | `{"advancedDispatching":{"enabled":true,"exclude_checks_from_dispatching":[],"rebalanceWithUtilization":true}}` | define cluster checks config options |
+| clusterAgent.clusterChecks.advancedDispatching.rebalanceWithUtilization | bool | `true` | distributing the cluster checks more fairly across the multiple cluster check runner |
 | clusterAgent.command | list | `[]` | Command to run in the Cluster Agent container as entrypoint |
 | clusterAgent.confd | object | `{}` | Provide additional cluster check configurations. Each key will become a file in /conf.d. |
 | clusterAgent.containerExclude | string | `nil` | Exclude containers from the Cluster Agent Autodiscovery, as a space-separated list. (Requires Agent/Cluster Agent 7.50.0+) |

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -416,6 +416,21 @@ spec:
                 name: {{ template "datadog.fullname" . }}-kpi-telemetry-configmap
                 key: install_type
           {{- include "fips-envvar" . | nindent 10 }}
+          
+          {{- if and .Values.clusterChecks .Values.clusterChecks.advancedDispatching }}
+            {{- if hasKey .Values.clusterChecks.advancedDispatching "enabled" }}
+          - name: DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED
+            value: {{ .Values.clusterChecks.advancedDispatching.enabled | quote }}
+            {{- end }}
+            {{- if hasKey .Values.clusterChecks.advancedDispatching "rebalanceWithUtilization" }}
+          - name: DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION
+            value: {{ .Values.clusterChecks.advancedDispatching.rebalanceWithUtilization | quote }}
+            {{- end }}
+            {{- if and (hasKey .Values.clusterChecks.advancedDispatching "exclude_checks_from_dispatching") (gt (len .Values.clusterChecks.advancedDispatching.exclude_checks_from_dispatching) 0) }}
+          - name: DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_EXCLUDE_CHECKS
+            value: {{ .Values.clusterChecks.advancedDispatching.exclude_checks_from_dispatching | join "," | quote }}
+            {{- end }}
+          {{- end }}
           {{- include "additional-env-entries" .Values.clusterAgent.env | indent 10 }}
           {{- include "additional-env-dict-entries" .Values.clusterAgent.envDict | indent 10 }}
         livenessProbe:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1189,6 +1189,16 @@ clusterAgent:
   # clusterAgent.shareProcessNamespace -- Set the process namespace sharing on the Datadog Cluster Agent
   shareProcessNamespace: false
 
+  # clusterAgent.clusterChecks -- define cluster checks config options
+  clusterChecks:
+    advancedDispatching:
+      # Set this to true to enable advanced dispatching of cluster checks
+      enabled: true
+      # clusterAgent.clusterChecks.advancedDispatching.rebalanceWithUtilization --  distributing the cluster checks more fairly across the multiple cluster check runner
+      rebalanceWithUtilization: true
+      # clusterAgent.clusterChecks.excludeChecksFromDispatching -- List of cluster checks to exclude from rebalancing
+      exclude_checks_from_dispatching: [] # e.g., ["kube_scheduler"]
+
   ## Define the Datadog Cluster-Agent image to work with
   image:
     # clusterAgent.image.name -- Cluster Agent image name to use (relative to `registry`)


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
