### PR TITLE
[observability-pipelines-worker] release 2.7.0

### DIFF
--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7.0
+
+- Official image `2.7.0`
+
 ## 2.6.0
 
 - Official image `2.6.0`
@@ -14,145 +18,145 @@
 
 ## 2.5.0
 
-* Official image `2.5.0`
+- Official image `2.5.0`
 
 ## 2.4.2
 
-* Official image `2.4.2`
+- Official image `2.4.2`
 
 ## 2.4.1
 
-* Official image `2.4.1`
+- Official image `2.4.1`
 
 ## 2.4.0
 
-* Official image `2.4.0`
+- Official image `2.4.0`
 
 ## 2.3.0
 
-* Official image `2.3.0`
+- Official image `2.3.0`
 
 ## 2.2.3
 
-* Official image `2.2.3`
+- Official image `2.2.3`
 
 ## 2.2.2
 
-* Official image `2.2.2`
+- Official image `2.2.2`
 
 ## 2.2.1
 
-* Official image `2.2.1`
+- Official image `2.2.1`
 
 ## 2.2.0
 
-* Official image `2.2.0`
+- Official image `2.2.0`
 
 ## 2.1.2
 
-* Official image `2.1.2`
+- Official image `2.1.2`
 
 ## 2.1.1
 
-* Official image `2.1.1`
+- Official image `2.1.1`
 
 ## 2.1.0
 
-* Official image `2.1.0`
+- Official image `2.1.0`
 
 ## 2.0.2
 
-* Official image `2.0.2`
+- Official image `2.0.2`
 
 ## 2.0.1
 
-* Official image `2.0.1`
+- Official image `2.0.1`
 
 ## 2.0.0
 
-* GA release of Observability Pipelines Worker v2
-* Removed `datadog.remoteConfigurationEnabled` and `pipelineConfig` values
+- GA release of Observability Pipelines Worker v2
+- Removed `datadog.remoteConfigurationEnabled` and `pipelineConfig` values
 
 ## 1.8.1
 
-* Migrate from `kubeval` to `kubeconform` for ci chart validation.
+- Migrate from `kubeval` to `kubeconform` for ci chart validation.
 
 ## 1.8.0
 
-* Official image `1.8.0`
+- Official image `1.8.0`
 
 ## 1.7.1
 
-* Official image `1.7.1`
+- Official image `1.7.1`
 
 ## 1.7.0
 
-* Official image `1.7.0`
+- Official image `1.7.0`
 
 ## 1.6.0
 
-* Official image `1.6.0`
+- Official image `1.6.0`
 
 ## 1.5.2
 
-* Dropped ArtifactHub license designation to avoid confusion
+- Dropped ArtifactHub license designation to avoid confusion
 
 ## 1.5.1
 
-* Official image `1.5.1`
+- Official image `1.5.1`
 
 ## 1.5.0
 
-* Official image `1.5.0`
+- Official image `1.5.0`
 
 ## 1.4.0
 
-* Official image `1.4.0`
+- Official image `1.4.0`
 
 ## 1.4.0-rc.0
 
-* Nightly image representative of `1.4.0`
-* Add `datadog.workerAPI.enabled`, `datadog.workerAPI.playground`, `datadog.workerAPI.address` for Worker API configuration
-* Expose Worker API port in pod and through service if enabled
-* Remove deprecated `datadog.configKey`
+- Nightly image representative of `1.4.0`
+- Add `datadog.workerAPI.enabled`, `datadog.workerAPI.playground`, `datadog.workerAPI.address` for Worker API configuration
+- Expose Worker API port in pod and through service if enabled
+- Remove deprecated `datadog.configKey`
 
 ## 1.3.1
 
-* Official image `1.3.1`
+- Official image `1.3.1`
 
 ## 1.3.0
 
-* Official image `1.3.0`
-* Add AP1 Site Comment in `values.yaml`.
+- Official image `1.3.0`
+- Add AP1 Site Comment in `values.yaml`.
 
 ## 1.2.1
 
-* Official image `1.2.1`
+- Official image `1.2.1`
 
 ## 1.2.0
 
-* Official image `1.2.0`
+- Official image `1.2.0`
 
 ## 1.2.0-rc.1
 
-* Nightly image `2023-05-04`
+- Nightly image `2023-05-04`
 
 ## 1.2.0-rc.0
 
-* Rename `config` to `pipelineConfig` in values
-* Add `datadog.pipelineId` value to replace `datadog.configKey`. `configKey` is still supported for backwards compatability.
-* Add new `datadog.remoteConfigurationEnabled` and `datadog.dataDir` values
+- Rename `config` to `pipelineConfig` in values
+- Add `datadog.pipelineId` value to replace `datadog.configKey`. `configKey` is still supported for backwards compatability.
+- Add new `datadog.remoteConfigurationEnabled` and `datadog.dataDir` values
 
 ## 1.1.1
 
-* Update `args` to use the `run` subcommand
-* Update default for `DATA_DIR`
-* `1.1.1` release
+- Update `args` to use the `run` subcommand
+- Update default for `DATA_DIR`
+- `1.1.1` release
 
 ## 1.0.0
 
-* GA release
+- GA release
 
 ## 0.1.0
 
-* Initial version
+- Initial version

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: "2.6.0"
+version: "2.7.0"
 description: Observability Pipelines Worker
 type: application
 keywords:
@@ -13,7 +13,7 @@ icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
 maintainers:
   - name: Datadog
     email: support@datadoghq.com
-appVersion: "2.6.0"
+appVersion: "2.7.0"
 annotations:
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.6.0](https://img.shields.io/badge/Version-2.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.0](https://img.shields.io/badge/AppVersion-2.6.0-informational?style=flat-square)
+![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 
@@ -110,7 +110,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.pullPolicy | string | `"IfNotPresent"` | Specify the [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy). |
 | image.pullSecrets | list | `[]` | Specify the [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod). |
 | image.repository | string | `"gcr.io/datadoghq"` | Specify the image repository to use. |
-| image.tag | string | `"2.6.0"` | Specify the image tag to use. |
+| image.tag | string | `"2.7.0"` | Specify the image tag to use. |
 | ingress.annotations | object | `{}` | Specify annotations for the Ingress. |
 | ingress.className | string | `""` | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18. |
 | ingress.enabled | bool | `false` | If **true**, create an Ingress resource. |

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -42,7 +42,7 @@ image:
   # image.name -- Specify the image name to use (relative to `image.repository`).
   name: observability-pipelines-worker
   # image.tag -- Specify the image tag to use.
-  tag: 2.6.0
+  tag: 2.7.0
   # image.digest -- (string) Specify the image digest to use; takes precedence over `image.tag`.
   digest:
   ## Currently, we offer images at:


### PR DESCRIPTION
#### What this PR does / why we need it:

Release for or OPW 2.7.0

#### Which issue this PR fixes

https://datadoghq.atlassian.net/browse/OPA-3561

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
