### PR TITLE
[ACTP] Update PAR helm description

### DIFF
--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.21.2
+
+* Update charts description
+
 ## 1.21.1
 
 * Bump private runner version to 1.17.1

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: Datadog Private Action Runner
 
 type: application
-version: 1.21.1
+version: 1.21.2
 appVersion: "v1.17.1"
 keywords:
     - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.21.1](https://img.shields.io/badge/Version-1.21.1-informational?style=flat-square) ![AppVersion: v1.17.1](https://img.shields.io/badge/AppVersion-v1.17.1-informational?style=flat-square)
+![Version: 1.21.2](https://img.shields.io/badge/Version-1.21.2-informational?style=flat-square) ![AppVersion: v1.17.1](https://img.shields.io/badge/AppVersion-v1.17.1-informational?style=flat-square)
 
 ## Overview
 

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -81,7 +81,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.17.1"
@@ -96,7 +96,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.17.1"

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -79,7 +79,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.17.1"
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.17.1"

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -79,7 +79,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.17.1"
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.17.1"

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -79,7 +79,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.17.1"
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.17.1"

--- a/test/private-action-runner/__snapshot__/deprecated-modes.yaml
+++ b/test/private-action-runner/__snapshot__/deprecated-modes.yaml
@@ -79,7 +79,7 @@ metadata:
   name: deprecated-modes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: deprecated-modes-test
     app.kubernetes.io/version: "v1.17.1"
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: deprecated-modes-test
         app.kubernetes.io/version: "v1.17.1"

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -132,7 +132,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.17.1"
@@ -147,7 +147,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.17.1"

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -195,7 +195,7 @@ metadata:
   name: example-test-private-action-runner-scripts
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.17.1"
@@ -259,7 +259,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.17.1"
@@ -274,7 +274,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.17.1"

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -77,7 +77,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.17.1"
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.17.1"

--- a/test/private-action-runner/__snapshot__/scc-enabled.yaml
+++ b/test/private-action-runner/__snapshot__/scc-enabled.yaml
@@ -79,7 +79,7 @@ metadata:
   name: scc-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scc-test
     app.kubernetes.io/version: "v1.17.1"
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: scc-test
         app.kubernetes.io/version: "v1.17.1"
@@ -134,7 +134,7 @@ apiVersion: security.openshift.io/v1
 metadata:
   name: scc-test-private-action-runner
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scc-test
     app.kubernetes.io/version: "v1.17.1"

--- a/test/private-action-runner/__snapshot__/scripts-configuration.yaml
+++ b/test/private-action-runner/__snapshot__/scripts-configuration.yaml
@@ -37,7 +37,7 @@ metadata:
   name: scripts-test-private-action-runner-scripts
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
     app.kubernetes.io/version: "v1.17.1"
@@ -101,7 +101,7 @@ metadata:
   name: scripts-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
     app.kubernetes.io/version: "v1.17.1"
@@ -116,7 +116,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: scripts-test
         app.kubernetes.io/version: "v1.17.1"

--- a/test/private-action-runner/__snapshot__/service-annotations.yaml
+++ b/test/private-action-runner/__snapshot__/service-annotations.yaml
@@ -82,7 +82,7 @@ metadata:
   name: scripts-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.21.1
+    helm.sh/chart: private-action-runner-1.21.2
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
     app.kubernetes.io/version: "v1.17.1"
@@ -97,7 +97,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.21.1
+        helm.sh/chart: private-action-runner-1.21.2
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: scripts-test
         app.kubernetes.io/version: "v1.17.1"


### PR DESCRIPTION
## What this PR does / why we need it:
Just aligning the result of `helm search repo datadog`

```
NAME                                  	CHART VERSION	APP VERSION	DESCRIPTION                                     
datadog/datadog                       	3.164.1      	7          	Datadog Agent                                   
datadog/datadog-crds                  	2.15.0       	1          	Datadog Kubernetes CRDs chart                   
datadog/datadog-csi-driver            	0.6.0        	0.1.0      	Datadog CSI Driver helm chart                   
datadog/datadog-operator              	2.17.0       	1.22.0     	Datadog Operator                                
datadog/cloudprem                     	0.1.14       	v0.1.16    	Datadog CloudPrem                               
datadog/extendeddaemonset             	v0.3.2       	v0.8.0     	Extended Daemonset Controller                   
datadog/observability-pipelines-worker	2.13.0       	2.13.0     	Observability Pipelines Worker                  
datadog/private-action-runner         	1.21.1       	v1.17.1    	A Helm chart to deploy the private action runner
datadog/synthetics-private-location   	0.17.20      	1.64.0     	Datadog Synthetics Private Location
```