### PR TITLE
[charts/datadog-operator] Add clusterRole.kubelet.fineGrainedAuthorization option

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.18.0-dev.5
+
+* Add `clusterRole.kubelet.fineGrainedAuthorization` option, allowing for finer grained kubelet API authorization (Kubernetes 1.32+).
+
 ## 2.18.0-dev.4
 
 * Update Datadog Operator chart for 1.23.0-rc.3.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.18.0-dev.4
+version: 2.18.0-dev.5
 appVersion: 1.23.0-rc.3
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.18.0-dev.4](https://img.shields.io/badge/Version-2.18.0--dev.4-informational?style=flat-square) ![AppVersion: 1.23.0-rc.3](https://img.shields.io/badge/AppVersion-1.23.0--rc.3-informational?style=flat-square)
+![Version: 2.18.0-dev.5](https://img.shields.io/badge/Version-2.18.0--dev.5-informational?style=flat-square) ![AppVersion: 1.23.0-rc.3](https://img.shields.io/badge/AppVersion-1.23.0--rc.3-informational?style=flat-square)
 
 ## Values
 
@@ -12,7 +12,9 @@
 | appKey | string | `nil` | Your Datadog APP key |
 | appKeyExistingSecret | string | `nil` | Use existing Secret which stores APP key instead of creating a new one |
 | clusterName | string | `nil` | Set a unique cluster name reporting from the Datadog Operator. |
-| clusterRole | object | `{"allowCreatePodsExec":false,"allowReadAllResources":false}` | Set specific configuration for the cluster role |
+| clusterRole | object | `{"allowCreatePodsExec":false,"allowReadAllResources":false,"kubelet":{"fineGrainedAuthorization":false}}` | Set specific configuration for the cluster role |
+| clusterRole.kubelet | object | `{"fineGrainedAuthorization":false}` | Set specific configuration for the kubelet RBAC rules |
+| clusterRole.kubelet.fineGrainedAuthorization | bool | `false` | Enable fine-grained authorization for kubelet (requires: Kubernetes 1.32+) |
 | collectOperatorMetrics | bool | `true` | Configures an openmetrics check to collect operator metrics |
 | containerSecurityContext | object | `{}` | A security context defines privileges and access control settings for a container. |
 | datadogAgent.enabled | bool | `true` | Enables Datadog Agent controller |

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -55,12 +55,15 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes/configz
-  - nodes/healthz
-  - nodes/logs
   - nodes/metrics
+  {{- if .Values.clusterRole.kubelet.fineGrainedAuthorization }}
   - nodes/pods
+  - nodes/healthz
+  - nodes/configz
+  - nodes/logs
+  {{- else }}
   - nodes/proxy
+  {{- end }}
   - nodes/spec
   - nodes/stats
   verbs:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -268,3 +268,8 @@ clusterRole:
 
   # allowCreatePodsExec is required for `remote_copy` mode of the CWS Instrumentation feature.
   allowCreatePodsExec: false
+
+  # clusterRole.kubelet -- Set specific configuration for the kubelet RBAC rules
+  kubelet:
+    # clusterRole.kubelet.fineGrainedAuthorization -- Enable fine-grained authorization for kubelet (requires: Kubernetes 1.32+)
+    fineGrainedAuthorization: false

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.18.0-dev.4
+    helm.sh/chart: datadog-operator-2.18.0-dev.5
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.23.0-rc.3"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION


#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes https://github.com/DataDog/helm-charts/issues/2338

#### Special notes for your reviewer:

Follow up to https://github.com/DataDog/helm-charts/pull/2049

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits