### PR TITLE
Update Operator CRD chart dependency to stable version

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 2.12.0 
+## 2.12.1
+
+* Update `datadog-crds` dependency to stable version (no-op change).
+
+## 2.12.0
 
 * Update Datadog Operator chart for 1.17.0.
 

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.10.0-dev.1
-digest: sha256:f493a38c7ae39cace64d8e0b8ed88392e2a517795cd8cbbbca739226a3fa5433
-generated: "2025-07-16T10:05:24.335521-04:00"
+  version: 2.10.0
+digest: sha256:bbad5f58e40e21758d047e8925d5eb1901636c1128330c8896652d9bad24928d
+generated: "2025-08-19T17:24:45.695341+04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.12.0
+version: 2.12.1
 appVersion: 1.17.0
 description: Datadog Operator
 keywords:
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "2.10.0-dev.1"
+  version: "2.10.0"
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.12.0](https://img.shields.io/badge/Version-2.12.0-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
+![Version: 2.12.1](https://img.shields.io/badge/Version-2.12.1-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
 
 ## Values
 

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-2.10.0-dev.1'
+    helm.sh/chart: 'datadogCRDs-2.10.0'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.12.0
+    helm.sh/chart: datadog-operator-2.12.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
