### PR TITLE
Add dd-octo-sts policy read-only, for Pulumi plugins download

### DIFF
--- a/.github/chainguard/self.gitlab.read.sts.yaml
+++ b/.github/chainguard/self.gitlab.read.sts.yaml
@@ -3,7 +3,7 @@ issuer: https://gitlab.ddbuild.io
 subject_pattern: "project_path:DataDog/.*"
 
 claim_pattern:
-  project_id: "1588"
+  project_path: "DataDog/helm-charts"
   ref: "*"
   ref_protected: "true"
 permissions:


### PR DESCRIPTION
#### What this PR does / why we need it:

Add a dd-octo-sts policy to be able to get a Github token inside Gitlab job downloading Pulumi plugins

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
