### PR TITLE
Remove hard-coded readOnly true from ds volumeMounts

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.125.1
+
+* Remove hard-coded `readOnly: true` from Agent daemonset host volumeMounts. 
+
 ## 3.125.0
 
 * Add `datadog.sbom.containerImage.containerInclude` and

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.125.0
+version: 3.125.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.125.0](https://img.shields.io/badge/Version-3.125.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.125.1](https://img.shields.io/badge/Version-3.125.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_container-agent-data-plane.yaml
+++ b/charts/datadog/templates/_container-agent-data-plane.yaml
@@ -68,7 +68,6 @@
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
-      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     {{- if not .Values.providers.gke.gdc }}
@@ -78,11 +77,9 @@
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     - name: cgroups
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- end }}
     {{- end }}
 {{- if .Values.agents.volumeMounts }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -265,7 +265,6 @@
     - name: installinfo
       subPath: install_info
       mountPath: /etc/datadog-agent/install_info
-      readOnly: true
     - name: tmpdir
       mountPath: /tmp
       readOnly: false # Need RW to write to /tmp directory
@@ -288,7 +287,6 @@
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
-      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     {{- if and (not .Values.providers.gke.gdc) (not .Values.providers.gke.autopilot) .Values.datadog.gpuMonitoring.enabled }}
@@ -303,24 +301,19 @@
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
-      readOnly: true
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml
-      readOnly: true
     {{- end }}
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     - name: cgroups
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- if and (eq (include "should-add-host-path-for-etc-passwd" .) "true") (eq (include "should-run-process-checks-on-core-agent" .) "true") }}
     - name: passwd
       mountPath: /etc/passwd
-      readOnly: true
     {{- end }}
     {{- end }}
     {{- if or .Values.datadog.logs.enabled .Values.datadog.logsEnabled }}
@@ -331,59 +324,46 @@
     - name: logpodpath
       mountPath: /var/log/pods
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     - name: logscontainerspath
       mountPath: /var/log/containers
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- if and (not .Values.datadog.criSocketPath) (not .Values.providers.gke.gdc) }}
     - name: logdockercontainerpath
       mountPath: /var/lib/docker/containers
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- end }}
     {{- end }}
     {{- if and (eq (include "should-enable-sbom-container-image-collection" .) "true") (or .Values.datadog.sbom.containerImage.uncompressedLayersSupport .Values.datadog.sbom.containerImage.overlayFSDirectScan)}}
     - name: host-containerd-dir
       mountPath: /host/var/lib/containerd
-      readOnly: true
     - name: host-docker-dir
       mountPath: /host/var/lib/docker
-      readOnly: true
     - name: host-crio-dir
       mountPath: /host/var/lib/containers
-      readOnly: true
     {{- end }}
     {{- if eq (include "should-enable-sbom-host-fs-collection" .) "true" }}
     - name: host-apk-dir
       mountPath: /host/var/lib/apk
-      readOnly: true
     - name: host-dpkg-dir
       mountPath: /host/var/lib/dpkg
-      readOnly: true
     - name: host-rpm-dir
       mountPath: /host/var/lib/rpm
-      readOnly: true
     {{- if eq (include "should-add-host-path-for-os-release-paths" .) "true" }}
     {{- if ne .Values.datadog.osReleasePath "/etc/redhat-release" }}
     - name: etc-redhat-release
       mountPath: /host/etc/redhat-release
-      readOnly: true
     {{- end }}
     {{- if ne .Values.datadog.osReleasePath "/etc/fedora-release" }}
     - name: etc-fedora-release
       mountPath: /host/etc/fedora-release
-      readOnly: true
     {{- end }}
     {{- if ne .Values.datadog.osReleasePath "/etc/lsb-release" }}
     - name: etc-lsb-release
       mountPath: /host/etc/lsb-release
-      readOnly: true
     {{- end }}
     {{- if ne .Values.datadog.osReleasePath "/etc/system-release" }}
     - name: etc-system-release
       mountPath: /host/etc/system-release
-      readOnly: true
     {{- end }}
     {{- end }}
     {{- end }}
@@ -395,10 +375,8 @@
       readOnly: false # Need RW for logs pointer
     - name: logpodpath
       mountPath: C:/var/log/pods
-      readOnly: true
     - name: logdockercontainerpath
       mountPath: C:/ProgramData
-      readOnly: true
     {{- end }}
     {{- end }}
     {{- if .Values.datadog.kubelet.hostCAPath }}

--- a/charts/datadog/templates/_container-cloudinit-volumemounts.yaml
+++ b/charts/datadog/templates/_container-cloudinit-volumemounts.yaml
@@ -3,7 +3,6 @@
 {{- if eq .Values.targetSystem "linux" }}
 - name: cloudinit-instance-id-file
   mountPath: /var/lib/cloud/data/instance-id
-  readOnly: true
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/datadog/templates/_container-cri-volumemounts.yaml
+++ b/charts/datadog/templates/_container-cri-volumemounts.yaml
@@ -4,7 +4,6 @@
 - name: runtimesocketdir
   mountPath: {{ print "/host/" (dir (include "datadog.dockerOrCriSocketPath" .)) | clean }}
   mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-  readOnly: true
 {{- end }}
 {{- if eq .Values.targetSystem "windows" }}
 - name: runtimesocket

--- a/charts/datadog/templates/_container-fips-proxy.yaml
+++ b/charts/datadog/templates/_container-fips-proxy.yaml
@@ -39,7 +39,6 @@
 - name: fips-proxy-cfg
   mountPath: /etc/datadog-fips-proxy/datadog-fips-proxy.cfg
   subPath: datadog-fips-proxy.cfg
-  readOnly: true
 {{- end -}}
 
 {{- define "linux-container-fips-proxy-cfg-volume" -}}

--- a/charts/datadog/templates/_container-host-release-volumemounts.yaml
+++ b/charts/datadog/templates/_container-host-release-volumemounts.yaml
@@ -3,11 +3,9 @@
     {{- if eq (include "should-enable-system-probe" .) "true" }}
 - name: os-release-file
   mountPath: /host{{ .Values.datadog.systemProbe.osReleasePath | default .Values.datadog.osReleasePath }}
-  readOnly: true
     {{- else if .Values.datadog.osReleasePath }}
 - name: os-release-file
   mountPath: /host{{ .Values.datadog.osReleasePath }}
-  readOnly: true
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -83,49 +83,40 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
-      readOnly: true
     - name: logdatadog
       mountPath: {{ template "datadog.logDirectoryPath" . }}
       readOnly: false # Need RW to write logs
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
-      readOnly: true
     {{- end }}
     - name: otelconfig
       mountPath: {{ template "datadog.otelconfPath" . }}
-      readOnly: true
     {{- if eq .Values.targetSystem "linux" }}
     {{- if not .Values.providers.gke.autopilot }}
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     - name: cgroups
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- end }}
     - name: tmpdir
       mountPath: /tmp
       readOnly: false # Need RW for tmp directory
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
-      readOnly: true
     {{- if and .Values.datadog.otelCollector.logs.enabled (eq (include "should-mount-logs-for-otel-agent" .) "true") }}
     - name: logpodpath
       mountPath: /var/log/pods
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     - name: logscontainerspath
       mountPath: /var/log/containers
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- if and (not .Values.datadog.criSocketPath) (not .Values.providers.gke.gdc) }}
     - name: logdockercontainerpath
       mountPath: /var/lib/docker/containers
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -60,14 +60,12 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
-      readOnly: true
     - name: logdatadog
       mountPath: {{ template "datadog.logDirectoryPath" . }}
       readOnly: false # Need RW to write logs
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
-      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     {{- if (not .Values.providers.gke.autopilot) }}
@@ -86,30 +84,24 @@
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
-      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     - name: cgroups
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- if and (eq (include "should-add-host-path-for-etc-passwd" .) "true") (or .Values.datadog.processAgent.processCollection .Values.datadog.processAgent.processDiscovery .Values.datadog.processAgent.containerCollection) }}
     - name: passwd
       mountPath: /etc/passwd
-      readOnly: true
     {{- end }}
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
-      readOnly: true
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml
-      readOnly: true
     {{- end }}
     {{- end }}
     {{- if .Values.datadog.kubelet.hostCAPath }}

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -64,14 +64,12 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
-      readOnly: true
     - name: logdatadog
       mountPath: {{ template "datadog.logDirectoryPath" . }}
       readOnly: false # Need RW to write logs
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
-      readOnly: true
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: false # Need RW for UDS DSD socket
@@ -88,49 +86,39 @@
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
-      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     {{- if .Values.datadog.securityAgent.compliance.enabled }}
     - name: cgroups
       mountPath: /host/sys/fs/cgroup
-      readOnly: true
     {{- if (eq (include "should-add-host-path-for-etc-passwd" .) "true") }}
     - name: passwd
       mountPath: /etc/passwd
-      readOnly: true
     {{- end }}
     - name: group
       mountPath: /etc/group
-      readOnly: true
     - name: hostroot
       mountPath: /host/root
-      readOnly: true
     - name: procdir
       mountPath: /host/proc
-      readOnly: true
     {{- if .Values.datadog.kubelet.hostCAPath }}
 {{ include "datadog.kubelet.volumeMount" . | indent 4 }}
     {{- end }}
     {{- if .Values.datadog.securityAgent.compliance.configMap }}
     - name: complianceconfigdir
       mountPath: /etc/datadog-agent/compliance.d
-      readOnly: true
     {{- end }}
     {{- end }}
     {{- if or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.securityAgent.runtime.fimEnabled }}
     {{- if .Values.datadog.securityAgent.runtime.policies.configMap }}
     - name: runtimepoliciesdir
       mountPath: /etc/datadog-agent/runtime-security.d
-      readOnly: true
     {{- end }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
-      readOnly: true
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml
-      readOnly: true
     {{- end }}
     {{- end }}
 {{- if .Values.agents.volumeMounts }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -42,7 +42,6 @@
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
-      readOnly: true
     {{- end }}
     - name: logdatadog
       mountPath: {{ template "datadog.logDirectoryPath" . }}
@@ -58,58 +57,48 @@
     - name: bpffs
       mountPath: /sys/fs/bpf
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
 {{- end }}
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
-      readOnly: true
     {{- include "container-cloudinit-volumemounts" . | nindent 4 }}
     {{- if and .Values.agents.useConfigMap (eq .Values.targetSystem "linux")}}
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
-      readOnly: true
     {{- end }}
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml
-      readOnly: true
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe
       readOnly: false # Need RW for sys-probe socket
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
 {{- if or .Values.datadog.serviceMonitoring.enabled .Values.datadog.networkMonitoring.enabled .Values.datadog.discovery.enabled .Values.datadog.gpuMonitoring.enabled }}
     - name: cgroups
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
 {{- end }}
     {{- include "linux-container-host-release-volumemounts" . | nindent 4 }}
   {{- if (eq (include "should-add-host-path-for-os-release-paths" .) "true") }}
     {{- if ne .Values.datadog.osReleasePath "/etc/redhat-release" }}
     - name: etc-redhat-release
       mountPath: /host/etc/redhat-release
-      readOnly: true
     {{- end }}
     {{- if ne .Values.datadog.osReleasePath "/etc/fedora-release" }}
     - name: etc-fedora-release
       mountPath: /host/etc/fedora-release
-      readOnly: true
     {{- end }}
     {{- if ne .Values.datadog.osReleasePath "/etc/lsb-release" }}
     - name: etc-lsb-release
       mountPath: /host/etc/lsb-release
-      readOnly: true
     {{- end }}
   {{- end }}
 {{- if or .Values.datadog.serviceMonitoring.enabled .Values.datadog.gpuMonitoring.enabled }}
     - name: hostroot
       mountPath: /host/root
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
 {{- end }}
 {{- if .Values.datadog.gpuMonitoring.enabled }}
     - name: gpu-devices
@@ -119,18 +108,15 @@
     - name: modules
       mountPath: /lib/modules
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
 {{- if eq (include "can-mount-host-usr-src" .) "false" }}
     - name: src
       mountPath: /usr/src
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
 {{- end }}
 {{- end }}
 {{- if and (or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.securityAgent.runtime.fimEnabled) .Values.datadog.securityAgent.runtime.policies.configMap }}
     - name: runtimepoliciesdir
       mountPath: /etc/datadog-agent/runtime-security.d
-      readOnly: true
 {{- end }}
 {{- if eq (include "runtime-compilation-enabled" .) "true" }}
     - name: runtime-compiler-output-dir
@@ -143,37 +129,28 @@
 {{- if not .Values.datadog.systemProbe.mountPackageManagementDirs }}
     - name: apt-config-dir
       mountPath: /host/etc/apt
-      readOnly: true
     - name: yum-repos-dir
       mountPath: /host/etc/yum.repos.d
-      readOnly: true
     - name: opensuse-repos-dir
       mountPath: /host/etc/zypp
-      readOnly: true
     - name: public-key-dir
       mountPath: /host/etc/pki
-      readOnly: true
     - name: yum-vars-dir
       mountPath: /host/etc/yum/vars
-      readOnly: true
     - name: dnf-vars-dir
       mountPath: /host/etc/dnf/vars
-      readOnly: true
     - name: rhel-subscription-dir
       mountPath: /host/etc/rhsm
-      readOnly: true
 {{- else }}
 {{- range .Values.datadog.systemProbe.mountPackageManagementDirs }}
     - name: {{ .name }}
       mountPath: {{ .mountPath }}
-      readOnly: true
 {{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.datadog.systemProbe.btfPath }}
     - name: btf-path
       mountPath: {{ .Values.datadog.systemProbe.btfPath }}
-      readOnly: true
 {{- end }}
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -82,31 +82,26 @@
   volumeMounts:
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
-      readOnly: true
     - name: logdatadog
       mountPath: {{ template "datadog.logDirectoryPath" . }}
       readOnly: false # Need RW to write logs
     {{- if (not .Values.providers.gke.autopilot) }}
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
-      readOnly: true
     {{- end }}
     {{- if and .Values.agents.useConfigMap (eq .Values.targetSystem "linux")}}
     - name: datadog-yaml
       mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
       subPath: datadog.yaml
-      readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     {{- if not (or .Values.providers.gke.autopilot .Values.providers.gke.gdc) }}
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     - name: cgroups
       mountPath: /host/sys/fs/cgroup
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- end }}
     - name: tmpdir
       mountPath: /tmp

--- a/charts/datadog/templates/_containers-init-linux.yaml
+++ b/charts/datadog/templates/_containers-init-linux.yaml
@@ -32,12 +32,10 @@
     {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
     - name: confd
       mountPath: /conf.d
-      readOnly: true
     {{- end }}
     {{- if .Values.datadog.checksd }}
     - name: checksd
       mountPath: /checks.d
-      readOnly: true
     {{- end }}
     {{- if not .Values.providers.gke.gdc }}
     - name: logdatadog
@@ -46,14 +44,12 @@
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}
-      readOnly: true
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- end }}
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-config
       mountPath: /etc/datadog-agent/system-probe.yaml
       subPath: system-probe.yaml
-      readOnly: true
     {{- end }}
     {{- if .Values.agents.containers.initContainers.volumeMounts }}
     {{ toYaml .Values.agents.containers.initContainers.volumeMounts | nindent 4 }}

--- a/charts/datadog/templates/_containers-init-windows.yaml
+++ b/charts/datadog/templates/_containers-init-windows.yaml
@@ -16,11 +16,9 @@
       readOnly: false # Need RW for config path
     - name: installinfo
       mountPath: C:/Temp/install_info
-      readOnly: true
     {{- if .Values.agents.useConfigMap }}
     - name: datadog-yaml
       mountPath: C:/Temp/datadog_yaml
-      readOnly: true
     {{- end}}
   resources:
 {{ toYaml .Values.agents.containers.initContainers.resources | indent 4 }}
@@ -37,12 +35,10 @@
     {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
     - name: confd
       mountPath: C:/conf.d
-      readOnly: true
     {{- end }}
     {{- if .Values.datadog.checksd }}
     - name: checksd
       mountPath: C:/checks.d
-      readOnly: true
     {{- end }}
     {{- include "container-crisocket-volumemounts" . | nindent 4 }}
     {{- if .Values.agents.containers.initContainers.volumeMounts }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -795,7 +795,6 @@ Return Kubelet volumeMount
   {{- if eq .Values.targetSystem "windows" }}
   mountPath: {{ dir (include "datadog.kubelet.mountPath" .) }}
   {{- end }}
-  readOnly: true
 {{- end -}}
 
 {{/*

--- a/charts/datadog/templates/_system-probe-init.yaml
+++ b/charts/datadog/templates/_system-probe-init.yaml
@@ -10,7 +10,6 @@
   volumeMounts:
   - name: datadog-agent-security
     mountPath: /etc/config
-    readOnly: true
   - name: seccomp-root
     mountPath: /host/var/lib/kubelet/seccomp
     mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}

--- a/test/datadog/baseline/manifests/adp_enabled.yaml
+++ b/test/datadog/baseline/manifests/adp_enabled.yaml
@@ -904,14 +904,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -921,21 +919,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1018,21 +1012,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1042,7 +1032,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
         - command:
             - agent-data-plane
             - run
@@ -1132,18 +1121,15 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1204,11 +1190,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -936,14 +936,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -953,21 +951,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1050,21 +1044,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1074,7 +1064,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1135,11 +1124,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -901,14 +901,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -918,21 +916,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1015,21 +1009,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1039,7 +1029,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1100,11 +1089,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -901,14 +901,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -918,21 +916,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1015,21 +1009,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1039,7 +1029,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1100,11 +1089,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -946,13 +946,11 @@ spec:
           volumeMounts:
             - mountPath: C:/ProgramData/Datadog
               name: config
-              readOnly: true
             - mountPath: C:/ProgramData/Datadog/logs
               name: logdatadog
               readOnly: false
             - mountPath: C:/ProgramData/Datadog/auth
               name: auth-token
-              readOnly: true
             - mountPath: \\.\pipe\docker_engine
               name: runtimesocket
             - mountPath: \\.\pipe\containerd-containerd
@@ -975,7 +973,6 @@ spec:
               readOnly: false
             - mountPath: C:/Temp/install_info
               name: installinfo
-              readOnly: true
         - args:
             - Get-ChildItem 'entrypoint-ps1' | ForEach-Object { & $_.FullName if (-Not $?) { exit 1 } }
           command:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -881,7 +881,6 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -881,7 +881,6 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
@@ -899,11 +898,9 @@ spec:
             - mountPath: /var/log/pods
               mountPropagation: None
               name: logpodpath
-              readOnly: true
             - mountPath: /var/log/containers
               mountPropagation: None
               name: logscontainerspath
-              readOnly: true
             - mountPath: /certs
               name: kubelet-cert-volume
       initContainers:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -918,7 +918,6 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
@@ -929,18 +928,15 @@ spec:
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
         - command:
             - process-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1016,7 +1012,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
@@ -1026,18 +1021,14 @@ spec:
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
       initContainers:
         - args:
             - cp -r /etc/datadog-agent /opt
@@ -1115,11 +1106,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -890,7 +890,6 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
@@ -901,18 +900,15 @@ spec:
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
         - command:
             - process-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -986,7 +982,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
@@ -996,18 +991,14 @@ spec:
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
       initContainers:
         - args:
             - cp -r /etc/datadog-agent /opt
@@ -1083,11 +1074,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1136,42 +1136,34 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - process-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1249,7 +1241,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
@@ -1258,28 +1249,21 @@ spec:
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - system-probe
@@ -1360,13 +1344,10 @@ spec:
             - mountPath: /sys/fs/bpf
               mountPropagation: None
               name: bpffs
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
@@ -1374,14 +1355,11 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
       initContainers:
         - args:
             - cp -r /etc/datadog-agent /opt
@@ -1459,14 +1437,11 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - cp
@@ -1479,7 +1454,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/config
               name: datadog-agent-security
-              readOnly: true
             - mountPath: /host/var/lib/kubelet/seccomp
               mountPropagation: None
               name: seccomp-root

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1136,42 +1136,34 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - process-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1249,7 +1241,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
@@ -1258,28 +1249,21 @@ spec:
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - system-probe
@@ -1360,13 +1344,10 @@ spec:
             - mountPath: /sys/fs/bpf
               mountPropagation: None
               name: bpffs
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
@@ -1374,18 +1355,14 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /lib/modules
               mountPropagation: None
               name: modules
-              readOnly: true
             - mountPath: /var/tmp/datadog-agent/system-probe/build
               mountPropagation: None
               name: runtime-compiler-output-dir
@@ -1395,25 +1372,18 @@ spec:
               readOnly: false
             - mountPath: /host/etc/apt
               name: apt-config-dir
-              readOnly: true
             - mountPath: /host/etc/yum.repos.d
               name: yum-repos-dir
-              readOnly: true
             - mountPath: /host/etc/zypp
               name: opensuse-repos-dir
-              readOnly: true
             - mountPath: /host/etc/pki
               name: public-key-dir
-              readOnly: true
             - mountPath: /host/etc/yum/vars
               name: yum-vars-dir
-              readOnly: true
             - mountPath: /host/etc/dnf/vars
               name: dnf-vars-dir
-              readOnly: true
             - mountPath: /host/etc/rhsm
               name: rhel-subscription-dir
-              readOnly: true
       initContainers:
         - args:
             - cp -r /etc/datadog-agent /opt
@@ -1491,14 +1461,11 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - cp
@@ -1511,7 +1478,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/config
               name: datadog-agent-security
-              readOnly: true
             - mountPath: /host/var/lib/kubelet/seccomp
               mountPropagation: None
               name: seccomp-root

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1132,42 +1132,34 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - system-probe
             - --config=/etc/datadog-agent/system-probe.yaml
@@ -1246,10 +1238,8 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
@@ -1257,18 +1247,14 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /lib/modules
               mountPropagation: None
               name: modules
-              readOnly: true
             - mountPath: /var/tmp/datadog-agent/system-probe/build
               mountPropagation: None
               name: runtime-compiler-output-dir
@@ -1278,25 +1264,18 @@ spec:
               readOnly: false
             - mountPath: /host/etc/apt
               name: apt-config-dir
-              readOnly: true
             - mountPath: /host/etc/yum.repos.d
               name: yum-repos-dir
-              readOnly: true
             - mountPath: /host/etc/zypp
               name: opensuse-repos-dir
-              readOnly: true
             - mountPath: /host/etc/pki
               name: public-key-dir
-              readOnly: true
             - mountPath: /host/etc/yum/vars
               name: yum-vars-dir
-              readOnly: true
             - mountPath: /host/etc/dnf/vars
               name: dnf-vars-dir
-              readOnly: true
             - mountPath: /host/etc/rhsm
               name: rhel-subscription-dir
-              readOnly: true
       initContainers:
         - args:
             - cp -r /etc/datadog-agent /opt
@@ -1374,14 +1353,11 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - cp
@@ -1394,7 +1370,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/config
               name: datadog-agent-security
-              readOnly: true
             - mountPath: /host/var/lib/kubelet/seccomp
               mountPropagation: None
               name: seccomp-root

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -916,7 +916,6 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
@@ -927,21 +926,17 @@ spec:
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
       initContainers:
         - args:
             - cp -r /etc/datadog-agent /opt
@@ -1019,11 +1014,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -966,14 +966,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -983,21 +981,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1080,21 +1074,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1104,7 +1094,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1165,11 +1154,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1154,14 +1154,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -1171,28 +1169,22 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1275,21 +1267,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1299,7 +1287,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
         - command:
             - process-agent
             - --cfgpath=/etc/datadog-agent/datadog.yaml
@@ -1365,13 +1352,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1380,28 +1365,21 @@ spec:
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - system-probe
@@ -1459,7 +1437,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
@@ -1473,13 +1450,10 @@ spec:
             - mountPath: /sys/fs/bpf
               mountPropagation: None
               name: bpffs
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
@@ -1487,23 +1461,17 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /host/etc/redhat-release
               name: etc-redhat-release
-              readOnly: true
             - mountPath: /host/etc/fedora-release
               name: etc-fedora-release
-              readOnly: true
             - mountPath: /host/etc/lsb-release
               name: etc-lsb-release
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1564,14 +1532,11 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - cp
@@ -1584,7 +1549,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/config
               name: datadog-agent-security
-              readOnly: true
             - mountPath: /host/var/lib/kubelet/seccomp
               mountPropagation: None
               name: seccomp-root

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -979,14 +979,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -996,21 +994,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1093,21 +1087,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1117,7 +1107,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
         - args:
             - --config=/etc/otel-agent/otel-config.yaml
           command:
@@ -1187,34 +1176,27 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /etc/otel-agent
               name: otelconfig
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1275,11 +1257,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -915,14 +915,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -932,21 +930,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1029,21 +1023,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1053,7 +1043,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
         - args:
             - --config=/etc/otel-agent/otel-config.yaml
           command:
@@ -1117,34 +1106,27 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /etc/otel-agent
               name: otelconfig
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1205,11 +1187,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -975,14 +975,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -992,21 +990,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1089,21 +1083,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1113,7 +1103,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
         - args:
             - --config=/etc/otel-agent/otel-config.yaml
           command:
@@ -1181,34 +1170,27 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /etc/otel-agent
               name: otelconfig
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1269,11 +1251,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -938,14 +938,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -955,21 +953,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1052,21 +1046,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1076,7 +1066,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
         - args:
             - --config=/etc/otel-agent/otel-config.yaml
           command:
@@ -1140,46 +1129,36 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /etc/otel-agent
               name: otelconfig
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
-              readOnly: true
             - mountPath: /var/log/pods
               mountPropagation: None
               name: logpodpath
-              readOnly: true
             - mountPath: /var/log/containers
               mountPropagation: None
               name: logscontainerspath
-              readOnly: true
             - mountPath: /var/lib/docker/containers
               mountPropagation: None
               name: logdockercontainerpath
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1240,11 +1219,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -975,14 +975,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -992,21 +990,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1089,21 +1083,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1113,7 +1103,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
         - args:
             - --config=/etc/otel-agent/otel-config.yaml
           command:
@@ -1177,34 +1166,27 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /etc/otel-agent
               name: otelconfig
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/log/custom
               name: logscustompath
               readOnly: true
@@ -1268,11 +1250,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -975,14 +975,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -992,21 +990,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1089,21 +1083,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1113,7 +1103,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
         - args:
             - --config=/etc/otel-agent/otel-config.yaml
           command:
@@ -1177,34 +1166,27 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /etc/otel-agent
               name: otelconfig
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /var/run/datadog
               name: dsdsocket
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1265,11 +1247,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -901,14 +901,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -918,21 +916,17 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1015,21 +1009,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1039,7 +1029,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1100,11 +1089,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -941,14 +941,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -958,18 +956,15 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1058,21 +1053,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1082,7 +1073,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       hostPID: true
       initContainers:
         - args:
@@ -1155,11 +1145,9 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1154,14 +1154,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -1171,28 +1169,22 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1275,21 +1267,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1299,7 +1287,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
         - command:
             - process-agent
             - --cfgpath=/etc/datadog-agent/datadog.yaml
@@ -1365,13 +1352,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1380,28 +1365,21 @@ spec:
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - system-probe
@@ -1461,7 +1439,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
@@ -1475,13 +1452,10 @@ spec:
             - mountPath: /sys/fs/bpf
               mountPropagation: None
               name: bpffs
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
@@ -1489,35 +1463,26 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /host/etc/redhat-release
               name: etc-redhat-release
-              readOnly: true
             - mountPath: /host/etc/fedora-release
               name: etc-fedora-release
-              readOnly: true
             - mountPath: /host/etc/lsb-release
               name: etc-lsb-release
-              readOnly: true
             - mountPath: /host/root
               mountPropagation: None
               name: hostroot
-              readOnly: true
             - mountPath: /lib/modules
               mountPropagation: None
               name: modules
-              readOnly: true
             - mountPath: /usr/src
               mountPropagation: None
               name: src
-              readOnly: true
             - mountPath: /var/tmp/datadog-agent/system-probe/build
               mountPropagation: None
               name: runtime-compiler-output-dir
@@ -1527,25 +1492,18 @@ spec:
               readOnly: false
             - mountPath: /host/etc/apt
               name: apt-config-dir
-              readOnly: true
             - mountPath: /host/etc/yum.repos.d
               name: yum-repos-dir
-              readOnly: true
             - mountPath: /host/etc/zypp
               name: opensuse-repos-dir
-              readOnly: true
             - mountPath: /host/etc/pki
               name: public-key-dir
-              readOnly: true
             - mountPath: /host/etc/yum/vars
               name: yum-vars-dir
-              readOnly: true
             - mountPath: /host/etc/dnf/vars
               name: dnf-vars-dir
-              readOnly: true
             - mountPath: /host/etc/rhsm
               name: rhel-subscription-dir
-              readOnly: true
         - command:
             - security-agent
             - start
@@ -1606,13 +1564,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1621,17 +1577,13 @@ spec:
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
       hostPID: true
       initContainers:
@@ -1693,14 +1645,11 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - cp
@@ -1713,7 +1662,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/config
               name: datadog-agent-security
-              readOnly: true
             - mountPath: /host/var/lib/kubelet/seccomp
               mountPropagation: None
               name: seccomp-root

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1154,14 +1154,12 @@ spec:
               readOnly: false
             - mountPath: /etc/datadog-agent/install_info
               name: installinfo
-              readOnly: true
               subPath: install_info
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
               readOnly: false
@@ -1171,28 +1169,22 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
         - command:
             - trace-agent
             - -config=/etc/datadog-agent/datadog.yaml
@@ -1275,21 +1267,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
@@ -1299,7 +1287,6 @@ spec:
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
         - command:
             - process-agent
             - --cfgpath=/etc/datadog-agent/datadog.yaml
@@ -1365,13 +1352,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1380,28 +1365,21 @@ spec:
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /etc/passwd
               name: passwd
-              readOnly: true
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - system-probe
@@ -1459,7 +1437,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
@@ -1473,13 +1450,10 @@ spec:
             - mountPath: /sys/fs/bpf
               mountPropagation: None
               name: bpffs
-              readOnly: true
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
@@ -1487,31 +1461,23 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               name: cgroups
-              readOnly: true
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /host/etc/redhat-release
               name: etc-redhat-release
-              readOnly: true
             - mountPath: /host/etc/fedora-release
               name: etc-fedora-release
-              readOnly: true
             - mountPath: /host/etc/lsb-release
               name: etc-lsb-release
-              readOnly: true
             - mountPath: /lib/modules
               mountPropagation: None
               name: modules
-              readOnly: true
             - mountPath: /usr/src
               mountPropagation: None
               name: src
-              readOnly: true
             - mountPath: /var/tmp/datadog-agent/system-probe/build
               mountPropagation: None
               name: runtime-compiler-output-dir
@@ -1521,25 +1487,18 @@ spec:
               readOnly: false
             - mountPath: /host/etc/apt
               name: apt-config-dir
-              readOnly: true
             - mountPath: /host/etc/yum.repos.d
               name: yum-repos-dir
-              readOnly: true
             - mountPath: /host/etc/zypp
               name: opensuse-repos-dir
-              readOnly: true
             - mountPath: /host/etc/pki
               name: public-key-dir
-              readOnly: true
             - mountPath: /host/etc/yum/vars
               name: yum-vars-dir
-              readOnly: true
             - mountPath: /host/etc/dnf/vars
               name: dnf-vars-dir
-              readOnly: true
             - mountPath: /host/etc/rhsm
               name: rhel-subscription-dir
-              readOnly: true
         - command:
             - security-agent
             - start
@@ -1600,13 +1559,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/datadog-agent
               name: config
-              readOnly: true
             - mountPath: /var/log/datadog
               name: logdatadog
               readOnly: false
             - mountPath: /etc/datadog-agent/auth
               name: auth-token
-              readOnly: true
             - mountPath: /var/run/datadog
               name: dsdsocket
               readOnly: false
@@ -1615,17 +1572,13 @@ spec:
               readOnly: false
             - mountPath: /host/etc/os-release
               name: os-release-file
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
       hostPID: true
       initContainers:
@@ -1687,14 +1640,11 @@ spec:
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
-              readOnly: true
             - mountPath: /host/var/run
               mountPropagation: None
               name: runtimesocketdir
-              readOnly: true
             - mountPath: /etc/datadog-agent/system-probe.yaml
               name: sysprobe-config
-              readOnly: true
               subPath: system-probe.yaml
         - command:
             - cp
@@ -1707,7 +1657,6 @@ spec:
           volumeMounts:
             - mountPath: /etc/config
               name: datadog-agent-security
-              readOnly: true
             - mountPath: /host/var/lib/kubelet/seccomp
               mountPropagation: None
               name: seccomp-root


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #1979

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
