### PR TITLE
[ACTP] Bump private actions runner version to v1.8.0

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 1.10.0
+
+* Fix http client denying private endpoints on enrolment. This is an issue when there is an egress proxy.
+* Bump private runner version to 1.8.0
+
 ## 1.9.0
 
 * Add support for custom scripts via `runner.scriptFiles`

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,8 +3,8 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.9.0
-appVersion: "v1.7.0"
+version: 1.10.0
+appVersion: "v1.8.0"
 keywords:
 - app builder
 - workflow automation

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![AppVersion: v1.7.0](https://img.shields.io/badge/AppVersion-v1.7.0-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![AppVersion: v1.8.0](https://img.shields.io/badge/AppVersion-v1.8.0-informational?style=flat-square)
 
 ## Overview
 
@@ -250,7 +250,7 @@ If actions requiring credentials fail:
 |-----|------|---------|-------------|
 | $schema | string | `"./values.schema.json"` | Schema for the values file, enables support in Jetbrains IDEs. You should probably use https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json. |
 | fullnameOverride | string | `""` | Override the full qualified app name |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.7.0"}` | Current Datadog Private Action Runner image |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.8.0"}` | Current Datadog Private Action Runner image |
 | nameOverride | string | `""` | Override name of app |
 | runner.affinity | object | `{}` | Kubernetes affinity settings for the runner pods |
 | runner.config | object | `{"actionsAllowlist":[],"allowIMDSEndpoint":false,"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":9016,"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -8,7 +8,7 @@ $schema: ./values.schema.json
 # -- Current Datadog Private Action Runner image
 image:
   repository: gcr.io/datadoghq/private-action-runner
-  tag: v1.7.0
+  tag: v1.8.0
   pullPolicy: IfNotPresent
 
 # nameOverride -- Override name of app

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -78,10 +78,10 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.9.0
+    helm.sh/chart: private-action-runner-1.10.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
-    app.kubernetes.io/version: "v1.7.0"
+    app.kubernetes.io/version: "v1.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -93,18 +93,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.9.0
+        helm.sh/chart: private-action-runner-1.10.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
-        app.kubernetes.io/version: "v1.7.0"
+        app.kubernetes.io/version: "v1.8.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: bc4d232b58a296704f944f8d8fc3ae1490e90a9bc0e61ed5371a675ba85fc2a6
+        checksum/values: 38424d2ae5426422a0652a8b592edef61187dbcfcec5ffd6eff26e277324716e
     spec:
       serviceAccountName: custom-full-name
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -77,10 +77,10 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.9.0
+    helm.sh/chart: private-action-runner-1.10.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
-    app.kubernetes.io/version: "v1.7.0"
+    app.kubernetes.io/version: "v1.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -92,18 +92,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.9.0
+        helm.sh/chart: private-action-runner-1.10.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
-        app.kubernetes.io/version: "v1.7.0"
+        app.kubernetes.io/version: "v1.8.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: d7790cb094a88b36fce60391e653c6552db774824aa0d608e7b296bfef922f75
+        checksum/values: 92fa8b86c1bda5423d670a88528d2081744e7ce911b76ef54d9fc31c6d389b92
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,10 +77,10 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.9.0
+    helm.sh/chart: private-action-runner-1.10.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
-    app.kubernetes.io/version: "v1.7.0"
+    app.kubernetes.io/version: "v1.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -92,18 +92,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.9.0
+        helm.sh/chart: private-action-runner-1.10.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
-        app.kubernetes.io/version: "v1.7.0"
+        app.kubernetes.io/version: "v1.8.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 809007cda039bb32ed185a21c72db9062a176d60d198f528f562caf1b734abe5
+        checksum/values: 4b8ea3dcd00c23ec2aab9aff2b63582c05e2583b25aebd83a6d0fabbd717506f
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,10 +77,10 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.9.0
+    helm.sh/chart: private-action-runner-1.10.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
-    app.kubernetes.io/version: "v1.7.0"
+    app.kubernetes.io/version: "v1.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -92,18 +92,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.9.0
+        helm.sh/chart: private-action-runner-1.10.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
-        app.kubernetes.io/version: "v1.7.0"
+        app.kubernetes.io/version: "v1.8.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 84b452dc133f7aec79bf34b469272125160542facd40889c054f9676f520065e
+        checksum/values: 9369d139bf9e984ffb83c956526afaaa6bbbc7fc557db73009186877fee5f115
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -130,10 +130,10 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.9.0
+    helm.sh/chart: private-action-runner-1.10.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
-    app.kubernetes.io/version: "v1.7.0"
+    app.kubernetes.io/version: "v1.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -145,18 +145,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.9.0
+        helm.sh/chart: private-action-runner-1.10.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
-        app.kubernetes.io/version: "v1.7.0"
+        app.kubernetes.io/version: "v1.8.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 2dab11773135d313e3444d62e753caf339d80c7252b47e95a085a188701bd257
+        checksum/values: b11d08c0f5bd9618584d5d028d2ce9a8acbef516c3b6e2b883f5bda9f232565e
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -194,10 +194,10 @@ metadata:
   name: example-test-private-action-runner-scripts
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.9.0
+    helm.sh/chart: private-action-runner-1.10.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
-    app.kubernetes.io/version: "v1.7.0"
+    app.kubernetes.io/version: "v1.8.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     checksum/scripts: 07b69ed4014b8716e5938f0efbe35e2c07897a48538054e6836a4b0fa9e7cc8d
@@ -258,10 +258,10 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.9.0
+    helm.sh/chart: private-action-runner-1.10.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
-    app.kubernetes.io/version: "v1.7.0"
+    app.kubernetes.io/version: "v1.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -273,18 +273,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.9.0
+        helm.sh/chart: private-action-runner-1.10.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
-        app.kubernetes.io/version: "v1.7.0"
+        app.kubernetes.io/version: "v1.8.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 4564d0f1d3032a3f99ca6aeecba4481455468451563f0b8eed6d936e3ca1ba16
+        checksum/values: 9746723c16877c5690fbdd255cfffdce78bf1852a21ca176b0b0de09decdb5c1
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,10 +75,10 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.9.0
+    helm.sh/chart: private-action-runner-1.10.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
-    app.kubernetes.io/version: "v1.7.0"
+    app.kubernetes.io/version: "v1.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -90,18 +90,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.9.0
+        helm.sh/chart: private-action-runner-1.10.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
-        app.kubernetes.io/version: "v1.7.0"
+        app.kubernetes.io/version: "v1.8.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 741803a205d32aff9bb388a38e383a6805511f1fa56f6f604dcf701054c3f49c
+        checksum/values: 2a792bd60da0ea822df822de9d6d263435ef4c11052ea1ba73ab91e09ff6a9ee
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/scripts-configuration.yaml
+++ b/test/private-action-runner/__snapshot__/scripts-configuration.yaml
@@ -35,10 +35,10 @@ metadata:
   name: scripts-test-private-action-runner-scripts
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.9.0
+    helm.sh/chart: private-action-runner-1.10.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
-    app.kubernetes.io/version: "v1.7.0"
+    app.kubernetes.io/version: "v1.8.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     checksum/scripts: 4851b03137485a89f46dace45318681a71dfca1317a040de2cb69d36929bd9f7
@@ -99,10 +99,10 @@ metadata:
   name: scripts-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.9.0
+    helm.sh/chart: private-action-runner-1.10.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
-    app.kubernetes.io/version: "v1.7.0"
+    app.kubernetes.io/version: "v1.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -114,18 +114,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.9.0
+        helm.sh/chart: private-action-runner-1.10.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: scripts-test
-        app.kubernetes.io/version: "v1.7.0"
+        app.kubernetes.io/version: "v1.8.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: f0b595946923515be6a2aefc3b97e08caf263da0d07d36a034135ea86fc83602
+        checksum/values: bcd59a33972633b317e377c27392984144a85b98851ff7fbdcd9184ffaa38877
     spec:
       serviceAccountName: scripts-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.7.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
This PR bump the private runner version in order to fix an issue where we deny http requests to private endpoint during enrolment.

The errors we are seeing when there is an egress proxy is this one:
```
FATAL could not provision runner identity error="failed to send enrollment request: 
Post \https://app.datadoghq.com/api/v2/on-prem-management-service/enrollments/complete\ 
(https://app.datadoghq.com/api/v2/on-prem-management-service/enrollments/complete/) : 
response filter round trip failed: request filter round trip failed: proxyconnect tcp: 
dial tcp 10.122.108.59:8080: tcp4/10.122.108.59:8080 is not authorized by the client: 
authorizer policy error: \"10.122.108.59\" address is private"
```


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
