### PR TITLE
Use `latest` and `7-rc` agent image tags in E2E

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,9 @@ e2e:
           - e2e
           - e2e_autopilot
           - e2e_autopilot_systemprobe
+        E2E_AGENT_VERSION:
+          - "latest"
+          - "7-rc"
   before_script:
     # Initial credentials setup with default build-stable AWS profile
     - echo "Starting setup for E2E testing..."
@@ -81,4 +84,4 @@ e2e:
     - export GOOGLE_APPLICATION_CREDENTIALS=~/gcp-credentials.json
 
   script:
-    - E2E_BUILD_TAGS=$E2E_BUILD_TAGS E2E_PROFILE=ci make test-e2e
+    - E2E_BUILD_TAGS=$E2E_BUILD_TAGS E2E_PROFILE=ci E2E_AGENT_VERSION=$E2E_AGENT_VERSION make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,4 @@ test-e2e: fmt vet e2e-test
 # aws-vault exec sso-agent-sandbox-account-admin -- make e2e-test
 .PHONY: e2e-test
 e2e-test:
-	E2E_CONFIG_PARAMS=$(E2E_CONFIG_PARAMS) E2E_PROFILE=$(E2E_PROFILE) go test -C test/e2e ./... --tags=$(E2E_BUILD_TAGS) -v -vet=off -timeout 1h -count=1
+	E2E_CONFIG_PARAMS=$(E2E_CONFIG_PARAMS) E2E_PROFILE=$(E2E_PROFILE) E2E_AGENT_VERSION=$(E2E_AGENT_VERSION) go test -C test/e2e ./... --tags=$(E2E_BUILD_TAGS) -v -vet=off -timeout 1h -count=1

--- a/test/common/common_e2e.go
+++ b/test/common/common_e2e.go
@@ -10,14 +10,20 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 )
 
-var defaultPulumiConfigs = runner.ConfigMap{
-	"ddinfra:kubernetesVersion": auto.ConfigValue{Value: "1.32"},
-}
+var (
+	defaultAgentVersion  = "latest"
+	agentVersion         = os.Getenv("E2E_AGENT_VERSION")
+	clusterAgentVersion  = os.Getenv("E2E_AGENT_VERSION")
+	defaultImageRegistry = "gcr.io/datadoghq"
+	defaultPulumiConfigs = runner.ConfigMap{
+		"ddinfra:kubernetesVersion": auto.ConfigValue{Value: "1.32"},
+	}
 
-var defaultCIPulumiConfigs = runner.ConfigMap{
-	"ddinfra:env":                           auto.ConfigValue{Value: "gcp/agent-qa"},
-	"ddinfra:gcp/defaultPrivateKeyPassword": auto.ConfigValue{Value: os.Getenv("E2E_GCP_PRIVATE_KEY_PASSWORD"), Secret: true},
-}
+	defaultCIPulumiConfigs = runner.ConfigMap{
+		"ddinfra:env":                           auto.ConfigValue{Value: "gcp/agent-qa"},
+		"ddinfra:gcp/defaultPrivateKeyPassword": auto.ConfigValue{Value: os.Getenv("E2E_GCP_PRIVATE_KEY_PASSWORD"), Secret: true},
+	}
+)
 
 func parseE2EConfigParams() []string {
 	// "key1=val1 key2=val2"
@@ -33,6 +39,25 @@ func parseE2EConfigParams() []string {
 func SetupConfig() (runner.ConfigMap, error) {
 	res := runner.ConfigMap{}
 	configs := parseE2EConfigParams()
+
+	if agentVersion == "" {
+		agentVersion = defaultAgentVersion
+	}
+
+	if clusterAgentVersion == "" {
+		clusterAgentVersion = defaultAgentVersion
+	}
+
+	if clusterAgentVersion == "7-rc" {
+		clusterAgentVersion = "rc"
+	}
+
+	agentImageConfigs := runner.ConfigMap{
+		"ddagent:fullImagePath":             auto.ConfigValue{Value: fmt.Sprintf("%s/agent:%s", defaultImageRegistry, agentVersion)},
+		"ddagent:clusterAgentFullImagePath": auto.ConfigValue{Value: fmt.Sprintf("%s/cluster-agent:%s", defaultImageRegistry, clusterAgentVersion)},
+	}
+	defaultPulumiConfigs.Merge(agentImageConfigs)
+
 	if os.Getenv("E2E_PROFILE") == "ci" {
 		res.Merge(defaultPulumiConfigs)
 		res.Merge(defaultCIPulumiConfigs)


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add an `E2E_AGENT_VERSION` env var to the E2E test config 
* Add `latest` and `7-rc` agent image tags to the gitlab E2E pipeline test matrix 

Support Generic QA E2E testing for GKE and GKE Autopilot 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
