### PR TITLE
Run GKE E2E tests less frequently

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 variables:
   TEST_INFRA_DEFINITIONS_BUILDIMAGES: 83c23398aae9
   RUN_E2E:
-    description: "set RUN_E2E to 'true' if you want to trigger the e2e test on your pipeline."
+    description: "Set RUN_E2E to 'true' if you want to trigger the e2e test on your pipeline."
 
 noop:
   stage: test


### PR DESCRIPTION
#### What this PR does / why we need it:

* Run GKE E2E tests only for the `7-rc` agent image
* Run E2E tests only for mergequeue branches and merge commits to `main` (disables automatic running on every pushed commit)
* Adds back manual run option

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
