### PR TITLE
[datadog-crds] Update operator crds from 1.18.0-rc.1

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.11.0-dev.1
+
+* Update CRDs from Datadog Operator v1.18.0-rc.1 release candidate tag.
+
 ## 2.10.0
 
 * Update CRDs from Datadog Operator v1.17.0 tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.10.0
+version: 2.11.0-dev.1
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.11.0-dev.1](https://img.shields.io/badge/Version-2.11.0--dev.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentinternals_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentinternals_v1.yaml
@@ -1071,6 +1071,15 @@ spec:
                             Default: false
                           type: boolean
                       type: object
+                    controlPlaneMonitoring:
+                      description: ControlPlaneMonitoring configuration.
+                      properties:
+                        enabled:
+                          description: |-
+                            Enabled enables control plane monitoring checks in the cluster agent.
+                            Default: true
+                          type: boolean
+                      type: object
                     cspm:
                       description: CSPM (Cloud Security Posture Management) configuration.
                       properties:
@@ -1471,7 +1480,12 @@ spec:
                       properties:
                         enabled:
                           description: |-
-                            Enabled enables GPU monitoring.
+                            Enabled enables GPU monitoring core check.
+                            Default: false
+                          type: boolean
+                        privilegedMode:
+                          description: |-
+                            PrivilegedMode enables GPU Probe module in System Probe.
                             Default: false
                           type: boolean
                         requiredRuntimeClassName:
@@ -2150,6 +2164,16 @@ spec:
                     criSocketPath:
                       description: Path to the container runtime socket (if different from Docker).
                       type: string
+                    csi:
+                      description: CSI contains configuration for Datadog CSI Driver
+                      properties:
+                        enabled:
+                          description: |-
+                            Enables the usage of CSI driver in Datadog Agent.
+                            Requires installation of Datadog CSI Driver https://github.com/DataDog/helm-charts/tree/main/charts/datadog-csi-driver
+                            Default: false
+                          type: boolean
+                      type: object
                     disableNonResourceRules:
                       description: |-
                         Set DisableNonResourceRules to exclude NonResourceURLs from default ClusterRoles.
@@ -8656,6 +8680,15 @@ spec:
                                 Default: false
                               type: boolean
                           type: object
+                        controlPlaneMonitoring:
+                          description: ControlPlaneMonitoring configuration.
+                          properties:
+                            enabled:
+                              description: |-
+                                Enabled enables control plane monitoring checks in the cluster agent.
+                                Default: true
+                              type: boolean
+                          type: object
                         cspm:
                           description: CSPM (Cloud Security Posture Management) configuration.
                           properties:
@@ -9056,7 +9089,12 @@ spec:
                           properties:
                             enabled:
                               description: |-
-                                Enabled enables GPU monitoring.
+                                Enabled enables GPU monitoring core check.
+                                Default: false
+                              type: boolean
+                            privilegedMode:
+                              description: |-
+                                PrivilegedMode enables GPU Probe module in System Probe.
                                 Default: false
                               type: boolean
                             requiredRuntimeClassName:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
@@ -1071,6 +1071,15 @@ spec:
                                 Default: false
                               type: boolean
                           type: object
+                        controlPlaneMonitoring:
+                          description: ControlPlaneMonitoring configuration.
+                          properties:
+                            enabled:
+                              description: |-
+                                Enabled enables control plane monitoring checks in the cluster agent.
+                                Default: true
+                              type: boolean
+                          type: object
                         cspm:
                           description: CSPM (Cloud Security Posture Management) configuration.
                           properties:
@@ -1471,7 +1480,12 @@ spec:
                           properties:
                             enabled:
                               description: |-
-                                Enabled enables GPU monitoring.
+                                Enabled enables GPU monitoring core check.
+                                Default: false
+                              type: boolean
+                            privilegedMode:
+                              description: |-
+                                PrivilegedMode enables GPU Probe module in System Probe.
                                 Default: false
                               type: boolean
                             requiredRuntimeClassName:
@@ -2150,6 +2164,16 @@ spec:
                         criSocketPath:
                           description: Path to the container runtime socket (if different from Docker).
                           type: string
+                        csi:
+                          description: CSI contains configuration for Datadog CSI Driver
+                          properties:
+                            enabled:
+                              description: |-
+                                Enables the usage of CSI driver in Datadog Agent.
+                                Requires installation of Datadog CSI Driver https://github.com/DataDog/helm-charts/tree/main/charts/datadog-csi-driver
+                                Default: false
+                              type: boolean
+                          type: object
                         disableNonResourceRules:
                           description: |-
                             Set DisableNonResourceRules to exclude NonResourceURLs from default ClusterRoles.

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -578,6 +578,11 @@ spec:
                         useClusterChecksRunners:
                           type: boolean
                       type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     cspm:
                       properties:
                         checkInterval:
@@ -795,6 +800,8 @@ spec:
                     gpu:
                       properties:
                         enabled:
+                          type: boolean
+                        privilegedMode:
                           type: boolean
                         requiredRuntimeClassName:
                           type: string
@@ -1157,6 +1164,11 @@ spec:
                       type: object
                     criSocketPath:
                       type: string
+                    csi:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     disableNonResourceRules:
                       type: boolean
                     dockerSocketPath:
@@ -4447,6 +4459,11 @@ spec:
                             useClusterChecksRunners:
                               type: boolean
                           type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                         cspm:
                           properties:
                             checkInterval:
@@ -4664,6 +4681,8 @@ spec:
                         gpu:
                           properties:
                             enabled:
+                              type: boolean
+                            privilegedMode:
                               type: boolean
                             requiredRuntimeClassName:
                               type: string

--- a/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
@@ -176,9 +176,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -206,7 +206,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -242,9 +242,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -272,7 +272,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -331,6 +331,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -359,6 +361,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -661,9 +665,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -691,7 +695,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -717,9 +721,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -747,7 +751,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -874,6 +878,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -902,6 +908,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload

--- a/crds/datadoghq.com_datadogagentinternals.yaml
+++ b/crds/datadoghq.com_datadogagentinternals.yaml
@@ -1065,6 +1065,15 @@ spec:
                             Default: false
                           type: boolean
                       type: object
+                    controlPlaneMonitoring:
+                      description: ControlPlaneMonitoring configuration.
+                      properties:
+                        enabled:
+                          description: |-
+                            Enabled enables control plane monitoring checks in the cluster agent.
+                            Default: true
+                          type: boolean
+                      type: object
                     cspm:
                       description: CSPM (Cloud Security Posture Management) configuration.
                       properties:
@@ -1465,7 +1474,12 @@ spec:
                       properties:
                         enabled:
                           description: |-
-                            Enabled enables GPU monitoring.
+                            Enabled enables GPU monitoring core check.
+                            Default: false
+                          type: boolean
+                        privilegedMode:
+                          description: |-
+                            PrivilegedMode enables GPU Probe module in System Probe.
                             Default: false
                           type: boolean
                         requiredRuntimeClassName:
@@ -2144,6 +2158,16 @@ spec:
                     criSocketPath:
                       description: Path to the container runtime socket (if different from Docker).
                       type: string
+                    csi:
+                      description: CSI contains configuration for Datadog CSI Driver
+                      properties:
+                        enabled:
+                          description: |-
+                            Enables the usage of CSI driver in Datadog Agent.
+                            Requires installation of Datadog CSI Driver https://github.com/DataDog/helm-charts/tree/main/charts/datadog-csi-driver
+                            Default: false
+                          type: boolean
+                      type: object
                     disableNonResourceRules:
                       description: |-
                         Set DisableNonResourceRules to exclude NonResourceURLs from default ClusterRoles.
@@ -8650,6 +8674,15 @@ spec:
                                 Default: false
                               type: boolean
                           type: object
+                        controlPlaneMonitoring:
+                          description: ControlPlaneMonitoring configuration.
+                          properties:
+                            enabled:
+                              description: |-
+                                Enabled enables control plane monitoring checks in the cluster agent.
+                                Default: true
+                              type: boolean
+                          type: object
                         cspm:
                           description: CSPM (Cloud Security Posture Management) configuration.
                           properties:
@@ -9050,7 +9083,12 @@ spec:
                           properties:
                             enabled:
                               description: |-
-                                Enabled enables GPU monitoring.
+                                Enabled enables GPU monitoring core check.
+                                Default: false
+                              type: boolean
+                            privilegedMode:
+                              description: |-
+                                PrivilegedMode enables GPU Probe module in System Probe.
                                 Default: false
                               type: boolean
                             requiredRuntimeClassName:

--- a/crds/datadoghq.com_datadogagentprofiles.yaml
+++ b/crds/datadoghq.com_datadogagentprofiles.yaml
@@ -1065,6 +1065,15 @@ spec:
                                 Default: false
                               type: boolean
                           type: object
+                        controlPlaneMonitoring:
+                          description: ControlPlaneMonitoring configuration.
+                          properties:
+                            enabled:
+                              description: |-
+                                Enabled enables control plane monitoring checks in the cluster agent.
+                                Default: true
+                              type: boolean
+                          type: object
                         cspm:
                           description: CSPM (Cloud Security Posture Management) configuration.
                           properties:
@@ -1465,7 +1474,12 @@ spec:
                           properties:
                             enabled:
                               description: |-
-                                Enabled enables GPU monitoring.
+                                Enabled enables GPU monitoring core check.
+                                Default: false
+                              type: boolean
+                            privilegedMode:
+                              description: |-
+                                PrivilegedMode enables GPU Probe module in System Probe.
                                 Default: false
                               type: boolean
                             requiredRuntimeClassName:
@@ -2144,6 +2158,16 @@ spec:
                         criSocketPath:
                           description: Path to the container runtime socket (if different from Docker).
                           type: string
+                        csi:
+                          description: CSI contains configuration for Datadog CSI Driver
+                          properties:
+                            enabled:
+                              description: |-
+                                Enables the usage of CSI driver in Datadog Agent.
+                                Requires installation of Datadog CSI Driver https://github.com/DataDog/helm-charts/tree/main/charts/datadog-csi-driver
+                                Default: false
+                              type: boolean
+                          type: object
                         disableNonResourceRules:
                           description: |-
                             Set DisableNonResourceRules to exclude NonResourceURLs from default ClusterRoles.

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -572,6 +572,11 @@ spec:
                         useClusterChecksRunners:
                           type: boolean
                       type: object
+                    controlPlaneMonitoring:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     cspm:
                       properties:
                         checkInterval:
@@ -789,6 +794,8 @@ spec:
                     gpu:
                       properties:
                         enabled:
+                          type: boolean
+                        privilegedMode:
                           type: boolean
                         requiredRuntimeClassName:
                           type: string
@@ -1151,6 +1158,11 @@ spec:
                       type: object
                     criSocketPath:
                       type: string
+                    csi:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     disableNonResourceRules:
                       type: boolean
                     dockerSocketPath:
@@ -4441,6 +4453,11 @@ spec:
                             useClusterChecksRunners:
                               type: boolean
                           type: object
+                        controlPlaneMonitoring:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                         cspm:
                           properties:
                             checkInterval:
@@ -4658,6 +4675,8 @@ spec:
                         gpu:
                           properties:
                             enabled:
+                              type: boolean
+                            privilegedMode:
                               type: boolean
                             requiredRuntimeClassName:
                               type: string

--- a/crds/datadoghq.com_datadogpodautoscalers.yaml
+++ b/crds/datadoghq.com_datadogpodautoscalers.yaml
@@ -170,9 +170,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -200,7 +200,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -236,9 +236,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -266,7 +266,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -325,6 +325,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -353,6 +355,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -655,9 +659,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -685,7 +689,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -711,9 +715,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -741,7 +745,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -868,6 +872,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -896,6 +902,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
