### PR TITLE
Update version of Datadog CRDs to 2.14.0-dev.5

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.16.0-dev.5
+
+* Update version of Datadog CRDs to 2.14.0-dev.5.
+
 ## 2.16.0-dev.4
 
 * Use values from Datadog chart's endpoint-config configMap,  if present.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.14.0-dev.4
-digest: sha256:a5c18d82c6d05bd2a6b4c466b0f6588d43b2fe2f5ca9eed63864642c6d5be755
-generated: "2025-12-05T16:07:33.946946-05:00"
+  version: 2.14.0-dev.5
+digest: sha256:6fe23e99bb300e709f818d3e7c8d098cb329b3279ef76e2d24dcf2d99c543722
+generated: "2025-12-10T15:42:06.311337-05:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.16.0-dev.4
+version: 2.16.0-dev.5
 appVersion: 1.21.0-rc.2
 description: Datadog Operator
 keywords:
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: "2.14.0-dev.4"
+  version: "2.14.0-dev.5"
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.16.0-dev.4](https://img.shields.io/badge/Version-2.16.0--dev.4-informational?style=flat-square) ![AppVersion: 1.21.0-rc.2](https://img.shields.io/badge/AppVersion-1.21.0--rc.2-informational?style=flat-square)
+![Version: 2.16.0-dev.5](https://img.shields.io/badge/Version-2.16.0--dev.5-informational?style=flat-square) ![AppVersion: 1.21.0-rc.2](https://img.shields.io/badge/AppVersion-1.21.0--rc.2-informational?style=flat-square)
 
 ## Values
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`
