### PR TITLE
fix: always allow operator to list datadogagentinternals

### DIFF
--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -359,6 +359,12 @@ rules:
   - ksh/metrics
   verbs:
   - get
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadogagentinternals
+  verbs:
+  - list
 {{- if .Values.datadogAgentProfile.enabled }}
 - apiGroups:
   - ""


### PR DESCRIPTION
It looks like the operator needs this permission:
```json
{"level":"ERROR","ts":"2025-08-14T13:19:58.044Z","logger":"setup","msg":"Failed to cleanup DatadogAgentInternal resources","error":"failed to list DatadogAgentInternal resources: datadogagentinternals.datadoghq.com is forbidden: User \"system:serviceaccount:datadog-operator:datadog-operator\" cannot list resource \"datadogagentinternals\" in API group \"datadoghq.com\" at the cluster scope","stacktrace":"main.run.func2\n\t/workspace/cmd/main.go:324"}
```