### PR TITLE
fix(octo-sts): Adapt the chainguard and fix the issue state check

### DIFF
--- a/.github/chainguard/self.stale.manage-stale.sts.yaml
+++ b/.github/chainguard/self.stale.manage-stale.sts.yaml
@@ -7,7 +7,7 @@ claim_pattern:
   event_name: (workflow_dispatch|schedule)
   ref: refs/heads/main
   ref_protected: "true"
-  job_workflow_ref: DataDog/helm-charts/\.github/workflows/stale\.yml@refs/heads/main
+  job_workflow_ref: DataDog/helm-charts/\.github/workflows/stale\.yaml@refs/heads/main
 
 permissions:
   actions: write

--- a/.github/workflows/check-issue-status.yaml
+++ b/.github/workflows/check-issue-status.yaml
@@ -1,4 +1,6 @@
 ---
+name: Check if datadog member commented the issue
+
 on:
   issue_comment:
     types: [created]
@@ -6,6 +8,7 @@ on:
 jobs:
   check_comment:
     runs-on: ubuntu-latest
+    if: github.event.issue.pull_request == null
     steps:
       - name: Check if there is a comment from a datadog member
         id: datadog-comment
@@ -51,8 +54,10 @@ jobs:
             for (const label of labels.data) {
               if (label.name === 'pending') {
                 await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: label.name
-            });
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label.name
+                });
+              }
+            }


### PR DESCRIPTION
#### What this PR does / why we need it:
- Add missing parenthesis on the check_issue_state workflow
- Add a name in this workflow
- Fix the typo related to the file extension which prevents current execution of the job

#### Which issue this PR fixes
Fixes [failed workflow](https://github.com/DataDog/helm-charts/actions/runs/18277235095/job/52032051290) for stale management

This is a follow-up of #2073 
