### PR TITLE
feat: Made `PodDisruptionBudget` configurable

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+* Add:
+- Allow configuring `minAvailable` and `maxUnavailable` in the `PodDisruptionBudget` for the cluster agent and cluster-checks runner.
+
+* Update:
+- The `createPodDisruptionBudget` setting is now set to be deprecated for both components in favor of a new, unified `pdb` configuration block.
+
 ## 3.130.0
 
 * Update Cluster Agent RBAC to allow list/watch on all Datadog custom resources if the orchestrator check is enabled.

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -637,6 +637,8 @@ helm install <RELEASE_NAME> \
 | clusterAgent.metricsProvider.wpaController | bool | `false` | Enable informer and controller of the watermark pod autoscaler |
 | clusterAgent.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster agent. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterAgent.nodeSelector | object | `{}` | Allow the Cluster Agent Deployment to be scheduled on selected nodes |
+| clusterAgent.pdb.create | bool | `false` | Create pod disruption budget for Cluster Agent deployments |
+| clusterAgent.pdb.minAvailable | int | `1` | PDB minAvailable to be available at all times |
 | clusterAgent.podAnnotations | object | `{}` | Annotations to add to the cluster-agents's pod(s) |
 | clusterAgent.podSecurity.podSecurityPolicy.create | bool | `false` | If true, create a PodSecurityPolicy resource for Cluster Agent pods |
 | clusterAgent.podSecurity.securityContextConstraints.create | bool | `false` | If true, create a SCC resource for Cluster Agent pods |
@@ -684,6 +686,8 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterChecksRunner.nodeSelector | object | `{}` | Allow the ClusterChecks Deployment to schedule on selected nodes |
+| clusterChecksRunner.pdb.create | bool | `false` | Create the pod disruption budget to apply to the cluster checks agents |
+| clusterChecksRunner.pdb.maxUnavailable | int | `1` | PDB maxUnavailable allowed to be unavailable during a disruption |
 | clusterChecksRunner.podAnnotations | object | `{}` | Annotations to add to the cluster-checks-runner's pod(s) |
 | clusterChecksRunner.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | clusterChecksRunner.priorityClassName | string | `nil` | Name of the priorityClass to apply to the Cluster checks runners |

--- a/charts/datadog/templates/agent-clusterchecks-pdb.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterChecksRunner.createPodDisruptionBudget -}}
+{{- if .Values.clusterChecksRunner.createPodDisruptionBudget .Values.clusterChecksRunner.pdb.enable -}}
 apiVersion: {{ template "policy.poddisruptionbudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -7,7 +7,11 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
 spec:
-  maxUnavailable: 1
+  {{- if .Values.clusterChecksRunner.pdb.minAvailable -}}
+  minAvailable: {{ .Values.clusterChecksRunner.pdb.minAvailable }}
+  {{- else -}}
+  maxUnavailable: {{ .Values.clusterChecksRunner.pdb.maxUnavailable | default 1 }}
+  {{- end -}}
   selector:
     matchLabels:
       app: {{ template "datadog.fullname" . }}-clusterchecks

--- a/charts/datadog/templates/agent-clusterchecks-pdb.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterChecksRunner.createPodDisruptionBudget .Values.clusterChecksRunner.pdb.enable -}}
+{{- if or .Values.clusterChecksRunner.createPodDisruptionBudget .Values.clusterChecksRunner.pdb.enable -}}
 apiVersion: {{ template "policy.poddisruptionbudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/datadog/templates/cluster-agent-pdb.yaml
+++ b/charts/datadog/templates/cluster-agent-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterAgent.createPodDisruptionBudget -}}
+{{- if or .Values.clusterAgent.createPodDisruptionBudget .Values.clusterAgent.pdb.enable -}}
 apiVersion: {{ template "policy.poddisruptionbudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -7,7 +7,11 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
 spec:
-  minAvailable: 1
+  {{- if .Values.clusterChecksRunner.pdb.minAvailable -}}
+  minAvailable: {{ .Values.clusterChecksRunner.pdb.minAvailable }}
+  {{- else -}}
+  maxUnavailable: {{ .Values.clusterChecksRunner.pdb.maxUnavailable | default 1 }}
+  {{- end -}}
   selector:
     matchLabels:
       app: {{ template "datadog.fullname" . }}-cluster-agent

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1656,7 +1656,13 @@ clusterAgent:
   datadog_cluster_yaml: {}
 
   # clusterAgent.createPodDisruptionBudget -- Create pod disruption budget for Cluster Agent deployments
-  createPodDisruptionBudget: false
+  createPodDisruptionBudget: false # To be deprecated
+  # Define PodDisruptionBudget for Cluster Agent deployments
+  pdb:
+    # clusterAgent.pdb.create -- Create pod disruption budget for Cluster Agent deployments
+    create: false
+    # clusterAgent.pdb.minAvailable -- PDB minAvailable to be available at all times
+    minAvailable: 1
 
   networkPolicy:
     # clusterAgent.networkPolicy.create -- If true, create a NetworkPolicy for the cluster agent.
@@ -2395,7 +2401,13 @@ clusterChecksRunner:
     #   - name: "<REG_SECRET>"
 
   # clusterChecksRunner.createPodDisruptionBudget -- Create the pod disruption budget to apply to the cluster checks agents
-  createPodDisruptionBudget: false
+  createPodDisruptionBudget: false # To be deprecated
+  # Define PodDisruptionBudget for cluster checks agents
+  pdb:
+    # clusterChecksRunner.pdb.create -- Create the pod disruption budget to apply to the cluster checks agents
+    create: false
+    # clusterChecksRunner.pdb.maxUnavailable -- PDB maxUnavailable allowed to be unavailable during a disruption
+    maxUnavailable: 1
 
   # Provide Cluster Checks Deployment pods RBAC configuration
   rbac:


### PR DESCRIPTION
## What this PR does / why we need it:

### Core Issue
At the moment it's not possible to configure the `PodDisruptionBudget` for the cluster agent. The existing configuration is hardcoded and set to `minAvailable: 1` which isn't highly available.

By allowing users to set `minAvailable` or `maxUnavailable` we can achieve proper HA in any respective environment.
With this example configuration we can have a highly available cluster agent.
- CA `replicas: 3`
- PDB `maxUnavailable: 1`

### Interface Consistency
In order to have a consistent interface in the chart, the same changes for `clusterAgent` are applied to `clusterChecksRunner` as well. Previous behavior are kept and changes are backwards compatible.

Both `createPodDisruptionBudget` are copied into the new `pdb` block so we can deprecate the additional flag in a future minor release.

## Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
