### PR TITLE
Bump operator version to 2.18.0 for image tag 1.23.0

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.169.0
+
+* Update Datadog Operator dependency to 2.18.0 for Operator image tag 1.23.0.
+
 ## 3.168.0
 
 * Update datadog-csi-driver chart dependency version.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.168.0
+version: 3.169.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.168.0](https://img.shields.io/badge/Version-3.168.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.169.0](https://img.shields.io/badge/Version-3.169.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -33,7 +33,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 |------------|------|---------|
 | https://helm.datadoghq.com | datadog-crds | 2.13.1 |
 | https://helm.datadoghq.com | datadog-csi-driver | 0.8.0 |
-| https://helm.datadoghq.com | operator(datadog-operator) | 2.17.0 |
+| https://helm.datadoghq.com | operator(datadog-operator) | 2.18.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 
 ## Quick start
@@ -1010,7 +1010,7 @@ helm install <RELEASE_NAME> \
 | operator.datadogGenericResource.enabled | bool | `false` | Enables the Datadog Generic Resource controller |
 | operator.datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | operator.datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
-| operator.image.tag | string | `"1.22.0"` | Define the Datadog Operator version to use |
+| operator.image.tag | string | `"1.23.0"` | Define the Datadog Operator version to use |
 | otelAgentGateway.additionalLabels | object | `{}` | Adds labels to the Agent Gateway Deployment and pods |
 | otelAgentGateway.affinity | object | `{}` | Allow the Gateway Deployment to schedule using affinity rules |
 | otelAgentGateway.autoscaling.annotations | object | `{}` | annotations for OTel Agent Gateway HPA |

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.8.0
 - name: datadog-operator
   repository: https://helm.datadoghq.com
-  version: 2.17.0
-digest: sha256:dbbf0d939b6ba05fc9a5a24a4d34061ed7368fce24bc92209269c6c0a8d32c6e
-generated: "2026-02-11T11:44:36.016969+01:00"
+  version: 2.18.0
+digest: sha256:290fcc8e7c98a7667cd8e8800295fdf578fe5ea4003be00d74e9ae86571d0b95
+generated: "2026-02-11T13:27:11.920221-05:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -14,7 +14,7 @@ dependencies:
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator
-    version: 2.17.0
+    version: 2.18.0
     repository: https://helm.datadoghq.com
     condition: datadog.operator.enabled
     alias: operator

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2759,7 +2759,7 @@ clusterChecksRunner:
 operator:
   image:
     # operator.image.tag -- Define the Datadog Operator version to use
-    tag: 1.22.0
+    tag: 1.23.0
 
   datadogAgent:
     # operator.datadogAgent.enabled -- Enables Datadog Agent controller

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1818,7 +1818,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1871,9 +1871,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1818,7 +1818,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1871,9 +1871,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1742,7 +1742,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1795,9 +1795,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1713,7 +1713,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1766,9 +1766,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1268,7 +1268,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1321,9 +1321,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1268,7 +1268,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1321,9 +1321,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1268,7 +1268,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1321,9 +1321,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1268,7 +1268,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1321,9 +1321,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -200,7 +200,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1784,7 +1784,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1837,9 +1837,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1707,7 +1707,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1760,9 +1760,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1707,7 +1707,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1760,9 +1760,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1592,7 +1592,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1645,9 +1645,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1538,7 +1538,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1591,9 +1591,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1557,7 +1557,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1610,9 +1610,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1611,7 +1611,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1664,9 +1664,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1581,7 +1581,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1634,9 +1634,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -2096,7 +2096,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2149,9 +2149,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -2160,7 +2160,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2213,9 +2213,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -2038,7 +2038,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2091,9 +2091,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1739,7 +1739,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1792,9 +1792,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1611,7 +1611,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1664,9 +1664,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -403,7 +403,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -2159,7 +2159,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2212,9 +2212,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -191,7 +191,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1772,7 +1772,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1825,9 +1825,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -2225,7 +2225,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2278,9 +2278,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -218,7 +218,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1901,7 +1901,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1954,9 +1954,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1820,7 +1820,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1873,9 +1873,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -218,7 +218,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1895,7 +1895,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1948,9 +1948,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -170,7 +170,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1864,7 +1864,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1917,9 +1917,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -218,7 +218,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1897,7 +1897,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1950,9 +1950,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -218,7 +218,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1891,7 +1891,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1944,9 +1944,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1707,7 +1707,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1760,9 +1760,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1783,7 +1783,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1836,9 +1836,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -1758,7 +1758,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1811,9 +1811,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -2403,7 +2403,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2456,9 +2456,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -2246,7 +2246,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2299,9 +2299,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -2296,7 +2296,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2349,9 +2349,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -2216,7 +2216,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2269,9 +2269,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -2124,7 +2124,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.22.0
+    app.kubernetes.io/version: 1.23.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2177,9 +2177,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-          image: gcr.io/datadoghq/operator:1.22.0
+          image: gcr.io/datadoghq/operator:1.23.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits