### PR TITLE
[helm operator POC] Add unit tests for yaml mapper functions

### DIFF
--- a/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper_test.go
+++ b/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper_test.go
@@ -30,7 +30,9 @@ const (
 	k8sVersionEnv = "K8S_VERSION"
 )
 
-func Test(t *testing.T) {
+// INTEGRATION TEST
+
+func YamlMapperTest(t *testing.T) {
 	// Prerequisites
 	context := common.CurrentContext(t)
 	t.Log("Checking current context:", context)
@@ -187,4 +189,595 @@ func isTimestampLine(line string) bool {
 	}
 
 	return false
+}
+
+// UNIT TESTS
+
+func TestMergeMaps(t *testing.T) {
+	tests := []struct {
+		name     string
+		map1     map[string]interface{}
+		map2     map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name: "merge non-overlapping maps",
+			map1: map[string]interface{}{
+				"key1": "value1",
+				"key2": 42,
+			},
+			map2: map[string]interface{}{
+				"key3": "value3",
+				"key4": []string{"a", "b"},
+			},
+			expected: map[string]interface{}{
+				"key1": "value1",
+				"key2": 42,
+				"key3": "value3",
+				"key4": []string{"a", "b"},
+			},
+		},
+		{
+			name: "merge overlapping maps with simple values (map2 overwrites map1)",
+			map1: map[string]interface{}{
+				"key1": "value1",
+				"key2": 42,
+			},
+			map2: map[string]interface{}{
+				"key1": "newvalue1",
+				"key3": "value3",
+			},
+			expected: map[string]interface{}{
+				"key1": "newvalue1",
+				"key2": 42,
+				"key3": "value3",
+			},
+		},
+		{
+			name: "merge nested maps",
+			map1: map[string]interface{}{
+				"config": map[string]interface{}{
+					"database": map[string]interface{}{
+						"host": "localhost",
+						"port": 5432,
+					},
+					"cache": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				"version": "1.0",
+			},
+			map2: map[string]interface{}{
+				"config": map[string]interface{}{
+					"database": map[string]interface{}{
+						"port":     3306,
+						"username": "admin",
+					},
+					"logging": map[string]interface{}{
+						"level": "debug",
+					},
+				},
+				"environment": "production",
+			},
+			expected: map[string]interface{}{
+				"config": map[string]interface{}{
+					"database": map[string]interface{}{
+						"host":     "localhost",
+						"port":     3306,
+						"username": "admin",
+					},
+					"cache": map[string]interface{}{
+						"enabled": true,
+					},
+					"logging": map[string]interface{}{
+						"level": "debug",
+					},
+				},
+				"version":     "1.0",
+				"environment": "production",
+			},
+		},
+		{
+			name: "one map is empty",
+			map1: map[string]interface{}{
+				"key1": "value1",
+			},
+			map2: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"key1": "value1",
+			},
+		},
+		{
+			name:     "both maps are empty",
+			map1:     map[string]interface{}{},
+			map2:     map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "mixed value types",
+			map1: map[string]interface{}{
+				"string":  "text",
+				"number":  123,
+				"boolean": true,
+				"array":   []interface{}{1, 2, 3},
+				"nested": map[string]interface{}{
+					"inner": "value",
+				},
+			},
+			map2: map[string]interface{}{
+				"string": "newtext",
+				"float":  3.14,
+				"nested": map[string]interface{}{
+					"additional": "data",
+				},
+			},
+			expected: map[string]interface{}{
+				"string":  "newtext",
+				"number":  123,
+				"boolean": true,
+				"array":   []interface{}{1, 2, 3},
+				"float":   3.14,
+				"nested": map[string]interface{}{
+					"inner":      "value",
+					"additional": "data",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			map1Copy := make(map[string]interface{})
+			for k, v := range tt.map1 {
+				map1Copy[k] = v
+			}
+			map2Copy := make(map[string]interface{})
+			for k, v := range tt.map2 {
+				map2Copy[k] = v
+			}
+
+			result := mergeMaps(map1Copy, map2Copy)
+			assert.Equal(t, tt.expected, result)
+
+			assert.Equal(t, tt.expected, map1Copy)
+		})
+	}
+}
+
+func TestCustomMapFuncs(t *testing.T) {
+	// Test that all custom map functions are properly registered
+	t.Run("customMapFuncs_dict", func(t *testing.T) {
+		expectedFuncs := []string{"mapApiSecretKey", "mapAppSecretKey", "mapTokenSecretKey"}
+
+		for _, funcName := range expectedFuncs {
+			t.Run(funcName+"_exists", func(t *testing.T) {
+				_, exists := customMapFuncs[funcName]
+				assert.True(t, exists, "Custom map function %s should be registered", funcName)
+			})
+		}
+
+		assert.Equal(t, len(expectedFuncs), len(customMapFuncs), "Should have exactly %d custom map functions", len(expectedFuncs))
+	})
+
+	// Test individual functions through the dictionary
+	tests := []struct {
+		name        string
+		funcName    string
+		interim     map[string]interface{}
+		newPath     string
+		pathVal     interface{}
+		expectedMap map[string]interface{}
+	}{
+		// mapApiSecretKey tests
+		{
+			name:     "mapApiSecretKey_empty_map",
+			funcName: "mapApiSecretKey",
+			interim:  map[string]interface{}{},
+			newPath:  "spec.global.credentials.apiSecret.secretName",
+			pathVal:  "my-api-secret",
+			expectedMap: map[string]interface{}{
+				"spec.global.credentials.apiSecret.secretName": "my-api-secret",
+				"spec.global.credentials.apiSecret.keyName":    "api-key",
+			},
+		},
+		{
+			name:     "mapApiSecretKey_existing_map",
+			funcName: "mapApiSecretKey",
+			interim: map[string]interface{}{
+				"spec.global.site":      "datadoghq.com",
+				"spec.agent.image.name": "datadog/agent",
+			},
+			newPath: "spec.global.credentials.apiSecret.secretName",
+			pathVal: "datadog-api-secret",
+			expectedMap: map[string]interface{}{
+				"spec.global.site":                             "datadoghq.com",
+				"spec.agent.image.name":                        "datadog/agent",
+				"spec.global.credentials.apiSecret.secretName": "datadog-api-secret",
+				"spec.global.credentials.apiSecret.keyName":    "api-key",
+			},
+		},
+		{
+			name:     "mapApiSecretKey_overwrite",
+			funcName: "mapApiSecretKey",
+			interim: map[string]interface{}{
+				"spec.global.credentials.apiSecret.secretName": "old-secret",
+				"spec.global.credentials.apiSecret.keyName":    "old-key",
+			},
+			newPath: "spec.global.credentials.apiSecret.secretName",
+			pathVal: "new-api-secret",
+			expectedMap: map[string]interface{}{
+				"spec.global.credentials.apiSecret.secretName": "new-api-secret",
+				"spec.global.credentials.apiSecret.keyName":    "api-key",
+			},
+		},
+		// mapAppSecretKey tests
+		{
+			name:     "mapAppSecretKey_empty_map",
+			funcName: "mapAppSecretKey",
+			interim:  map[string]interface{}{},
+			newPath:  "spec.global.credentials.appSecret.secretName",
+			pathVal:  "my-app-secret",
+			expectedMap: map[string]interface{}{
+				"spec.global.credentials.appSecret.secretName": "my-app-secret",
+				"spec.global.credentials.appSecret.keyName":    "app-key",
+			},
+		},
+		{
+			name:     "mapAppSecretKey_with_existing_api_secret",
+			funcName: "mapAppSecretKey",
+			interim: map[string]interface{}{
+				"spec.global.credentials.apiSecret.secretName": "api-secret",
+				"spec.global.credentials.apiSecret.keyName":    "api-key",
+			},
+			newPath: "spec.global.credentials.appSecret.secretName",
+			pathVal: "datadog-app-secret",
+			expectedMap: map[string]interface{}{
+				"spec.global.credentials.apiSecret.secretName": "api-secret",
+				"spec.global.credentials.apiSecret.keyName":    "api-key",
+				"spec.global.credentials.appSecret.secretName": "datadog-app-secret",
+				"spec.global.credentials.appSecret.keyName":    "app-key",
+			},
+		},
+		{
+			name:     "mapAppSecretKey_overwrite",
+			funcName: "mapAppSecretKey",
+			interim: map[string]interface{}{
+				"spec.global.credentials.appSecret.secretName": "old-app-secret",
+				"spec.global.credentials.appSecret.keyName":    "old-app-key",
+			},
+			newPath: "spec.global.credentials.appSecret.secretName",
+			pathVal: "new-app-secret",
+			expectedMap: map[string]interface{}{
+				"spec.global.credentials.appSecret.secretName": "new-app-secret",
+				"spec.global.credentials.appSecret.keyName":    "app-key",
+			},
+		},
+		// mapTokenSecretKey tests
+		{
+			name:     "mapTokenSecretKey_empty_map",
+			funcName: "mapTokenSecretKey",
+			interim:  map[string]interface{}{},
+			newPath:  "spec.global.clusterAgentTokenSecret.secretName",
+			pathVal:  "my-token-secret",
+			expectedMap: map[string]interface{}{
+				"spec.global.clusterAgentTokenSecret.secretName": "my-token-secret",
+				"spec.global.clusterAgentTokenSecret.keyName":    "token",
+			},
+		},
+		{
+			name:     "mapTokenSecretKey_with_existing_secrets",
+			funcName: "mapTokenSecretKey",
+			interim: map[string]interface{}{
+				"spec.global.credentials.apiSecret.secretName": "api-secret",
+				"spec.global.credentials.appSecret.secretName": "app-secret",
+			},
+			newPath: "spec.global.clusterAgentTokenSecret.secretName",
+			pathVal: "cluster-agent-token",
+			expectedMap: map[string]interface{}{
+				"spec.global.credentials.apiSecret.secretName":   "api-secret",
+				"spec.global.credentials.appSecret.secretName":   "app-secret",
+				"spec.global.clusterAgentTokenSecret.secretName": "cluster-agent-token",
+				"spec.global.clusterAgentTokenSecret.keyName":    "token",
+			},
+		},
+		{
+			name:     "mapTokenSecretKey_overwrite",
+			funcName: "mapTokenSecretKey",
+			interim: map[string]interface{}{
+				"spec.global.clusterAgentTokenSecret.secretName": "old-token-secret",
+				"spec.global.clusterAgentTokenSecret.keyName":    "old-token",
+			},
+			newPath: "spec.global.clusterAgentTokenSecret.secretName",
+			pathVal: "new-token-secret",
+			expectedMap: map[string]interface{}{
+				"spec.global.clusterAgentTokenSecret.secretName": "new-token-secret",
+				"spec.global.clusterAgentTokenSecret.keyName":    "token",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			customFunc, exists := customMapFuncs[tt.funcName]
+			require.True(t, exists, "Custom function %s should exist in registry", tt.funcName)
+
+			customFunc(tt.interim, tt.newPath, tt.pathVal)
+
+			assert.Equal(t, tt.expectedMap, tt.interim)
+		})
+	}
+
+	t.Run("non_existent_function", func(t *testing.T) {
+		_, exists := customMapFuncs["nonExistentFunc"]
+		assert.False(t, exists, "Non-existent function should not be in registry")
+	})
+}
+
+func TestMakeTable(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		val      interface{}
+		mapName  map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:    "simple single level path",
+			path:    "key",
+			val:     "value",
+			mapName: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"key": "value",
+			},
+		},
+		{
+			name:    "three level nested path",
+			path:    "spec.global.site",
+			val:     "datadoghq.com",
+			mapName: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"global": map[string]interface{}{
+						"site": "datadoghq.com",
+					},
+				},
+			},
+		},
+		{
+			name:    "deep nested path",
+			path:    "spec.override.nodeAgent.containers.agent.resources.limits.memory",
+			val:     "512Mi",
+			mapName: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"override": map[string]interface{}{
+						"nodeAgent": map[string]interface{}{
+							"containers": map[string]interface{}{
+								"agent": map[string]interface{}{
+									"resources": map[string]interface{}{
+										"limits": map[string]interface{}{
+											"memory": "512Mi",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "merge with existing map - non-overlapping",
+			path: "spec.global.site",
+			val:  "datadoghq.com",
+			mapName: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "datadog",
+				},
+			},
+			expected: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "datadog",
+				},
+				"spec": map[string]interface{}{
+					"global": map[string]interface{}{
+						"site": "datadoghq.com",
+					},
+				},
+			},
+		},
+		{
+			name: "merge with existing map - overlapping paths",
+			path: "spec.global.logLevel",
+			val:  "debug",
+			mapName: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"global": map[string]interface{}{
+						"site": "datadoghq.com",
+					},
+					"features": map[string]interface{}{
+						"apm": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"global": map[string]interface{}{
+						"site":     "datadoghq.com",
+						"logLevel": "debug",
+					},
+					"features": map[string]interface{}{
+						"apm": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "overwrite existing value",
+			path: "spec.global.site",
+			val:  "datadoghq.eu",
+			mapName: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"global": map[string]interface{}{
+						"site": "datadoghq.com",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"global": map[string]interface{}{
+						"site": "datadoghq.eu",
+					},
+				},
+			},
+		},
+		{
+			name:    "empty path",
+			path:    "",
+			val:     "",
+			mapName: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"": "",
+			},
+		},
+		{
+			name:    "different value types - integer",
+			path:    "spec.override.clusterAgent.replicas",
+			val:     3,
+			mapName: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"override": map[string]interface{}{
+						"clusterAgent": map[string]interface{}{
+							"replicas": 3,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "different value types - boolean",
+			path:    "spec.features.apm.enabled",
+			val:     true,
+			mapName: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"features": map[string]interface{}{
+						"apm": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "different value types - slice",
+			path:    "spec.global.tags",
+			val:     []string{"env:prod", "team:backend"},
+			mapName: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"global": map[string]interface{}{
+						"tags": []string{"env:prod", "team:backend"},
+					},
+				},
+			},
+		},
+		{
+			name:    "different value types - map",
+			path:    "spec.override.nodeAgent.resources",
+			val:     map[string]interface{}{"limits": map[string]interface{}{"memory": "1Gi"}},
+			mapName: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"override": map[string]interface{}{
+						"nodeAgent": map[string]interface{}{
+							"resources": map[string]interface{}{
+								"limits": map[string]interface{}{
+									"memory": "1Gi",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy of the input map to avoid modifying the test data
+			mapNameCopy := make(map[string]interface{})
+			for k, v := range tt.mapName {
+				mapNameCopy[k] = v
+			}
+
+			result := makeTable(tt.path, tt.val, mapNameCopy)
+
+			// Verify that the result matches expected
+			assert.Equal(t, tt.expected, result)
+
+			// Verify that the function modifies the input map in place
+			assert.Equal(t, tt.expected, mapNameCopy)
+
+			// Verify that the returned map is the same object as the input map
+			assert.True(t, fmt.Sprintf("%p", result) == fmt.Sprintf("%p", mapNameCopy), "makeTable should return the same map object that was passed in")
+		})
+	}
+}
+
+func TestMakeTableEdgeCases(t *testing.T) {
+	t.Run("nil_value", func(t *testing.T) {
+		mapName := map[string]interface{}{}
+		result := makeTable("spec.global.site", nil, mapName)
+
+		expected := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"global": map[string]interface{}{
+					"site": nil,
+				},
+			},
+		}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("path_with_multiple_dots", func(t *testing.T) {
+		mapName := map[string]interface{}{}
+		result := makeTable("a.b.c.d.e.f", "deep_value", mapName)
+
+		expected := map[string]interface{}{
+			"a": map[string]interface{}{
+				"b": map[string]interface{}{
+					"c": map[string]interface{}{
+						"d": map[string]interface{}{
+							"e": map[string]interface{}{
+								"f": "deep_value",
+							},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("path_with_numeric_keys", func(t *testing.T) {
+		mapName := map[string]interface{}{}
+		result := makeTable("spec.containers.0.name", "agent", mapName)
+
+		expected := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"containers": map[string]interface{}{
+					"0": map[string]interface{}{
+						"name": "agent",
+					},
+				},
+			},
+		}
+		assert.Equal(t, expected, result)
+	})
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
