### PR TITLE
Fix minor syntax issue in service account

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.12.0-dev.5
+
+* Fix minor syntax issue in service account. 
+
 ## 2.12.0-dev.4
 
 * Add option to disable service account automountServiceAccountToken. 

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.12.0-dev.4
+version: 2.12.0-dev.5
 appVersion: 1.17.0-rc.3
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.12.0-dev.4](https://img.shields.io/badge/Version-2.12.0--dev.4-informational?style=flat-square) ![AppVersion: 1.17.0-rc.3](https://img.shields.io/badge/AppVersion-1.17.0--rc.3-informational?style=flat-square)
+![Version: 2.12.0-dev.5](https://img.shields.io/badge/Version-2.12.0--dev.5-informational?style=flat-square) ![AppVersion: 1.17.0-rc.3](https://img.shields.io/badge/AppVersion-1.17.0--rc.3-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/service_account.yaml
+++ b/charts/datadog-operator/templates/service_account.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.serviceAccount.annotations }}
   annotations:
-{{- toYaml .Values.serviceAccount.annotations | nindent 4 | }}
+{{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}
   labels:
 {{ include "datadog-operator.labels" . | indent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
