### PR TITLE
Add additional resources to the operator’s ClusterRole.

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.13.2
+* Add `nodes/pods`, `nodes/healthz`, `nodes/configz`, and `nodes/logs` resources to the operator’s ClusterRole.
+
 ## 2.13.1
 
 * Add default `initialDelaySeconds: 15` to the Liveness Probe

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -59,6 +59,10 @@ rules:
   - nodes/proxy
   - nodes/spec
   - nodes/stats
+  - nodes/pods
+  - nodes/healthz
+  - nodes/configz
+  - nodes/logs
   verbs:
   - get
 - apiGroups:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates the `datadog-operator` helm chart to provide additional subresources to the operator's ClusterRole. It is in support of this [new feature](https://github.com/kubernetes/enhancements/issues/2862) introduced in K8s v1.32+. 

#### Which issue this PR fixes
[https://datadoghq.atlassian.net/jira/software/c/projects/CONTINT/boards/5407?selectedIssue=CONTINT-4829](https://datadoghq.atlassian.net/jira/software/c/projects/CONTINT/boards/5407?selectedIssue=CONTINT-4829
)

#### Special notes for your reviewer:
This PR relies on an update to the Datadog Operator, which is done in [this separate PR](?). 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
