### PR TITLE
allow enablement of cluster autoscaling

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.155.0
+
+* Allow activation of cluster autoscaling.
+
 ## 3.154.1
 
 * Expose `datadog.workload.autoscaling.enabled` parameter.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.154.1
+version: 3.155.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.154.1](https://img.shields.io/badge/Version-3.154.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.155.0](https://img.shields.io/badge/Version-3.155.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -425,6 +425,10 @@ spec:
           - name: DD_AUTOSCALING_FAILOVER_ENABLED
             value: {{ (((.Values.datadog.autoscaling).workload).enabled) | quote }}
           {{- end }}
+          {{- if (((.Values.datadog.autoscaling).cluster).enabled) }}
+          - name: DD_AUTOSCALING_CLUSTER_ENABLED
+            value: {{ (((.Values.datadog.autoscaling).cluster).enabled) | quote }}
+          {{- end }}
           - name: DD_INSTRUMENTATION_INSTALL_TIME
             valueFrom:
               configMapKeyRef:

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -508,7 +508,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end -}}
 
-{{- if (((.Values.datadog.autoscaling).workload).enabled) }}
+{{- if or (((.Values.datadog.autoscaling).workload).enabled) (((.Values.datadog.autoscaling).cluster).enabled) }}
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
@@ -518,6 +518,15 @@ metadata:
   name: {{ template "datadog.fullname" . }}-cluster-agent-autoscaling
   namespace: {{ .Release.Namespace }}
 rules:
+# Ability to generate events
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+{{- if (((.Values.datadog.autoscaling).workload).enabled) }}
 # Access to own CRD
 - apiGroups:
   - "datadoghq.com"
@@ -534,14 +543,6 @@ rules:
   verbs:
   - 'update'
   - 'get'
-# Ability to generate events
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 # Patching POD to add annotations. TODO: Remove when we have a better way to generate single event
 - apiGroups:
   - ""
@@ -562,6 +563,27 @@ rules:
   - rollouts
   verbs:
   - patch
+{{- end}}
+{{- if (((.Values.datadog.autoscaling).cluster).enabled) }}
+- apiGroups:
+  - karpenter.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+- apiGroups:
+  - karpenter.k8s.aws
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+{{- end}}
+
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows enablement of cluster autoscaling feature, in preview

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [X] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated 
- [X] Variables are documented in the `README.md`
