### PR TITLE
[datadog-operator] Update dev branch with updated CRDs

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 2.16.0-dev.2
+
+* Same as 2.16.0-dev.1 and update version of Datadog CRDs to 2.14.0-dev.2 to pick up changes to DatadogPodAutoscaler.
+
 ## 2.16.0-dev.1
 
-Update Datadog Operator image tag to 1.21.0-rc.1.
+* Update Datadog Operator image tag to 1.21.0-rc.1.
 
 ## 2.15.2
 

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.13.1
-digest: sha256:4fe3fb999e8a2055819494099ef6a2a019d965c9f388ac4463d2364293b7df76
-generated: "2025-11-28T14:42:37.048512+01:00"
+  version: 2.14.0-dev.2
+digest: sha256:1edf8c07931e9fe9d9c40d1aaf8e8d34ddf0889a5e483d7a4473c57e93f5a30d
+generated: "2025-11-28T17:57:08.189049+01:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.15.2
-appVersion: 1.20.0
+version: 2.16.0-dev.2
+appVersion: 1.21.0-rc.1
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "2.13.1"
+  version: "2.14.0-dev.2"
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.15.2](https://img.shields.io/badge/Version-2.15.2-informational?style=flat-square) ![AppVersion: 1.20.0](https://img.shields.io/badge/AppVersion-1.20.0-informational?style=flat-square)
+![Version: 2.16.0-dev.2](https://img.shields.io/badge/Version-2.16.0--dev.2-informational?style=flat-square) ![AppVersion: 1.21.0-rc.1](https://img.shields.io/badge/AppVersion-1.21.0--rc.1-informational?style=flat-square)
 
 ## Values
 
@@ -37,7 +37,7 @@
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.20.0"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.21.0-rc.1"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |

--- a/charts/datadog-operator/templates/_helpers.tpl
+++ b/charts/datadog-operator/templates/_helpers.tpl
@@ -87,6 +87,6 @@ Check operator image tag version.
 {{- $parts := split "@" $tag -}}
 {{- index $parts "_0"}}
 {{- else -}}
-{{ "1.20.0" }}
+{{ "1.21.0-rc.1" }}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -95,6 +95,13 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - controllerrevisions
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - daemonsets
   - deployments
   verbs:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.20.0
+  tag: 1.21.0-rc.1
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
   # image.doNotCheckTag -- Permit skipping operator image tag compatibility with the chart.

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.17.3
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-2.13.1'
+    helm.sh/chart: 'datadogCRDs-2.14.0-dev.2'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -1642,8 +1642,6 @@ spec:
                       type: object
                     registry:
                       type: string
-                    runProcessChecksInCoreAgent:
-                      type: boolean
                     secretBackend:
                       properties:
                         args:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.15.2
+    helm.sh/chart: datadog-operator-2.16.0-dev.2
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0-rc.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.20.0"
+          image: "gcr.io/datadoghq/operator:1.21.0-rc.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -144,7 +144,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "gcr.io/datadoghq/operator:1.20.0", operatorContainer.Image)
+	assert.Equal(t, "gcr.io/datadoghq/operator:1.21.0-rc.1", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Continue operator release cycle and make sure changes from main (DPA CRD update) are picked up

#### Special notes for your reviewer:

Easily review -> compare with `c932e0b9` (`2.16.0-dev.1` release):
* `git diff c932e0b9..HEAD -- charts/datadog-operator/`
    <img width="2560" height="1363" alt="image" src="https://github.com/user-attachments/assets/cc7dfe96-317a-4141-8fc0-e83d0c16685e" />

* `git diff c932e0b9..HEAD -- test/datadog-operator`
    <img width="1610" height="684" alt="image" src="https://github.com/user-attachments/assets/f3a4812a-3b8d-461c-9b55-3301b92dded8" />


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
