### PR TITLE
[PAR] add support for script action

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 1.7.0
+
+* Bump runner version to `v1.7.0`
+* Add example for script action credentials file
+
 ## 1.6.0
 
 * Add support for long-running actions.

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.6.0
+version: 1.7.0
 appVersion: "v1.6.0"
 keywords:
 - app builder

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to deploy the private action runner
 
 type: application
 version: 1.7.0
-appVersion: "v1.6.0"
+appVersion: "v1.7.0"
 keywords:
 - app builder
 - workflow automation

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![AppVersion: v1.6.0](https://img.shields.io/badge/AppVersion-v1.6.0-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![AppVersion: v1.7.0](https://img.shields.io/badge/AppVersion-v1.7.0-informational?style=flat-square)
 
 ## Overview
 

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![AppVersion: v1.6.0](https://img.shields.io/badge/AppVersion-v1.6.0-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![AppVersion: v1.6.0](https://img.shields.io/badge/AppVersion-v1.6.0-informational?style=flat-square)
 
 ## Overview
 
@@ -228,7 +228,7 @@ If actions requiring credentials fail:
 |-----|------|---------|-------------|
 | $schema | string | `"./values.schema.json"` | Schema for the values file, enables support in Jetbrains IDEs. You should probably use https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json. |
 | fullnameOverride | string | `""` | Override the full qualified app name |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.6.0"}` | Current Datadog Private Action Runner image |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"datadog/private-action-runner-dev","tag":"latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"}` | Current Datadog Private Action Runner image |
 | nameOverride | string | `""` | Override name of app |
 | runner.affinity | object | `{}` | Kubernetes affinity settings for the runner pods |
 | runner.config | object | `{"actionsAllowlist":[],"allowIMDSEndpoint":false,"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":9016,"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -228,7 +228,7 @@ If actions requiring credentials fail:
 |-----|------|---------|-------------|
 | $schema | string | `"./values.schema.json"` | Schema for the values file, enables support in Jetbrains IDEs. You should probably use https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json. |
 | fullnameOverride | string | `""` | Override the full qualified app name |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"datadog/private-action-runner-dev","tag":"latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"}` | Current Datadog Private Action Runner image |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.7.0"}` | Current Datadog Private Action Runner image |
 | nameOverride | string | `""` | Override name of app |
 | runner.affinity | object | `{}` | Kubernetes affinity settings for the runner pods |
 | runner.config | object | `{"actionsAllowlist":[],"allowIMDSEndpoint":false,"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":9016,"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -209,6 +209,25 @@ runner:
             }
           ]
         }
+    - fileName: "script.yaml"
+      data: |
+        schemaId: script-credentials-v1
+        runPredefinedScript:
+          echo:
+            # you have to use an array to specify the command
+            command: ["echo", "Hello world"]
+          echo-parametrized:
+            # you can use [workflow-like syntax](https://docs.datadoghq.com/actions/workflows/variables/) to retrieve values from the parameters object
+            command: [ "echo", "{{ parameters.echoValue }}" ]
+            # you can use [json schema](https://json-schema.org/) to validate the parameters
+            parameterSchema:
+              properties:
+                echoValue:
+                  type: string
+                  const: "world"
+              required:
+                - echoValue
+
 
   credentialSecrets: []
     # a kubernetes secret containing multiple credentials files mounted at /etc/dd-action-runner/config/credentials/<filename-from-secret> see https://github.com/DataDog/helm-charts/blob/main/charts/private-action-runner/README.md

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -7,8 +7,8 @@ $schema: ./values.schema.json
 
 # -- Current Datadog Private Action Runner image
 image:
-  repository: gcr.io/datadoghq/private-action-runner
-  tag: v1.6.0
+  repository: datadog/private-action-runner-dev
+  tag: latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d
   pullPolicy: IfNotPresent
 
 # nameOverride -- Override name of app

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -7,8 +7,8 @@ $schema: ./values.schema.json
 
 # -- Current Datadog Private Action Runner image
 image:
-  repository: datadog/private-action-runner-dev
-  tag: latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d
+  repository: gcr.io/datadoghq/private-action-runner
+  tag: v1.7.0
   pullPolicy: IfNotPresent
 
 # nameOverride -- Override name of app

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -99,12 +99,12 @@ spec:
         app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: cac47c3f542cc6e832032964c72c2eb7126cc6c0e55993eaa95511446ac50f84
+        checksum/values: 79375e56ce6c64bed27d92ce10a333cdc9b9d2a081450c2225cecdefd8d88f23
     spec:
       serviceAccountName: custom-full-name
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
+          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -81,7 +81,7 @@ metadata:
     helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
-    app.kubernetes.io/version: "v1.6.0"
+    app.kubernetes.io/version: "v1.7.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -96,7 +96,7 @@ spec:
         helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
-        app.kubernetes.io/version: "v1.6.0"
+        app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/values: cac47c3f542cc6e832032964c72c2eb7126cc6c0e55993eaa95511446ac50f84

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -99,12 +99,12 @@ spec:
         app.kubernetes.io/version: "v1.6.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 70faaf000688d72e98fb35126a4a17eddb33704ebeef34fc4efe446432943b08
+        checksum/values: cac47c3f542cc6e832032964c72c2eb7126cc6c0e55993eaa95511446ac50f84
     spec:
       serviceAccountName: custom-full-name
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.6.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -78,7 +78,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.6.0
+    helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.6.0"
@@ -93,7 +93,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.6.0
+        helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.6.0"

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.6.0
+    helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.6.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.6.0
+        helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.6.0"

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 8e775192c1a3941d43ff3190be9c86e0ad374b31af34afb5bccd659dca0aef47
+        checksum/values: c8aa8a8bfafaf5f792cd6b9e005c89357db0f23f560c68eadb2182765466fb4a
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
+          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.6.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 603e51a6472754d7d1fa421e5cf8daab7da1060093f34cef388a51a5c0d494ed
+        checksum/values: 8e775192c1a3941d43ff3190be9c86e0ad374b31af34afb5bccd659dca0aef47
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.6.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -80,7 +80,7 @@ metadata:
     helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
-    app.kubernetes.io/version: "v1.6.0"
+    app.kubernetes.io/version: "v1.7.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -95,7 +95,7 @@ spec:
         helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
-        app.kubernetes.io/version: "v1.6.0"
+        app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/values: 8e775192c1a3941d43ff3190be9c86e0ad374b31af34afb5bccd659dca0aef47

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,7 +77,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.6.0
+    helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.6.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.6.0
+        helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.6.0"

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: ae67afa4d1146902652cbf5cb5bab9ce4a2f99e8c0765acf3e32aff4d4b2d755
+        checksum/values: 2c1f4fa9359d7986abb245021d060b143e6d6b1ec043e74b19121467331e5e3f
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
+          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -80,7 +80,7 @@ metadata:
     helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
-    app.kubernetes.io/version: "v1.6.0"
+    app.kubernetes.io/version: "v1.7.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -95,7 +95,7 @@ spec:
         helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
-        app.kubernetes.io/version: "v1.6.0"
+        app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/values: ae67afa4d1146902652cbf5cb5bab9ce4a2f99e8c0765acf3e32aff4d4b2d755

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.6.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 0c5a98df15f74a0978f001147b87da221464e2482aef40938b8cf9393427b9ed
+        checksum/values: ae67afa4d1146902652cbf5cb5bab9ce4a2f99e8c0765acf3e32aff4d4b2d755
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.6.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,7 +77,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.6.0
+    helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.6.0"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.6.0
+        helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.6.0"

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 33fbd1a08018b020334898c595e086af17ab53134cb1455f55b695981d4dcb23
+        checksum/values: 26a45d722c526bbcff92d7f7efbe61e1bf0eb17090769725a7a5d8262aadd15c
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
+          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -98,12 +98,12 @@ spec:
         app.kubernetes.io/version: "v1.6.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 407a29a74e8b04f228626af4f2378818c982dedbddfd0ff5d5c88ddde2eb7641
+        checksum/values: 33fbd1a08018b020334898c595e086af17ab53134cb1455f55b695981d4dcb23
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.6.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -80,7 +80,7 @@ metadata:
     helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
-    app.kubernetes.io/version: "v1.6.0"
+    app.kubernetes.io/version: "v1.7.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -95,7 +95,7 @@ spec:
         helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
-        app.kubernetes.io/version: "v1.6.0"
+        app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/values: 33fbd1a08018b020334898c595e086af17ab53134cb1455f55b695981d4dcb23

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -151,12 +151,12 @@ spec:
         app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: e9e1aafff270ad0bf2d2b48c0a9a5f42445e45c65972f41a32e4eb7d571718b5
+        checksum/values: f8af117b20cf088cf172bf690c8c8c025ebeed9fe1c656673110a496ca836dc1
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
+          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -151,12 +151,12 @@ spec:
         app.kubernetes.io/version: "v1.6.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: e8e71ba5f6e33e6cb5b85ac396e0342700e1d31b457ca28269ce987908ebcd72
+        checksum/values: e9e1aafff270ad0bf2d2b48c0a9a5f42445e45c65972f41a32e4eb7d571718b5
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.6.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -133,7 +133,7 @@ metadata:
     helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
-    app.kubernetes.io/version: "v1.6.0"
+    app.kubernetes.io/version: "v1.7.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -148,7 +148,7 @@ spec:
         helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
-        app.kubernetes.io/version: "v1.6.0"
+        app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/values: e9e1aafff270ad0bf2d2b48c0a9a5f42445e45c65972f41a32e4eb7d571718b5

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -130,7 +130,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.6.0
+    helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.6.0"
@@ -145,7 +145,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.6.0
+        helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.6.0"

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -250,12 +250,12 @@ spec:
         app.kubernetes.io/version: "v1.6.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: bc5340f0df311224d5c13a1126c9adfe482a5dff66f5c9d24987f3b2780a006d
+        checksum/values: 400c67f275a4b8dd87bf92a0ee2c66b31af4d6049325c8d18e00ddbf4351c24d
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.6.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -250,12 +250,12 @@ spec:
         app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 400c67f275a4b8dd87bf92a0ee2c66b31af4d6049325c8d18e00ddbf4351c24d
+        checksum/values: eaf27909280efe805a787fb5ae1054e52edb07e9522caedb339e2a0d5f928619
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
+          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -158,6 +158,24 @@ stringData:
         }
       ]
     }
+    
+  script.yaml: |
+    schemaId: script-credentials-v1
+    runPredefinedScript:
+      echo:
+        # you have to use an array to specify the command
+        command: ["echo", "Hello world"]
+      echo-parametrized:
+        # you can use [workflow-like syntax](https://docs.datadoghq.com/actions/workflows/variables/) to retrieve values from the parameters object
+        command: [ "echo", "{{ parameters.echoValue }}" ]
+        # you can use [json schema](https://json-schema.org/) to validate the parameters
+        parameterSchema:
+          properties:
+            echoValue:
+              type: string
+              const: "world"
+          required:
+            - echoValue
 ---
 # Source: private-action-runner/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -232,7 +250,7 @@ spec:
         app.kubernetes.io/version: "v1.6.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: adad3f640e0ae87995cb9d411c902915bdfa984442f8093f376bedf70ede7832
+        checksum/values: bc5340f0df311224d5c13a1126c9adfe482a5dff66f5c9d24987f3b2780a006d
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -229,7 +229,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.6.0
+    helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.6.0"
@@ -244,7 +244,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.6.0
+        helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.6.0"

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -232,7 +232,7 @@ metadata:
     helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
-    app.kubernetes.io/version: "v1.6.0"
+    app.kubernetes.io/version: "v1.7.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -247,7 +247,7 @@ spec:
         helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
-        app.kubernetes.io/version: "v1.6.0"
+        app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/values: 400c67f275a4b8dd87bf92a0ee2c66b31af4d6049325c8d18e00ddbf4351c24d

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -96,12 +96,12 @@ spec:
         app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 96d20cdb8e807edb3bfbe9f63682f61312b1dbdd9e6fceb893295beadc3fd9d7
+        checksum/values: 1bd9da67be7019e4636ba101ff9aae7c331f3def7277bc48710120a0c7e6c366
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
         - name: runner
-          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
+          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -96,12 +96,12 @@ spec:
         app.kubernetes.io/version: "v1.6.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: f77099cc546fb8b253ce0c09edef0f3543cef6c08ad75cb9c0e6beb37d506096
+        checksum/values: 96d20cdb8e807edb3bfbe9f63682f61312b1dbdd9e6fceb893295beadc3fd9d7
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.6.0"
+          image: "datadog/private-action-runner-dev:latest@sha256:363444a0b2cb47de3f4734806181cdf071ad4a0eed598c0558308fd9df312d4d"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -78,7 +78,7 @@ metadata:
     helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
-    app.kubernetes.io/version: "v1.6.0"
+    app.kubernetes.io/version: "v1.7.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -93,7 +93,7 @@ spec:
         helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
-        app.kubernetes.io/version: "v1.6.0"
+        app.kubernetes.io/version: "v1.7.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/values: 96d20cdb8e807edb3bfbe9f63682f61312b1dbdd9e6fceb893295beadc3fd9d7

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,7 +75,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.6.0
+    helm.sh/chart: private-action-runner-1.7.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.6.0"
@@ -90,7 +90,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.6.0
+        helm.sh/chart: private-action-runner-1.7.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.6.0"


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for script actions for the private action runner

#### Which issue this PR fixes

ACTP-757

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
