### PR TITLE
Revert "Add timercreate to list of system-probe allowed syscalls"

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.140.1
+
+* Revert addition of `timer_create` syscall to system-probe seccomp profile.
+
 ## 3.140.0
 
 * Update agent, cluster-agent, and cluster-checks-runner pod labels ([#2111](https://github.com/DataDog/helm-charts/pull/2111)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.140.0
+version: 3.140.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.140.0](https://img.shields.io/badge/Version-3.140.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.140.1](https://img.shields.io/badge/Version-3.140.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -312,7 +312,6 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
-            "timer_create",
             "tkill",
             "umask",
             "uname",

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -302,7 +302,6 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
-            "timer_create",
             "tkill",
             "umask",
             "uname",

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -302,7 +302,6 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
-            "timer_create",
             "tkill",
             "umask",
             "uname",

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -302,7 +302,6 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
-            "timer_create",
             "tkill",
             "umask",
             "uname",

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -305,7 +305,6 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
-            "timer_create",
             "tkill",
             "umask",
             "uname",

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -302,7 +302,6 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
-            "timer_create",
             "tkill",
             "umask",
             "uname",

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -302,7 +302,6 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
-            "timer_create",
             "tkill",
             "umask",
             "uname",

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -302,7 +302,6 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
-            "timer_create",
             "tkill",
             "umask",
             "uname",

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -302,7 +302,6 @@ data:
             "symlinkat",
             "sysinfo",
             "tgkill",
-            "timer_create",
             "tkill",
             "umask",
             "uname",


### PR DESCRIPTION
#### What this PR does / why we need it:

Reverts https://github.com/DataDog/helm-charts/pull/2118, due to an issue detected in our infra with allowing this syscall (#incident-45060).

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
