### PR TITLE
Set `service.ports` to an empty list instead of nil

### DIFF
--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.13.2
 
+- Set service.ports to empty list to fix nil issue
+
+## 2.13.2
+
 - Official image `2.13.2`
 
 ## 2.13.1

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: "2.13.2"
+version: "2.13.3"
 description: Observability Pipelines Worker
 type: application
 keywords:

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.13.2](https://img.shields.io/badge/Version-2.13.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.13.2](https://img.shields.io/badge/AppVersion-2.13.2-informational?style=flat-square)
+![Version: 2.13.3](https://img.shields.io/badge/Version-2.13.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.13.2](https://img.shields.io/badge/AppVersion-2.13.2-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 
@@ -151,7 +151,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | service.ipFamilies | list | `[]` | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/). |
 | service.ipFamilyPolicy | string | `""` | Configure [IPv4/IPv6 dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/). |
 | service.loadBalancerIP | string | `""` | Specify the [loadBalancerIP](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer). |
-| service.ports | array | `nil` | Manually set the ServicePort array, overriding automated generation of ServicePorts. |
+| service.ports | array | `[]` | Manually set the ServicePort array, overriding automated generation of ServicePorts. |
 | service.topologyKeys | array | `nil` | Specify the [topologyKeys](https://kubernetes.io/docs/concepts/services-networking/service-topology/#using-service-topology). |
 | service.type | string | `"ClusterIP"` | Specify the type for the Service. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount, if `serviceAccount.create` is **true**. |

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -217,7 +217,7 @@ service:
   #  - "topology.kubernetes.io/region"
   #  - "*"
   # service.ports -- (array) Manually set the ServicePort array, overriding automated generation of ServicePorts.
-  ports:
+  ports: []
   # service.externalTrafficPolicy -- Specify the
   # [externalTrafficPolicy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip).
   externalTrafficPolicy: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes OPA-4571
  - From this Slack [thread](https://dd.slack.com/archives/C02JRE3DKMY/p1770719774188799) when installing the Worker with helm 
 ```
Error: failed parsing --set data: unable to parse key: interface conversion: interface {} is nil, not []interface {}
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits