### PR TITLE
obs-pipelines: clarify instructions to configure secrets management

### DIFF
--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.12.2
+
+- Add clarifying note to values.yaml configuration for custom secrets management
+
 ## 2.12.1
 
 - Add support for custom secrets management via datadog.bootstrap in values.yaml

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: "2.12.1"
+version: "2.12.2"
 description: Observability Pipelines Worker
 type: application
 keywords:

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.12.1](https://img.shields.io/badge/Version-2.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.12.0](https://img.shields.io/badge/AppVersion-2.12.0-informational?style=flat-square)
+![Version: 2.12.2](https://img.shields.io/badge/Version-2.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.12.0](https://img.shields.io/badge/AppVersion-2.12.0-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 
@@ -92,8 +92,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | datadog.apiKey | string | `nil` | Specify your Datadog API key. |
 | datadog.apiKeyExistingSecret | string | `""` | Specify a preexisting Secret that has your API key instead of creating a new one. The value must be stored under the `api-key`. |
 | datadog.bootstrap | object | `{"config":{},"secretFileContents":{}}` | Provide a bootstrap file that conforms to the options provided in this documentation:   https://docs.datadoghq.com/observability_pipelines/configuration/install_the_worker/advanced_worker_configurations/#bootstrap-options |
-| datadog.bootstrap.config | object | `{}` | The bootstrap file contents |
-| datadog.bootstrap.secretFileContents | object | `{}` | Additional helper for the "secrets" portion of the bootstrap file. Use if your backend_type is of type 'file'. Helm chart will copy the provided secrets into a new file, and correctly setup the bootstrap to point to the secrets file. eg: { "SOURCE_DATADOG_AGENT_ADDRESS" : " 0.0.0.0:8282" } |
+| datadog.bootstrap.config | object | `{}` | The bootstrap file contents. Use only if `secretFileContents` is not provided. |
+| datadog.bootstrap.secretFileContents | object | `{}` | Additional helper for the "secrets" portion of the bootstrap file. Use if your backend_type is of type 'file'. Helm chart will copy the provided secrets into a new file, and correctly setup the bootstrap to point to the secrets file in `bootstrap.config`. eg: { "SOURCE_DATADOG_AGENT_ADDRESS" : " 0.0.0.0:8282" } |
 | datadog.dataDir | string | `"/var/lib/observability-pipelines-worker"` | The data directory for OPW to store runtime data in. |
 | datadog.pipelineId | string | `nil` | Specify your Datadog Observability Pipelines pipeline ID |
 | datadog.site | string | `"datadoghq.com"` | The [site](https://docs.datadoghq.com/getting_started/site/) of the Datadog intake to send data to. |

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -41,11 +41,11 @@ datadog:
   # datadog.bootstrap -- Provide a bootstrap file that conforms to the options provided in this documentation:
   #   https://docs.datadoghq.com/observability_pipelines/configuration/install_the_worker/advanced_worker_configurations/#bootstrap-options
   bootstrap:
-    # datadog.bootstrap.config -- The bootstrap file contents
+    # datadog.bootstrap.config -- The bootstrap file contents. Use only if `secretFileContents` is not provided.
     config: {}
     # datadog.bootstrap.secretFileContents -- Additional helper for the "secrets" portion of the bootstrap file.
     # Use if your backend_type is of type 'file'. Helm chart will copy the provided secrets into a new file,
-    # and correctly setup the bootstrap to point to the secrets file.
+    # and correctly setup the bootstrap to point to the secrets file in `bootstrap.config`.
     # eg: { "SOURCE_DATADOG_AGENT_ADDRESS" : " 0.0.0.0:8282" }
     secretFileContents: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Add clarifying note on secrets management.

Original [PR](https://github.com/DataDog/helm-charts/pull/2226).
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits