### PR TITLE
Fix Allowlistsynchronizer helper

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.3
+
+* Fix AllowlistSynchronizer helper
+
 ## 0.4.2
 
 * Add gke AllowlistSynchronizer

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 

--- a/charts/datadog-csi-driver/templates/_helpers.tpl
+++ b/charts/datadog-csi-driver/templates/_helpers.tpl
@@ -73,7 +73,7 @@ Create the name of the service account to use
 Check if target cluster supports GKE Autopilot WorkloadAllowlists.
 GKE Autopilot WorkloadAllowlists are supported in GKE versions >= 1.32.1-gke.1729000.
 */}}
-{{- define "gke-autopilot-workloadallowlists-enabled" -}}
+{{- define "csi.gke-autopilot-workloadallowlists-enabled" -}}
 {{- if and (.Capabilities.APIVersions.Has "auto.gke.io/v1/AllowlistSynchronizer") (.Capabilities.APIVersions.Has "auto.gke.io/v1/WorkloadAllowlist") (semverCompare ">=v1.32.1-gke.1729000" .Capabilities.KubeVersion.Version) -}}
 true
 {{- else -}}

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   name: {{ include "datadog-csi-driver.daemonsetName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- if (eq (include "gke-autopilot-workloadallowlists-enabled" .) "true") }}
+  {{- if (eq (include "csi.gke-autopilot-workloadallowlists-enabled" .) "true") }}
   labels:
     cloud.google.com/matching-allowlist: "datadog-datadog-csi-driver-daemonset-exemption-v1.0.1"
   {{- end }}

--- a/charts/datadog-csi-driver/templates/gke_autopilot_allowlist_synchronizer.yaml
+++ b/charts/datadog-csi-driver/templates/gke_autopilot_allowlist_synchronizer.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (include "gke-autopilot-workloadallowlists-enabled" .) "true") }}
+{{- if (eq (include "csi.gke-autopilot-workloadallowlists-enabled" .) "true") }}
 apiVersion: auto.gke.io/v1
 kind: AllowlistSynchronizer
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the naming of the GKE WorkloadAllowlists helper. The name collides with the [helper](https://github.com/DataDog/helm-charts/blob/242e5107f1e70e6514a39bedcfb331d5bc08babe/charts/datadog/templates/_helpers.tpl#L59) in the datadog chart. As a result, when the csi-driver chart is rendered as a sub-chart of the datadog chart, the parent helper takes precedence, but its conditions fail with the csi-driver chart's values (the parent datadog helper uses some Values fields that don't exist in the csi-driver chart (i.e. `.Values.providers.gke`).

This fix is needed to properly render and create the CSI driver AllowlistSynchronizer when installed as a sub-chart of the Datadog chart. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #2081

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
