### PR TITLE
[devel][datadog-operator] 1.24.0-rc.1

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.19.0-dev.1
+
+* Update Datadog Operator chart for 1.24.0-rc.1.
+
 ## 2.18.1
 
 * Update Datadog Operator chart for 1.23.1.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.16.0
-digest: sha256:1f3e1f48c752da51bf27f6068e67067784958dbaa137aa7fc1ce59d47fba0979
-generated: "2026-02-11T15:53:44.18891+01:00"
+  version: 2.17.0-dev.1
+digest: sha256:2f3fe6bb82f8b5eebbe3d9edff8871124b447798a4c4e75fc69fba2eeff2f464
+generated: "2026-02-12T14:00:15.009338-05:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.18.1
-appVersion: 1.23.1
+version: 2.19.0-dev.1
+appVersion: 1.24.0-rc.1
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: 2.16.0
+  version: 2.17.0-dev.1
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.18.1](https://img.shields.io/badge/Version-2.18.1-informational?style=flat-square) ![AppVersion: 1.23.1](https://img.shields.io/badge/AppVersion-1.23.1-informational?style=flat-square)
+![Version: 2.19.0-dev.1](https://img.shields.io/badge/Version-2.19.0--dev.1-informational?style=flat-square) ![AppVersion: 1.24.0-rc.1](https://img.shields.io/badge/AppVersion-1.24.0--rc.1-informational?style=flat-square)
 
 ## Values
 
@@ -39,7 +39,7 @@
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.23.1"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.24.0-rc.1"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |

--- a/charts/datadog-operator/templates/_helpers.tpl
+++ b/charts/datadog-operator/templates/_helpers.tpl
@@ -156,6 +156,6 @@ Check operator image tag version.
 {{- $parts := split "@" $tag -}}
 {{- index $parts "_0"}}
 {{- else -}}
-{{ "1.23.1" }}
+{{ "1.24.0-rc.1" }}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -126,6 +126,14 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
+  - applications
+  - applicationsets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
   - rollouts
   verbs:
   - list
@@ -339,6 +347,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - kustomize.toolkit.fluxcd.io
+  resources:
+  - kustomizations
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - metrics.eks.amazonaws.com
   resources:
   - kcm/metrics
@@ -428,6 +443,18 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - source.toolkit.fluxcd.io
+  resources:
+  - buckets
+  - externalartifacts
+  - gitrepositories
+  - helmcharts
+  - helmrepositories
+  - ocirepositories
+  verbs:
+  - list
+  - watch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.23.1
+  tag: 1.24.0-rc.1
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
   # image.doNotCheckTag -- Permit skipping operator image tag compatibility with the chart.

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.17.3
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-2.16.0'
+    helm.sh/chart: 'datadogCRDs-2.17.0-dev.1'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -628,6 +628,8 @@ spec:
                             enabled:
                               type: boolean
                           type: object
+                        runInSystemProbe:
+                          type: boolean
                       type: object
                     cws:
                       properties:
@@ -1022,6 +1024,8 @@ spec:
                     npm:
                       properties:
                         collectDNSStats:
+                          type: boolean
+                        directSend:
                           type: boolean
                         enableConntrack:
                           type: boolean
@@ -4767,6 +4771,8 @@ spec:
                                 enabled:
                                   type: boolean
                               type: object
+                            runInSystemProbe:
+                              type: boolean
                           type: object
                         cws:
                           properties:
@@ -5161,6 +5167,8 @@ spec:
                         npm:
                           properties:
                             collectDNSStats:
+                              type: boolean
+                            directSend:
                               type: boolean
                             enableConntrack:
                               type: boolean

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.18.1
+    helm.sh/chart: datadog-operator-2.19.0-dev.1
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.23.1"
+    app.kubernetes.io/version: "1.24.0-rc.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "gcr.io/datadoghq/operator:1.23.1"
+          image: "gcr.io/datadoghq/operator:1.24.0-rc.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -144,7 +144,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "gcr.io/datadoghq/operator:1.23.1", operatorContainer.Image)
+	assert.Equal(t, "gcr.io/datadoghq/operator:1.24.0-rc.1", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates operator devel chart for 1.24.0-rc.1

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits