### PR TITLE
Update default Agent version to 7.68.3

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.126.0
+
+* Upgrade default Agent version to `7.68.3`.
+ 
 ## 3.125.0
 
 * Add `datadog.sbom.containerImage.containerInclude` and

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.125.0
+version: 3.126.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.125.0](https://img.shields.io/badge/Version-3.125.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.126.0](https://img.shields.io/badge/Version-3.126.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -537,7 +537,7 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.67.0"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.68.3"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | agents.lifecycle | object | `{}` | Configure the lifecycle of the Agent |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
@@ -623,7 +623,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"7.67.0"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"7.68.3"` | Cluster Agent image tag to use |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
@@ -679,7 +679,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
-| clusterChecksRunner.image.tag | string | `"7.67.0"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.68.3"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1210,7 +1210,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 7.67.0
+    tag: 7.68.3
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -1754,7 +1754,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.67.0
+    tag: 7.68.3
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2340,7 +2340,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.67.0
+    tag: 7.68.3
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""

--- a/test/datadog/baseline/manifests/adp_enabled.yaml
+++ b/test/datadog/baseline/manifests/adp_enabled.yaml
@@ -863,7 +863,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1001,7 +1001,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1151,7 +1151,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1190,7 +1190,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1411,7 +1411,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1484,7 +1484,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -892,7 +892,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1033,7 +1033,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1082,7 +1082,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1121,7 +1121,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1291,7 +1291,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1340,7 +1340,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1353,7 +1353,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1527,7 +1527,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1600,7 +1600,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -885,7 +885,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -958,7 +958,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -899,7 +899,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -972,7 +972,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -832,7 +832,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
               value: agent
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-              value: 7.67.0
+              value: 7.68.3
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -895,7 +895,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -968,7 +968,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -857,7 +857,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -998,7 +998,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1047,7 +1047,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1086,7 +1086,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1307,7 +1307,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1380,7 +1380,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -857,7 +857,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -998,7 +998,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1047,7 +1047,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1086,7 +1086,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1307,7 +1307,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1380,7 +1380,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -834,7 +834,7 @@ spec:
               value: /var/lib/kubelet/pod-resources/kubelet.sock
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -939,7 +939,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -965,7 +965,7 @@ spec:
           command:
             - pwsh
             - -Command
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1007,7 +1007,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1202,7 +1202,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1275,7 +1275,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -837,7 +837,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -900,7 +900,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -952,7 +952,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1148,7 +1148,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1221,7 +1221,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -837,7 +837,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -912,7 +912,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -964,7 +964,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1169,7 +1169,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1242,7 +1242,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -878,7 +878,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1003,7 +1003,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1044,7 +1044,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1095,7 +1095,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1266,7 +1266,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1321,7 +1321,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1340,7 +1340,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1524,7 +1524,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1603,7 +1603,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -850,7 +850,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -973,7 +973,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1014,7 +1014,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1063,7 +1063,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1283,7 +1283,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1362,7 +1362,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1096,7 +1096,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1236,7 +1236,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1318,7 +1318,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1388,7 +1388,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1439,7 +1439,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1472,7 +1472,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1699,7 +1699,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1778,7 +1778,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1096,7 +1096,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1236,7 +1236,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1318,7 +1318,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1420,7 +1420,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1471,7 +1471,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1504,7 +1504,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1763,7 +1763,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1842,7 +1842,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1092,7 +1092,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1205,7 +1205,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1303,7 +1303,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1354,7 +1354,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1387,7 +1387,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1643,7 +1643,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1722,7 +1722,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -876,7 +876,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -948,7 +948,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -999,7 +999,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1170,7 +1170,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1225,7 +1225,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1244,7 +1244,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1428,7 +1428,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1507,7 +1507,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -922,7 +922,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1063,7 +1063,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1112,7 +1112,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1151,7 +1151,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1372,7 +1372,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1445,7 +1445,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1110,7 +1110,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1258,7 +1258,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1358,7 +1358,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1434,7 +1434,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1511,7 +1511,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1550,7 +1550,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1577,7 +1577,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1820,7 +1820,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1893,7 +1893,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -935,7 +935,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1076,7 +1076,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1167,7 +1167,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.68.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1222,7 +1222,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1261,7 +1261,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1488,7 +1488,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1561,7 +1561,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -871,7 +871,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1012,7 +1012,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1103,7 +1103,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.68.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1152,7 +1152,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1191,7 +1191,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1418,7 +1418,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1491,7 +1491,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -931,7 +931,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1072,7 +1072,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1163,7 +1163,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.68.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1216,7 +1216,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1255,7 +1255,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1482,7 +1482,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1555,7 +1555,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -894,7 +894,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1035,7 +1035,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1126,7 +1126,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.68.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1187,7 +1187,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1226,7 +1226,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1465,7 +1465,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1538,7 +1538,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -931,7 +931,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1072,7 +1072,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1163,7 +1163,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.68.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1215,7 +1215,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1254,7 +1254,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1484,7 +1484,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1557,7 +1557,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -931,7 +931,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1072,7 +1072,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1163,7 +1163,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.67.0
+          image: gcr.io/datadoghq/ddot-collector:7.68.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1212,7 +1212,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1251,7 +1251,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1478,7 +1478,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1551,7 +1551,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -857,7 +857,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -998,7 +998,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1047,7 +1047,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1086,7 +1086,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1307,7 +1307,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1380,7 +1380,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -890,7 +890,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1035,7 +1035,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1090,7 +1090,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1135,7 +1135,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1310,7 +1310,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1359,7 +1359,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1378,7 +1378,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1562,7 +1562,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1639,7 +1639,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           securityContext:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1110,7 +1110,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1258,7 +1258,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1358,7 +1358,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1436,7 +1436,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1599,7 +1599,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -1640,7 +1640,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1679,7 +1679,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1706,7 +1706,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1989,7 +1989,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2062,7 +2062,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1110,7 +1110,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1258,7 +1258,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1358,7 +1358,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1434,7 +1434,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1593,7 +1593,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -1634,7 +1634,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1673,7 +1673,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1700,7 +1700,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.67.0
+          image: gcr.io/datadoghq/agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1980,7 +1980,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2053,7 +2053,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.67.0
+          image: gcr.io/datadoghq/cluster-agent:7.68.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:
Update default agent version to current latest version 7.68.3

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
