### PR TITLE
update version of datadog csi driver chart dependency in datadog chart

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.166.4
+
+* Update datadog-csi-driver chart dependency version.
+
 ## 3.166.3
 
 * [CXP-2640][helm] Remove envvar ovveride for controlling whether process checks run in core or process agent ([#2339](https://github.com/DataDog/helm-charts/pull/2339)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.166.3
+version: 3.166.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.166.3](https://img.shields.io/badge/Version-3.166.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.166.4](https://img.shields.io/badge/Version-3.166.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -32,7 +32,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 | Repository | Name | Version |
 |------------|------|---------|
 | https://helm.datadoghq.com | datadog-crds | 2.13.1 |
-| https://helm.datadoghq.com | datadog-csi-driver | 0.4.3 |
+| https://helm.datadoghq.com | datadog-csi-driver | 0.6.0 |
 | https://helm.datadoghq.com | operator(datadog-operator) | 2.17.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 2.13.2
 - name: datadog-csi-driver
   repository: https://helm.datadoghq.com
-  version: 0.4.3
+  version: 0.6.0
 - name: datadog-operator
   repository: https://helm.datadoghq.com
   version: 2.17.0
-digest: sha256:5eafd967383658e32008144297123a655dfd32de40ae0964d5dd1512b366378d
-generated: "2026-01-15T14:05:27.583593-05:00"
+digest: sha256:22e471f2808ec9ac2480b856e424483e8b38cbe4927aadabb909a5b4c6ff7ccc
+generated: "2026-02-06T15:16:39.176644+01:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: datadog.kubeStateMetricsEnabled
   - name: datadog-csi-driver
-    version: 0.4.3
+    version: 0.6.0
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator


### PR DESCRIPTION
#### What this PR does / why we need it:

Update version of datadog csi driver chart dependency in datadog chart


#### Which issue this PR fixes

Ensures datadog is using the most up to date version of the csi driver as a dependency.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits