### PR TITLE
Obs Pipelines: Enable API, add liveness and readiness probes

### DIFF
--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -32,11 +32,12 @@ datadog:
   dataDir: "/var/lib/observability-pipelines-worker"
   workerAPI:
     # datadog.workerAPI.enabled -- Whether to enable the Worker's API.
-    enabled: false
+    enabled: true
     # datadog.workerAPI.playground -- Whether to enable the Worker's API GraphQL playground.
-    playground: true
+    playground: false
     # datadog.workerAPI.address -- Local address to bind the Worker's API to.
-    address: "127.0.0.1:8686"
+    # if you change this port, you'll need to update the livenessProbe and readinessProbe
+    address: "0.0.0.0:8686"
 
 image:
   # image.name -- Specify the image name to use (relative to `image.repository`).
@@ -301,8 +302,28 @@ dnsConfig: {}
 
 # livenessProbe -- Specify the livenessProbe
 # [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).
-livenessProbe: {}
+livenessProbe:
+  failureThreshold: 5
+  httpGet:
+    path: /health
+    # if you modify datadog.workerAPI.address to a different port you'll need to update here as well
+    port: 8686
+    scheme: HTTP
+  initialDelaySeconds: 15
+  timeoutSeconds: 15
+  periodSeconds: 10
+  successThreshold: 1
 
 # readinessProbe -- Specify the readinessProbe
 # [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).
-readinessProbe: {}
+readinessProbe:
+  failureThreshold: 3
+  httpGet:
+    path: /health
+    # if you modify datadog.workerAPI.address to a different port you'll need to update here as well
+    port: 8686
+    scheme: HTTP
+  initialDelaySeconds: 15
+  timeoutSeconds: 15
+  periodSeconds: 10
+  successThreshold: 1


### PR DESCRIPTION
### Overview

This is an exact copy of https://github.com/DataDog/helm-charts/pull/1890, however @ckelner does not have permission to create a branch on this repo (and merging changes from a fork is not compatible with the CI), so needed to duplicate the changes to a new branch/PR