### PR TITLE
[datadog/cluster-agent-rbac] Add watch for role bindings and cluster role bindings for CSPM

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.160.4
+
+* Add "watch" permission for cluster roles and cluster role bindings in the Cluster Agent RBAC when the CSPM feature is enabled.
+
 ## 3.160.3
 
 * Update `fips.image.tag` to `1.1.18` fixing CVEs and updating packages.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.160.3
+version: 3.160.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.160.3](https://img.shields.io/badge/Version-3.160.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.160.4](https://img.shields.io/badge/Version-3.160.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds the Datadog Agent to all nodes in your cluster via a DaemonSet. It also optionally depends on the [kube-state-metrics chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics). For more information about monitoring Kubernetes with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/).
 

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -307,6 +307,7 @@ rules:
   - rolebindings
   verbs:
   - list
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

This PR adds watch permission for role bindings and cluster role bindings when the CSPM feature is enabled.

This is needed because this PR in the Agent https://github.com/DataDog/datadog-agent/pull/45029 added an optimization in the CSPM feature and now it requires "watch" permissions for cluster role bindings and cluster roles.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits