### PR TITLE
[datadog-operator] v1.18.0-rc.4

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.13.0-dev.5
+
+* Update Datadog Operator image tag to 1.18.0-rc.4.
+
 ## 2.13.0-dev.4
 
 * Update Datadog Operator image tag to 1.18.0-rc.3.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.13.0-dev.4
-appVersion: 1.18.0-rc.3
+version: 2.13.0-dev.5
+appVersion: 1.18.0-rc.4
 description: Datadog Operator
 keywords:
 - monitoring

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.13.0-dev.4](https://img.shields.io/badge/Version-2.13.0--dev.4-informational?style=flat-square) ![AppVersion: 1.18.0-rc.3](https://img.shields.io/badge/AppVersion-1.18.0--rc.3-informational?style=flat-square)
+![Version: 2.13.0-dev.5](https://img.shields.io/badge/Version-2.13.0--dev.5-informational?style=flat-square) ![AppVersion: 1.18.0-rc.4](https://img.shields.io/badge/AppVersion-1.18.0--rc.4-informational?style=flat-square)
 
 ## Values
 
@@ -36,7 +36,7 @@
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.18.0-rc.3"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.18.0-rc.4"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.18.0-rc.3
+  tag: 1.18.0-rc.4
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
   # image.doNotCheckTag -- Permit skipping operator image tag compatibility with the chart.

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.18.0-rc.3"
+          image: "gcr.io/datadoghq/operator:1.18.0-rc.4"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -144,7 +144,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "gcr.io/datadoghq/operator:1.18.0-rc.3", operatorContainer.Image)
+	assert.Equal(t, "gcr.io/datadoghq/operator:1.18.0-rc.4", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

* Release Operator 1.18.0-rc.3

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
