### PR TITLE
Update default Agent version to 7.70.2

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+# 3.135.0
+
+* Upgrade default Agent version to `7.70.2`.
+
 # 3.134.0
 
 * Deprecates `createPodDisruptionBudget` setting in favour of `pdb` block, allowing you to configure `minAvailable` or `maxUnavailable` for the Cluster Agent and Cluster Checks Runners. Using solely `<component>.pdb.create` without specifying `minAvailable`/`maxUnavailable` will create the same PodDisruptionBudget as the previous option.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.134.0
+version: 3.135.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.134.0](https://img.shields.io/badge/Version-3.134.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.135.0](https://img.shields.io/badge/Version-3.135.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -538,7 +538,7 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.69.3"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.70.2"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | agents.lifecycle | object | `{}` | Configure the lifecycle of the Agent. Note: The `exec` lifecycle handler is not supported in GKE Autopilot. |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
@@ -624,7 +624,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"7.69.3"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"7.70.2"` | Cluster Agent image tag to use |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
@@ -683,7 +683,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
-| clusterChecksRunner.image.tag | string | `"7.69.3"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.70.2"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1239,7 +1239,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 7.69.3
+    tag: 7.70.2
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -1794,7 +1794,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.69.3
+    tag: 7.70.2
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2388,7 +2388,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.69.3
+    tag: 7.70.2
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""

--- a/test/datadog/baseline/manifests/adp_enabled.yaml
+++ b/test/datadog/baseline/manifests/adp_enabled.yaml
@@ -880,7 +880,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1018,7 +1018,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1168,7 +1168,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1207,7 +1207,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1428,7 +1428,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1501,7 +1501,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -909,7 +909,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1050,7 +1050,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1099,7 +1099,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1138,7 +1138,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1308,7 +1308,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1357,7 +1357,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1370,7 +1370,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1544,7 +1544,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1617,7 +1617,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -902,7 +902,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -975,7 +975,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -916,7 +916,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -989,7 +989,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -849,7 +849,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
               value: agent
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-              value: 7.69.3
+              value: 7.70.2
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -912,7 +912,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -985,7 +985,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -874,7 +874,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1015,7 +1015,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1064,7 +1064,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1103,7 +1103,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1324,7 +1324,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1397,7 +1397,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -874,7 +874,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1015,7 +1015,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1064,7 +1064,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1103,7 +1103,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1324,7 +1324,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1397,7 +1397,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -851,7 +851,7 @@ spec:
               value: /var/lib/kubelet/pod-resources/kubelet.sock
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -956,7 +956,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -982,7 +982,7 @@ spec:
           command:
             - pwsh
             - -Command
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1024,7 +1024,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1219,7 +1219,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1292,7 +1292,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -854,7 +854,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -917,7 +917,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -969,7 +969,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1165,7 +1165,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1238,7 +1238,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -854,7 +854,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -929,7 +929,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -981,7 +981,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1186,7 +1186,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1259,7 +1259,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -893,7 +893,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -965,7 +965,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1016,7 +1016,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1187,7 +1187,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1242,7 +1242,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1261,7 +1261,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1445,7 +1445,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1524,7 +1524,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -865,7 +865,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -937,7 +937,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -986,7 +986,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1206,7 +1206,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1285,7 +1285,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1113,7 +1113,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1253,7 +1253,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1335,7 +1335,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1405,7 +1405,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1456,7 +1456,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1489,7 +1489,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1716,7 +1716,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1795,7 +1795,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1113,7 +1113,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1253,7 +1253,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1335,7 +1335,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1437,7 +1437,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1488,7 +1488,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1521,7 +1521,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1780,7 +1780,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1859,7 +1859,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1109,7 +1109,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1222,7 +1222,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1320,7 +1320,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1371,7 +1371,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1404,7 +1404,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1660,7 +1660,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1739,7 +1739,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -893,7 +893,7 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -965,7 +965,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1016,7 +1016,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1187,7 +1187,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1242,7 +1242,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1261,7 +1261,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1445,7 +1445,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1524,7 +1524,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -939,7 +939,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1080,7 +1080,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1129,7 +1129,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1168,7 +1168,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1389,7 +1389,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1462,7 +1462,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1127,7 +1127,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1275,7 +1275,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1375,7 +1375,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1451,7 +1451,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1528,7 +1528,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1567,7 +1567,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1594,7 +1594,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1837,7 +1837,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1910,7 +1910,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -952,7 +952,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1093,7 +1093,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1184,7 +1184,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.69.3
+          image: gcr.io/datadoghq/ddot-collector:7.70.2
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1239,7 +1239,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1278,7 +1278,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1505,7 +1505,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1578,7 +1578,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -888,7 +888,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1029,7 +1029,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1120,7 +1120,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.69.3
+          image: gcr.io/datadoghq/ddot-collector:7.70.2
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1169,7 +1169,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1208,7 +1208,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1435,7 +1435,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1508,7 +1508,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -948,7 +948,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1089,7 +1089,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1180,7 +1180,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.69.3
+          image: gcr.io/datadoghq/ddot-collector:7.70.2
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1233,7 +1233,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1272,7 +1272,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1499,7 +1499,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1572,7 +1572,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -911,7 +911,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1052,7 +1052,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1143,7 +1143,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.69.3
+          image: gcr.io/datadoghq/ddot-collector:7.70.2
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1204,7 +1204,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1243,7 +1243,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1482,7 +1482,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1555,7 +1555,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -948,7 +948,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1089,7 +1089,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1180,7 +1180,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.69.3
+          image: gcr.io/datadoghq/ddot-collector:7.70.2
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1232,7 +1232,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1271,7 +1271,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1501,7 +1501,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1574,7 +1574,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -948,7 +948,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1089,7 +1089,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1180,7 +1180,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.69.3
+          image: gcr.io/datadoghq/ddot-collector:7.70.2
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1229,7 +1229,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1268,7 +1268,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1495,7 +1495,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1568,7 +1568,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -874,7 +874,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1015,7 +1015,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1064,7 +1064,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1103,7 +1103,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1324,7 +1324,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1397,7 +1397,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -907,7 +907,7 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1052,7 +1052,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1107,7 +1107,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1152,7 +1152,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1327,7 +1327,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1376,7 +1376,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1395,7 +1395,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1579,7 +1579,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1656,7 +1656,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           securityContext:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1127,7 +1127,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1275,7 +1275,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1375,7 +1375,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1453,7 +1453,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1616,7 +1616,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -1657,7 +1657,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1696,7 +1696,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1723,7 +1723,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2006,7 +2006,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2079,7 +2079,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1127,7 +1127,7 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1275,7 +1275,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1375,7 +1375,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1451,7 +1451,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -1610,7 +1610,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -1651,7 +1651,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1690,7 +1690,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1717,7 +1717,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.69.3
+          image: gcr.io/datadoghq/agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -1997,7 +1997,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2070,7 +2070,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.69.3
+          image: gcr.io/datadoghq/cluster-agent:7.70.2
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:

* Changes default to latest `7.70.2`: https://github.com/DataDog/datadog-agent/releases/tag/7.70.2

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
