### PR TITLE
Remove Docs Team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 *  @DataDog/container-helm-chart-maintainers
 
 # Documentation
-*.md             @DataDog/documentation @DataDog/container-helm-chart-maintainers
+*.md             @DataDog/container-helm-chart-maintainers
 
 # Charts
 charts/cloudprem                                       @DataDog/logs-cloudprem


### PR DESCRIPTION
#### What this PR does / why we need it:

Removes Docs as CODEOWNERS from the repo. As part of a project to reduce courtesy reviews, the Docs Team is limiting CODEOWNERS entries to repos that single-source content into the docs site or where our review is critical. We’re still happy to review content if you reach out to us directly.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
