### PR TITLE
[charts/datadog] update ClusterRole, ClusterRoleBinding RBAC

### DIFF
--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -542,7 +542,6 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
   name: {{ template "datadog.fullname" . }}-cluster-agent-autoscaling
-  namespace: {{ .Release.Namespace }}
 rules:
 # Ability to generate events
 - apiGroups:
@@ -636,7 +635,6 @@ metadata:
   labels:
 {{ include "datadog.labels" . | indent 4 }}
   name: {{ template "datadog.fullname" . }}-cluster-agent-annotations-and-labels-as-tags
-  namespace: {{ .Release.Namespace }}
 
 {{- $groupedResources := dict }}
 {{- $mergedResources := mergeOverwrite (deepCopy (default dict .Values.datadog.kubernetesResourcesAnnotationsAsTags)) (deepCopy (default dict .Values.datadog.kubernetesResourcesLabelsAsTags))}}


### PR DESCRIPTION
#### What this PR does / why we need it:
removing `metadata.namespace` from cluster-wide resources, e.g. ClusterRole and ClusterRoleBinding

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] All commits are signed (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [X] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits