### PR TITLE
Add agents.lifecycle support for GKE Autopilot

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.132.1
+
+* Support lifecycle handlers for the agent via `agents.lifecycle` in GKE Autopilot.
+
 ## 3.132.0
 
 * Add `datadog-csi-driver` as a dependency of the `datadog-agent` chart to allow installing Datadog CSI Driver automatically when csi is enabled.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.132.0
+version: 3.132.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.132.0](https://img.shields.io/badge/Version-3.132.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.132.1](https://img.shields.io/badge/Version-3.132.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -540,7 +540,7 @@ helm install <RELEASE_NAME> \
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
 | agents.image.tag | string | `"7.69.3"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
-| agents.lifecycle | object | `{}` | Configure the lifecycle of the Agent |
+| agents.lifecycle | object | `{}` | Configure the lifecycle of the Agent. Note: The `exec` lifecycle handler is not supported in GKE Autopilot. |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
 | agents.localService.overrideName | string | `""` | Name of the internal traffic service to target the agent running on the local node |
 | agents.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the agents. DEPRECATED. Use datadog.networkPolicy.create instead |

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -412,6 +412,15 @@ The option is overriden to avoid mounting volumes that are not allowed which wou
 
 {{- end }}
 
+{{- if and .Values.agents.lifecycle (or (and .Values.agents.lifecycle.postStart .Values.agents.lifecycle.postStart.exec) (and .Values.agents.lifecycle.preStop .Values.agents.lifecycle.preStop.exec)) }}
+##############################################################################
+####   WARNING: Agent lifecycle exec handler is not supported in GKE Autopilot
+##############################################################################
+
+{{ fail "On GKE autopilot environments, agents.lifecycle.[postStart|preStop].exec.command is not supported." }}
+
+{{- end }}
+
 {{- end }}
 
 {{- if or .Values.providers.gke.autopilot .Values.providers.gke.gdc }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -2,7 +2,7 @@
 - name: agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  {{- if and (.Values.agents.lifecycle) (not .Values.providers.gke.autopilot) }}
+  {{- if .Values.agents.lifecycle }}
   lifecycle:
 {{ toYaml .Values.agents.lifecycle | indent 4 }}
   {{- end }}

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -2,7 +2,7 @@
 - name: process-agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  {{- if and (.Values.agents.lifecycle) (not .Values.providers.gke.autopilot) }}
+  {{- if .Values.agents.lifecycle }}
   lifecycle:
 {{ toYaml .Values.agents.lifecycle | indent 4 }}
   {{- end }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -2,7 +2,7 @@
 - name: trace-agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  {{- if and (.Values.agents.lifecycle) (not .Values.providers.gke.autopilot) }}
+  {{- if and .Values.agents.lifecycle }}
   lifecycle:
 {{ toYaml .Values.agents.lifecycle | indent 4 }}
   {{- end }}

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -2,7 +2,7 @@
 - name: trace-agent
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
-  {{- if and .Values.agents.lifecycle }}
+  {{- if .Values.agents.lifecycle }}
   lifecycle:
 {{ toYaml .Values.agents.lifecycle | indent 4 }}
   {{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2346,11 +2346,19 @@ agents:
     # This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled.
     forceLocalServiceEnabled: false
 
-  # agents.lifecycle -- Configure the lifecycle of the Agent
+  # agents.lifecycle -- Configure the lifecycle of the Agent.
+  # Note: The `exec` lifecycle handler is not supported in GKE Autopilot.
   lifecycle: {}
     # preStop:
+    #   sleep:
+    #     seconds: 5
     #   exec:
     #     command: ["/bin/sh", "-c", "sleep 70"]
+    # postStart:
+    #   exec:
+    #     command: ["/bin/sh", "-c", "sleep 70"]
+    #   sleep:
+    #     seconds: 5
 
   # agents.terminationGracePeriodSeconds -- (int) Configure the termination grace period for the Agent
   terminationGracePeriodSeconds:  # 70


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `agents.lifecycle` support for GKE Autopilot. 
Note: The `exec` lifecycle handler is not supported in GKE Autopilot.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - closes #2007

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
