### PR TITLE
add(datadog-csi-driver): add podLabels settings to the CSI driver.

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.5
+* Support the definition of podLabels
+
 ## 0.4.4
 
 * Support the definition of tolerations

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -20,6 +20,7 @@ Datadog CSI Driver helm chart
 | image.repository | string | `"gcr.io/datadoghq/csi-driver"` | Override default registry + image.name for CSI driver |
 | image.tag | string | `"1.0.0"` | CSI driver image tag to use |
 | nameOverride | string | `""` | Allows overriding the name of the chart. If set, this value replaces the default chart name. |
+| podLabels | object | `{}` | Additional labels to add to the csi driver daemonset pods. |
 | registrar.image.pullPolicy | string | `"IfNotPresent"` | CSI registrar image pullPolicy |
 | registrar.image.repository | string | `"k8s.gcr.io/sig-storage/csi-node-driver-registrar"` | Override default registry + image.name for the registrar |
 | registrar.image.tag | string | `"v2.0.1"` | CSI registrar image tag to use |

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         app: {{ include "datadog-csi-driver.daemonsetName" . }}
         admission.datadoghq.com/enabled: "false"
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/datadog-csi-driver/values.yaml
+++ b/charts/datadog-csi-driver/values.yaml
@@ -54,3 +54,8 @@ sockets:
 
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
+
+# podLabels -- Additional labels to add to the csi driver daemonset pods.
+
+## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Datadog changelog
 
+## 3.148.1
+* Add new `datadog-csi-driver.podLabels` field.
+
 ## 3.148.0
 
 * Enable readOnlyRootFilesystem by default on all Datadog Agent containers.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.148.0
+version: 3.148.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -716,6 +716,7 @@ helm install <RELEASE_NAME> \
 | commonLabels | object | `{}` | Labels to apply to all resources |
 | datadog-crds.crds.datadogMetrics | bool | `true` | Set to true to deploy the DatadogMetrics CRD |
 | datadog-crds.crds.datadogPodAutoscalers | bool | `true` | Set to true to deploy the DatadogPodAutoscalers CRD |
+| datadog-csi-driver.podLabels | object | `{}` | additional labels to add to the csi driver daemonset pods. |
 | datadog.agentDataPlane.enabled | bool | `false` | Whether or not Agent Data Plane is enabled |
 | datadog.agentDataPlane.image.digest | string | `""` | Define Agent Data Plane image digest to use, takes precedence over tag if specified |
 | datadog.agentDataPlane.image.name | string | `"agent-data-plane"` | Agent Data Plane image name to use (relative to `registry`) |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2996,3 +2996,10 @@ otelAgentGateway:
       scaleUp: {}
       # otelAgentGateway.autoscaling.behavior.scaleDown -- defines the scaling down behavior in OTel Agent Gateway HPA
       scaleDown: {}
+
+## Configuration for the datadog-csi-driver subchart. The values in this section will override the values.yaml
+## file of the datadog-csi-driver subchart. This is only meaningful if datadog.csi.enabled is set to true.
+datadog-csi-driver:
+  # datadog-csi-driver.podLabels -- additional labels to add to the csi driver daemonset pods.
+  podLabels: {}
+

--- a/test/datadog/baseline/manifests/adp_enabled.yaml
+++ b/test/datadog/baseline/manifests/adp_enabled.yaml
@@ -710,33 +710,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -745,33 +745,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -724,33 +724,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -724,33 +724,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -724,33 +724,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -710,33 +710,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -710,33 +710,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -710,33 +710,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -710,33 +710,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -710,33 +710,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -743,33 +743,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -717,33 +717,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -959,33 +959,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1009,6 +982,7 @@ spec:
     metadata:
       annotations:
         autopilot.gke.io/no-connect: "true"
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1357,8 +1331,6 @@ spec:
               cpu: 100m
               memory: 400Mi
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -959,33 +959,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1009,6 +982,7 @@ spec:
     metadata:
       annotations:
         autopilot.gke.io/no-connect: "true"
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1357,8 +1331,6 @@ spec:
               cpu: 100m
               memory: 400Mi
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -959,33 +959,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1009,6 +982,7 @@ spec:
     metadata:
       annotations:
         autopilot.gke.io/no-connect: "true"
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1242,8 +1216,6 @@ spec:
               cpu: 100m
               memory: 400Mi
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -743,33 +743,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -962,33 +962,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1009,7 +982,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1384,8 +1358,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -775,33 +775,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -959,33 +959,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1006,7 +979,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1469,8 +1443,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -770,45 +770,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-    - name: otel-statsd
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -710,41 +710,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -770,41 +770,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -733,41 +733,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -770,41 +770,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -770,41 +770,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -710,33 +710,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -710,33 +710,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -757,7 +730,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/agent: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -924,8 +898,6 @@ spec:
             timeoutSeconds: 5
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             readOnlyRootFilesystem: true
           startupProbe:
             failureThreshold: 6

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -743,33 +743,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -959,33 +959,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1006,7 +979,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1471,8 +1445,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -959,33 +959,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1006,7 +979,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1495,8 +1469,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -959,33 +959,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1006,7 +979,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1471,8 +1445,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -959,33 +959,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1006,7 +979,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1362,8 +1336,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds a new `podLabels` value to the CSI driver chart, which allows customizing the labels added to the pods spawned by the CSI chart. It additionally allows specifying this value in the main Datadog chart, which will pass this value through to the CSI sub chart.

#### Which issue this PR fixes
  - fixes #2191 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
