### PR TITLE
[Tooling] Bump go setup action to 6.1.0

### DIFF
--- a/.github/workflows/go-test-datadog.yaml
+++ b/.github/workflows/go-test-datadog.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@0caeaed6fd66a828038c2da3c0f662a42862658f # v1.1.3
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version: 1.21
         id: go

--- a/.github/workflows/go-test-operator.yaml
+++ b/.github/workflows/go-test-operator.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@0caeaed6fd66a828038c2da3c0f662a42862658f # v1.1.3
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
         go-version: 1.21
       id: go


### PR DESCRIPTION
#### What this PR does / why we need it:

* We need to use https://github.com/actions/setup-go/pull/665 as storage.googleapis.com/golang no longer allows anonymous bucket access: it's part of `6.1.0`: https://github.com/actions/setup-go/releases/tag/v6.1.0

#### Which issue this PR fixes

* Fixes CI

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
