### PR TITLE
[AGENTRUN-741] Update FIPS proxy version references to 1.1.17

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.138.1
+
+* Update `fips.image.tag` to `1.1.17` fixing CVEs and updating packages.
+
+
 ## 3.138.0
 
 * [CONTP-977] Bump Datadog CSI Driver chart dependency version. ([#2042](https://github.com/DataDog/helm-charts/pull/2042)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.138.0
+version: 3.138.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.138.0](https://img.shields.io/badge/Version-3.138.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.138.1](https://img.shields.io/badge/Version-3.138.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -957,7 +957,7 @@ helm install <RELEASE_NAME> \
 | fips.image.name | string | `"fips-proxy"` |  |
 | fips.image.pullPolicy | string | `"IfNotPresent"` | Datadog the FIPS sidecar image pull policy |
 | fips.image.repository | string | `nil` | Override default registry + image.name for the FIPS sidecar container. |
-| fips.image.tag | string | `"1.1.16"` | Define the FIPS sidecar container version to use. |
+| fips.image.tag | string | `"1.1.17"` | Define the FIPS sidecar container version to use. |
 | fips.local_address | string | `"127.0.0.1"` | Set local IP address. This setting is only used for the fips-proxy sidecar. |
 | fips.port | int | `9803` | Specifies which port is used by the containers to communicate to the FIPS sidecar. This setting is only used for the fips-proxy sidecar. |
 | fips.portRange | int | `15` | Specifies the number of ports used, defaults to 13 https://github.com/DataDog/datadog-agent/blob/7.44.x/pkg/config/config.go#L1564-L1577. This setting is only used for the fips-proxy sidecar. |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1755,7 +1755,7 @@ fips:
     name: fips-proxy
 
     # fips.image.tag -- Define the FIPS sidecar container version to use.
-    tag: 1.1.16
+    tag: 1.1.17
 
     # fips.image.pullPolicy -- Datadog the FIPS sidecar image pull policy
     pullPolicy: IfNotPresent


### PR DESCRIPTION
#### What this PR does / why we need it:

Update FIPS Proxy version to 1.1.17 fixing CVEs and updating packages

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
