### PR TITLE
Update paths-ignore for no-ci GH workflow

### DIFF
--- a/.github/workflows/no-ci.yaml
+++ b/.github/workflows/no-ci.yaml
@@ -2,7 +2,14 @@ name: No chart lint and test needed
 on:
   pull_request:
     paths-ignore:
-      - 'charts/**'
+      - "charts/**/Chart.yaml"
+      - "charts/**/Chart.lock"
+      - "charts/**/requirements.yaml"
+      - "charts/**/requirements.lock"
+      - "charts/**/values.yaml"
+      - "charts/**/values.schema.json"
+      - "charts/**/templates/**"
+      - "charts/**/*.tpl"
 jobs:
   pr-validated:
     name: pr-validated


### PR DESCRIPTION
#### What this PR does / why we need it:

- Updates the `no-ci` GH workflow's `paths-ignore` key so that the workflow runs when `no-ci` is needed (i.e. for docs or ci-only changes)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits