### PR TITLE
Allow excluding containers from security signals generation

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Datadog changelog
 
+## 3.127.0
+
+* Add:
+  - `datadog.securityAgent.runtime.containerInclude`
+  - `datadog.securityAgent.runtime.containerExclude`
+  - `datadog.securityAgent.compliance.containerInclude`
+  - `datadog.securityAgent.compliance.containerExclude`
+
 ## 3.126.1
 
 * Update `fips.image.tag` to `1.1.14` fixing CVEs and updating packages.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.126.1
+version: 3.127.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.126.1](https://img.shields.io/badge/Version-3.126.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.127.0](https://img.shields.io/badge/Version-3.127.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -884,6 +884,7 @@ helm install <RELEASE_NAME> \
 | datadog.secretBackend.timeout | string | `nil` | Configure the secret backend command timeout in seconds. |
 | datadog.securityAgent.compliance.checkInterval | string | `"20m"` | Compliance check run interval |
 | datadog.securityAgent.compliance.configMap | string | `nil` | Contains CSPM compliance benchmarks that will be used |
+| datadog.securityAgent.compliance.containerInclude | string | `nil` | Include containers in CSPM monitoring, as a space-separated list. If a container matches an include rule, it’s always included |
 | datadog.securityAgent.compliance.enabled | bool | `false` | Set to true to enable Cloud Security Posture Management (CSPM) |
 | datadog.securityAgent.compliance.host_benchmarks.enabled | bool | `true` | Set to false to disable host benchmarks. If enabled, this feature requires 160 MB extra memory for the `security-agent` container. (Requires Agent 7.47.0+) |
 | datadog.securityAgent.compliance.xccdf.enabled | bool | `false` |  |
@@ -892,6 +893,8 @@ helm install <RELEASE_NAME> \
 | datadog.securityAgent.runtime.activityDump.enabled | bool | `true` | Set to true to enable the collection of CWS activity dumps |
 | datadog.securityAgent.runtime.activityDump.pathMerge.enabled | bool | `false` | Set to true to enable the merging of similar paths |
 | datadog.securityAgent.runtime.activityDump.tracedCgroupsCount | int | `3` | Set to the number of containers that should be traced concurrently |
+| datadog.securityAgent.runtime.containerExclude | string | `nil` |  |
+| datadog.securityAgent.runtime.containerInclude | string | `nil` | Include containers in runtime security monitoring, as a space-separated list. If a container matches an include rule, it’s always included |
 | datadog.securityAgent.runtime.enabled | bool | `false` | Set to true to enable Cloud Workload Security (CWS) |
 | datadog.securityAgent.runtime.fimEnabled | bool | `false` | Set to true to enable Cloud Workload Security (CWS) File Integrity Monitoring |
 | datadog.securityAgent.runtime.network.enabled | bool | `true` | Set to true to enable the collection of CWS network events |

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -44,6 +44,14 @@
       value: {{ (or .Values.datadog.securityAgent.compliance.xccdf.enabled .Values.datadog.securityAgent.compliance.host_benchmarks.enabled) | quote }}
     - name: HOST_ROOT
       value: /host/root
+    {{- if .Values.datadog.securityAgent.compliance.containerInclude }}
+    - name: DD_COMPLIANCE_CONFIG_CONTAINER_INCLUDE
+      value: {{ .Values.datadog.securityAgent.compliance.containerInclude | quote }}
+    {{- end }}
+    {{- if .Values.datadog.securityAgent.compliance.containerExclude }}
+    - name: DD_COMPLIANCE_CONFIG_CONTAINER_EXCLUDE
+      value: {{ .Values.datadog.securityAgent.compliance.containerExclude | quote }}
+    {{- end }}
     {{- end }}
     - name: DD_RUNTIME_SECURITY_CONFIG_ENABLED
       value: {{ .Values.datadog.securityAgent.runtime.enabled | quote }}

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -79,6 +79,18 @@ data:
       configure_cgroup_perms: {{ $.Values.datadog.gpuMonitoring.configureCgroupPerms }}
     runtime_security_config:
       enabled: {{ $.Values.datadog.securityAgent.runtime.enabled }}
+{{- if .Values.datadog.securityAgent.runtime.containerInclude }}
+      container_include:
+{{- range (split " " .Values.datadog.securityAgent.runtime.containerInclude) }}
+      - {{ .  | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.datadog.securityAgent.runtime.containerExclude }}
+      container_exclude:
+{{- range (split " " .Values.datadog.securityAgent.runtime.containerExclude) }}
+      - {{ . | quote }}
+{{- end }}
+{{- end }}
       fim_enabled: {{ $.Values.datadog.securityAgent.runtime.fimEnabled }}
       use_secruntime_track: {{ $.Values.datadog.securityAgent.runtime.useSecruntimeTrack }}
       socket: /var/run/sysprobe/runtime-security.sock

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1020,6 +1020,12 @@ datadog:
       # datadog.securityAgent.compliance.checkInterval -- Compliance check run interval
       checkInterval: 20m
 
+      # datadog.securityAgent.compliance.containerInclude -- Include containers in CSPM monitoring, as a space-separated list.
+      # If a container matches an include rule, it’s always included
+
+      ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#include-containers
+      containerInclude:
+
       # DEPRECATED. Use datadog.securityAgent.compliance.host_benchmarks.enabled instead.
       xccdf:
         enabled: false
@@ -1037,6 +1043,15 @@ datadog:
 
       # datadog.securityAgent.runtime.useSecruntimeTrack -- Set to true to send Cloud Workload Security (CWS) events directly to the Agent events explorer
       useSecruntimeTrack: true
+
+      ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
+      containerExclude:  # "image:datadog/agent"
+
+      # datadog.securityAgent.runtime.containerInclude -- Include containers in runtime security monitoring, as a space-separated list.
+      # If a container matches an include rule, it’s always included
+
+      ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#include-containers
+      containerInclude:
 
       policies:
         # datadog.securityAgent.runtime.policies.configMap -- Contains CWS policies that will be used


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
