### PR TITLE
Add datadog-csi-driver as a dependency of the datadog-agent chart

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.130.1
+
+* Add `datadog-csi-driver` as a dependency of the `datadog-agent` chart to allow installing Datadog CSI Driver automatically when csi is enabled.
+
 ## 3.129.0
 
 * Add:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.129.0
+version: 3.130.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.129.0](https://img.shields.io/badge/Version-3.129.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.130.0](https://img.shields.io/badge/Version-3.130.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
-digest: sha256:15f05b44b105c4e1a08082ef0b12b1e7da076ef5db04ca880474c1e4a58dd36f
-generated: "2025-06-10T12:39:11.353853-04:00"
+- name: datadog-csi-driver
+  repository: https://helm.datadoghq.com
+  version: 0.4.1
+digest: sha256:6aa935aeea321a6670b8e31fe2f8340c989c3bea0d3acb4562d038eba870e540
+generated: "2025-08-21T12:34:53.45343+02:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -9,3 +9,7 @@ dependencies:
     version: 2.13.2
     repository: https://prometheus-community.github.io/helm-charts
     condition: datadog.kubeStateMetricsEnabled
+  - name: datadog-csi-driver
+    version: 0.4.1
+    repository: https://helm.datadoghq.com
+    condition: datadog.csi.enabled

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1197,7 +1197,7 @@ datadog:
     enabled: true
 
   csi:
-    # datadog.csi.enabled -- Enable datadog csi driver (Requires installation of Datadog CSI Driver https://github.com/DataDog/helm-charts/tree/main/charts/datadog-csi-driver)
+    # datadog.csi.enabled -- Enable datadog csi driver
     # This feature is still in beta
     # Requires version 7.67 or later of the cluster agent
     enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `datadog-csi-driver` as a dependency of the `datadog-agent` chart to allow installing Datadog CSI Driver automatically when csi is enabled.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
