### PR TITLE
[datadog-crds]: chart v2.17.0-dev.1 for Operator v1.24.0-rc.1

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 2.17.0-dev.1
+
+* Update CRDs from Datadog Operator v1.24.0-rc.1 release candidate tag.
+
 ## 2.16.0
 
 * Update CRDs from Datadog Operator v1.23.0 tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.16.0
+version: 2.17.0-dev.1
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.16.0](https://img.shields.io/badge/Version-2.16.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.17.0-dev.1](https://img.shields.io/badge/Version-2.17.0--dev.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentinternals_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentinternals_v1.yaml
@@ -1163,6 +1163,12 @@ spec:
                                 Default: true
                               type: boolean
                           type: object
+                        runInSystemProbe:
+                          description: |-
+                            RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                            This is an experimental feature. Contact support before using.
+                            Default: false
+                          type: boolean
                       type: object
                     cws:
                       description: CWS (Cloud Workload Security) configuration.
@@ -1348,6 +1354,7 @@ spec:
                         tagCardinality:
                           description: |-
                             TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                            This setting only applies when OriginDetectionEnabled is true.
                             See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                             Cardinality default: low
                           type: string
@@ -1857,6 +1864,11 @@ spec:
                         collectDNSStats:
                           description: |-
                             CollectDNSStats enables DNS stat collection.
+                            Default: false
+                          type: boolean
+                        directSend:
+                          description: |-
+                            DirectSend enables CNM/USM to send data directly to the backend
                             Default: false
                           type: boolean
                         enableConntrack:
@@ -9156,6 +9168,12 @@ spec:
                                     Default: true
                                   type: boolean
                               type: object
+                            runInSystemProbe:
+                              description: |-
+                                RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                                This is an experimental feature. Contact support before using.
+                                Default: false
+                              type: boolean
                           type: object
                         cws:
                           description: CWS (Cloud Workload Security) configuration.
@@ -9341,6 +9359,7 @@ spec:
                             tagCardinality:
                               description: |-
                                 TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                                This setting only applies when OriginDetectionEnabled is true.
                                 See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                                 Cardinality default: low
                               type: string
@@ -9850,6 +9869,11 @@ spec:
                             collectDNSStats:
                               description: |-
                                 CollectDNSStats enables DNS stat collection.
+                                Default: false
+                              type: boolean
+                            directSend:
+                              description: |-
+                                DirectSend enables CNM/USM to send data directly to the backend
                                 Default: false
                               type: boolean
                             enableConntrack:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
@@ -1163,6 +1163,12 @@ spec:
                                     Default: true
                                   type: boolean
                               type: object
+                            runInSystemProbe:
+                              description: |-
+                                RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                                This is an experimental feature. Contact support before using.
+                                Default: false
+                              type: boolean
                           type: object
                         cws:
                           description: CWS (Cloud Workload Security) configuration.
@@ -1348,6 +1354,7 @@ spec:
                             tagCardinality:
                               description: |-
                                 TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                                This setting only applies when OriginDetectionEnabled is true.
                                 See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                                 Cardinality default: low
                               type: string
@@ -1857,6 +1864,11 @@ spec:
                             collectDNSStats:
                               description: |-
                                 CollectDNSStats enables DNS stat collection.
+                                Default: false
+                              type: boolean
+                            directSend:
+                              description: |-
+                                DirectSend enables CNM/USM to send data directly to the backend
                                 Default: false
                               type: boolean
                             enableConntrack:

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -631,6 +631,8 @@ spec:
                             enabled:
                               type: boolean
                           type: object
+                        runInSystemProbe:
+                          type: boolean
                       type: object
                     cws:
                       properties:
@@ -1025,6 +1027,8 @@ spec:
                     npm:
                       properties:
                         collectDNSStats:
+                          type: boolean
+                        directSend:
                           type: boolean
                         enableConntrack:
                           type: boolean
@@ -4770,6 +4774,8 @@ spec:
                                 enabled:
                                   type: boolean
                               type: object
+                            runInSystemProbe:
+                              type: boolean
                           type: object
                         cws:
                           properties:
@@ -5164,6 +5170,8 @@ spec:
                         npm:
                           properties:
                             collectDNSStats:
+                              type: boolean
+                            directSend:
                               type: boolean
                             enableConntrack:
                               type: boolean

--- a/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogmonitors_v1.yaml
@@ -37,7 +37,7 @@ spec:
           jsonPath: .status.monitorStateLastUpdateTime
           name: last state sync
           type: string
-        - jsonPath: .status.syncStatus
+        - jsonPath: .status.monitorStateSyncStatus
           name: sync status
           type: string
         - jsonPath: .metadata.creationTimestamp

--- a/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
@@ -1502,6 +1502,24 @@ spec:
                   minItems: 1
                   type: array
                   x-kubernetes-list-type: atomic
+                options:
+                  description: Options defines optional behavior modifications for the autoscaler.
+                  properties:
+                    outOfMemory:
+                      description: OutOfMemory configures behavior when OOM events are detected.
+                      properties:
+                        bumpUpRatio:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            BumpUpRatio defines the ratio to multiply memory by when OOM is detected.
+                            For example, "1.2" means increase memory by 20%.
+                            Represented as a resource.Quantity to avoid floating point in CRDs.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 owner:
                   description: |-
                     Owner defines the source of truth for this object (local or remote).

--- a/crds/datadoghq.com_datadogagentinternals.yaml
+++ b/crds/datadoghq.com_datadogagentinternals.yaml
@@ -1154,6 +1154,12 @@ spec:
                                 Default: true
                               type: boolean
                           type: object
+                        runInSystemProbe:
+                          description: |-
+                            RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                            This is an experimental feature. Contact support before using.
+                            Default: false
+                          type: boolean
                       type: object
                     cws:
                       description: CWS (Cloud Workload Security) configuration.
@@ -1339,6 +1345,7 @@ spec:
                         tagCardinality:
                           description: |-
                             TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                            This setting only applies when OriginDetectionEnabled is true.
                             See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                             Cardinality default: low
                           type: string
@@ -1848,6 +1855,11 @@ spec:
                         collectDNSStats:
                           description: |-
                             CollectDNSStats enables DNS stat collection.
+                            Default: false
+                          type: boolean
+                        directSend:
+                          description: |-
+                            DirectSend enables CNM/USM to send data directly to the backend
                             Default: false
                           type: boolean
                         enableConntrack:
@@ -9147,6 +9159,12 @@ spec:
                                     Default: true
                                   type: boolean
                               type: object
+                            runInSystemProbe:
+                              description: |-
+                                RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                                This is an experimental feature. Contact support before using.
+                                Default: false
+                              type: boolean
                           type: object
                         cws:
                           description: CWS (Cloud Workload Security) configuration.
@@ -9332,6 +9350,7 @@ spec:
                             tagCardinality:
                               description: |-
                                 TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                                This setting only applies when OriginDetectionEnabled is true.
                                 See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                                 Cardinality default: low
                               type: string
@@ -9841,6 +9860,11 @@ spec:
                             collectDNSStats:
                               description: |-
                                 CollectDNSStats enables DNS stat collection.
+                                Default: false
+                              type: boolean
+                            directSend:
+                              description: |-
+                                DirectSend enables CNM/USM to send data directly to the backend
                                 Default: false
                               type: boolean
                             enableConntrack:

--- a/crds/datadoghq.com_datadogagentprofiles.yaml
+++ b/crds/datadoghq.com_datadogagentprofiles.yaml
@@ -1154,6 +1154,12 @@ spec:
                                     Default: true
                                   type: boolean
                               type: object
+                            runInSystemProbe:
+                              description: |-
+                                RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                                This is an experimental feature. Contact support before using.
+                                Default: false
+                              type: boolean
                           type: object
                         cws:
                           description: CWS (Cloud Workload Security) configuration.
@@ -1339,6 +1345,7 @@ spec:
                             tagCardinality:
                               description: |-
                                 TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                                This setting only applies when OriginDetectionEnabled is true.
                                 See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                                 Cardinality default: low
                               type: string
@@ -1848,6 +1855,11 @@ spec:
                             collectDNSStats:
                               description: |-
                                 CollectDNSStats enables DNS stat collection.
+                                Default: false
+                              type: boolean
+                            directSend:
+                              description: |-
+                                DirectSend enables CNM/USM to send data directly to the backend
                                 Default: false
                               type: boolean
                             enableConntrack:

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -622,6 +622,8 @@ spec:
                             enabled:
                               type: boolean
                           type: object
+                        runInSystemProbe:
+                          type: boolean
                       type: object
                     cws:
                       properties:
@@ -1016,6 +1018,8 @@ spec:
                     npm:
                       properties:
                         collectDNSStats:
+                          type: boolean
+                        directSend:
                           type: boolean
                         enableConntrack:
                           type: boolean
@@ -4761,6 +4765,8 @@ spec:
                                 enabled:
                                   type: boolean
                               type: object
+                            runInSystemProbe:
+                              type: boolean
                           type: object
                         cws:
                           properties:
@@ -5155,6 +5161,8 @@ spec:
                         npm:
                           properties:
                             collectDNSStats:
+                              type: boolean
+                            directSend:
                               type: boolean
                             enableConntrack:
                               type: boolean

--- a/crds/datadoghq.com_datadogmonitors.yaml
+++ b/crds/datadoghq.com_datadogmonitors.yaml
@@ -28,7 +28,7 @@ spec:
           jsonPath: .status.monitorStateLastUpdateTime
           name: last state sync
           type: string
-        - jsonPath: .status.syncStatus
+        - jsonPath: .status.monitorStateSyncStatus
           name: sync status
           type: string
         - jsonPath: .metadata.creationTimestamp

--- a/crds/datadoghq.com_datadogpodautoscalers.yaml
+++ b/crds/datadoghq.com_datadogpodautoscalers.yaml
@@ -1493,6 +1493,24 @@ spec:
                   minItems: 1
                   type: array
                   x-kubernetes-list-type: atomic
+                options:
+                  description: Options defines optional behavior modifications for the autoscaler.
+                  properties:
+                    outOfMemory:
+                      description: OutOfMemory configures behavior when OOM events are detected.
+                      properties:
+                        bumpUpRatio:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            BumpUpRatio defines the ratio to multiply memory by when OOM is detected.
+                            For example, "1.2" means increase memory by 20%.
+                            Represented as a resource.Quantity to avoid floating point in CRDs.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 owner:
                   description: |-
                     Owner defines the source of truth for this object (local or remote).


### PR DESCRIPTION
#### What this PR does / why we need it:

Update Datadog CRDs helm chart for Operator v1.24.0-rc.1

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits