### PR TITLE
Add new allowlist

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.126.2
+
+* Add support for otel agent in GKE autopilot.
+
 ## 3.126.1
 
 * Update `fips.image.tag` to `1.1.14` fixing CVEs and updating packages.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.126.1
+version: 3.126.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.131.2](https://img.shields.io/badge/Version-3.131.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.131.2](https://img.shields.io/badge/Version-3.131.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.127.1](https://img.shields.io/badge/Version-3.127.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.127.1](https://img.shields.io/badge/Version-3.127.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.126.1](https://img.shields.io/badge/Version-3.126.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.126.2](https://img.shields.io/badge/Version-3.126.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -659,16 +659,6 @@ This version still supports both but the support of the old name will be dropped
 More information about this change: https://github.com/DataDog/helm-charts/pull/1161
 {{- end }}
 
-
-{{- if and (eq (include "should-enable-otel-agent" .) "true") .Values.providers.gke.autopilot }}
-#################################################################
-####               WARNING: Configuration notice             ####
-#################################################################
-OTel collector is not supported on GKE Autopilot.
-{{- fail "The OTel collector cannot be run on GKE Autopilot." }}
-{{- end }}
-
-
 {{- if and (eq (include "should-enable-otel-agent" .) "true") (hasSuffix "-full" (.Values.agents.image.tag | toString)) }}
 #################################################################
 ####               WARNING: Configuration notice             ####

--- a/charts/datadog/templates/gke_autopilot_allowlist_synchronizer.yaml
+++ b/charts/datadog/templates/gke_autopilot_allowlist_synchronizer.yaml
@@ -9,4 +9,5 @@ metadata:
 spec:
   allowlistPaths:
   - Datadog/datadog/datadog-datadog-daemonset-exemption-v1.0.1.yaml
+  - Datadog/datadog/datadog-datadog-daemonset-exemption-v1.0.2.yaml
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the new GKE autopilot allowlist that supports the otel agent, see: https://github.com/DataDog/datadog-gke-workload-allowlist/pull/6. It also removes the otel agent limitation in GKE Autopilot.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
