### PR TITLE
[observability-pipelines-worker] 2.9.1 release

### DIFF
--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.1
+
+- Official image `2.9.1`
+
 ## 2.9.0
 
 - Official image `2.9.0`

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: "2.9.0"
+version: "2.9.1"
 description: Observability Pipelines Worker
 type: application
 keywords:
@@ -13,7 +13,7 @@ icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
 maintainers:
   - name: Datadog
     email: support@datadoghq.com
-appVersion: "2.9.0"
+appVersion: "2.9.1"
 annotations:
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 
@@ -110,7 +110,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.pullPolicy | string | `"IfNotPresent"` | Specify the [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy). |
 | image.pullSecrets | list | `[]` | Specify the [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod). |
 | image.repository | string | `"gcr.io/datadoghq"` | Specify the image repository to use. |
-| image.tag | string | `"2.9.0"` | Specify the image tag to use. |
+| image.tag | string | `"2.9.1"` | Specify the image tag to use. |
 | ingress.annotations | object | `{}` | Specify annotations for the Ingress. |
 | ingress.className | string | `""` | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18. |
 | ingress.enabled | bool | `false` | If **true**, create an Ingress resource. |

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -43,7 +43,7 @@ image:
   # image.name -- Specify the image name to use (relative to `image.repository`).
   name: observability-pipelines-worker
   # image.tag -- Specify the image tag to use.
-  tag: 2.9.0
+  tag: 2.9.1
   # image.digest -- (string) Specify the image digest to use; takes precedence over `image.tag`.
   digest:
   ## Currently, we offer images at:


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates OPW to the version 2.9.1 release

#### Which issue this PR fixes
OPA-3861

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
