### PR TITLE
Update crds for operator 1.20.0-rc.1

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.13.0-dev.1
+
+* Update CRDs from Datadog Operator v1.20.0-rc.1 release candidate tag.
+
 ## 2.12.0
 
 * Update CRDs from Datadog Operator v1.19.0 release candidate tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.12.0
+version: 2.13.0-dev.1
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.12.0](https://img.shields.io/badge/Version-2.12.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.13.0-dev.1](https://img.shields.io/badge/Version-2.13.0--dev.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentinternals_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentinternals_v1.yaml
@@ -1533,6 +1533,163 @@ spec:
                     kubeStateMetricsCore:
                       description: KubeStateMetricsCore check configuration.
                       properties:
+                        collectCrMetrics:
+                          description: |-
+                            `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                            The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                            The exact structure and existing fields of each item in this list can be found in:
+                            https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                          items:
+                            description: Resource configures a custom resource for metric generation.
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels are added to all metrics.
+                                type: object
+                              groupVersionKind:
+                                description: GroupVersionKind of the custom resource to be monitored.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                type: object
+                              metricNamePrefix:
+                                description: |-
+                                  MetricNamePrefix defines a prefix for all metrics of the resource.
+                                  If set to "", no prefix will be added.
+                                  Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                                type: string
+                              metrics:
+                                description: Metrics are the custom resource fields to be collected.
+                                items:
+                                  description: Generator describes a unique metric name.
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: CommonLabels are added to all metrics.
+                                      type: object
+                                    each:
+                                      description: Each targets a value or values from the resource.
+                                      properties:
+                                        gauge:
+                                          description: Gauge defines a gauge metric.
+                                          properties:
+                                            labelFromKey:
+                                              description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                              type: object
+                                            nilIsZero:
+                                              description: NilIsZero indicates that if a value is nil it will be treated as zero value.
+                                              type: boolean
+                                            path:
+                                              description: Path is the path to to generate metric(s) for.
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              description: ValueFrom is the path to a numeric field under Path that will be the metric value.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          description: Info defines an info metric.
+                                          properties:
+                                            labelFromKey:
+                                              description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                              type: object
+                                            path:
+                                              description: Path is the path to to generate metric(s) for.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          description: StateSet defines a state set metric.
+                                          properties:
+                                            labelName:
+                                              description: LabelName is the key of the label which is used for each entry in List to expose the value.
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                              type: object
+                                            list:
+                                              description: List is the list of values to expose a value for.
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              description: Path is the path to to generate metric(s) for.
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              description: ValueFrom is the subpath to compare the list to.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          description: Type defines the type of the metric.
+                                          type: string
+                                      type: object
+                                    help:
+                                      description: Help text for the metric.
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                      type: object
+                                    name:
+                                      description: Name of the metric. Subject to prefixing based on the configuration of the Resource.
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                description: ResourcePlural sets the plural name of the resource. Defaults to the plural version of the Kind according to flect.Pluralize.
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         conf:
                           description: |-
                             Conf overrides the configuration for the default Kubernetes State Metrics Core check.
@@ -9160,6 +9317,163 @@ spec:
                         kubeStateMetricsCore:
                           description: KubeStateMetricsCore check configuration.
                           properties:
+                            collectCrMetrics:
+                              description: |-
+                                `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                                The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                                The exact structure and existing fields of each item in this list can be found in:
+                                https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                              items:
+                                description: Resource configures a custom resource for metric generation.
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels are added to all metrics.
+                                    type: object
+                                  groupVersionKind:
+                                    description: GroupVersionKind of the custom resource to be monitored.
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                    type: object
+                                  metricNamePrefix:
+                                    description: |-
+                                      MetricNamePrefix defines a prefix for all metrics of the resource.
+                                      If set to "", no prefix will be added.
+                                      Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                                    type: string
+                                  metrics:
+                                    description: Metrics are the custom resource fields to be collected.
+                                    items:
+                                      description: Generator describes a unique metric name.
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels are added to all metrics.
+                                          type: object
+                                        each:
+                                          description: Each targets a value or values from the resource.
+                                          properties:
+                                            gauge:
+                                              description: Gauge defines a gauge metric.
+                                              properties:
+                                                labelFromKey:
+                                                  description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                nilIsZero:
+                                                  description: NilIsZero indicates that if a value is nil it will be treated as zero value.
+                                                  type: boolean
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  description: ValueFrom is the path to a numeric field under Path that will be the metric value.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              description: Info defines an info metric.
+                                              properties:
+                                                labelFromKey:
+                                                  description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              description: StateSet defines a state set metric.
+                                              properties:
+                                                labelName:
+                                                  description: LabelName is the key of the label which is used for each entry in List to expose the value.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                list:
+                                                  description: List is the list of values to expose a value for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  description: ValueFrom is the subpath to compare the list to.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              description: Type defines the type of the metric.
+                                              type: string
+                                          type: object
+                                        help:
+                                          description: Help text for the metric.
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                          type: object
+                                        name:
+                                          description: Name of the metric. Subject to prefixing based on the configuration of the Resource.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    description: ResourcePlural sets the plural name of the resource. Defaults to the plural version of the Kind according to flect.Pluralize.
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             conf:
                               description: |-
                                 Conf overrides the configuration for the default Kubernetes State Metrics Core check.

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
@@ -1533,6 +1533,163 @@ spec:
                         kubeStateMetricsCore:
                           description: KubeStateMetricsCore check configuration.
                           properties:
+                            collectCrMetrics:
+                              description: |-
+                                `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                                The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                                The exact structure and existing fields of each item in this list can be found in:
+                                https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                              items:
+                                description: Resource configures a custom resource for metric generation.
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels are added to all metrics.
+                                    type: object
+                                  groupVersionKind:
+                                    description: GroupVersionKind of the custom resource to be monitored.
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                    type: object
+                                  metricNamePrefix:
+                                    description: |-
+                                      MetricNamePrefix defines a prefix for all metrics of the resource.
+                                      If set to "", no prefix will be added.
+                                      Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                                    type: string
+                                  metrics:
+                                    description: Metrics are the custom resource fields to be collected.
+                                    items:
+                                      description: Generator describes a unique metric name.
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels are added to all metrics.
+                                          type: object
+                                        each:
+                                          description: Each targets a value or values from the resource.
+                                          properties:
+                                            gauge:
+                                              description: Gauge defines a gauge metric.
+                                              properties:
+                                                labelFromKey:
+                                                  description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                nilIsZero:
+                                                  description: NilIsZero indicates that if a value is nil it will be treated as zero value.
+                                                  type: boolean
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  description: ValueFrom is the path to a numeric field under Path that will be the metric value.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              description: Info defines an info metric.
+                                              properties:
+                                                labelFromKey:
+                                                  description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              description: StateSet defines a state set metric.
+                                              properties:
+                                                labelName:
+                                                  description: LabelName is the key of the label which is used for each entry in List to expose the value.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                list:
+                                                  description: List is the list of values to expose a value for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  description: ValueFrom is the subpath to compare the list to.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              description: Type defines the type of the metric.
+                                              type: string
+                                          type: object
+                                        help:
+                                          description: Help text for the metric.
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                          type: object
+                                        name:
+                                          description: Name of the metric. Subject to prefixing based on the configuration of the Resource.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    description: ResourcePlural sets the plural name of the resource. Defaults to the plural version of the Kind according to flect.Pluralize.
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             conf:
                               description: |-
                                 Conf overrides the configuration for the default Kubernetes State Metrics Core check.

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -823,6 +823,124 @@ spec:
                       type: object
                     kubeStateMetricsCore:
                       properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         conf:
                           properties:
                             configData:
@@ -4710,6 +4828,124 @@ spec:
                           type: object
                         kubeStateMetricsCore:
                           properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             conf:
                               properties:
                                 configData:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
@@ -329,10 +329,21 @@ spec:
                           value:
                             description: Value is the value of the objective
                             properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               type:
-                                description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
                                 enum:
                                   - Utilization
+                                  - AbsoluteValue
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -348,6 +359,130 @@ spec:
                           - name
                           - value
                         type: object
+                      customQueryObjective:
+                        description: CustomQueryObjective allows to set a controller-level objective.
+                        properties:
+                          query:
+                            description: Query is the timeseries query to use for the objective.
+                            properties:
+                              formulas:
+                                description: Formulas to compute (optional).
+                                items:
+                                  properties:
+                                    formula:
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                    - formula
+                                  type: object
+                                type: array
+                              queries:
+                                items:
+                                  description: TimeseriesQuery is a discriminated union. Only Metrics and APMMetrics are supported for autoscaling.
+                                  properties:
+                                    apm_metrics:
+                                      properties:
+                                        group_by:
+                                          items:
+                                            type: string
+                                          type: array
+                                        operation_name:
+                                          type: string
+                                        query_filter:
+                                          type: string
+                                        resource_hash:
+                                          description: ResourceHash is a fingerprint of the resource name that can be used to identify the resource instead of the resource name.
+                                          type: string
+                                        resource_name:
+                                          type: string
+                                        service:
+                                          type: string
+                                        span_kind:
+                                          type: string
+                                        stat:
+                                          description: DatadogPodAutoscalerApmMetricsStat represents the statistic to compute for an APM metrics query.
+                                          enum:
+                                            - error_rate
+                                            - errors
+                                            - errors_per_second
+                                            - hits
+                                            - hits_per_second
+                                            - apdex
+                                            - latency_avg
+                                            - latency_max
+                                            - latency_p50
+                                            - latency_p75
+                                            - latency_p90
+                                            - latency_p95
+                                            - latency_p99
+                                            - latency_p999
+                                            - latency_distribution
+                                            - total_time
+                                          type: string
+                                      required:
+                                        - stat
+                                      type: object
+                                    metrics:
+                                      properties:
+                                        query:
+                                          description: Classic Datadog metrics query, e.g. "avg:system.cpu.user{*} by {env}".
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                        - query
+                                      type: object
+                                    name:
+                                      description: Optional variable name ("a", "b", etc.) to reference in formulas.
+                                      type: string
+                                    source:
+                                      enum:
+                                        - metrics
+                                        - apm_metrics
+                                      type: string
+                                  required:
+                                    - source
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                              - queries
+                            type: object
+                          value:
+                            description: Value is the value of the objective
+                            properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type:
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                enum:
+                                  - Utilization
+                                  - AbsoluteValue
+                                type: string
+                              utilization:
+                                description: Utilization defines a percentage of the target compared to requested workload
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                            required:
+                              - type
+                            type: object
+                          window:
+                            description: Window is the time duration over which the query is computed. It should contain at least one full sample.
+                            type: string
+                        required:
+                          - query
+                          - value
+                          - window
+                        type: object
                       podResource:
                         description: PodResource allows to set a pod-level resource objective.
                         properties:
@@ -359,10 +494,21 @@ spec:
                           value:
                             description: Value is the value of the objective.
                             properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               type:
-                                description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
                                 enum:
                                   - Utilization
+                                  - AbsoluteValue
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -382,6 +528,7 @@ spec:
                         enum:
                           - PodResource
                           - ContainerResource
+                          - CustomQuery
                         type: string
                     required:
                       - type
@@ -868,6 +1015,233 @@ spec:
                           default: true
                           description: 'Enabled determines whether recommendations should be applied by the controller:'
                           type: boolean
+                        objectives:
+                          description: |-
+                            Objectives are the objectives to reach and maintain for the target resource in fallback mode.
+                            If not set, the regular objectives will be used.
+                          items:
+                            description: DatadogPodAutoscalerObjective defines the objectives to reach and maintain for the target workload.
+                            properties:
+                              containerResource:
+                                description: ContainerResource allows to set a container-level resource objective.
+                                properties:
+                                  container:
+                                    description: Container is the name of the container.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the resource.
+                                    enum:
+                                      - cpu
+                                    type: string
+                                  value:
+                                    description: Value is the value of the objective
+                                    properties:
+                                      absoluteValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                          Use a plain number (e.g., "11" or "11.5").
+                                          Represented as a resource.Quantity to avoid floating point in CRDs.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                        enum:
+                                          - Utilization
+                                          - AbsoluteValue
+                                        type: string
+                                      utilization:
+                                        description: Utilization defines a percentage of the target compared to requested workload
+                                        format: int32
+                                        maximum: 100
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                      - type
+                                    type: object
+                                required:
+                                  - container
+                                  - name
+                                  - value
+                                type: object
+                              customQueryObjective:
+                                description: CustomQueryObjective allows to set a controller-level objective.
+                                properties:
+                                  query:
+                                    description: Query is the timeseries query to use for the objective.
+                                    properties:
+                                      formulas:
+                                        description: Formulas to compute (optional).
+                                        items:
+                                          properties:
+                                            formula:
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                            - formula
+                                          type: object
+                                        type: array
+                                      queries:
+                                        items:
+                                          description: TimeseriesQuery is a discriminated union. Only Metrics and APMMetrics are supported for autoscaling.
+                                          properties:
+                                            apm_metrics:
+                                              properties:
+                                                group_by:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                operation_name:
+                                                  type: string
+                                                query_filter:
+                                                  type: string
+                                                resource_hash:
+                                                  description: ResourceHash is a fingerprint of the resource name that can be used to identify the resource instead of the resource name.
+                                                  type: string
+                                                resource_name:
+                                                  type: string
+                                                service:
+                                                  type: string
+                                                span_kind:
+                                                  type: string
+                                                stat:
+                                                  description: DatadogPodAutoscalerApmMetricsStat represents the statistic to compute for an APM metrics query.
+                                                  enum:
+                                                    - error_rate
+                                                    - errors
+                                                    - errors_per_second
+                                                    - hits
+                                                    - hits_per_second
+                                                    - apdex
+                                                    - latency_avg
+                                                    - latency_max
+                                                    - latency_p50
+                                                    - latency_p75
+                                                    - latency_p90
+                                                    - latency_p95
+                                                    - latency_p99
+                                                    - latency_p999
+                                                    - latency_distribution
+                                                    - total_time
+                                                  type: string
+                                              required:
+                                                - stat
+                                              type: object
+                                            metrics:
+                                              properties:
+                                                query:
+                                                  description: Classic Datadog metrics query, e.g. "avg:system.cpu.user{*} by {env}".
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                                - query
+                                              type: object
+                                            name:
+                                              description: Optional variable name ("a", "b", etc.) to reference in formulas.
+                                              type: string
+                                            source:
+                                              enum:
+                                                - metrics
+                                                - apm_metrics
+                                              type: string
+                                          required:
+                                            - source
+                                          type: object
+                                        minItems: 1
+                                        type: array
+                                    required:
+                                      - queries
+                                    type: object
+                                  value:
+                                    description: Value is the value of the objective
+                                    properties:
+                                      absoluteValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                          Use a plain number (e.g., "11" or "11.5").
+                                          Represented as a resource.Quantity to avoid floating point in CRDs.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                        enum:
+                                          - Utilization
+                                          - AbsoluteValue
+                                        type: string
+                                      utilization:
+                                        description: Utilization defines a percentage of the target compared to requested workload
+                                        format: int32
+                                        maximum: 100
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                      - type
+                                    type: object
+                                  window:
+                                    description: Window is the time duration over which the query is computed. It should contain at least one full sample.
+                                    type: string
+                                required:
+                                  - query
+                                  - value
+                                  - window
+                                type: object
+                              podResource:
+                                description: PodResource allows to set a pod-level resource objective.
+                                properties:
+                                  name:
+                                    description: Name is the name of the resource.
+                                    enum:
+                                      - cpu
+                                    type: string
+                                  value:
+                                    description: Value is the value of the objective.
+                                    properties:
+                                      absoluteValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                          Use a plain number (e.g., "11" or "11.5").
+                                          Represented as a resource.Quantity to avoid floating point in CRDs.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                        enum:
+                                          - Utilization
+                                          - AbsoluteValue
+                                        type: string
+                                      utilization:
+                                        description: Utilization defines a percentage of the target compared to requested workload
+                                        format: int32
+                                        maximum: 100
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                      - type
+                                    type: object
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type:
+                                description: Type sets the type of the objective.
+                                enum:
+                                  - PodResource
+                                  - ContainerResource
+                                  - CustomQuery
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         triggers:
                           default: {}
                           description: Triggers defines the triggers that will generate recommendations.
@@ -903,10 +1277,21 @@ spec:
                           value:
                             description: Value is the value of the objective
                             properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               type:
-                                description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
                                 enum:
                                   - Utilization
+                                  - AbsoluteValue
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -922,6 +1307,130 @@ spec:
                           - name
                           - value
                         type: object
+                      customQueryObjective:
+                        description: CustomQueryObjective allows to set a controller-level objective.
+                        properties:
+                          query:
+                            description: Query is the timeseries query to use for the objective.
+                            properties:
+                              formulas:
+                                description: Formulas to compute (optional).
+                                items:
+                                  properties:
+                                    formula:
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                    - formula
+                                  type: object
+                                type: array
+                              queries:
+                                items:
+                                  description: TimeseriesQuery is a discriminated union. Only Metrics and APMMetrics are supported for autoscaling.
+                                  properties:
+                                    apm_metrics:
+                                      properties:
+                                        group_by:
+                                          items:
+                                            type: string
+                                          type: array
+                                        operation_name:
+                                          type: string
+                                        query_filter:
+                                          type: string
+                                        resource_hash:
+                                          description: ResourceHash is a fingerprint of the resource name that can be used to identify the resource instead of the resource name.
+                                          type: string
+                                        resource_name:
+                                          type: string
+                                        service:
+                                          type: string
+                                        span_kind:
+                                          type: string
+                                        stat:
+                                          description: DatadogPodAutoscalerApmMetricsStat represents the statistic to compute for an APM metrics query.
+                                          enum:
+                                            - error_rate
+                                            - errors
+                                            - errors_per_second
+                                            - hits
+                                            - hits_per_second
+                                            - apdex
+                                            - latency_avg
+                                            - latency_max
+                                            - latency_p50
+                                            - latency_p75
+                                            - latency_p90
+                                            - latency_p95
+                                            - latency_p99
+                                            - latency_p999
+                                            - latency_distribution
+                                            - total_time
+                                          type: string
+                                      required:
+                                        - stat
+                                      type: object
+                                    metrics:
+                                      properties:
+                                        query:
+                                          description: Classic Datadog metrics query, e.g. "avg:system.cpu.user{*} by {env}".
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                        - query
+                                      type: object
+                                    name:
+                                      description: Optional variable name ("a", "b", etc.) to reference in formulas.
+                                      type: string
+                                    source:
+                                      enum:
+                                        - metrics
+                                        - apm_metrics
+                                      type: string
+                                  required:
+                                    - source
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                              - queries
+                            type: object
+                          value:
+                            description: Value is the value of the objective
+                            properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type:
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                enum:
+                                  - Utilization
+                                  - AbsoluteValue
+                                type: string
+                              utilization:
+                                description: Utilization defines a percentage of the target compared to requested workload
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                            required:
+                              - type
+                            type: object
+                          window:
+                            description: Window is the time duration over which the query is computed. It should contain at least one full sample.
+                            type: string
+                        required:
+                          - query
+                          - value
+                          - window
+                        type: object
                       podResource:
                         description: PodResource allows to set a pod-level resource objective.
                         properties:
@@ -933,10 +1442,21 @@ spec:
                           value:
                             description: Value is the value of the objective.
                             properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               type:
-                                description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
                                 enum:
                                   - Utilization
+                                  - AbsoluteValue
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -956,6 +1476,7 @@ spec:
                         enum:
                           - PodResource
                           - ContainerResource
+                          - CustomQuery
                         type: string
                     required:
                       - type

--- a/crds/datadoghq.com_datadogagentinternals.yaml
+++ b/crds/datadoghq.com_datadogagentinternals.yaml
@@ -1527,6 +1527,163 @@ spec:
                     kubeStateMetricsCore:
                       description: KubeStateMetricsCore check configuration.
                       properties:
+                        collectCrMetrics:
+                          description: |-
+                            `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                            The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                            The exact structure and existing fields of each item in this list can be found in:
+                            https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                          items:
+                            description: Resource configures a custom resource for metric generation.
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels are added to all metrics.
+                                type: object
+                              groupVersionKind:
+                                description: GroupVersionKind of the custom resource to be monitored.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                type: object
+                              metricNamePrefix:
+                                description: |-
+                                  MetricNamePrefix defines a prefix for all metrics of the resource.
+                                  If set to "", no prefix will be added.
+                                  Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                                type: string
+                              metrics:
+                                description: Metrics are the custom resource fields to be collected.
+                                items:
+                                  description: Generator describes a unique metric name.
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: CommonLabels are added to all metrics.
+                                      type: object
+                                    each:
+                                      description: Each targets a value or values from the resource.
+                                      properties:
+                                        gauge:
+                                          description: Gauge defines a gauge metric.
+                                          properties:
+                                            labelFromKey:
+                                              description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                              type: object
+                                            nilIsZero:
+                                              description: NilIsZero indicates that if a value is nil it will be treated as zero value.
+                                              type: boolean
+                                            path:
+                                              description: Path is the path to to generate metric(s) for.
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              description: ValueFrom is the path to a numeric field under Path that will be the metric value.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          description: Info defines an info metric.
+                                          properties:
+                                            labelFromKey:
+                                              description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                              type: object
+                                            path:
+                                              description: Path is the path to to generate metric(s) for.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          description: StateSet defines a state set metric.
+                                          properties:
+                                            labelName:
+                                              description: LabelName is the key of the label which is used for each entry in List to expose the value.
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                              type: object
+                                            list:
+                                              description: List is the list of values to expose a value for.
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              description: Path is the path to to generate metric(s) for.
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              description: ValueFrom is the subpath to compare the list to.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          description: Type defines the type of the metric.
+                                          type: string
+                                      type: object
+                                    help:
+                                      description: Help text for the metric.
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                      type: object
+                                    name:
+                                      description: Name of the metric. Subject to prefixing based on the configuration of the Resource.
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                description: ResourcePlural sets the plural name of the resource. Defaults to the plural version of the Kind according to flect.Pluralize.
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         conf:
                           description: |-
                             Conf overrides the configuration for the default Kubernetes State Metrics Core check.
@@ -9154,6 +9311,163 @@ spec:
                         kubeStateMetricsCore:
                           description: KubeStateMetricsCore check configuration.
                           properties:
+                            collectCrMetrics:
+                              description: |-
+                                `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                                The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                                The exact structure and existing fields of each item in this list can be found in:
+                                https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                              items:
+                                description: Resource configures a custom resource for metric generation.
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels are added to all metrics.
+                                    type: object
+                                  groupVersionKind:
+                                    description: GroupVersionKind of the custom resource to be monitored.
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                    type: object
+                                  metricNamePrefix:
+                                    description: |-
+                                      MetricNamePrefix defines a prefix for all metrics of the resource.
+                                      If set to "", no prefix will be added.
+                                      Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                                    type: string
+                                  metrics:
+                                    description: Metrics are the custom resource fields to be collected.
+                                    items:
+                                      description: Generator describes a unique metric name.
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels are added to all metrics.
+                                          type: object
+                                        each:
+                                          description: Each targets a value or values from the resource.
+                                          properties:
+                                            gauge:
+                                              description: Gauge defines a gauge metric.
+                                              properties:
+                                                labelFromKey:
+                                                  description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                nilIsZero:
+                                                  description: NilIsZero indicates that if a value is nil it will be treated as zero value.
+                                                  type: boolean
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  description: ValueFrom is the path to a numeric field under Path that will be the metric value.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              description: Info defines an info metric.
+                                              properties:
+                                                labelFromKey:
+                                                  description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              description: StateSet defines a state set metric.
+                                              properties:
+                                                labelName:
+                                                  description: LabelName is the key of the label which is used for each entry in List to expose the value.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                list:
+                                                  description: List is the list of values to expose a value for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  description: ValueFrom is the subpath to compare the list to.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              description: Type defines the type of the metric.
+                                              type: string
+                                          type: object
+                                        help:
+                                          description: Help text for the metric.
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                          type: object
+                                        name:
+                                          description: Name of the metric. Subject to prefixing based on the configuration of the Resource.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    description: ResourcePlural sets the plural name of the resource. Defaults to the plural version of the Kind according to flect.Pluralize.
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             conf:
                               description: |-
                                 Conf overrides the configuration for the default Kubernetes State Metrics Core check.

--- a/crds/datadoghq.com_datadogagentprofiles.yaml
+++ b/crds/datadoghq.com_datadogagentprofiles.yaml
@@ -1527,6 +1527,163 @@ spec:
                         kubeStateMetricsCore:
                           description: KubeStateMetricsCore check configuration.
                           properties:
+                            collectCrMetrics:
+                              description: |-
+                                `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                                The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                                The exact structure and existing fields of each item in this list can be found in:
+                                https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                              items:
+                                description: Resource configures a custom resource for metric generation.
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels are added to all metrics.
+                                    type: object
+                                  groupVersionKind:
+                                    description: GroupVersionKind of the custom resource to be monitored.
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                    type: object
+                                  metricNamePrefix:
+                                    description: |-
+                                      MetricNamePrefix defines a prefix for all metrics of the resource.
+                                      If set to "", no prefix will be added.
+                                      Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                                    type: string
+                                  metrics:
+                                    description: Metrics are the custom resource fields to be collected.
+                                    items:
+                                      description: Generator describes a unique metric name.
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels are added to all metrics.
+                                          type: object
+                                        each:
+                                          description: Each targets a value or values from the resource.
+                                          properties:
+                                            gauge:
+                                              description: Gauge defines a gauge metric.
+                                              properties:
+                                                labelFromKey:
+                                                  description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                nilIsZero:
+                                                  description: NilIsZero indicates that if a value is nil it will be treated as zero value.
+                                                  type: boolean
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  description: ValueFrom is the path to a numeric field under Path that will be the metric value.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              description: Info defines an info metric.
+                                              properties:
+                                                labelFromKey:
+                                                  description: LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              description: StateSet defines a state set metric.
+                                              properties:
+                                                labelName:
+                                                  description: LabelName is the key of the label which is used for each entry in List to expose the value.
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+                                                  type: object
+                                                list:
+                                                  description: List is the list of values to expose a value for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  description: Path is the path to to generate metric(s) for.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  description: ValueFrom is the subpath to compare the list to.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              description: Type defines the type of the metric.
+                                              type: string
+                                          type: object
+                                        help:
+                                          description: Help text for the metric.
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          description: LabelsFromPath adds additional labels where the value is taken from a field in the resource.
+                                          type: object
+                                        name:
+                                          description: Name of the metric. Subject to prefixing based on the configuration of the Resource.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    description: ResourcePlural sets the plural name of the resource. Defaults to the plural version of the Kind according to flect.Pluralize.
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             conf:
                               description: |-
                                 Conf overrides the configuration for the default Kubernetes State Metrics Core check.

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -817,6 +817,124 @@ spec:
                       type: object
                     kubeStateMetricsCore:
                       properties:
+                        collectCrMetrics:
+                          items:
+                            properties:
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              groupVersionKind:
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                              labelsFromPath:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                type: object
+                              metricNamePrefix:
+                                type: string
+                              metrics:
+                                items:
+                                  properties:
+                                    commonLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    each:
+                                      properties:
+                                        gauge:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            nilIsZero:
+                                              type: boolean
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        info:
+                                          properties:
+                                            labelFromKey:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        stateSet:
+                                          properties:
+                                            labelName:
+                                              type: string
+                                            labelsFromPath:
+                                              additionalProperties:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              type: object
+                                            list:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              items:
+                                                type: string
+                                              type: array
+                                            valueFrom:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - path
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                    help:
+                                      type: string
+                                    labelsFromPath:
+                                      additionalProperties:
+                                        items:
+                                          type: string
+                                        type: array
+                                      type: object
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              resourcePlural:
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         conf:
                           properties:
                             configData:
@@ -4704,6 +4822,124 @@ spec:
                           type: object
                         kubeStateMetricsCore:
                           properties:
+                            collectCrMetrics:
+                              items:
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  groupVersionKind:
+                                    properties:
+                                      group:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      version:
+                                        type: string
+                                    type: object
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    type: object
+                                  metricNamePrefix:
+                                    type: string
+                                  metrics:
+                                    items:
+                                      properties:
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        each:
+                                          properties:
+                                            gauge:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                nilIsZero:
+                                                  type: boolean
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            info:
+                                              properties:
+                                                labelFromKey:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            stateSet:
+                                              properties:
+                                                labelName:
+                                                  type: string
+                                                labelsFromPath:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  type: object
+                                                list:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                valueFrom:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - path
+                                              type: object
+                                            type:
+                                              type: string
+                                          type: object
+                                        help:
+                                          type: string
+                                        labelsFromPath:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          type: object
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourcePlural:
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             conf:
                               properties:
                                 configData:

--- a/crds/datadoghq.com_datadogpodautoscalers.yaml
+++ b/crds/datadoghq.com_datadogpodautoscalers.yaml
@@ -323,10 +323,21 @@ spec:
                           value:
                             description: Value is the value of the objective
                             properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               type:
-                                description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
                                 enum:
                                   - Utilization
+                                  - AbsoluteValue
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -342,6 +353,130 @@ spec:
                           - name
                           - value
                         type: object
+                      customQueryObjective:
+                        description: CustomQueryObjective allows to set a controller-level objective.
+                        properties:
+                          query:
+                            description: Query is the timeseries query to use for the objective.
+                            properties:
+                              formulas:
+                                description: Formulas to compute (optional).
+                                items:
+                                  properties:
+                                    formula:
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                    - formula
+                                  type: object
+                                type: array
+                              queries:
+                                items:
+                                  description: TimeseriesQuery is a discriminated union. Only Metrics and APMMetrics are supported for autoscaling.
+                                  properties:
+                                    apm_metrics:
+                                      properties:
+                                        group_by:
+                                          items:
+                                            type: string
+                                          type: array
+                                        operation_name:
+                                          type: string
+                                        query_filter:
+                                          type: string
+                                        resource_hash:
+                                          description: ResourceHash is a fingerprint of the resource name that can be used to identify the resource instead of the resource name.
+                                          type: string
+                                        resource_name:
+                                          type: string
+                                        service:
+                                          type: string
+                                        span_kind:
+                                          type: string
+                                        stat:
+                                          description: DatadogPodAutoscalerApmMetricsStat represents the statistic to compute for an APM metrics query.
+                                          enum:
+                                            - error_rate
+                                            - errors
+                                            - errors_per_second
+                                            - hits
+                                            - hits_per_second
+                                            - apdex
+                                            - latency_avg
+                                            - latency_max
+                                            - latency_p50
+                                            - latency_p75
+                                            - latency_p90
+                                            - latency_p95
+                                            - latency_p99
+                                            - latency_p999
+                                            - latency_distribution
+                                            - total_time
+                                          type: string
+                                      required:
+                                        - stat
+                                      type: object
+                                    metrics:
+                                      properties:
+                                        query:
+                                          description: Classic Datadog metrics query, e.g. "avg:system.cpu.user{*} by {env}".
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                        - query
+                                      type: object
+                                    name:
+                                      description: Optional variable name ("a", "b", etc.) to reference in formulas.
+                                      type: string
+                                    source:
+                                      enum:
+                                        - metrics
+                                        - apm_metrics
+                                      type: string
+                                  required:
+                                    - source
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                              - queries
+                            type: object
+                          value:
+                            description: Value is the value of the objective
+                            properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type:
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                enum:
+                                  - Utilization
+                                  - AbsoluteValue
+                                type: string
+                              utilization:
+                                description: Utilization defines a percentage of the target compared to requested workload
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                            required:
+                              - type
+                            type: object
+                          window:
+                            description: Window is the time duration over which the query is computed. It should contain at least one full sample.
+                            type: string
+                        required:
+                          - query
+                          - value
+                          - window
+                        type: object
                       podResource:
                         description: PodResource allows to set a pod-level resource objective.
                         properties:
@@ -353,10 +488,21 @@ spec:
                           value:
                             description: Value is the value of the objective.
                             properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               type:
-                                description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
                                 enum:
                                   - Utilization
+                                  - AbsoluteValue
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -376,6 +522,7 @@ spec:
                         enum:
                           - PodResource
                           - ContainerResource
+                          - CustomQuery
                         type: string
                     required:
                       - type
@@ -862,6 +1009,233 @@ spec:
                           default: true
                           description: 'Enabled determines whether recommendations should be applied by the controller:'
                           type: boolean
+                        objectives:
+                          description: |-
+                            Objectives are the objectives to reach and maintain for the target resource in fallback mode.
+                            If not set, the regular objectives will be used.
+                          items:
+                            description: DatadogPodAutoscalerObjective defines the objectives to reach and maintain for the target workload.
+                            properties:
+                              containerResource:
+                                description: ContainerResource allows to set a container-level resource objective.
+                                properties:
+                                  container:
+                                    description: Container is the name of the container.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the resource.
+                                    enum:
+                                      - cpu
+                                    type: string
+                                  value:
+                                    description: Value is the value of the objective
+                                    properties:
+                                      absoluteValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                          Use a plain number (e.g., "11" or "11.5").
+                                          Represented as a resource.Quantity to avoid floating point in CRDs.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                        enum:
+                                          - Utilization
+                                          - AbsoluteValue
+                                        type: string
+                                      utilization:
+                                        description: Utilization defines a percentage of the target compared to requested workload
+                                        format: int32
+                                        maximum: 100
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                      - type
+                                    type: object
+                                required:
+                                  - container
+                                  - name
+                                  - value
+                                type: object
+                              customQueryObjective:
+                                description: CustomQueryObjective allows to set a controller-level objective.
+                                properties:
+                                  query:
+                                    description: Query is the timeseries query to use for the objective.
+                                    properties:
+                                      formulas:
+                                        description: Formulas to compute (optional).
+                                        items:
+                                          properties:
+                                            formula:
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                            - formula
+                                          type: object
+                                        type: array
+                                      queries:
+                                        items:
+                                          description: TimeseriesQuery is a discriminated union. Only Metrics and APMMetrics are supported for autoscaling.
+                                          properties:
+                                            apm_metrics:
+                                              properties:
+                                                group_by:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                operation_name:
+                                                  type: string
+                                                query_filter:
+                                                  type: string
+                                                resource_hash:
+                                                  description: ResourceHash is a fingerprint of the resource name that can be used to identify the resource instead of the resource name.
+                                                  type: string
+                                                resource_name:
+                                                  type: string
+                                                service:
+                                                  type: string
+                                                span_kind:
+                                                  type: string
+                                                stat:
+                                                  description: DatadogPodAutoscalerApmMetricsStat represents the statistic to compute for an APM metrics query.
+                                                  enum:
+                                                    - error_rate
+                                                    - errors
+                                                    - errors_per_second
+                                                    - hits
+                                                    - hits_per_second
+                                                    - apdex
+                                                    - latency_avg
+                                                    - latency_max
+                                                    - latency_p50
+                                                    - latency_p75
+                                                    - latency_p90
+                                                    - latency_p95
+                                                    - latency_p99
+                                                    - latency_p999
+                                                    - latency_distribution
+                                                    - total_time
+                                                  type: string
+                                              required:
+                                                - stat
+                                              type: object
+                                            metrics:
+                                              properties:
+                                                query:
+                                                  description: Classic Datadog metrics query, e.g. "avg:system.cpu.user{*} by {env}".
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                                - query
+                                              type: object
+                                            name:
+                                              description: Optional variable name ("a", "b", etc.) to reference in formulas.
+                                              type: string
+                                            source:
+                                              enum:
+                                                - metrics
+                                                - apm_metrics
+                                              type: string
+                                          required:
+                                            - source
+                                          type: object
+                                        minItems: 1
+                                        type: array
+                                    required:
+                                      - queries
+                                    type: object
+                                  value:
+                                    description: Value is the value of the objective
+                                    properties:
+                                      absoluteValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                          Use a plain number (e.g., "11" or "11.5").
+                                          Represented as a resource.Quantity to avoid floating point in CRDs.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                        enum:
+                                          - Utilization
+                                          - AbsoluteValue
+                                        type: string
+                                      utilization:
+                                        description: Utilization defines a percentage of the target compared to requested workload
+                                        format: int32
+                                        maximum: 100
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                      - type
+                                    type: object
+                                  window:
+                                    description: Window is the time duration over which the query is computed. It should contain at least one full sample.
+                                    type: string
+                                required:
+                                  - query
+                                  - value
+                                  - window
+                                type: object
+                              podResource:
+                                description: PodResource allows to set a pod-level resource objective.
+                                properties:
+                                  name:
+                                    description: Name is the name of the resource.
+                                    enum:
+                                      - cpu
+                                    type: string
+                                  value:
+                                    description: Value is the value of the objective.
+                                    properties:
+                                      absoluteValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                          Use a plain number (e.g., "11" or "11.5").
+                                          Represented as a resource.Quantity to avoid floating point in CRDs.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                        enum:
+                                          - Utilization
+                                          - AbsoluteValue
+                                        type: string
+                                      utilization:
+                                        description: Utilization defines a percentage of the target compared to requested workload
+                                        format: int32
+                                        maximum: 100
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                      - type
+                                    type: object
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type:
+                                description: Type sets the type of the objective.
+                                enum:
+                                  - PodResource
+                                  - ContainerResource
+                                  - CustomQuery
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         triggers:
                           default: {}
                           description: Triggers defines the triggers that will generate recommendations.
@@ -897,10 +1271,21 @@ spec:
                           value:
                             description: Value is the value of the objective
                             properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               type:
-                                description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
                                 enum:
                                   - Utilization
+                                  - AbsoluteValue
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -916,6 +1301,130 @@ spec:
                           - name
                           - value
                         type: object
+                      customQueryObjective:
+                        description: CustomQueryObjective allows to set a controller-level objective.
+                        properties:
+                          query:
+                            description: Query is the timeseries query to use for the objective.
+                            properties:
+                              formulas:
+                                description: Formulas to compute (optional).
+                                items:
+                                  properties:
+                                    formula:
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                    - formula
+                                  type: object
+                                type: array
+                              queries:
+                                items:
+                                  description: TimeseriesQuery is a discriminated union. Only Metrics and APMMetrics are supported for autoscaling.
+                                  properties:
+                                    apm_metrics:
+                                      properties:
+                                        group_by:
+                                          items:
+                                            type: string
+                                          type: array
+                                        operation_name:
+                                          type: string
+                                        query_filter:
+                                          type: string
+                                        resource_hash:
+                                          description: ResourceHash is a fingerprint of the resource name that can be used to identify the resource instead of the resource name.
+                                          type: string
+                                        resource_name:
+                                          type: string
+                                        service:
+                                          type: string
+                                        span_kind:
+                                          type: string
+                                        stat:
+                                          description: DatadogPodAutoscalerApmMetricsStat represents the statistic to compute for an APM metrics query.
+                                          enum:
+                                            - error_rate
+                                            - errors
+                                            - errors_per_second
+                                            - hits
+                                            - hits_per_second
+                                            - apdex
+                                            - latency_avg
+                                            - latency_max
+                                            - latency_p50
+                                            - latency_p75
+                                            - latency_p90
+                                            - latency_p95
+                                            - latency_p99
+                                            - latency_p999
+                                            - latency_distribution
+                                            - total_time
+                                          type: string
+                                      required:
+                                        - stat
+                                      type: object
+                                    metrics:
+                                      properties:
+                                        query:
+                                          description: Classic Datadog metrics query, e.g. "avg:system.cpu.user{*} by {env}".
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                        - query
+                                      type: object
+                                    name:
+                                      description: Optional variable name ("a", "b", etc.) to reference in formulas.
+                                      type: string
+                                    source:
+                                      enum:
+                                        - metrics
+                                        - apm_metrics
+                                      type: string
+                                  required:
+                                    - source
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                              - queries
+                            type: object
+                          value:
+                            description: Value is the value of the objective
+                            properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type:
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                enum:
+                                  - Utilization
+                                  - AbsoluteValue
+                                type: string
+                              utilization:
+                                description: Utilization defines a percentage of the target compared to requested workload
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                            required:
+                              - type
+                            type: object
+                          window:
+                            description: Window is the time duration over which the query is computed. It should contain at least one full sample.
+                            type: string
+                        required:
+                          - query
+                          - value
+                          - window
+                        type: object
                       podResource:
                         description: PodResource allows to set a pod-level resource objective.
                         properties:
@@ -927,10 +1436,21 @@ spec:
                           value:
                             description: Value is the value of the objective.
                             properties:
+                              absoluteValue:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                  Use a plain number (e.g., "11" or "11.5").
+                                  Represented as a resource.Quantity to avoid floating point in CRDs.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               type:
-                                description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
                                 enum:
                                   - Utilization
+                                  - AbsoluteValue
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -950,6 +1470,7 @@ spec:
                         enum:
                           - PodResource
                           - ContainerResource
+                          - CustomQuery
                         type: string
                     required:
                       - type


### PR DESCRIPTION
#### What this PR does / why we need it:

Update CRDs for operator 1.20.0-rc.1

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
