### PR TITLE
[AGENTONB-2560] use full helm values in mapper integration test

### DIFF
--- a/tools/yaml-mapper/mapping_datadog_helm_to_datadogagent_crd_v2.yaml
+++ b/tools/yaml-mapper/mapping_datadog_helm_to_datadogagent_crd_v2.yaml
@@ -485,10 +485,10 @@ datadog.otlp.receiver.protocols.http.useHostPort: ""
 datadog.podAnnotationsAsTags: spec.global.podAnnotationsAsTags
 datadog.podLabelsAsTags: spec.global.podLabelsAsTags
 datadog.processAgent.containerCollection: spec.features.liveContainerCollection.enabled
-datadog.processAgent.enabled: spec.features.liveProcessCollection.enabled
+datadog.processAgent.enabled: "" # TODO FIX 
 datadog.processAgent.processCollection: spec.features.liveProcessCollection.enabled
 datadog.processAgent.processDiscovery: spec.features.processDiscovery.enabled
-datadog.processAgent.runInCoreAgent: spec.global.runProcessChecksInCoreAgent
+datadog.processAgent.runInCoreAgent: spec.global.runProcessChecksInCoreAgent # TODO: will be removed in operator v1.21
 datadog.processAgent.stripProcessArguments: spec.features.liveProcessCollection.stripProcessArguments
 datadog.profiling.enabled: ""
 datadog.prometheusScrape.additionalConfigs:

--- a/tools/yaml-mapper/mapping_datadog_helm_to_datadogagent_crd_v2.yaml
+++ b/tools/yaml-mapper/mapping_datadog_helm_to_datadogagent_crd_v2.yaml
@@ -558,7 +558,9 @@ datadog.systemProbe.enableTCPQueueLength: spec.features.tcpQueueLength.enabled
 datadog.systemProbe.maxTrackedConnections: ""
 datadog.systemProbe.mountPackageManagementDirs: ""
 datadog.systemProbe.runtimeCompilationAssetDir: ""
-datadog.systemProbe.seccomp: spec.override.nodeAgent.containers.system-probe.securityContext.seccompProfile.localhostProfile
+datadog.systemProbe.seccomp:
+  newPath: spec.override.nodeAgent.containers.system-probe.securityContext.seccompProfile
+  mapFunc: mapSeccompProfile
 datadog.systemProbe.seccompRoot: spec.override.nodeAgent.containers.system-probe.seccompConfig.customRootPath
 datadog.tags: spec.global.tags
 datadog.traceroute.enabled: ""

--- a/tools/yaml-mapper/mapping_datadog_helm_to_datadogagent_crd_v2.yaml
+++ b/tools/yaml-mapper/mapping_datadog_helm_to_datadogagent_crd_v2.yaml
@@ -101,7 +101,9 @@ agents.image.repository: "" # TODO: add support
 agents.image.tag: spec.override.nodeAgent.image.tag
 agents.image.tagSuffix: ""
 agents.localService.forceLocalServiceEnabled: spec.global.localService.forceEnableLocalService
-agents.localService.overrideName: spec.global.localService.nameOverride
+agents.localService.overrideName: 
+  newPath: spec.global.localService.nameOverride
+  mapFunc: mapLocalServiceName
 agents.networkPolicy.create: spec.global.networkPolicy.create
 agents.nodeSelector: spec.override.nodeAgent.nodeSelector
 agents.podAnnotations: spec.override.nodeAgent.annotations
@@ -543,7 +545,9 @@ datadog.serviceMonitoring.tls.istio.enabled: ""
 datadog.serviceMonitoring.tls.native.enabled: ""
 datadog.serviceMonitoring.tls.nodejs.enabled: ""
 datadog.site: spec.global.site
-datadog.systemProbe.apparmor: spec.override.nodeAgent.containers.system-probe.appArmorProfileName
+datadog.systemProbe.apparmor:
+  newPath: spec.override.nodeAgent.containers.system-probe.appArmorProfileName
+  mapFunc: mapSystemProbeAppArmor
 datadog.systemProbe.bpfDebug: ""
 datadog.systemProbe.btfPath: ""
 datadog.systemProbe.collectDNSStats: spec.features.npm.collectDNSStats

--- a/tools/yaml-mapper/mapping_datadog_helm_to_datadogagent_crd_v2.yaml
+++ b/tools/yaml-mapper/mapping_datadog_helm_to_datadogagent_crd_v2.yaml
@@ -57,20 +57,20 @@ agents.containers.otelAgent.ports: spec.features.otelCollector.ports
 agents.containers.otelAgent.volumeMounts: ""
 agents.containers.processAgent.env: spec.override.nodeAgent.containers.process-agent.env
 agents.containers.processAgent.envDict: "" # TODO: env dict support?
-agents.containers.processAgent.envFrom: spec.override.nodeAgent.containers.process-agent.envFrom
+agents.containers.processAgent.envFrom: "" # TODO: add support
 agents.containers.processAgent.logLevel: spec.override.nodeAgent.containers.process-agent.logLevel
 agents.containers.processAgent.ports: spec.override.nodeAgent.containers.process-agent.ports
 agents.containers.processAgent.resources: spec.override.nodeAgent.containers.process-agent.resources
 agents.containers.processAgent.securityContext: spec.override.nodeAgent.containers.process-agent.securityContext
 agents.containers.securityAgent.env: spec.override.nodeAgent.containers.security-agent.env
 agents.containers.securityAgent.envDict: ""
-agents.containers.securityAgent.envFrom: spec.override.nodeAgent.containers.security-agent.envFrom
+agents.containers.securityAgent.envFrom: "" # TODO: add support
 agents.containers.securityAgent.logLevel: spec.override.nodeAgent.containers.security-agent.logLevel
 agents.containers.securityAgent.ports: spec.override.nodeAgent.containers.security-agent.ports
 agents.containers.securityAgent.resources: spec.override.nodeAgent.containers.security-agent.resources
 agents.containers.systemProbe.env: spec.override.nodeAgent.containers.system-probe.env
 agents.containers.systemProbe.envDict: ""
-agents.containers.systemProbe.envFrom: spec.override.nodeAgent.containers.system-probe.envFrom
+agents.containers.systemProbe.envFrom: "" # TODO: add support
 agents.containers.systemProbe.logLevel: spec.override.nodeAgent.containers.system-probe.logLevel
 agents.containers.systemProbe.ports: spec.override.nodeAgent.containers.system-probe.ports
 agents.containers.systemProbe.resources: spec.override.nodeAgent.containers.system-probe.resources
@@ -79,7 +79,7 @@ agents.containers.systemProbe.securityContext.capabilities.add: spec.override.no
 agents.containers.systemProbe.securityContext.privileged: spec.override.nodeAgent.containers.system-probe.securityContext.privileged
 agents.containers.traceAgent.env: spec.override.nodeAgent.containers.trace-agent.env
 agents.containers.traceAgent.envDict: ""
-agents.containers.traceAgent.envFrom: spec.override.nodeAgent.containers.trace-agent.envFrom
+agents.containers.traceAgent.envFrom: "" # TODO: add support
 agents.containers.traceAgent.livenessProbe: spec.override.nodeAgent.containers.trace-agent.livenessProbe
 agents.containers.traceAgent.livenessProbe.initialDelaySeconds: spec.override.nodeAgent.containers.trace-agent.livenessProbe.initialDelaySeconds
 agents.containers.traceAgent.livenessProbe.periodSeconds: spec.override.nodeAgent.containers.trace-agent.livenessProbe.periodSeconds

--- a/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper.go
+++ b/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper.go
@@ -330,6 +330,7 @@ var customMapFuncs = map[string]customMapFunc{
 	"mapApiSecretKey":   mapApiSecretKey,
 	"mapAppSecretKey":   mapAppSecretKey,
 	"mapTokenSecretKey": mapTokenSecretKey,
+	"mapSeccompProfile": mapSeccompProfile,
 }
 
 type customMapFunc func(values map[string]interface{}, newPath string, pathVal interface{})
@@ -348,6 +349,26 @@ func mapAppSecretKey(interim map[string]interface{}, newPath string, pathVal int
 func mapTokenSecretKey(interim map[string]interface{}, newPath string, pathVal interface{}) {
 	interim[newPath] = pathVal
 	interim["spec.global.clusterAgentTokenSecret.keyName"] = "token"
+}
+
+func mapSeccompProfile(interim map[string]interface{}, newPath string, pathVal interface{}) {
+	seccompValue, ok := pathVal.(string)
+	if !ok {
+		return
+	}
+
+	if strings.HasPrefix(seccompValue, "localhost/") {
+		profileName := strings.TrimPrefix(seccompValue, "localhost/")
+		interim[newPath+".type"] = "Localhost"
+		interim[newPath+".localhostProfile"] = profileName
+
+	} else if seccompValue == "runtime/default" {
+		interim[newPath+".type"] = "RuntimeDefault"
+
+	} else if seccompValue == "unconfined" {
+		interim[newPath+".type"] = "Unconfined"
+
+	}
 }
 
 func fetchUrl(ctx context.Context, url string) (*http.Response, error) {

--- a/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper.go
+++ b/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper.go
@@ -354,8 +354,8 @@ func mapTokenSecretKey(interim map[string]interface{}, newPath string, pathVal i
 }
 
 func mapSeccompProfile(interim map[string]interface{}, newPath string, pathVal interface{}) {
-	seccompValue, ok := pathVal.(string)
-	if !ok {
+	seccompValue, err := pathVal.(string)
+	if !err {
 		return
 	}
 
@@ -374,8 +374,9 @@ func mapSeccompProfile(interim map[string]interface{}, newPath string, pathVal i
 }
 
 func mapSystemProbeAppArmor(interim map[string]interface{}, newPath string, pathVal interface{}) {
-	appArmorValue, ok := pathVal.(string)
-	if !ok || appArmorValue == "" {
+	appArmorValue, err := pathVal.(string)
+	if !err || appArmorValue == "" {
+		// must be set to non-empty string
 		return
 	}
 
@@ -410,19 +411,17 @@ func mapSystemProbeAppArmor(interim map[string]interface{}, newPath string, path
 	}
 
 	if hasSystemProbeFeature {
+		// must be set to non-empty string
 		interim[newPath] = appArmorValue
 	}
 }
 
 func mapLocalServiceName(interim map[string]interface{}, newPath string, pathVal interface{}) {
 	nameOverride, ok := pathVal.(string)
-	if !ok {
+	if !ok || nameOverride == "" {
 		return
 	}
-
-	if nameOverride != "" {
-		interim[newPath] = nameOverride
-	}
+	interim[newPath] = nameOverride
 }
 
 func fetchUrl(ctx context.Context, url string) (*http.Response, error) {

--- a/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper_test.go
+++ b/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper_test.go
@@ -349,7 +349,7 @@ func TestMergeMaps(t *testing.T) {
 func TestCustomMapFuncs(t *testing.T) {
 	// Test that all custom map functions are properly registered
 	t.Run("customMapFuncs_dict", func(t *testing.T) {
-		expectedFuncs := []string{"mapApiSecretKey", "mapAppSecretKey", "mapTokenSecretKey"}
+		expectedFuncs := []string{"mapApiSecretKey", "mapAppSecretKey", "mapTokenSecretKey", "mapSeccompProfile"}
 
 		for _, funcName := range expectedFuncs {
 			t.Run(funcName+"_exists", func(t *testing.T) {
@@ -494,6 +494,38 @@ func TestCustomMapFuncs(t *testing.T) {
 			expectedMap: map[string]interface{}{
 				"spec.global.clusterAgentTokenSecret.secretName": "new-token-secret",
 				"spec.global.clusterAgentTokenSecret.keyName":    "token",
+			},
+		},
+		// mapSeccompProfile tests
+		{
+			name:     "mapSeccompProfile_localhost",
+			funcName: "mapSeccompProfile",
+			interim:  map[string]interface{}{},
+			newPath:  "spec.override.nodeAgent.containers.system-probe.securityContext.seccompProfile",
+			pathVal:  "localhost/system-probe",
+			expectedMap: map[string]interface{}{
+				"spec.override.nodeAgent.containers.system-probe.securityContext.seccompProfile.type":             "Localhost",
+				"spec.override.nodeAgent.containers.system-probe.securityContext.seccompProfile.localhostProfile": "system-probe",
+			},
+		},
+		{
+			name:     "mapSeccompProfile_runtime_default",
+			funcName: "mapSeccompProfile",
+			interim:  map[string]interface{}{},
+			newPath:  "spec.override.nodeAgent.containers.system-probe.securityContext.seccompProfile",
+			pathVal:  "runtime/default",
+			expectedMap: map[string]interface{}{
+				"spec.override.nodeAgent.containers.system-probe.securityContext.seccompProfile.type": "RuntimeDefault",
+			},
+		},
+		{
+			name:     "mapSeccompProfile_unconfined",
+			funcName: "mapSeccompProfile",
+			interim:  map[string]interface{}{},
+			newPath:  "spec.override.nodeAgent.containers.system-probe.securityContext.seccompProfile",
+			pathVal:  "unconfined",
+			expectedMap: map[string]interface{}{
+				"spec.override.nodeAgent.containers.system-probe.securityContext.seccompProfile.type": "Unconfined",
 			},
 		},
 	}

--- a/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper_test.go
+++ b/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/helm-charts/test/common"
+	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"
@@ -78,6 +79,30 @@ func Test(t *testing.T) {
 			defer cleanUpDatadog()
 			time.Sleep(60 * time.Second)
 
+			t.Log("Finding datadog release name...")
+			helmListOutput, err := helm.RunHelmCommandAndGetOutputE(t, &helm.Options{KubectlOptions: kubectlOptions}, "list", "-n", namespaceName, "--short")
+			require.NoError(t, err, "failed to list helm releases")
+
+			var datadogReleaseName string
+			releaseNames := strings.Split(strings.TrimSpace(helmListOutput), "\n")
+			for _, releaseName := range releaseNames {
+				releaseName = strings.TrimSpace(releaseName)
+				if strings.HasPrefix(releaseName, tt.command.ReleaseName+"-") {
+					datadogReleaseName = releaseName
+					break
+				}
+			}
+			require.NotEmpty(t, datadogReleaseName, "could not find datadog release")
+			t.Log("Found datadog release name:", datadogReleaseName)
+
+			valuesCmd := common.HelmCommand{
+				ReleaseName: datadogReleaseName,
+			}
+			actualValuesFilePath := common.GetFullValues(t, valuesCmd, namespaceName)
+			defer os.Remove(actualValuesFilePath)
+
+			t.Log("GetFullValues created temp file:", actualValuesFilePath)
+
 			cleanUpOperator := common.InstallChart(t, kubectlOptions, common.HelmCommand{
 				ReleaseName: "datadog-operator",
 				ChartPath:   "../../../../charts/datadog-operator",
@@ -85,7 +110,7 @@ func Test(t *testing.T) {
 			defer cleanUpOperator()
 
 			for _, assertion := range tt.assertions {
-				assertion(t, kubectlOptions, tt.valuesPath, namespaceName)
+				assertion(t, kubectlOptions, actualValuesFilePath, namespaceName)
 			}
 
 		})
@@ -111,6 +136,13 @@ func verifyAgentConf(t *testing.T, kubectlOptions *k8s.KubectlOptions, valuesPat
 	helmAgentPods, err := k8s.ListPodsE(t, kubectlOptions, metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=agent,app.kubernetes.io/managed-by=Helm"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, helmAgentPods)
+
+	t.Logf("HELM PODS: Found %d pods with Helm labels", len(helmAgentPods))
+	for i, pod := range helmAgentPods {
+		t.Logf("  Helm Pod %d: %s (Labels: %v)", i, pod.Name, pod.Labels)
+	}
+
+	t.Logf("HELM EXEC: Running 'agent config' on pod: %s", helmAgentPods[0].Name)
 	helmAgentConf, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, []string{"exec", helmAgentPods[0].Name, "--", "agent", "config"}...)
 	require.NoError(t, err)
 	helmAgentConf = normalizeAgentConf(helmAgentConf)
@@ -124,9 +156,14 @@ func verifyAgentConf(t *testing.T, kubectlOptions *k8s.KubectlOptions, valuesPat
 	time.Sleep(60 * time.Second)
 
 	// Get agent conf from operator install
-	operatorAgentPods, err := k8s.ListPodsE(t, kubectlOptions, metav1.ListOptions{})
-
+	operatorAgentPods, err := k8s.ListPodsE(t, kubectlOptions, metav1.ListOptions{LabelSelector: "agent.datadoghq.com/component=agent,app.kubernetes.io/managed-by=datadog-operator"})
 	require.NoError(t, err)
+
+	t.Logf("OPERATOR PODS: Found %d pods with operator labels", len(operatorAgentPods))
+	for i, pod := range operatorAgentPods {
+		t.Logf("  Operator Pod %d: %s (Labels: %v)", i, pod.Name, pod.Labels)
+	}
+
 	assert.NotEmpty(t, operatorAgentPods)
 	operatorAgentConf, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, []string{"exec", operatorAgentPods[0].Name, "--", "agent", "config"}...)
 	require.NoError(t, err)
@@ -349,7 +386,7 @@ func TestMergeMaps(t *testing.T) {
 func TestCustomMapFuncs(t *testing.T) {
 	// Test that all custom map functions are properly registered
 	t.Run("customMapFuncs_dict", func(t *testing.T) {
-		expectedFuncs := []string{"mapApiSecretKey", "mapAppSecretKey", "mapTokenSecretKey", "mapSeccompProfile"}
+		expectedFuncs := []string{"mapApiSecretKey", "mapAppSecretKey", "mapTokenSecretKey", "mapSeccompProfile", "mapSystemProbeAppArmor", "mapLocalServiceName"}
 
 		for _, funcName := range expectedFuncs {
 			t.Run(funcName+"_exists", func(t *testing.T) {

--- a/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper_test.go
+++ b/tools/yaml-mapper/pkg/yamlmapper/yaml_mapper_test.go
@@ -565,6 +565,120 @@ func TestCustomMapFuncs(t *testing.T) {
 				"spec.override.nodeAgent.containers.system-probe.securityContext.seccompProfile.type": "Unconfined",
 			},
 		},
+		// mapSystemProbeAppArmor tests
+		{
+			name:     "mapSystemProbeAppArmor_no_features_enabled",
+			funcName: "mapSystemProbeAppArmor",
+			interim: map[string]interface{}{
+				"spec.features.cws.enabled": false,
+				"spec.features.npm.enabled": false,
+			},
+			newPath: "spec.override.nodeAgent.containers.system-probe.appArmorProfile",
+			pathVal: "unconfined",
+			expectedMap: map[string]interface{}{
+				"spec.features.cws.enabled": false,
+				"spec.features.npm.enabled": false,
+			},
+		},
+		{
+			name:     "mapSystemProbeAppArmor_multiple_features_enabled",
+			funcName: "mapSystemProbeAppArmor",
+			interim: map[string]interface{}{
+				"spec.features.cws.enabled":            true,
+				"spec.features.npm.enabled":            false,
+				"spec.features.tcpQueueLength.enabled": true,
+			},
+			newPath: "spec.override.nodeAgent.containers.system-probe.appArmorProfile",
+			pathVal: "unconfined",
+			expectedMap: map[string]interface{}{
+				"spec.features.cws.enabled":                                       true,
+				"spec.features.npm.enabled":                                       false,
+				"spec.features.tcpQueueLength.enabled":                            true,
+				"spec.override.nodeAgent.containers.system-probe.appArmorProfile": "unconfined",
+			},
+		},
+		{
+			name:     "mapSystemProbeAppArmor_gpu_enabled_privileged",
+			funcName: "mapSystemProbeAppArmor",
+			interim: map[string]interface{}{
+				"spec.features.gpu.enabled":        true,
+				"spec.features.gpu.privilegedMode": true,
+			},
+			newPath: "spec.override.nodeAgent.containers.system-probe.appArmorProfile",
+			pathVal: "unconfined",
+			expectedMap: map[string]interface{}{
+				"spec.features.gpu.enabled":                                       true,
+				"spec.features.gpu.privilegedMode":                                true,
+				"spec.override.nodeAgent.containers.system-probe.appArmorProfile": "unconfined",
+			},
+		},
+		{
+			name:     "mapSystemProbeAppArmor_gpu_enabled_not_privileged",
+			funcName: "mapSystemProbeAppArmor",
+			interim: map[string]interface{}{
+				"spec.features.gpu.enabled":        true,
+				"spec.features.gpu.privilegedMode": false,
+			},
+			newPath: "spec.override.nodeAgent.containers.system-probe.appArmorProfile",
+			pathVal: "unconfined",
+			expectedMap: map[string]interface{}{
+				"spec.features.gpu.enabled":        true,
+				"spec.features.gpu.privilegedMode": false,
+			},
+		},
+		{
+			name:     "mapSystemProbeAppArmor_empty_apparmor_value",
+			funcName: "mapSystemProbeAppArmor",
+			interim: map[string]interface{}{
+				"spec.features.cws.enabled": true,
+			},
+			newPath: "spec.override.nodeAgent.containers.system-probe.appArmorProfile",
+			pathVal: "",
+			expectedMap: map[string]interface{}{
+				"spec.features.cws.enabled": true,
+			},
+		},
+		{
+			name:     "mapSystemProbeAppArmor_invalid_apparmor_type",
+			funcName: "mapSystemProbeAppArmor",
+			interim: map[string]interface{}{
+				"spec.features.cws.enabled": true,
+			},
+			newPath: "spec.override.nodeAgent.containers.system-probe.appArmorProfile",
+			pathVal: 123,
+			expectedMap: map[string]interface{}{
+				"spec.features.cws.enabled": true,
+			},
+		},
+		// mapLocalServiceName tests
+		{
+			name:        "mapLocalServiceName_empty_name",
+			funcName:    "mapLocalServiceName",
+			interim:     map[string]interface{}{},
+			newPath:     "spec.override.clusterAgent.config.external_metrics.local_service_name",
+			pathVal:     "",
+			expectedMap: map[string]interface{}{},
+		},
+		{
+			name:        "mapLocalServiceName_invalid_type",
+			funcName:    "mapLocalServiceName",
+			interim:     map[string]interface{}{},
+			newPath:     "spec.override.clusterAgent.config.external_metrics.local_service_name",
+			pathVal:     123,
+			expectedMap: map[string]interface{}{},
+		},
+		{
+			name:     "mapLocalServiceName_overwrite_existing",
+			funcName: "mapLocalServiceName",
+			interim: map[string]interface{}{
+				"spec.override.clusterAgent.config.external_metrics.local_service_name": "old-service",
+			},
+			newPath: "spec.override.clusterAgent.config.external_metrics.local_service_name",
+			pathVal: "new-service",
+			expectedMap: map[string]interface{}{
+				"spec.override.clusterAgent.config.external_metrics.local_service_name": "new-service",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
