### PR TITLE
Update default Agent to `7.69.3`

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.131.0
+
+* Upgrade default Agent version to `7.69.3`.
+
 ## 3.130.1
 
 * Mount `/host/run` when `datadog.gpuMonitoring.configureCgroupPerms` is set to `true`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.130.1
+version: 3.131.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.130.1](https://img.shields.io/badge/Version-3.130.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.131.0](https://img.shields.io/badge/Version-3.131.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -537,7 +537,7 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.68.3"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.69.3"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | agents.lifecycle | object | `{}` | Configure the lifecycle of the Agent |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
@@ -623,7 +623,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"7.68.3"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"7.69.3"` | Cluster Agent image tag to use |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
@@ -679,7 +679,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
-| clusterChecksRunner.image.tag | string | `"7.68.3"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.69.3"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1240,7 +1240,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 7.68.3
+    tag: 7.69.3
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -1784,7 +1784,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.68.3
+    tag: 7.69.3
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2370,7 +2370,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.68.3
+    tag: 7.69.3
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""

--- a/test/datadog/baseline/manifests/adp_enabled.yaml
+++ b/test/datadog/baseline/manifests/adp_enabled.yaml
@@ -870,7 +870,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1008,7 +1008,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1158,7 +1158,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1197,7 +1197,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1418,7 +1418,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1491,7 +1491,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -899,7 +899,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1040,7 +1040,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1089,7 +1089,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1128,7 +1128,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1298,7 +1298,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1347,7 +1347,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1360,7 +1360,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1534,7 +1534,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1607,7 +1607,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -892,7 +892,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -965,7 +965,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -906,7 +906,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -979,7 +979,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -839,7 +839,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
               value: agent
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-              value: 7.68.3
+              value: 7.69.3
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -902,7 +902,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -975,7 +975,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -864,7 +864,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1005,7 +1005,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1054,7 +1054,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1093,7 +1093,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1314,7 +1314,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1387,7 +1387,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -864,7 +864,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1005,7 +1005,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1054,7 +1054,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1093,7 +1093,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1314,7 +1314,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1387,7 +1387,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -841,7 +841,7 @@ spec:
               value: /var/lib/kubelet/pod-resources/kubelet.sock
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -946,7 +946,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -972,7 +972,7 @@ spec:
           command:
             - pwsh
             - -Command
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1014,7 +1014,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1209,7 +1209,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1282,7 +1282,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -844,7 +844,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -907,7 +907,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -959,7 +959,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1155,7 +1155,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1228,7 +1228,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -844,7 +844,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -919,7 +919,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -971,7 +971,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1176,7 +1176,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1249,7 +1249,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -883,7 +883,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -955,7 +955,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1006,7 +1006,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1177,7 +1177,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1232,7 +1232,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1251,7 +1251,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1435,7 +1435,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1514,7 +1514,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -855,7 +855,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -927,7 +927,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -976,7 +976,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1196,7 +1196,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1275,7 +1275,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1103,7 +1103,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1243,7 +1243,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1325,7 +1325,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1395,7 +1395,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1446,7 +1446,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1479,7 +1479,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1706,7 +1706,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1785,7 +1785,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1103,7 +1103,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1243,7 +1243,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1325,7 +1325,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1427,7 +1427,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1478,7 +1478,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1511,7 +1511,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1770,7 +1770,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1849,7 +1849,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1099,7 +1099,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1212,7 +1212,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1310,7 +1310,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1361,7 +1361,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1394,7 +1394,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1650,7 +1650,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1729,7 +1729,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -883,7 +883,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -955,7 +955,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1006,7 +1006,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1177,7 +1177,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1232,7 +1232,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1251,7 +1251,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1435,7 +1435,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1514,7 +1514,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -929,7 +929,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1070,7 +1070,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1119,7 +1119,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1158,7 +1158,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1379,7 +1379,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1452,7 +1452,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1117,7 +1117,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1265,7 +1265,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1365,7 +1365,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1441,7 +1441,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1518,7 +1518,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1557,7 +1557,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1584,7 +1584,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1827,7 +1827,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1900,7 +1900,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -942,7 +942,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1083,7 +1083,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1174,7 +1174,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.68.3
+          image: gcr.io/datadoghq/ddot-collector:7.69.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1229,7 +1229,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1268,7 +1268,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1495,7 +1495,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1568,7 +1568,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -878,7 +878,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1019,7 +1019,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1110,7 +1110,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.68.3
+          image: gcr.io/datadoghq/ddot-collector:7.69.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1159,7 +1159,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1198,7 +1198,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1425,7 +1425,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1498,7 +1498,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -938,7 +938,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1079,7 +1079,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1170,7 +1170,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.68.3
+          image: gcr.io/datadoghq/ddot-collector:7.69.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1223,7 +1223,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1262,7 +1262,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1489,7 +1489,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1562,7 +1562,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -901,7 +901,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1042,7 +1042,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1133,7 +1133,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.68.3
+          image: gcr.io/datadoghq/ddot-collector:7.69.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1194,7 +1194,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1233,7 +1233,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1472,7 +1472,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1545,7 +1545,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -938,7 +938,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1079,7 +1079,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1170,7 +1170,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.68.3
+          image: gcr.io/datadoghq/ddot-collector:7.69.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1222,7 +1222,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1261,7 +1261,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1491,7 +1491,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1564,7 +1564,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -938,7 +938,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1079,7 +1079,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1170,7 +1170,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.68.3
+          image: gcr.io/datadoghq/ddot-collector:7.69.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1219,7 +1219,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1258,7 +1258,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1485,7 +1485,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1558,7 +1558,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -864,7 +864,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1005,7 +1005,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1054,7 +1054,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1093,7 +1093,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1314,7 +1314,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1387,7 +1387,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -897,7 +897,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1042,7 +1042,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1097,7 +1097,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1142,7 +1142,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1317,7 +1317,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1366,7 +1366,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1385,7 +1385,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1569,7 +1569,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1646,7 +1646,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           securityContext:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1117,7 +1117,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1265,7 +1265,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1365,7 +1365,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1443,7 +1443,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1606,7 +1606,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -1647,7 +1647,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1686,7 +1686,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1713,7 +1713,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1996,7 +1996,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2069,7 +2069,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1117,7 +1117,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1265,7 +1265,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1365,7 +1365,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1441,7 +1441,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1600,7 +1600,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -1641,7 +1641,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1680,7 +1680,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1707,7 +1707,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.68.3
+          image: gcr.io/datadoghq/agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1987,7 +1987,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2060,7 +2060,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.68.3
+          image: gcr.io/datadoghq/cluster-agent:7.69.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:

* Updates default Agent to latest released tag `7.69.3` (https://github.com/DataDog/datadog-agent/releases/tag/7.69.3)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
