### PR TITLE
Fix endpoint-config ConfigMap to respect fullnameOverride

### DIFF
--- a/charts/datadog/templates/datadog-endpoint-configmap.yaml
+++ b/charts/datadog/templates/datadog-endpoint-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: datadog-endpoint-config
+  name: {{ include "datadog.fullname" . }}-endpoint-config
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "datadog.labels" . | indent 4 }}


### PR DESCRIPTION
## What does this PR do?

Fixes the `datadog-endpoint-config` ConfigMap to respect `fullnameOverride` and `nameOverride` values, making it consistent with all other chart resources.

## Motivation

Closes #2187

The endpoint-config ConfigMap introduced in #2176 uses a hardcoded name, preventing multiple Datadog installations in the same namespace. This is a common pattern for:
- Monitoring different node pools separately (e.g., Karpenter nodes)
- Different tagging strategies per workload type
- Isolating metrics from specific workloads

## Changes

Changed line 4 of `charts/datadog/templates/datadog-endpoint-configmap.yaml`:
```yaml
# Before:
  name: datadog-endpoint-config

# After:
  name: {{ include "datadog.fullname" . }}-endpoint-config
```

This makes it consistent with other resources like:
- `{{ include "datadog.fullname" . }}-cluster-agent`
- `{{ include "datadog.fullname" . }}-installinfo`
- etc.

## Testing

With this change, multiple installations work correctly:
- Default: Creates `datadog-endpoint-config`
- With `fullnameOverride: karpenter-datadog`: Creates `karpenter-datadog-endpoint-config`

## Checklist

- [x] The code change addresses the root cause
- [x] Follows existing naming patterns in the chart
- [x] Backwards compatible (ConfigMap name changes, but this is expected when using overrides)
- [ ] Tested locally with multiple installations