### PR TITLE
fix security context generation on GKE

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.135.3
+
+* Fix AppArmor profile for agent and system-probe containers on GKE.
+
 ## 3.135.2
 
 * Pass APM and DSD hostSocketPath to Cluster Agent deployment.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.135.2
+version: 3.135.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.135.2](https://img.shields.io/badge/Version-3.135.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.135.3](https://img.shields.io/badge/Version-3.135.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -944,7 +944,7 @@ securityContext:
     localhostProfile: {{ trimPrefix "localhost/" .seccomp }}
     {{- end }}
 {{- end -}}
-{{- if and .apparmor .kubeversion (semverCompare ">=1.30.0" .kubeversion) }}
+{{- if and .apparmor .kubeversion (semverCompare ">=1.30.0-0" .kubeversion) }}
   appArmorProfile:
     {{- if hasPrefix "localhost/" .apparmor }}
     type: Localhost

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -55,14 +55,14 @@ spec:
         checksum/agent-config: {{ tpl (toYaml .Values.agents.customAgentConfig) . | sha256sum }}
         {{- end }}
         {{- if eq  (include "should-enable-system-probe" .) "true" }}
-        {{- if and (.Values.agents.podSecurity.apparmor.enabled) (semverCompare "<1.30.0" .Capabilities.KubeVersion.Version) }}
+        {{- if and (.Values.agents.podSecurity.apparmor.enabled) (semverCompare "<1.30.0-0" .Capabilities.KubeVersion.Version) }}
         container.apparmor.security.beta.kubernetes.io/system-probe: {{ .Values.datadog.systemProbe.apparmor }}
         {{- end }}
         {{- if semverCompare "<1.19.0" .Capabilities.KubeVersion.Version }}
         container.seccomp.security.alpha.kubernetes.io/system-probe: {{ .Values.datadog.systemProbe.seccomp }}
         {{- end }}
         {{- end }}
-        {{- if and .Values.agents.podSecurity.apparmor.enabled (eq (include "should-enable-sbom-container-image-collection" .) "true") .Values.datadog.sbom.containerImage.uncompressedLayersSupport (semverCompare "<1.30.0" .Capabilities.KubeVersion.Version) }}
+        {{- if and .Values.agents.podSecurity.apparmor.enabled (eq (include "should-enable-sbom-container-image-collection" .) "true") .Values.datadog.sbom.containerImage.uncompressedLayersSupport (semverCompare "<1.30.0-0" .Capabilities.KubeVersion.Version) }}
         container.apparmor.security.beta.kubernetes.io/agent: unconfined
         {{- end }}
         {{- if .Values.providers.gke.autopilot }}  # Workaround for GKE Autopilot bug in versions >= 1.32.2-gke.1182000 and < 1.32.2-gke.1652000.

--- a/test/datadog/apparmor_test.go
+++ b/test/datadog/apparmor_test.go
@@ -1,6 +1,8 @@
 package datadog
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -146,4 +148,86 @@ func TestApparmor(t *testing.T) {
 		assert.NotContains(t, deployment.Spec.Template.Annotations, "container.apparmor.security.beta.kubernetes.io/system-probe")
 	})
 
+}
+
+func innerTestApparmorGKE(t *testing.T, kubeVersion string, requiresSysprobeUnconfined bool, requiresAgentUnconfined bool) {
+	helmCommand := common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/daemonset.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"datadog.apiKeyExistingSecret": "datadog-secret",
+			"datadog.appKeyExistingSecret": "datadog-secret",
+			"providers.gke.cos":            "true",
+		},
+		ExtraArgs: []string{"--kube-version=" + kubeVersion},
+	}
+	if requiresSysprobeUnconfined {
+		helmCommand.Overrides["datadog.serviceMonitoring.enabled"] = "true"
+	}
+	if requiresAgentUnconfined {
+		helmCommand.Overrides["datadog.sbom.containerImage.enabled"] = "true"
+		helmCommand.Overrides["datadog.sbom.containerImage.uncompressedLayersSupport"] = "true"
+	}
+	manifest, err := common.RenderChart(t, helmCommand)
+	require.NoError(t, err)
+	var deployment appsv1.DaemonSet
+	common.Unmarshal(t, manifest, &deployment)
+
+	usesAnnotation := strings.HasPrefix(kubeVersion, "1.29")
+	checkApparmorConfinement := func(containerName string) {
+		container, ok := getContainer(t, deployment.Spec.Template.Spec.Containers, containerName)
+
+		if assert.True(t, ok, "has "+containerName+" container") {
+			if assert.NotNil(t, container.SecurityContext, containerName+" securityContext not found") {
+				profile := container.SecurityContext.AppArmorProfile
+				if assert.NotNil(t, profile, containerName+" apparmor profile not found") {
+					assert.Equal(t, v1.AppArmorProfileTypeUnconfined, profile.Type, containerName+" apparmor profile type")
+				}
+			}
+		}
+	}
+
+	checkApparmorAnnotation := func(containerName string) {
+		assert.NotNil(t, deployment.Spec.Template.Annotations, "annotations not found")
+		assert.Equal(t, "unconfined", deployment.Spec.Template.Annotations["container.apparmor.security.beta.kubernetes.io/"+containerName], containerName+" apparmor profile type")
+	}
+
+	checkFunc := checkApparmorConfinement
+	if usesAnnotation {
+		checkFunc = checkApparmorAnnotation
+	}
+
+	if requiresAgentUnconfined {
+		checkFunc("agent")
+	}
+	if requiresSysprobeUnconfined {
+		checkFunc("system-probe")
+	}
+}
+
+func TestApparmorGKE(t *testing.T) {
+	// 1.29 should use annotation for the apparmor profile, 1.30+ should use securityContext
+	kubeVersions := []string{"1.29.4-gke.1172000", "1.33.4-gke.1172000"}
+	for _, kubeVersion := range kubeVersions {
+		t.Run(kubeVersion, func(t *testing.T) {
+			for _, requiresSysprobeUnconfined := range []bool{true, false} {
+				for _, requiresAgentUnconfined := range []bool{true, false} {
+					sysprobeConfinementStr := "Confined"
+					if requiresSysprobeUnconfined {
+						sysprobeConfinementStr = "Unconfined"
+					}
+					agentConfinementStr := "Confined"
+					if requiresAgentUnconfined {
+						agentConfinementStr = "Unconfined"
+					}
+					testName := fmt.Sprintf("agent%s_sysprobe%s", agentConfinementStr, sysprobeConfinementStr)
+					t.Run(testName, func(t *testing.T) {
+						innerTestApparmorGKE(t, kubeVersion, requiresSysprobeUnconfined, requiresAgentUnconfined)
+					})
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

A customer pointed that system-probe was not running correctly on GKE with kubernetes version > 1.33. This issue was introduced in https://github.com/DataDog/helm-charts/pull/1865, where the `semverCompare` function was used in a way such as prereleases will not match. In GKE, kubernetes versions have the suffix `-gke` so the `semverCompare` was not matching in any case. 

#### Which issue this PR fixes

https://datadoghq.atlassian.net/browse/EBPF-823

#### Special notes for your reviewer:

Added two unit tests to ensure correctness.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
