### PR TITLE
[datadog-operator] Update Datadog Operator chart for 1.19.0-rc.1

### DIFF
--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.11.0
-digest: sha256:c5cc0ab50e8f206e0ca54f9add7638529558694d512182ef44229af1b7ac4f94
-generated: "2025-09-08T18:14:10.501328+02:00"
+  version: 2.12.0-dev.1
+digest: sha256:acd380c7b67ee7d439c96f7bc9f0db2360d296ac6e7ae26df3a4aa0c402cd761
+generated: "2025-09-23T08:30:03.490161-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.13.1
-appVersion: 1.18.0
+version: 2.14.0-dev.1
+appVersion: 1.19.0-rc.1
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "2.11.0"
+  version: "2.12.0-dev.1"
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.13.1](https://img.shields.io/badge/Version-2.13.1-informational?style=flat-square) ![AppVersion: 1.18.0](https://img.shields.io/badge/AppVersion-1.18.0-informational?style=flat-square)
+![Version: 2.14.0-dev.1](https://img.shields.io/badge/Version-2.14.0--dev.1-informational?style=flat-square) ![AppVersion: 1.19.0-rc.1](https://img.shields.io/badge/AppVersion-1.19.0--rc.1-informational?style=flat-square)
 
 ## Values
 
@@ -36,7 +36,7 @@
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.18.0"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.19.0-rc.1"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |

--- a/charts/datadog-operator/templates/NOTES.txt
+++ b/charts/datadog-operator/templates/NOTES.txt
@@ -41,3 +41,13 @@ The maximumGoroutines parameter isn't supported by the Operator 1.0.0-rc.12 and 
 Setting a value will not change the default defined in the Operator.
     {{- end }}
 {{- end }}
+
+{{- if (semverCompare ">=1.18.0-rc.1" $version) }}
+##############################################################################
+####               WARNING: Upcoming metadata change in Operator 1.21.    ####
+##############################################################################
+
+We are changing Datadog Agent daemonset and pod metadata handling in upcoming releases.
+Please check Operator README for more details https://github.com/DataDog/datadog-operator/blob/main/README.md
+
+{{- end }}

--- a/charts/datadog-operator/templates/_helpers.tpl
+++ b/charts/datadog-operator/templates/_helpers.tpl
@@ -87,6 +87,6 @@ Check operator image tag version.
 {{- $parts := split "@" $tag -}}
 {{- index $parts "_0"}}
 {{- else -}}
-{{ "1.18.0" }}
+{{ "1.19.0-rc.1" }}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -115,6 +115,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -255,6 +262,16 @@ rules:
   - watermarkpodautoscalers
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - datadoghq.com
+  - karpenter.azure.com
+  - karpenter.k8s.aws
+  - karpenter.sh
+  resources:
+  - '*'
+  verbs:
   - list
   - watch
 - apiGroups:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.18.0
+  tag: 1.19.0-rc.1
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
   # image.doNotCheckTag -- Permit skipping operator image tag compatibility with the chart.

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-2.11.0'
+    helm.sh/chart: 'datadogCRDs-2.12.0-dev.1'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -653,6 +653,8 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        directSendFromSystemProbe:
+                          type: boolean
                         enabled:
                           type: boolean
                         network:
@@ -801,6 +803,8 @@ spec:
                       properties:
                         enabled:
                           type: boolean
+                        patchCgroupPermissions:
+                          type: boolean
                         privilegedMode:
                           type: boolean
                         requiredRuntimeClassName:
@@ -866,6 +870,8 @@ spec:
                       type: object
                     logCollection:
                       properties:
+                        autoMultiLineDetection:
+                          type: boolean
                         containerCollectAll:
                           type: boolean
                         containerCollectUsingFiles:
@@ -4534,6 +4540,8 @@ spec:
                                       type: string
                                   type: object
                               type: object
+                            directSendFromSystemProbe:
+                              type: boolean
                             enabled:
                               type: boolean
                             network:
@@ -4682,6 +4690,8 @@ spec:
                           properties:
                             enabled:
                               type: boolean
+                            patchCgroupPermissions:
+                              type: boolean
                             privilegedMode:
                               type: boolean
                             requiredRuntimeClassName:
@@ -4747,6 +4757,8 @@ spec:
                           type: object
                         logCollection:
                           properties:
+                            autoMultiLineDetection:
+                              type: boolean
                             containerCollectAll:
                               type: boolean
                             containerCollectUsingFiles:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.13.1
+    helm.sh/chart: datadog-operator-2.14.0-dev.1
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.18.0"
+    app.kubernetes.io/version: "1.19.0-rc.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.18.0"
+          image: "gcr.io/datadoghq/operator:1.19.0-rc.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -144,7 +144,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "gcr.io/datadoghq/operator:1.18.0", operatorContainer.Image)
+	assert.Equal(t, "gcr.io/datadoghq/operator:1.19.0-rc.1", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Update chart for Operator  `1.19.0-rc.1`. Includes warning for upcoming changes in metadata handling. Role changes for reference [here](https://github.com/DataDog/datadog-operator/compare/v1.18...v1.19#diff-6d4c4e29ec096149781536bb9118fde8242c1901df764e3eda3019ac8503d6c7R122-R290).


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
