### PR TITLE
[ACTP] Bump private actions runner version to v1.9.0

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.11.0
+
+* Add your changelog here!
+
 ## 1.10.0
 
 * Fix http client denying private endpoints on enrolment. This is an issue when there is an egress proxy.

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.11.0
 
 * Bump private runner version to 1.9.0
-* Rename `workflowAutomation` mode to `pull` and `appBuilder` mode to `push`
+* Introduce to new modes `pull` and `push` to replace respectively `workflowAutomation`and `appBuilder` modes.
 
 ## 1.10.0
 

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.11.0
 
 * Bump private runner version to 1.9.0
+* Rename `workflowAutomation` mode to `pull` and `appBuilder` mode to `push`
 
 ## 1.10.0
 

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.11.0
 
-* Add your changelog here!
+* Bump private runner version to 1.9.0
 
 ## 1.10.0
 

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,8 +3,8 @@ name: private-action-runner
 description: A Helm chart to deploy the private action runner
 
 type: application
-version: 1.10.0
-appVersion: "v1.8.0"
+version: 1.11.0
+appVersion: "v1.9.0"
 keywords:
 - app builder
 - workflow automation

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![AppVersion: v1.8.0](https://img.shields.io/badge/AppVersion-v1.8.0-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![AppVersion: v1.9.0](https://img.shields.io/badge/AppVersion-v1.9.0-informational?style=flat-square)
 
 ## Overview
 
@@ -250,7 +250,7 @@ If actions requiring credentials fail:
 |-----|------|---------|-------------|
 | $schema | string | `"./values.schema.json"` | Schema for the values file, enables support in Jetbrains IDEs. You should probably use https://raw.githubusercontent.com/DataDog/helm-charts/refs/heads/main/charts/private-action-runner/values.schema.json. |
 | fullnameOverride | string | `""` | Override the full qualified app name |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.8.0"}` | Current Datadog Private Action Runner image |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"gcr.io/datadoghq/private-action-runner","tag":"v1.9.0"}` | Current Datadog Private Action Runner image |
 | nameOverride | string | `""` | Override name of app |
 | runner.affinity | object | `{}` | Kubernetes affinity settings for the runner pods |
 | runner.config | object | `{"actionsAllowlist":[],"allowIMDSEndpoint":false,"ddBaseURL":"https://app.datadoghq.com","modes":["workflowAutomation","appBuilder"],"port":9016,"privateKey":"CHANGE_ME_PRIVATE_KEY_FROM_CONFIG","urn":"CHANGE_ME_URN_FROM_CONFIG"}` | Configuration for the Datadog Private Action Runner |

--- a/charts/private-action-runner/examples/values.yaml
+++ b/charts/private-action-runner/examples/values.yaml
@@ -9,8 +9,7 @@ runner:
     urn: "CHANGE_ME_URN_FROM_CONFIG"
     privateKey: "CHANGE_ME_PRIVATE_KEY_FROM_CONFIG"
     modes:
-      - appBuilder
-      - workflowAutomation
+      - pull
     allowIMDSEndpoint: false
     port: 9016
     actionsAllowlist:

--- a/charts/private-action-runner/values.schema.json
+++ b/charts/private-action-runner/values.schema.json
@@ -76,7 +76,7 @@
               "description": "Modes that the runner can run in",
               "items": {
                 "type": "string",
-                "enum": ["appBuilder", "workflowAutomation"]
+                "enum": ["appBuilder", "workflowAutomation", "push", "pull"]
               }
             },
             "port": {

--- a/charts/private-action-runner/values.yaml
+++ b/charts/private-action-runner/values.yaml
@@ -8,7 +8,7 @@ $schema: ./values.schema.json
 # -- Current Datadog Private Action Runner image
 image:
   repository: gcr.io/datadoghq/private-action-runner
-  tag: v1.8.0
+  tag: v1.9.0
   pullPolicy: IfNotPresent
 
 # nameOverride -- Override name of app

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -78,10 +78,10 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.10.0
+    helm.sh/chart: private-action-runner-1.11.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
-    app.kubernetes.io/version: "v1.8.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -93,18 +93,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.10.0
+        helm.sh/chart: private-action-runner-1.11.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
-        app.kubernetes.io/version: "v1.8.0"
+        app.kubernetes.io/version: "v1.9.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 38424d2ae5426422a0652a8b592edef61187dbcfcec5ffd6eff26e277324716e
+        checksum/values: 390d3e99e5f3e42e86512904b74cab29c0de886649bb4ecbff4e75bc09de3ad5
     spec:
       serviceAccountName: custom-full-name
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.9.0"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -77,10 +77,10 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.10.0
+    helm.sh/chart: private-action-runner-1.11.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
-    app.kubernetes.io/version: "v1.8.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -92,18 +92,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.10.0
+        helm.sh/chart: private-action-runner-1.11.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
-        app.kubernetes.io/version: "v1.8.0"
+        app.kubernetes.io/version: "v1.9.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 92fa8b86c1bda5423d670a88528d2081744e7ce911b76ef54d9fc31c6d389b92
+        checksum/values: 59383b4be191bf41a544bbe0718232a06018cd55f27d70bcf9970a26697a8c74
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.9.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -77,10 +77,10 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.10.0
+    helm.sh/chart: private-action-runner-1.11.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
-    app.kubernetes.io/version: "v1.8.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -92,18 +92,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.10.0
+        helm.sh/chart: private-action-runner-1.11.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
-        app.kubernetes.io/version: "v1.8.0"
+        app.kubernetes.io/version: "v1.9.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 4b8ea3dcd00c23ec2aab9aff2b63582c05e2583b25aebd83a6d0fabbd717506f
+        checksum/values: 219f5413d4b5f2d0c73a76b80f4910bf8a1e156b29c28f97702eec5663714666
     spec:
       serviceAccountName: resources-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.9.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -77,10 +77,10 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.10.0
+    helm.sh/chart: private-action-runner-1.11.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
-    app.kubernetes.io/version: "v1.8.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -92,18 +92,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.10.0
+        helm.sh/chart: private-action-runner-1.11.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
-        app.kubernetes.io/version: "v1.8.0"
+        app.kubernetes.io/version: "v1.9.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 9369d139bf9e984ffb83c956526afaaa6bbbc7fc557db73009186877fee5f115
+        checksum/values: 033bbd3c12b02e201e84efcf6870a994a648adfcb2f34d46d16eca7849ce3756
     spec:
       serviceAccountName: default-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.9.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/deprecated-modes.yaml
+++ b/test/private-action-runner/__snapshot__/deprecated-modes.yaml
@@ -1,0 +1,127 @@
+---
+# Source: private-action-runner/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deprecated-modes-test-private-action-runner
+  namespace: datadog-agent
+---
+# Source: private-action-runner/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: deprecated-modes-test-private-action-runner
+  namespace: datadog-agent
+stringData:
+  config.yaml: |
+    ddBaseURL: https://app.datadoghq.com
+    urn: CHANGE_ME_URN_FROM_CONFIG
+    privateKey: CHANGE_ME_PRIVATE_KEY_FROM_CONFIG
+    modes:
+      - workflowAutomation
+      - appBuilder
+    port: 9016
+    actionsAllowlist:
+      - com.datadoghq.kubernetes.core.getPod
+      - com.datadoghq.kubernetes.core.listPod
+---
+# Source: private-action-runner/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: datadog-agent
+  name: deprecated-modes-test-private-action-runner
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+---
+# Source: private-action-runner/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: deprecated-modes-test-private-action-runner
+  namespace: datadog-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deprecated-modes-test-private-action-runner
+subjects:
+  - kind: ServiceAccount
+    name: deprecated-modes-test-private-action-runner
+    namespace: datadog-agent
+---
+# Source: private-action-runner/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: deprecated-modes-test-private-action-runner
+  namespace: datadog-agent
+spec:
+  selector:
+      app.kubernetes.io/name: private-action-runner
+      app.kubernetes.io/instance: deprecated-modes-test
+  ports:
+    - name: http
+      port: 9016
+      targetPort: 9016
+---
+# Source: private-action-runner/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deprecated-modes-test-private-action-runner
+  namespace: datadog-agent
+  labels:
+    helm.sh/chart: private-action-runner-1.11.0
+    app.kubernetes.io/name: private-action-runner
+    app.kubernetes.io/instance: deprecated-modes-test
+    app.kubernetes.io/version: "v1.9.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: private-action-runner
+      app.kubernetes.io/instance: deprecated-modes-test
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: private-action-runner-1.11.0
+        app.kubernetes.io/name: private-action-runner
+        app.kubernetes.io/instance: deprecated-modes-test
+        app.kubernetes.io/version: "v1.9.0"
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        checksum/values: 033bbd3c12b02e201e84efcf6870a994a648adfcb2f34d46d16eca7849ce3756
+    spec:
+      serviceAccountName: deprecated-modes-test-private-action-runner
+      containers:
+        - name: runner
+          image: "gcr.io/datadoghq/private-action-runner:v1.9.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9016
+          resources:
+            limits:
+              cpu: 250m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/dd-action-runner/config
+          env:
+            - name: DD_PRIVATE_RUNNER_CONFIG_DIR
+              value: /etc/dd-action-runner/config
+      volumes:
+        - name: secrets
+          secret:
+            secretName: deprecated-modes-test-private-action-runner

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -130,10 +130,10 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.10.0
+    helm.sh/chart: private-action-runner-1.11.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
-    app.kubernetes.io/version: "v1.8.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -145,18 +145,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.10.0
+        helm.sh/chart: private-action-runner-1.11.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
-        app.kubernetes.io/version: "v1.8.0"
+        app.kubernetes.io/version: "v1.9.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: b11d08c0f5bd9618584d5d028d2ce9a8acbef516c3b6e2b883f5bda9f232565e
+        checksum/values: 213ec801330a7b451ddb03639b6ee50b2e37d68bb188061f3abae5be8c2af322
     spec:
       serviceAccountName: kubernetes-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.9.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -18,8 +18,7 @@ stringData:
     urn: CHANGE_ME_URN_FROM_CONFIG
     privateKey: CHANGE_ME_PRIVATE_KEY_FROM_CONFIG
     modes:
-      - appBuilder
-      - workflowAutomation
+      - pull
     port: 9016
     actionsAllowlist:
       - com.datadoghq.http.request
@@ -279,7 +278,7 @@ spec:
         app.kubernetes.io/version: "v1.9.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: ad62963a7efa09122c62936b0bd2f70ecb058b84e7274e7c2eda6409855e2808
+        checksum/values: c139d3fee561da83dc6b48d70d3ec369a201edd36db557c68d01ab4bf09255bc
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -194,10 +194,10 @@ metadata:
   name: example-test-private-action-runner-scripts
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.10.0
+    helm.sh/chart: private-action-runner-1.11.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
-    app.kubernetes.io/version: "v1.8.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     checksum/scripts: 07b69ed4014b8716e5938f0efbe35e2c07897a48538054e6836a4b0fa9e7cc8d
@@ -258,10 +258,10 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.10.0
+    helm.sh/chart: private-action-runner-1.11.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
-    app.kubernetes.io/version: "v1.8.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -273,18 +273,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.10.0
+        helm.sh/chart: private-action-runner-1.11.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
-        app.kubernetes.io/version: "v1.8.0"
+        app.kubernetes.io/version: "v1.9.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 9746723c16877c5690fbdd255cfffdce78bf1852a21ca176b0b0de09decdb5c1
+        checksum/values: ad62963a7efa09122c62936b0bd2f70ecb058b84e7274e7c2eda6409855e2808
     spec:
       serviceAccountName: example-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.9.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -75,10 +75,10 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.10.0
+    helm.sh/chart: private-action-runner-1.11.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
-    app.kubernetes.io/version: "v1.8.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -90,18 +90,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.10.0
+        helm.sh/chart: private-action-runner-1.11.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
-        app.kubernetes.io/version: "v1.8.0"
+        app.kubernetes.io/version: "v1.9.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: 2a792bd60da0ea822df822de9d6d263435ef4c11052ea1ba73ab91e09ff6a9ee
+        checksum/values: a506bd27700a1979ddbcf5bebd6f80725eee2f774c2062353632212e0535d994
     spec:
       serviceAccountName: secrets-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.9.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/__snapshot__/scripts-configuration.yaml
+++ b/test/private-action-runner/__snapshot__/scripts-configuration.yaml
@@ -35,10 +35,10 @@ metadata:
   name: scripts-test-private-action-runner-scripts
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.10.0
+    helm.sh/chart: private-action-runner-1.11.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
-    app.kubernetes.io/version: "v1.8.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     checksum/scripts: 4851b03137485a89f46dace45318681a71dfca1317a040de2cb69d36929bd9f7
@@ -99,10 +99,10 @@ metadata:
   name: scripts-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.10.0
+    helm.sh/chart: private-action-runner-1.11.0
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
-    app.kubernetes.io/version: "v1.8.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -114,18 +114,18 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.10.0
+        helm.sh/chart: private-action-runner-1.11.0
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: scripts-test
-        app.kubernetes.io/version: "v1.8.0"
+        app.kubernetes.io/version: "v1.9.0"
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/values: bcd59a33972633b317e377c27392984144a85b98851ff7fbdcd9184ffaa38877
+        checksum/values: e8c0bbb006e21d57a41c92ffcc18d9f5118b06bcf2c641d176f54dc58afaeb06
     spec:
       serviceAccountName: scripts-test-private-action-runner
       containers:
         - name: runner
-          image: "gcr.io/datadoghq/private-action-runner:v1.8.0"
+          image: "gcr.io/datadoghq/private-action-runner:v1.9.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/test/private-action-runner/baseline_test.go
+++ b/test/private-action-runner/baseline_test.go
@@ -26,7 +26,21 @@ func Test_baseline_manifests(t *testing.T) {
 			},
 			snapshotName: "default",
 			assertions:   verifyPrivateActionRunner,
-		}, {
+		},
+		{
+			name: "Private Action Runner deprecated mode values",
+			command: common.HelmCommand{
+				ReleaseName: "deprecated-modes-test",
+				ChartPath:   "../../charts/private-action-runner",
+				Values:      []string{"../../charts/private-action-runner/values.yaml"},
+				OverridesJson: map[string]string{
+					"runner.config.modes": `["workflowAutomation", "appBuilder"]`,
+				},
+			},
+			snapshotName: "deprecated-modes",
+			assertions:   verifyPrivateActionRunner,
+		},
+		{
 			name: "Private Action Runner example file",
 			command: common.HelmCommand{
 				ReleaseName: "example-test",


### PR DESCRIPTION
#### What this PR does / why we need it:
- Bump PAR version to `v1.9.0` and deprecate old runner modes

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
