### PR TITLE
fix: use the correct syntax to pass DD_API_KEY from a secret

### DIFF
--- a/charts/cloudprem/templates/_helpers.tpl
+++ b/charts/cloudprem/templates/_helpers.tpl
@@ -227,7 +227,7 @@ Quickwit environment
   value: {{ .Values.datadog.site | quote }}
 {{- if or .Values.datadog.apiKey .Values.datadog.apiKeyExistingSecret }}
 - name: DD_API_KEY
-  valuesFrom:
+  valueFrom:
     secretKeyRef:
       {{- if .Values.datadog.apiKeyExistingSecret }}
       name: {{ .Values.datadog.apiKeyExistingSecret }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Use the right syntax to pass DD_API_KEY from a secret.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
