### PR TITLE
[CONS-7653] Allow configuring `minAvailable`/`maxUnavailable` PDBs for DCA/CLC

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 3.134.0
+
+* Deprecates `createPodDisruptionBudget` setting in favour of `pdb` block, allowing you to configure `minAvailable` or `maxUnavailable` for the Cluster Agent and Cluster Checks Runners.
+
 ## 3.133.0
 
 * Revert changes in 3.131.4 because the configuration is going to be deprecated.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 3.134.0
 
-* Deprecates `createPodDisruptionBudget` setting in favour of `pdb` block, allowing you to configure `minAvailable` or `maxUnavailable` for the Cluster Agent and Cluster Checks Runners.
+* Deprecates `createPodDisruptionBudget` setting in favour of `pdb` block, allowing you to configure `minAvailable` or `maxUnavailable` for the Cluster Agent and Cluster Checks Runners. Using solely `<component>.pdb.create` without specifying `minAvailable`/`maxUnavailable` will create the same PodDisruptionBudget as the previous option.
 
 ## 3.133.0
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.133.0
+version: 3.134.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -640,7 +640,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.nodeSelector | object | `{}` | Allow the Cluster Agent Deployment to be scheduled on selected nodes |
 | clusterAgent.pdb.create | bool | `false` | Enable pod disruption budget for Cluster Agent deployments. |
 | clusterAgent.pdb.maxUnavailable | string | `nil` | Maximum number of pods that can be unavailable during a disruption |
-| clusterAgent.pdb.minAvailable | int | `1` | Minimum number of pods that must remain available during a disruption |
+| clusterAgent.pdb.minAvailable | string | `nil` |  |
 | clusterAgent.podAnnotations | object | `{}` | Annotations to add to the cluster-agents's pod(s) |
 | clusterAgent.podSecurity.podSecurityPolicy.create | bool | `false` | If true, create a PodSecurityPolicy resource for Cluster Agent pods |
 | clusterAgent.podSecurity.securityContextConstraints.create | bool | `false` | If true, create a SCC resource for Cluster Agent pods |
@@ -689,7 +689,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterChecksRunner.nodeSelector | object | `{}` | Allow the ClusterChecks Deployment to schedule on selected nodes |
 | clusterChecksRunner.pdb.create | bool | `false` | Enable pod disruption budget for Cluster Checks Runner deployments. |
-| clusterChecksRunner.pdb.maxUnavailable | int | `1` | Maximum number of pods that can be unavailable during a disruption |
+| clusterChecksRunner.pdb.maxUnavailable | string | `nil` | Maximum number of pods that can be unavailable during a disruption |
 | clusterChecksRunner.pdb.minAvailable | string | `nil` | Minimum number of pods that must remain available during a disruption |
 | clusterChecksRunner.podAnnotations | object | `{}` | Annotations to add to the cluster-checks-runner's pod(s) |
 | clusterChecksRunner.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.133.0](https://img.shields.io/badge/Version-3.133.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.134.0](https://img.shields.io/badge/Version-3.134.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -609,7 +609,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.containers.clusterAgent.securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true}` | Specify securityContext on the cluster-agent container. |
 | clusterAgent.containers.initContainers.resources | object | `{}` | Resource requests and limits for the Cluster Agent init containers |
 | clusterAgent.containers.initContainers.securityContext | object | `{}` | Specify securityContext on the initContainers. |
-| clusterAgent.createPodDisruptionBudget | bool | `false` | Create pod disruption budget for Cluster Agent deployments |
+| clusterAgent.createPodDisruptionBudget | bool | `false` | Create pod disruption budget for Cluster Agent deployments DEPRECATED. Use clusterAgent.pdb.create instead |
 | clusterAgent.datadog_cluster_yaml | object | `{}` | Specify custom contents for the datadog cluster agent config (datadog-cluster.yaml) |
 | clusterAgent.deploymentAnnotations | object | `{}` | Annotations to add to the cluster-agents's deployment |
 | clusterAgent.dnsConfig | object | `{}` | Specify dns configuration options for datadog cluster agent containers e.g ndots |
@@ -638,6 +638,8 @@ helm install <RELEASE_NAME> \
 | clusterAgent.metricsProvider.wpaController | bool | `false` | Enable informer and controller of the watermark pod autoscaler |
 | clusterAgent.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster agent. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterAgent.nodeSelector | object | `{}` | Allow the Cluster Agent Deployment to be scheduled on selected nodes |
+| clusterAgent.pdb.create | bool | `false` | Enable pod disruption budget for Cluster Agent deployments. |
+| clusterAgent.pdb.minAvailable | int | `1` | Minimum number of pods that must remain available during a disruption |
 | clusterAgent.podAnnotations | object | `{}` | Annotations to add to the cluster-agents's pod(s) |
 | clusterAgent.podSecurity.podSecurityPolicy.create | bool | `false` | If true, create a PodSecurityPolicy resource for Cluster Agent pods |
 | clusterAgent.podSecurity.securityContextConstraints.create | bool | `false` | If true, create a SCC resource for Cluster Agent pods |
@@ -667,7 +669,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.affinity | object | `{}` | Allow the ClusterChecks Deployment to schedule using affinity rules. |
 | clusterChecksRunner.containers.agent.securityContext | object | `{}` | Specify securityContext on the agent container |
 | clusterChecksRunner.containers.initContainers.securityContext | object | `{}` | Specify securityContext on the init containers |
-| clusterChecksRunner.createPodDisruptionBudget | bool | `false` | Create the pod disruption budget to apply to the cluster checks agents |
+| clusterChecksRunner.createPodDisruptionBudget | bool | `false` | Create the pod disruption budget to apply to the cluster checks agents DEPRECATED. Use clusterChecksRunner.pdb.create instead |
 | clusterChecksRunner.deploymentAnnotations | object | `{}` | Annotations to add to the cluster-checks-runner's Deployment |
 | clusterChecksRunner.dnsConfig | object | `{}` | specify dns configuration options for datadog cluster agent containers e.g ndots |
 | clusterChecksRunner.enabled | bool | `false` | If true, deploys agent dedicated for running the Cluster Checks instead of running in the Daemonset's agents. |
@@ -685,6 +687,8 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterChecksRunner.nodeSelector | object | `{}` | Allow the ClusterChecks Deployment to schedule on selected nodes |
+| clusterChecksRunner.pdb.create | bool | `false` | Enable pod disruption budget for Cluster Checks Runner deployments. |
+| clusterChecksRunner.pdb.maxUnavailable | int | `1` |  |
 | clusterChecksRunner.podAnnotations | object | `{}` | Annotations to add to the cluster-checks-runner's pod(s) |
 | clusterChecksRunner.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | clusterChecksRunner.priorityClassName | string | `nil` | Name of the priorityClass to apply to the Cluster checks runners |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -639,6 +639,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster agent. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterAgent.nodeSelector | object | `{}` | Allow the Cluster Agent Deployment to be scheduled on selected nodes |
 | clusterAgent.pdb.create | bool | `false` | Enable pod disruption budget for Cluster Agent deployments. |
+| clusterAgent.pdb.maxUnavailable | string | `nil` | Maximum number of pods that can be unavailable during a disruption |
 | clusterAgent.pdb.minAvailable | int | `1` | Minimum number of pods that must remain available during a disruption |
 | clusterAgent.podAnnotations | object | `{}` | Annotations to add to the cluster-agents's pod(s) |
 | clusterAgent.podSecurity.podSecurityPolicy.create | bool | `false` | If true, create a PodSecurityPolicy resource for Cluster Agent pods |
@@ -688,7 +689,8 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterChecksRunner.nodeSelector | object | `{}` | Allow the ClusterChecks Deployment to schedule on selected nodes |
 | clusterChecksRunner.pdb.create | bool | `false` | Enable pod disruption budget for Cluster Checks Runner deployments. |
-| clusterChecksRunner.pdb.maxUnavailable | int | `1` |  |
+| clusterChecksRunner.pdb.maxUnavailable | int | `1` | Maximum number of pods that can be unavailable during a disruption |
+| clusterChecksRunner.pdb.minAvailable | string | `nil` | Minimum number of pods that must remain available during a disruption |
 | clusterChecksRunner.podAnnotations | object | `{}` | Annotations to add to the cluster-checks-runner's pod(s) |
 | clusterChecksRunner.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | clusterChecksRunner.priorityClassName | string | `nil` | Name of the priorityClass to apply to the Cluster checks runners |

--- a/charts/datadog/templates/agent-clusterchecks-pdb.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-pdb.yaml
@@ -7,11 +7,16 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
 spec:
-  {{- if .Values.clusterChecksRunner.pdb.minAvailable -}}
+  {{- if and .Values.clusterChecksRunner.pdb.minAvailable .Values.clusterChecksRunner.pdb.maxUnavailable }}
+  {{- fail "clusterChecksRunner.pdb: set only one of minAvailable or maxUnavailable" }}
+  {{- end }}
+  {{- if .Values.clusterChecksRunner.pdb.minAvailable }}
   minAvailable: {{ .Values.clusterChecksRunner.pdb.minAvailable }}
-  {{- else -}}
-  maxUnavailable: {{ .Values.clusterChecksRunner.pdb.maxUnavailable | default 1 }}
-  {{- end -}}
+  {{- else if .Values.clusterChecksRunner.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.clusterChecksRunner.pdb.maxUnavailable }}
+  {{- else }}
+  maxUnavailable: 1
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "datadog.fullname" . }}-clusterchecks

--- a/charts/datadog/templates/agent-clusterchecks-pdb.yaml
+++ b/charts/datadog/templates/agent-clusterchecks-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterChecksRunner.createPodDisruptionBudget -}}
+{{- if or .Values.clusterChecksRunner.createPodDisruptionBudget .Values.clusterChecksRunner.pdb.create -}}
 apiVersion: {{ template "policy.poddisruptionbudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -7,7 +7,11 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
 spec:
-  maxUnavailable: 1
+  {{- if .Values.clusterChecksRunner.pdb.minAvailable -}}
+  minAvailable: {{ .Values.clusterChecksRunner.pdb.minAvailable }}
+  {{- else -}}
+  maxUnavailable: {{ .Values.clusterChecksRunner.pdb.maxUnavailable | default 1 }}
+  {{- end -}}
   selector:
     matchLabels:
       app: {{ template "datadog.fullname" . }}-clusterchecks

--- a/charts/datadog/templates/cluster-agent-pdb.yaml
+++ b/charts/datadog/templates/cluster-agent-pdb.yaml
@@ -7,11 +7,16 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
 spec:
-  {{- if .Values.clusterAgent.pdb.minAvailable -}}
-  minAvailable: {{ .Values.clusterAgent.pdb.minAvailable | default 1 }}
-  {{- else -}}
+  {{- if and .Values.clusterAgent.pdb.minAvailable .Values.clusterAgent.pdb.maxUnavailable }}
+  {{- fail "clusterAgent.pdb: set only one of minAvailable or maxUnavailable" }}
+  {{- end }}
+  {{- if .Values.clusterAgent.pdb.minAvailable }}
+  minAvailable: {{ .Values.clusterAgent.pdb.minAvailable }}
+  {{- else if .Values.clusterAgent.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.clusterAgent.pdb.maxUnavailable }}
-  {{- end -}}
+  {{- else }}
+  minAvailable: 1
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "datadog.fullname" . }}-cluster-agent

--- a/charts/datadog/templates/cluster-agent-pdb.yaml
+++ b/charts/datadog/templates/cluster-agent-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterAgent.createPodDisruptionBudget -}}
+{{- if or .Values.clusterAgent.createPodDisruptionBudget .Values.clusterAgent.pdb.create -}}
 apiVersion: {{ template "policy.poddisruptionbudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -7,7 +7,11 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
 spec:
-  minAvailable: 1
+  {{- if .Values.clusterAgent.pdb.minAvailable -}}
+  minAvailable: {{ .Values.clusterAgent.pdb.minAvailable | default 1 }}
+  {{- else -}}
+  maxUnavailable: {{ .Values.clusterAgent.pdb.maxUnavailable }}
+  {{- end -}}
   selector:
     matchLabels:
       app: {{ template "datadog.fullname" . }}-cluster-agent

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1659,11 +1659,13 @@ clusterAgent:
   createPodDisruptionBudget: false
   pdb:
     # clusterAgent.pdb.create -- Enable pod disruption budget for Cluster Agent deployments.
+
+    ## Only one of `minAvailable` or `maxUnavailable` can be set. More information: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
     create: false
     # clusterAgent.pdb.minAvailable -- Minimum number of pods that must remain available during a disruption
     minAvailable: 1
     # clusterAgent.pdb.maxUnavailable -- Maximum number of pods that can be unavailable during a disruption
-    # maxUnavailable: 1
+    maxUnavailable:
 
   networkPolicy:
     # clusterAgent.networkPolicy.create -- If true, create a NetworkPolicy for the cluster agent.
@@ -2414,9 +2416,11 @@ clusterChecksRunner:
   createPodDisruptionBudget: false
   pdb:
     # clusterChecksRunner.pdb.create -- Enable pod disruption budget for Cluster Checks Runner deployments.
+
+    ## Only one of `minAvailable` or `maxUnavailable` can be set. More information: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
     create: false
     # clusterChecksRunner.pdb.minAvailable -- Minimum number of pods that must remain available during a disruption
-    # minAvailable: 1
+    minAvailable:
     # clusterChecksRunner.pdb.maxUnavailable -- Maximum number of pods that can be unavailable during a disruption
     maxUnavailable: 1
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1655,7 +1655,15 @@ clusterAgent:
   datadog_cluster_yaml: {}
 
   # clusterAgent.createPodDisruptionBudget -- Create pod disruption budget for Cluster Agent deployments
+  # DEPRECATED. Use clusterAgent.pdb.create instead
   createPodDisruptionBudget: false
+  pdb:
+    # clusterAgent.pdb.create -- Enable pod disruption budget for Cluster Agent deployments.
+    create: false
+    # clusterAgent.pdb.minAvailable -- Minimum number of pods that must remain available during a disruption
+    minAvailable: 1
+    # clusterAgent.pdb.maxUnavailable -- Maximum number of pods that can be unavailable during a disruption
+    # maxUnavailable: 1
 
   networkPolicy:
     # clusterAgent.networkPolicy.create -- If true, create a NetworkPolicy for the cluster agent.
@@ -2402,7 +2410,15 @@ clusterChecksRunner:
     #   - name: "<REG_SECRET>"
 
   # clusterChecksRunner.createPodDisruptionBudget -- Create the pod disruption budget to apply to the cluster checks agents
+  # DEPRECATED. Use clusterChecksRunner.pdb.create instead
   createPodDisruptionBudget: false
+  pdb:
+    # clusterChecksRunner.pdb.create -- Enable pod disruption budget for Cluster Checks Runner deployments.
+    create: false
+    # clusterChecksRunner.pdb.minAvailable -- Minimum number of pods that must remain available during a disruption
+    # minAvailable: 1
+    # clusterChecksRunner.pdb.maxUnavailable -- Maximum number of pods that can be unavailable during a disruption
+    maxUnavailable: 1
 
   # Provide Cluster Checks Deployment pods RBAC configuration
   rbac:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1661,9 +1661,10 @@ clusterAgent:
     # clusterAgent.pdb.create -- Enable pod disruption budget for Cluster Agent deployments.
 
     ## Only one of `minAvailable` or `maxUnavailable` can be set. More information: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+    ## By default, minAvailable is set to 1 for cluster agent.
     create: false
-    # clusterAgent.pdb.minAvailable -- Minimum number of pods that must remain available during a disruption
-    minAvailable: 1
+    # clusterAgent.pdb.minAvailable -- Minimum number of pods that must remain available during a disruption -- default to 1
+    minAvailable:
     # clusterAgent.pdb.maxUnavailable -- Maximum number of pods that can be unavailable during a disruption
     maxUnavailable:
 
@@ -2418,11 +2419,12 @@ clusterChecksRunner:
     # clusterChecksRunner.pdb.create -- Enable pod disruption budget for Cluster Checks Runner deployments.
 
     ## Only one of `minAvailable` or `maxUnavailable` can be set. More information: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+    ## By default, maxUnavailable is set to 1 for cluster checks runners.
     create: false
     # clusterChecksRunner.pdb.minAvailable -- Minimum number of pods that must remain available during a disruption
     minAvailable:
     # clusterChecksRunner.pdb.maxUnavailable -- Maximum number of pods that can be unavailable during a disruption
-    maxUnavailable: 1
+    maxUnavailable:
 
   # Provide Cluster Checks Deployment pods RBAC configuration
   rbac:

--- a/test/datadog/pdb_test.go
+++ b/test/datadog/pdb_test.go
@@ -1,0 +1,224 @@
+package datadog
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/helm-charts/test/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_clusterAgentPDB(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides map[string]string
+		verify    func(t *testing.T, spec map[string]string)
+	}{
+		{
+			name: "deprecated clusterAgent.createPodDisruptionBudget true",
+			overrides: map[string]string{
+				"clusterAgent.createPodDisruptionBudget": "true",
+			},
+			verify: func(t *testing.T, spec map[string]string) {
+				_, hasMax := spec["maxUnavailable"]
+				assert.False(t, hasMax)
+				assertYamlIntEquals(t, spec["minAvailable"], 1)
+			},
+		},
+		{
+			name: "clusterAgent.pdb.create true (default minAvailable 1)",
+			overrides: map[string]string{
+				"clusterAgent.pdb.create": "true",
+			},
+			verify: func(t *testing.T, spec map[string]string) {
+				_, hasMax := spec["maxUnavailable"]
+				assert.False(t, hasMax)
+				assertYamlIntEquals(t, spec["minAvailable"], 1)
+			},
+		},
+		{
+			name: "clusterAgent.pdb.create true with minAvailable 2",
+			overrides: map[string]string{
+				"clusterAgent.pdb.create":       "true",
+				"clusterAgent.pdb.minAvailable": "2",
+			},
+			verify: func(t *testing.T, spec map[string]string) {
+				_, hasMax := spec["maxUnavailable"]
+				assert.False(t, hasMax)
+				assertYamlIntEquals(t, spec["minAvailable"], 2)
+			},
+		},
+		{
+			name: "clusterAgent.pdb.create true with maxUnavailable 3",
+			overrides: map[string]string{
+				"clusterAgent.pdb.create":         "true",
+				"clusterAgent.pdb.maxUnavailable": "3",
+			},
+			verify: func(t *testing.T, spec map[string]string) {
+				_, hasMin := spec["minAvailable"]
+				assert.False(t, hasMin)
+				assertYamlIntEquals(t, spec["maxUnavailable"], 3)
+			},
+		},
+		{
+			name: "clusterAgent.pdb.create true fails with both minAvailable and maxUnavailable",
+			overrides: map[string]string{
+				"clusterAgent.pdb.create":         "true",
+				"clusterAgent.pdb.minAvailable":   "1",
+				"clusterAgent.pdb.maxUnavailable": "2",
+			},
+			verify: func(t *testing.T, spec map[string]string) {
+				// This test should fail during chart rendering, not reach verification
+				t.Fatal("Chart should have failed to render with both minAvailable and maxUnavailable")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := common.RenderChart(t, common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/cluster-agent-pdb.yaml"},
+				Overrides:   tt.overrides,
+			})
+
+			// Special handling for the test that should fail
+			if strings.Contains(tt.name, "fails with both") {
+				assert.NotNil(t, err, "Chart should have failed to render with both minAvailable and maxUnavailable")
+				return
+			}
+
+			assert.Nil(t, err, "couldn't render template")
+			tt.verify(t, extractSpec(manifest))
+		})
+	}
+}
+
+func Test_clusterChecksRunnerPDB(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides map[string]string
+		verify    func(t *testing.T, spec map[string]string)
+	}{
+		{
+			name: "deprecated clusterChecksRunner.createPodDisruptionBudget true",
+			overrides: map[string]string{
+				"clusterChecksRunner.createPodDisruptionBudget": "true",
+			},
+			verify: func(t *testing.T, spec map[string]string) {
+				_, hasMin := spec["minAvailable"]
+				assert.False(t, hasMin)
+				assertYamlIntEquals(t, spec["maxUnavailable"], 1)
+			},
+		},
+		{
+			name: "clusterChecksRunner.pdb.create true (default maxUnavailable 1)",
+			overrides: map[string]string{
+				"clusterChecksRunner.pdb.create": "true",
+			},
+			verify: func(t *testing.T, spec map[string]string) {
+				_, hasMin := spec["minAvailable"]
+				assert.False(t, hasMin)
+				assertYamlIntEquals(t, spec["maxUnavailable"], 1)
+			},
+		},
+		{
+			name: "clusterChecksRunner.pdb.create true with maxUnavailable 2",
+			overrides: map[string]string{
+				"clusterChecksRunner.pdb.create":         "true",
+				"clusterChecksRunner.pdb.maxUnavailable": "2",
+			},
+			verify: func(t *testing.T, spec map[string]string) {
+				_, hasMin := spec["minAvailable"]
+				assert.False(t, hasMin)
+				assertYamlIntEquals(t, spec["maxUnavailable"], 2)
+			},
+		},
+		{
+			name: "clusterChecksRunner.pdb.create true with minAvailable 1",
+			overrides: map[string]string{
+				"clusterChecksRunner.pdb.create":       "true",
+				"clusterChecksRunner.pdb.minAvailable": "1",
+			},
+			verify: func(t *testing.T, spec map[string]string) {
+				_, hasMax := spec["maxUnavailable"]
+				assert.False(t, hasMax)
+				assertYamlIntEquals(t, spec["minAvailable"], 1)
+			},
+		},
+		{
+			name: "clusterChecksRunner.pdb.create true fails with both minAvailable and maxUnavailable",
+			overrides: map[string]string{
+				"clusterChecksRunner.pdb.create":         "true",
+				"clusterChecksRunner.pdb.minAvailable":   "1",
+				"clusterChecksRunner.pdb.maxUnavailable": "2",
+			},
+			verify: func(t *testing.T, spec map[string]string) {
+				// This test should fail during chart rendering, not reach verification
+				t.Fatal("Chart should have failed to render with both minAvailable and maxUnavailable")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := common.RenderChart(t, common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/agent-clusterchecks-pdb.yaml"},
+				Overrides:   tt.overrides,
+			})
+
+			// Special handling for the test that should fail
+			if strings.Contains(tt.name, "fails with both") {
+				assert.NotNil(t, err, "Chart should have failed to render with both minAvailable and maxUnavailable")
+				return
+			}
+
+			assert.Nil(t, err, "couldn't render template")
+			tt.verify(t, extractSpec(manifest))
+		})
+	}
+}
+
+// extractSpec returns a simplified view of the spec section as key->line string
+// so we can do presence/absence checks easily.
+func extractSpec(manifest string) map[string]string {
+	spec := map[string]string{}
+	lines := strings.Split(manifest, "\n")
+	inSpec := false
+	for _, l := range lines {
+		if strings.HasPrefix(l, "spec:") {
+			inSpec = true
+			continue
+		}
+		if inSpec {
+			// stop at selector (next top-level key in our template)
+			if strings.HasPrefix(l, "  selector:") {
+				break
+			}
+			if strings.Contains(l, "minAvailable:") {
+				parts := strings.SplitN(l, ":", 2)
+				if len(parts) == 2 {
+					spec["minAvailable"] = strings.TrimSpace(parts[1])
+				}
+			}
+			if strings.Contains(l, "maxUnavailable:") {
+				parts := strings.SplitN(l, ":", 2)
+				if len(parts) == 2 {
+					spec["maxUnavailable"] = strings.TrimSpace(parts[1])
+				}
+			}
+		}
+	}
+	return spec
+}
+
+func assertYamlIntEquals(t *testing.T, got string, expected int) {
+	i, err := strconv.Atoi(strings.TrimSpace(got))
+	if assert.NoError(t, err) {
+		assert.Equal(t, expected, i)
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
* Allows configuring PDBs instead of hard-coding `minAvailable: 1` for DCA and `maxUnavailable: 1` for CLC.
* Deprecates `createPDB` setting
* Uses same default if the new setting is used

#### Which issue this PR fixes
* https://github.com/DataDog/helm-charts/pull/2000

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
