### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.160.4
+
+# Update README to remove mention of deployment as way to deploy datadog-agent 
+
 ## 3.160.3
 
 * Update `fips.image.tag` to `1.1.18` fixing CVEs and updating packages.


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

N/A

Fixes README discrepancy with actual state of Datadog agent deploy methods

Helm Chart docs say datadog-agent can be deployed as an Deployment or Daemon here: https://github.com/DataDog/helm-charts/blob/fadacf52a199e9b92c236e11f095e1f31d810e24/charts/datadog/README.md.gotmpl#L31

but Deployment support was apparently removed over 5 years ago

https://github.com/DataDog/helm-charts/pull/50#issuecomment-699875559

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ x] `CHANGELOG.md` has been updated 
- [ x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits