### PR TITLE
[fix(datadog)] rbac templating when datadog.secretBackend.roles is defined

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.145.2
+
+* Fix templating granular roles defined in `datadog.secretBackend.roles` by removing the checksum annotation
+
 ## 3.145.1
 
 * [CONS-7793] Add necessary RBAC for ArgoRollout to be provide read access to the admission controller.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.145.1
+version: 3.145.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.145.1](https://img.shields.io/badge/Version-3.145.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.145.2](https://img.shields.io/badge/Version-3.145.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/rbac.yaml
+++ b/charts/datadog/templates/rbac.yaml
@@ -189,8 +189,6 @@ kind: Role
 metadata:
   name: {{ template "datadog.fullname" $ }}-secret-reader-{{ $role.namespace }}
   namespace: {{ $role.namespace }}
-  annotations:
-    checksum/secret-backend-roles: {{ tpl (toYaml $.Values.datadog.secretBackend.roles) . | sha256sum }}
   labels:
 {{ include "datadog.labels" $ | indent 4 }}
 rules:
@@ -209,8 +207,6 @@ kind: RoleBinding
 metadata:
   name: {{ template "datadog.fullname" $ }}-read-secrets-{{ $role.namespace }}
   namespace: {{ $role.namespace }}
-  annotations:
-    checksum/secret-backend-roles: {{ tpl (toYaml $.Values.datadog.secretBackend.roles) . | sha256sum }}
   labels:
 {{ include "datadog.labels" $ | indent 4 }}
 subjects:


### PR DESCRIPTION


#### What this PR does / why we need it:

Fixes a bug when templating roles:

```
Error: Failed to render chart: exit status 1: Error: template: datadog/templates/rbac.yaml:193:38: executing "datadog/templates/rbac.yaml" at <tpl (toYaml $.Values.datadog.secretBackend.roles) .>: error calling tpl: cannot retrieve Template.Basepath from values inside tpl function: - namespace: namespace
  secrets:
  - secret-name: "BasePath" is not a value

Use --debug flag to render out invalid YAML

```

Checksums do not need to be on the Role and RoleBinding manifests, so remove them. Otherwise the fix would be:

```yaml
        checksum/secret-backend-roles: {{ tpl (toYaml .Values.datadog.secretBackend.roles) $ | sha256sum }}
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #2163

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
