### PR TITLE
Update CloudPrem Helm chart

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.14
+
+* Add support for PodDisruptionBudget for metastore
+
 ## 0.1.13
 
 * Update Docker image to `v0.1.16`

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.1.13
+version: 0.1.14
 # This is the version of the "application". Right now, we follow the image version.
 appVersion: v0.1.16
 home: https://www.datadoghq.com/

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.16](https://img.shields.io/badge/AppVersion-v0.1.16-informational?style=flat-square)
+![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.16](https://img.shields.io/badge/AppVersion-v0.1.16-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/templates/metastore-pdb.yaml
+++ b/charts/cloudprem/templates/metastore-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.metastore.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "quickwit.fullname" . }}-metastore
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "quickwit.metastore.selectorLabels" . | nindent 6 }}
+  {{- toYaml .Values.metastore.podDisruptionBudget | nindent 2 }}
+{{- end -}}

--- a/charts/cloudprem/values.yaml
+++ b/charts/cloudprem/values.yaml
@@ -314,11 +314,11 @@ indexer:
   resources:
     # See https://docs.datadoghq.com/cloudprem/configure/cluster_sizing/
     limits:
-      cpu: 2
-      memory: 8Gi
+      cpu: 4
+      memory: 16Gi
     requests:
-      cpu: 2
-      memory: 8Gi
+      cpu: 4
+      memory: 16Gi
 
   ## Pod distruption budget
   podDisruptionBudget: {}
@@ -461,6 +461,11 @@ metastore:
     requests:
       cpu: 2
       memory: 4Gi
+
+  ## Pod distruption budget
+  podDisruptionBudget: {}
+    # maxUnavailable: 1
+    # minAvailable: 2
 
   updateStrategy: {}
     # type: RollingUpdate


### PR DESCRIPTION
#### What this PR does / why we need it:
Update CloudPrem Helm chart, adding support for PodDisruptionBudget for the metastore service.

#### Checklist
- [x] Chart Version semver bump label added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
