### PR TITLE
Update setup-go in gh actions

### DIFF
--- a/.github/workflows/go-test-datadog.yaml
+++ b/.github/workflows/go-test-datadog.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version: 1.21
+          go-version: 1.24
         id: go
       - name: Set up Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0

--- a/.github/workflows/go-test-operator.yaml
+++ b/.github/workflows/go-test-operator.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: 1.21
+        go-version: 1.24
       id: go
     - name: Set up Helm
       uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0

--- a/.github/workflows/go-test-private-action-runner.yaml
+++ b/.github/workflows/go-test-private-action-runner.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: 1.21
+        go-version: 1.24
       id: go
     - name: Set up Helm
       uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5.0


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the setup-go version to solve a CI issue. the current version is not able anymore to download the golang tarball

We need to use https://github.com/actions/setup-go/pull/665 as storage.googleapis.com/golang no longer allows anonymous bucket access: it's part of 6.1.0: https://github.com/actions/setup-go/releases/tag/v6.1.0

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
