### PR TITLE
Bugfix: Bump `datadog-csi-driver` dependency to version 0.4.4

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.161.2
+
+* Bump `datadog-csi-driver` dependency to version 0.4.4.
+
 ## 3.161.1
 
 * Update Cluster Agent RBAC to allow list/watch on `source.toolkit.fluxcd.io/*`, `kustomize.toolkit.fluxcd.io/*`, `argoproj.io/*` if the orchestrator check is enabled.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.161.1
+version: 3.161.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.161.1](https://img.shields.io/badge/Version-3.161.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.161.2](https://img.shields.io/badge/Version-3.161.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -32,7 +32,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 | Repository | Name | Version |
 |------------|------|---------|
 | https://helm.datadoghq.com | datadog-crds | 2.13.1 |
-| https://helm.datadoghq.com | datadog-csi-driver | 0.4.3 |
+| https://helm.datadoghq.com | datadog-csi-driver | 0.4.4 |
 | https://helm.datadoghq.com | operator(datadog-operator) | 2.17.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 2.13.2
 - name: datadog-csi-driver
   repository: https://helm.datadoghq.com
-  version: 0.4.3
+  version: 0.4.4
 - name: datadog-operator
   repository: https://helm.datadoghq.com
   version: 2.17.0

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: datadog.kubeStateMetricsEnabled
   - name: datadog-csi-driver
-    version: 0.4.3
+    version: 0.4.4
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator

--- a/test/datadog/baseline/manifests/adp_enabled.yaml
+++ b/test/datadog/baseline/manifests/adp_enabled.yaml
@@ -1256,33 +1256,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -1291,33 +1291,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -1256,33 +1256,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -1269,33 +1269,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -1269,33 +1269,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -1269,33 +1269,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -1269,33 +1269,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -1256,33 +1256,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -1256,33 +1256,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -1256,33 +1256,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -1256,33 +1256,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -1256,33 +1256,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -1289,33 +1289,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -1263,33 +1263,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1506,33 +1506,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1556,6 +1529,7 @@ spec:
     metadata:
       annotations:
         autopilot.gke.io/no-connect: "true"
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1910,8 +1884,6 @@ spec:
               cpu: 100m
               memory: 400Mi
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1506,33 +1506,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1556,6 +1529,7 @@ spec:
     metadata:
       annotations:
         autopilot.gke.io/no-connect: "true"
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1910,8 +1884,6 @@ spec:
               cpu: 100m
               memory: 400Mi
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1506,33 +1506,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1556,6 +1529,7 @@ spec:
     metadata:
       annotations:
         autopilot.gke.io/no-connect: "true"
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1795,8 +1769,6 @@ spec:
               cpu: 100m
               memory: 400Mi
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -1289,33 +1289,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -1512,33 +1512,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1559,7 +1532,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1937,8 +1911,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -1321,33 +1321,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1506,33 +1506,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1553,7 +1526,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -2022,8 +1996,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -1327,45 +1327,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-    - name: otel-statsd
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -1256,41 +1256,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -1327,41 +1327,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1279,41 +1279,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -1327,41 +1327,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -1327,41 +1327,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-    - name: otel-grpc
-      port: 4317
-      protocol: TCP
-      targetPort: 4317
-    - name: otel-http
-      port: 4318
-      protocol: TCP
-      targetPort: 4318
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -1256,33 +1256,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -1256,33 +1256,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1303,7 +1276,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/agent: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1474,8 +1448,6 @@ spec:
             timeoutSeconds: 5
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             readOnlyRootFilesystem: true
           startupProbe:
             failureThreshold: 6

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -1289,33 +1289,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1506,33 +1506,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1553,7 +1526,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -2024,8 +1998,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -1506,33 +1506,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1553,7 +1526,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -2046,8 +2020,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1506,33 +1506,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1553,7 +1526,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -2024,8 +1998,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -1506,33 +1506,6 @@ spec:
   selector:
     app: datadog-cluster-agent
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: datadog
-    app.kubernetes.io/instance: datadog
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: datadog
-    app.kubernetes.io/version: "7"
-    heritage: Helm
-    release: datadog
-  name: datadog
-  namespace: datadog-agent
-spec:
-  internalTrafficPolicy: Local
-  ports:
-    - name: dogstatsdport
-      port: 8125
-      protocol: UDP
-      targetPort: 8125
-    - name: traceport
-      port: 8126
-      protocol: TCP
-      targetPort: 8126
-  selector:
-    app: datadog
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1553,7 +1526,8 @@ spec:
       app: datadog
   template:
     metadata:
-      annotations: {}
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
         admission.datadoghq.com/enabled: "false"
         agent.datadoghq.com/component: agent
@@ -1915,8 +1889,6 @@ spec:
           name: system-probe
           resources: {}
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             capabilities:
               add:
                 - SYS_ADMIN


### PR DESCRIPTION
CSI driver subchart 0.4.3 lacks tolerations templating, potentially causing incomplete deployment.

#### What this PR does / why we need it:

Use case: Cluster with nodes with NoSchedule for normal workloads, but which we want the csi driver daemonset deployed to. With current latest chart version, there is no way to apply tolerances to the daemonset other than hotpatching as `, but datadog-csi-driver.tolerations` is silently ignored.

#### Which issue this PR fixes

#### Special notes for your reviewer:

Test baseline changes are from drift in dependencies and not related to this change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version semver bump label added: `datadog/patch-version`
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`
