### PR TITLE
discovery: add useSdAgent config option

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.167.0
+
+* Add `datadog.discovery.useSystemProbeLite` option to wrap system-probe with system-probe-lite for lightweight service discovery.
+
 ## 3.166.5
 
 * Conditionally set env vars to match datadog-operator: logs, prometheusScrape, process-agent

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.166.5
+version: 3.167.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.166.5](https://img.shields.io/badge/Version-3.166.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.167.0](https://img.shields.io/badge/Version-3.167.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -784,6 +784,7 @@ helm install <RELEASE_NAME> \
 | datadog.disablePasswdMount | bool | `false` | Set this to true to disable mounting /etc/passwd in all containers |
 | datadog.discovery.enabled | bool | `nil` | Enable Service Discovery |
 | datadog.discovery.networkStats.enabled | bool | `true` | Enable Service Discovery Network Stats |
+| datadog.discovery.useSystemProbeLite | bool | `false` | Use system-probe-lite to wrap system-probe for discovery. When enabled, system-probe-lite runs as a lightweight alternative to system-probe when only discovery features are needed. Falls back to system-probe automatically on older agent images that don't include system-probe-lite or when non-discovery features are also enabled. |
 | datadog.dockerSocketPath | string | `nil` | Path to the docker socket |
 | datadog.dogstatsd.hostSocketPath | string | `"/var/run/datadog"` | Host path to the DogStatsD socket |
 | datadog.dogstatsd.nonLocalTraffic | bool | `true` | Enable this to make each node accept non-local statsd traffic (from outside of the pod) |

--- a/charts/datadog/ci/with-system-probe-lite-and-npm-values.yaml
+++ b/charts/datadog/ci/with-system-probe-lite-and-npm-values.yaml
@@ -1,0 +1,7 @@
+datadog:
+  apiKey: xxx
+  discovery:
+    enabled: true
+    useSystemProbeLite: true
+  networkMonitoring:
+    enabled: true

--- a/charts/datadog/ci/with-system-probe-lite-values.yaml
+++ b/charts/datadog/ci/with-system-probe-lite-values.yaml
@@ -1,0 +1,5 @@
+datadog:
+  apiKey: xxx
+  discovery:
+    enabled: true
+    useSystemProbeLite: true

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -3,7 +3,12 @@
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
 {{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.systemProbe.securityContext "targetSystem" .Values.targetSystem "seccomp" .Values.datadog.systemProbe.seccomp "kubeversion" .Capabilities.KubeVersion.Version "apparmor" (and .Values.agents.podSecurity.apparmor.enabled .Values.datadog.systemProbe.apparmor) "mknod" (and .Values.datadog.gpuMonitoring.enabled .Values.datadog.gpuMonitoring.privilegedMode) "kill" .Values.datadog.securityAgent.runtime.enforcement.enabled) | nindent 2 }}
+{{- if and .Values.datadog.discovery.useSystemProbeLite (eq (include "only-discovery-system-probe-feature" .) "true") }}
+  command: ["/bin/sh", "-c"]
+  args: ["if [ -x /opt/datadog-agent/embedded/bin/system-probe-lite ]; then exec /opt/datadog-agent/embedded/bin/system-probe-lite; else exec system-probe --config=/etc/datadog-agent/system-probe.yaml; fi"]
+{{- else }}
   command: ["system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
+{{- end }}
 {{- if .Values.agents.containers.systemProbe.ports }}
   ports:
 {{ toYaml .Values.agents.containers.systemProbe.ports | indent 2 }}
@@ -21,6 +26,10 @@
     {{- include "containers-common-env" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.systemProbe.logLevel | default .Values.datadog.logLevel | quote }}
+    {{- if and .Values.datadog.discovery.useSystemProbeLite (eq (include "only-discovery-system-probe-feature" .) "true") }}
+    - name: DD_DISCOVERY_USE_SYSTEM_PROBE_LITE
+      value: "true"
+    {{- end }}
     {{- if or .Values.datadog.securityAgent.runtime.enabled .Values.datadog.serviceMonitoring.enabled (and .Values.datadog.gpuMonitoring.enabled .Values.datadog.gpuMonitoring.privilegedMode) }}
     - name: HOST_ROOT
       value: "/host/root"

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -527,6 +527,25 @@ false
 {{- end -}}
 
 {{/*
+Return true if discovery is the ONLY system-probe feature enabled.
+*/}}
+{{- define "only-discovery-system-probe-feature" -}}
+{{- if and .Values.datadog.discovery.enabled
+          (not .Values.datadog.securityAgent.runtime.enabled)
+          (not .Values.datadog.networkMonitoring.enabled)
+          (not .Values.datadog.systemProbe.enableTCPQueueLength)
+          (not .Values.datadog.systemProbe.enableOOMKill)
+          (not .Values.datadog.serviceMonitoring.enabled)
+          (not .Values.datadog.traceroute.enabled)
+          (not (and .Values.datadog.gpuMonitoring.enabled .Values.datadog.gpuMonitoring.privilegedMode))
+          (not .Values.datadog.dynamicInstrumentationGo.enabled) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return true if the system-probe container should be created.
 */}}
 {{- define "should-enable-system-probe" -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1035,6 +1035,9 @@ datadog:
     # datadog.discovery.enabled -- (bool) Enable Service Discovery
     enabled:  # false
 
+    # datadog.discovery.useSystemProbeLite -- (bool) Use system-probe-lite to wrap system-probe for discovery.
+    useSystemProbeLite: false
+
     # datadog.discovery.networkStats.enabled -- (bool) Enable Service Discovery Network Stats
     networkStats:
       enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds a new `datadog.discovery.useSdAgent` config option, that sets the corresponding system-probe configuration option. When this option is enabled, `system-probe` is wrapped by the new `sd-agent` binary, which will run when only `discovery` is enabled. If any other system-probe feature is required, `sd-agent` automatically fallbacks to system-probe.

The PR also changes the command line of the system-probe container to first check if the sd-agent binary exists first. This is needed to support older agent versions. This was tested with a deployment of 7.75 with the updated chart, and `useSdAgent` set to true.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes DSCVR-271

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] All commits are signed (see: [signing commits][1])
- [X] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [X] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated 
- [X] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits