### PR TITLE
Revert CRDs to main + DPA changes

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.14.0-dev.2
+
+* Same as 2.14.0-dev.1 + changes from 2.13.1 for DPA CRD.
+
 ## 2.14.0-dev.1
 
 * Update CRDs from Datadog Operator v1.21.0-rc.1 release candidate tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.13.1
+version: 2.14.0-dev.2
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.13.1](https://img.shields.io/badge/Version-2.13.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.14.0-dev.2](https://img.shields.io/badge/Version-2.14.0--dev.2-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentinternals_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentinternals_v1.yaml
@@ -2975,14 +2975,6 @@ spec:
                         Use 'docker.io/datadog' for DockerHub.
                         Default: 'gcr.io/datadoghq'
                       type: string
-                    runProcessChecksInCoreAgent:
-                      description: |-
-                        Configure whether the Process Agent or core Agent collects process and/or container information (Linux only).
-                        If no other checks are running, the Process Agent container will not initialize.
-                        (Requires Agent 7.60.0+)
-                        Default: 'true'
-                        Deprecated: Functionality now handled automatically. Use env var `DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED` to override.
-                      type: boolean
                     secretBackend:
                       description: |-
                         Configure the secret backend feature https://docs.datadoghq.com/agent/guide/secrets-management

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
@@ -2975,14 +2975,6 @@ spec:
                             Use 'docker.io/datadog' for DockerHub.
                             Default: 'gcr.io/datadoghq'
                           type: string
-                        runProcessChecksInCoreAgent:
-                          description: |-
-                            Configure whether the Process Agent or core Agent collects process and/or container information (Linux only).
-                            If no other checks are running, the Process Agent container will not initialize.
-                            (Requires Agent 7.60.0+)
-                            Default: 'true'
-                            Deprecated: Functionality now handled automatically. Use env var `DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED` to override.
-                          type: boolean
                         secretBackend:
                           description: |-
                             Configure the secret backend feature https://docs.datadoghq.com/agent/guide/secrets-management

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -1642,8 +1642,6 @@ spec:
                       type: object
                     registry:
                       type: string
-                    runProcessChecksInCoreAgent:
-                      type: boolean
                     secretBackend:
                       properties:
                         args:

--- a/crds/datadoghq.com_datadogagentinternals.yaml
+++ b/crds/datadoghq.com_datadogagentinternals.yaml
@@ -2969,14 +2969,6 @@ spec:
                         Use 'docker.io/datadog' for DockerHub.
                         Default: 'gcr.io/datadoghq'
                       type: string
-                    runProcessChecksInCoreAgent:
-                      description: |-
-                        Configure whether the Process Agent or core Agent collects process and/or container information (Linux only).
-                        If no other checks are running, the Process Agent container will not initialize.
-                        (Requires Agent 7.60.0+)
-                        Default: 'true'
-                        Deprecated: Functionality now handled automatically. Use env var `DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED` to override.
-                      type: boolean
                     secretBackend:
                       description: |-
                         Configure the secret backend feature https://docs.datadoghq.com/agent/guide/secrets-management

--- a/crds/datadoghq.com_datadogagentprofiles.yaml
+++ b/crds/datadoghq.com_datadogagentprofiles.yaml
@@ -2969,14 +2969,6 @@ spec:
                             Use 'docker.io/datadog' for DockerHub.
                             Default: 'gcr.io/datadoghq'
                           type: string
-                        runProcessChecksInCoreAgent:
-                          description: |-
-                            Configure whether the Process Agent or core Agent collects process and/or container information (Linux only).
-                            If no other checks are running, the Process Agent container will not initialize.
-                            (Requires Agent 7.60.0+)
-                            Default: 'true'
-                            Deprecated: Functionality now handled automatically. Use env var `DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED` to override.
-                          type: boolean
                         secretBackend:
                           description: |-
                             Configure the secret backend feature https://docs.datadoghq.com/agent/guide/secrets-management

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -1636,8 +1636,6 @@ spec:
                       type: object
                     registry:
                       type: string
-                    runProcessChecksInCoreAgent:
-                      type: boolean
                     secretBackend:
                       properties:
                         args:


### PR DESCRIPTION
#### What this PR does / why we need it:

Revert CRDs to main before 2.13.1 while keeping DPA changes.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
