### PR TITLE
add example for VECTOR_HOSTNAME override

### DIFF
--- a/charts/observability-pipelines-worker/README.md.gotmpl
+++ b/charts/observability-pipelines-worker/README.md.gotmpl
@@ -44,6 +44,30 @@ helm install --name <RELEASE_NAME> \
     datadog/observability-pipelines-worker
 ```
 
+### Runtime-derived hostnames (VECTOR_HOSTNAME)
+
+Helm renders manifests at install/upgrade time, but pod name or node name are only known after scheduling. Use the
+[Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) to inject those runtime values, then build
+`VECTOR_HOSTNAME` inside the container at startup (Kubernetes env vars cannot concatenate other env vars).
+
+Example `values.yaml` override (POD_NAME.CLUSTER_NAME):
+
+```yaml
+env:
+  - name: CLUSTER_NAME
+    value: "my-cluster"
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+
+command: ["/bin/sh", "-c"]
+args:
+  - >
+    export VECTOR_HOSTNAME="${POD_NAME}.${CLUSTER_NAME}";
+    exec /usr/bin/observability-pipelines-worker
+```
+
 #### Create and provide a Secret that contains your Datadog API Key
 
 To create a Secret that contains your Datadog API key, replace the `<DATADOG_API_KEY>` below with the API key for your

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -133,14 +133,16 @@ podSecurityContext: {}
 securityContext: {}
 
 # command -- Override default image command.
-command: []
+command: ["/bin/sh", "-c"]
 
 # args -- Override default image arguments.
 args:
-  - run
+  - >
+    export VECTOR_HOSTNAME="${POD_NAME}.${CLUSTER_NAME}";
+    exec /usr/bin/observability-pipelines-worker run
 
 # env -- Define environment variables.
-env: []
+env:
 #  - name: <ENV_VAR_NAME>
 #    value: <ENV_VAR_VALUE>
 #  - name: <ENV_VAR_NAME>
@@ -148,6 +150,13 @@ env: []
 #      secretKeyRef:
 #        name: <SECRET_NAME>
 #        key: <KEY_NAME>
+  # Example: create VECTOR_HOSTNAME from POD_NAME.CLUSTER_NAME at runtime
+  - name: CLUSTER_NAME
+    value: "my-cluster"
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
 
 # envFrom -- Define environment variables from ConfigMap or Secret data.
 envFrom: []


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR demonstrates how we can override VECTOR_HOSTNAME based on the k8s pod name and the cluster name. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits