### PR TITLE
feat: add ability to disable configSync

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.146.0
+
+* Add ability to disable configSync between otel-agent and agent container via `datadog.otelCollector.enableConfigSync`. Default is true to match previous behaviour.
+
 ## 3.145.1
 
 * [CONS-7793] Add necessary RBAC for ArgoRollout to be provide read access to the admission controller.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.145.1
+version: 3.146.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.145.1](https://img.shields.io/badge/Version-3.145.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.146.0](https://img.shields.io/badge/Version-3.146.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 
@@ -855,6 +855,7 @@ helm install <RELEASE_NAME> \
 | datadog.otelCollector.configMap.items | string | `nil` | Items within the ConfigMap that contain DDOT Collector configuration |
 | datadog.otelCollector.configMap.key | string | `"otel-config.yaml"` | Key within the ConfigMap that contains the DDOT Collector configuration |
 | datadog.otelCollector.configMap.name | string | `nil` | Name of the existing ConfigMap that contains the DDOT Collector configuration |
+| datadog.otelCollector.enableConfigSync | bool | `true` |  |
 | datadog.otelCollector.enabled | bool | `false` | Enable the OTel Collector |
 | datadog.otelCollector.featureGates | string | `nil` | Feature gates to pass to OTel collector, as a comma separated list |
 | datadog.otelCollector.logs.enabled | bool | `false` | Enable logs support in the OTel Collector. If true, checks OTel Collector config for filelog receiver and mounts additional volumes to collect containers and pods logs. |

--- a/charts/datadog/ci/agent-otel-collector-disable-configsync.yaml
+++ b/charts/datadog/ci/agent-otel-collector-disable-configsync.yaml
@@ -1,0 +1,12 @@
+targetSystem: "linux"
+agents:
+  image:
+    tagSuffix: full
+datadog:
+  apiKey: "f0000000000000000000000000000000"
+  appKey: "f000000000000000000000000000000000000000"
+  kubelet:
+    tlsVerify: false
+  otelCollector:
+    enabled: true
+    enableConfigSync: false

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -67,8 +67,13 @@
   env:
     {{- include "containers-common-env" . | nindent 4 }}
     {{- include "containers-cluster-agent-env" . | nindent 4 }}
+    {{- if .Values.datadog.otelCollector.enableConfigSync }}
     - name: DD_AGENT_IPC_PORT
       value: "5009"
+    {{- else }}
+    - name: DD_AGENT_IPC_PORT
+      value: "0"
+    {{- end }}
     - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
       value: "60"
     {{- if .Values.datadog.otelCollector.enabled }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -698,6 +698,9 @@ datadog:
       # If true, checks OTel Collector config for filelog receiver and mounts additional volumes to collect containers
       # and pods logs.
       enabled: false
+    # datadog.otelCollector.enableConfigSync controls configSync mechanism
+    # between otel-agent container and agent container.
+    enableConfigSync: true
 
   ## Continuous Profiler configuration
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently, if you enable ddot in helm chart, it automatically configures configSync for you. While it is a great feature, I faced some cases where I would like to disable it.
This pr adds config option to disable it
#### Which issue this PR fixes
fixes #2133

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
