### PR TITLE
[netpath] Add tunables for Network Traffic Paths

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Datadog changelog
 
+## 3.129.0
+
+* Add:
+  - `datadog.networkPath.collector.pathtestContextsLimit`
+  - `datadog.networkPath.collector.pathtestInterval`
+  - `datadog.networkPath.collector.pathtestMaxPerMinute`
+  - `datadog.networkPath.collector.pathtestTTL`
+  - `datadog.networkPath.collector.workers`
+
 ## 3.128.0
 
 * Update:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.128.0
+version: 3.129.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.128.0](https://img.shields.io/badge/Version-3.128.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.129.0](https://img.shields.io/badge/Version-3.129.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -827,6 +827,11 @@ helm install <RELEASE_NAME> \
 | datadog.namespaceAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Namespace Annotations to Datadog Tags |
 | datadog.namespaceLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Namespace Labels to Datadog Tags |
 | datadog.networkMonitoring.enabled | bool | `false` | Enable network performance monitoring |
+| datadog.networkPath.collector.pathtestContextsLimit | string | `nil` | Override maximum number of pathtests stored to run |
+| datadog.networkPath.collector.pathtestInterval | string | `nil` | Override time interval between pathtest runs |
+| datadog.networkPath.collector.pathtestMaxPerMinute | string | `nil` | Override limit for total pathtests run, per minute |
+| datadog.networkPath.collector.pathtestTTL | string | `nil` | Override TTL in minutes for pathtests |
+| datadog.networkPath.collector.workers | string | `nil` | Override the number of workers |
 | datadog.networkPath.connectionsMonitoring.enabled | bool | `false` | Enable Network Path's "Network traffic paths" feature. Requires the `traceroute` system-probe module to be enabled. |
 | datadog.networkPolicy.cilium.dnsSelector | object | kube-dns in namespace kube-system | Cilium selector of the DNS server entity |
 | datadog.networkPolicy.create | bool | `false` | If true, create NetworkPolicy for all the components |

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -49,6 +49,26 @@
     - name: DD_NETWORK_PATH_CONNECTIONS_MONITORING_ENABLED
       value: {{ .Values.datadog.networkPath.connectionsMonitoring.enabled | quote }}
     {{- end }}
+    {{- if .Values.datadog.networkPath.collector.workers }}
+    - name: DD_NETWORK_PATH_COLLECTOR_WORKERS
+      value: {{ .Values.datadog.networkPath.collector.workers | quote }}
+    {{- end }}
+    {{- if .Values.datadog.networkPath.collector.pathtestTTL }}
+    - name: DD_NETWORK_PATH_COLLECTOR_PATHTEST_TTL
+      value: {{ .Values.datadog.networkPath.collector.pathtestTTL | quote }}
+    {{- end }}
+    {{- if .Values.datadog.networkPath.collector.pathtestInterval }}
+    - name: DD_NETWORK_PATH_COLLECTOR_PATHTEST_INTERVAL
+      value: {{ .Values.datadog.networkPath.collector.pathtestInterval | quote }}
+    {{- end }}
+    {{- if .Values.datadog.networkPath.collector.pathtestContextsLimit }}
+    - name: DD_NETWORK_PATH_COLLECTOR_PATHTEST_CONTEXTS_LIMIT
+      value: {{ .Values.datadog.networkPath.collector.pathtestContextsLimit | quote }}
+    {{- end }}
+    {{- if .Values.datadog.networkPath.collector.pathtestMaxPerMinute }}
+    - name: DD_NETWORK_PATH_COLLECTOR_PATHTEST_MAX_PER_MINUTE
+      value: {{ .Values.datadog.networkPath.collector.pathtestMaxPerMinute | quote }}
+    {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -929,6 +929,17 @@ datadog:
     connectionsMonitoring:
       # datadog.networkPath.connectionsMonitoring.enabled -- Enable Network Path's "Network traffic paths" feature. Requires the `traceroute` system-probe module to be enabled.
       enabled: false
+    collector:
+      # datadog.networkPath.collector.workers -- Override the number of workers
+      workers:
+      # datadog.networkPath.collector.pathtestTTL -- Override TTL in minutes for pathtests
+      pathtestTTL:
+      # datadog.networkPath.collector.pathtestInterval -- Override time interval between pathtest runs
+      pathtestInterval:
+      # datadog.networkPath.collector.pathtestContextsLimit -- Override maximum number of pathtests stored to run
+      pathtestContextsLimit:
+      # datadog.networkPath.collector.pathtestMaxPerMinute -- Override limit for total pathtests run, per minute
+      pathtestMaxPerMinute:
 
   serviceMonitoring:
     # datadog.serviceMonitoring.enabled -- Enable Universal Service Monitoring


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds tunables related to number of workers/performance/throttling in Network Traffic Paths. This is needed because a customer has noted they hit the upper limit that their default 4 workers can process.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
