### PR TITLE
[CONTP-841]: Cluster-agent-deployment template change to fix admission webhook bug

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 3.135.2
 
-* Fix handling of `hostSocketPath` values so mutated pods correctly mount custom UDS sockets and update CSI driver documentation in `values.yaml`to Clarify that when set to `true`, the CSI driver subchart will be installed automatically and warn users not to install the CSI driver separately when enabled to avoid conflicts.
+* Pass APM and DSD hostSocketPath to Cluster Agent deployment.
+* Clarify seting `csi.enabled` to `true` will install the CSI driver subchart automatically and warn users not to install the CSI driver separately when enabled to avoid conflicts.
 
 ## 3.135.1
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.133.1
+
+* Fix handling of `hostSocketPath` values so mutated pods correctly mount custom UDS sockets.
+
 ## 3.133.0
 
 * Revert changes in 3.131.4 because the configuration is going to be deprecated.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.133.1
 
-* Fix handling of `hostSocketPath` values so mutated pods correctly mount custom UDS sockets.
+* Fix handling of `hostSocketPath` values so mutated pods correctly mount custom UDS sockets and update CSI driver documentation in `values.yaml`to Clarify that when set to `true`, the CSI driver subchart will be installed automatically and warn users not to install the CSI driver separately when enabled to avoid conflicts.
 
 ## 3.133.0
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.133.0
+version: 3.133.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.133.0](https://img.shields.io/badge/Version-3.133.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.133.1](https://img.shields.io/badge/Version-3.133.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -756,7 +756,7 @@ helm install <RELEASE_NAME> \
 | datadog.containerLifecycle.enabled | bool | `true` | Enable container lifecycle events collection |
 | datadog.containerRuntimeSupport.enabled | bool | `true` | Set this to false to disable agent access to container runtime. |
 | datadog.criSocketPath | string | `nil` | Path to the container runtime socket (if different from Docker) |
-| datadog.csi.enabled | bool | `false` | Enable datadog csi driver Requires version 7.67 or later of the cluster agent |
+| datadog.csi.enabled | bool | `false` | Enable datadog csi driver Requires version 7.67 or later of the cluster agent Note:   - When set to true, the CSI driver subchart will be installed automatically.   - Do not install the CSI driver separately if this is enabled, or you may hit conflicts. |
 | datadog.dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | datadog.disableDefaultOsReleasePaths | bool | `false` | Set this to true to disable mounting datadog.osReleasePath in all containers |
 | datadog.disablePasswdMount | bool | `false` | Set this to true to disable mounting /etc/passwd in all containers |

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -204,8 +204,4 @@ Return a list of env-vars if the cluster-agent is enabled
 - name: DD_DOGSTATSD_SOCKET
   value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
 {{- end }}
-{{- if and (eq .Values.targetSystem "linux") (not .Values.providers.gke.gdc) }}
-- name: DD_APM_RECEIVER_SOCKET
-  value: {{ .Values.datadog.apm.socketPath | quote }}
-{{- end }}
 {{- end -}}

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -204,4 +204,8 @@ Return a list of env-vars if the cluster-agent is enabled
 - name: DD_DOGSTATSD_SOCKET
   value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
 {{- end }}
+{{- if and (eq .Values.targetSystem "linux") (not .Values.providers.gke.gdc) }}
+- name: DD_APM_RECEIVER_SOCKET
+  value: {{ .Values.datadog.apm.socketPath | quote }}
+{{- end }}
 {{- end -}}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -218,11 +218,11 @@ spec:
             value: {{ .Values.clusterAgent.admissionController.validation.enabled | quote }}
           - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
             value: {{ .Values.clusterAgent.admissionController.mutation.enabled | quote }}
-          {{- if .Values.datadog.dogstatsd.hostSocketPath }}
+          {{- if .Values.datadog.apm.hostSocketPath }}
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
             value: {{ .Values.datadog.apm.hostSocketPath | quote }}
           {{- end }}
-          {{- if .Values.datadog.apm.hostSocketPath }}
+          {{- if .Values.datadog.dogstatsd.hostSocketPath }}
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
             value: {{ .Values.datadog.dogstatsd.hostSocketPath | quote }}
           {{- end }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -226,6 +226,14 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
             value: {{ .Values.datadog.dogstatsd.hostSocketPath | quote }}
           {{- end }}
+          {{- if .Values.datadog.dogstatsd.socketPath }}
+          - name: DD_DOGSTATSD_SOCKET
+            value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
+          {{- end }}
+          {{- if .Values.datadog.apm.socketPath }}
+          - name: DD_APM_RECEIVER_SOCKET
+            value: {{ .Values.datadog.apm.socketPath | quote }}
+          {{- end }}
           - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
             value: {{ .Values.clusterAgent.admissionController.webhookName | quote }}
           - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -218,14 +218,6 @@ spec:
             value: {{ .Values.clusterAgent.admissionController.validation.enabled | quote }}
           - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
             value: {{ .Values.clusterAgent.admissionController.mutation.enabled | quote }}
-          {{- if .Values.datadog.apm.socketPath }}
-          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_SOCKET_FILENAME
-            value: {{ .Values.datadog.apm.socketPath | base | quote }}
-          {{- end }}
-          {{- if .Values.datadog.dogstatsd.socketPath }}
-          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_SOCKET_FILENAME
-            value: {{ .Values.datadog.dogstatsd.socketPath | base | quote }}
-          {{- end }}
           {{- if .Values.datadog.apm.hostSocketPath }}
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
             value: {{ .Values.datadog.apm.hostSocketPath | quote }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -218,6 +218,14 @@ spec:
             value: {{ .Values.clusterAgent.admissionController.validation.enabled | quote }}
           - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
             value: {{ .Values.clusterAgent.admissionController.mutation.enabled | quote }}
+          {{- if .Values.datadog.apm.socketPath }}
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_SOCKET_FILENAME
+            value: {{ .Values.datadog.apm.socketPath | base | quote }}
+          {{- end }}
+          {{- if .Values.datadog.dogstatsd.socketPath }}
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_SOCKET_FILENAME
+            value: {{ .Values.datadog.dogstatsd.socketPath | base | quote }}
+          {{- end }}
           {{- if .Values.datadog.apm.hostSocketPath }}
           - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
             value: {{ .Values.datadog.apm.hostSocketPath | quote }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -219,11 +219,11 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
             value: {{ .Values.clusterAgent.admissionController.mutation.enabled | quote }}
           {{- if .Values.datadog.apm.hostSocketPath }}
-          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+          - name: DD_TRACE_AGENT_HOST_SOCKET_PATH
             value: {{ .Values.datadog.apm.hostSocketPath | quote }}
           {{- end }}
           {{- if .Values.datadog.dogstatsd.hostSocketPath }}
-          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+          - name: DD_DOGSTATSD_HOST_SOCKET_PATH
             value: {{ .Values.datadog.dogstatsd.hostSocketPath | quote }}
           {{- end }}
           {{- if .Values.datadog.dogstatsd.socketPath }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -219,16 +219,12 @@ spec:
           - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
             value: {{ .Values.clusterAgent.admissionController.mutation.enabled | quote }}
           {{- if .Values.datadog.dogstatsd.hostSocketPath }}
-          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_HOST_SOCKET_PATH
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+            value: {{ .Values.datadog.apm.hostSocketPath | quote }}
+          {{- end }}
+          {{- if .Values.datadog.apm.hostSocketPath }}
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
             value: {{ .Values.datadog.dogstatsd.hostSocketPath | quote }}
-          {{- end }}
-          {{- if .Values.datadog.dogstatsd.hostSocketPath }}
-          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_HOST_TRACE_AGENT_SOCKET_PATH
-            value: {{printf "%s/apm.socket" .Values.datadog.dogstatsd.hostSocketPath | quote }}
-          {{- end }}
-          {{- if .Values.datadog.dogstatsd.hostSocketPath }}
-          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_HOST_DOGSTATSD_AGENT_SOCKET_PATH
-            value: {{printf "%s/dsd.socket" .Values.datadog.dogstatsd.hostSocketPath | quote }}
           {{- end }}
           - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
             value: {{ .Values.clusterAgent.admissionController.webhookName | quote }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -218,6 +218,18 @@ spec:
             value: {{ .Values.clusterAgent.admissionController.validation.enabled | quote }}
           - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
             value: {{ .Values.clusterAgent.admissionController.mutation.enabled | quote }}
+          {{- if .Values.datadog.dogstatsd.hostSocketPath }}
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_HOST_SOCKET_PATH
+            value: {{ .Values.datadog.dogstatsd.hostSocketPath | quote }}
+          {{- end }}
+          {{- if .Values.datadog.dogstatsd.hostSocketPath }}
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_HOST_TRACE_AGENT_SOCKET_PATH
+            value: {{printf "%s/apm.socket" .Values.datadog.dogstatsd.hostSocketPath | quote }}
+          {{- end }}
+          {{- if .Values.datadog.dogstatsd.hostSocketPath }}
+          - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_HOST_DOGSTATSD_AGENT_SOCKET_PATH
+            value: {{printf "%s/dsd.socket" .Values.datadog.dogstatsd.hostSocketPath | quote }}
+          {{- end }}
           - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
             value: {{ .Values.clusterAgent.admissionController.webhookName | quote }}
           - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1199,6 +1199,9 @@ datadog:
   csi:
     # datadog.csi.enabled -- Enable datadog csi driver
     # Requires version 7.67 or later of the cluster agent
+    # Note:
+    #   - When set to true, the CSI driver subchart will be installed automatically.
+    #   - Do not install the CSI driver separately if this is enabled, or you may hit conflicts.
     enabled: false
 
   ## Agent Data Plane is currently in preview. Please reach out to your Datadog representative for more information.

--- a/test/datadog/baseline/manifests/adp_enabled.yaml
+++ b/test/datadog/baseline/manifests/adp_enabled.yaml
@@ -1350,6 +1350,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/adp_enabled.yaml
+++ b/test/datadog/baseline/manifests/adp_enabled.yaml
@@ -1098,6 +1098,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_LOG_LEVEL
               value: INFO
             - name: DD_API_LISTEN_ADDRESS

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -849,6 +849,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -1464,6 +1464,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -824,6 +824,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -824,6 +824,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -824,6 +824,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -814,6 +814,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -1246,6 +1246,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -814,6 +814,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -1246,6 +1246,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -1141,6 +1141,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -1087,6 +1087,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -1108,6 +1108,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -856,6 +856,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -1365,6 +1365,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -828,6 +828,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -1128,6 +1128,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1072,6 +1072,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1638,6 +1638,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1072,6 +1072,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1702,6 +1702,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1072,6 +1072,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1582,6 +1582,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -856,6 +856,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -1365,6 +1365,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -879,6 +879,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -1311,6 +1311,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1759,6 +1759,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1063,6 +1063,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -890,6 +890,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -1427,6 +1427,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -1357,6 +1357,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -826,6 +826,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -1421,6 +1421,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -886,6 +886,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1404,6 +1404,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -849,6 +849,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -1423,6 +1423,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -886,6 +886,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -1417,6 +1417,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -886,6 +886,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -814,6 +814,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -1246,6 +1246,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -847,6 +847,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -1499,6 +1499,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1063,6 +1063,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1926,6 +1926,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1063,6 +1063,8 @@ spec:
               value: low
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
+            - name: DD_APM_RECEIVER_SOCKET
+              value: /var/run/datadog/apm.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1917,6 +1917,10 @@ spec:
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_MUTATION_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TRACE_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
+            - name: DD_ADMISSION_CONTROLLER_INJECT_CONFIG_DOGSTATSD_AGENT_HOST_SOCKET_PATH
+              value: /var/run/datadog/
             - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
               value: datadog-webhook
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes an issue in the Admission Controller where the UDS socket host path was hardcoded to /var/run/datadog. This caused the controller to ignore the hostSocketPath values configured via the Helm chart or Operator. As a result, mutated pods could not access APM or DogStatsD sockets when custom paths were used.

This PR updates:
	•	The Agent config to expose new config keys for
                 admission_controller.inject_config.trace_agent_host_socket_path, and
                 admission_controller.inject_config.dogstatsd_host_agent_socket_path
	•	The Helm chart to pass these values down as env vars to the Cluster Agent
	•	The mutator code to consume these values instead of relying on hardcoded defaults
	•	Unit tests to validate both the default behavior and user-defined socket paths


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

  - Fixes : [CONTP-841]: Cluster-agent-deployment template change to fix admission webhook bug ([#2040](https://github.com/DataDog/helm-charts/pull/2040)).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`


[CONTP-841]: https://datadoghq.atlassian.net/browse/CONTP-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ