### PR TITLE
Add appProtocol to OTLP service ports

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.174.1
+
+* Add `appProtocol` field to OTLP service ports (`otlpgrpcport` and `otlphttpport`) so that Envoy-based service meshes (Istio, Gloo, etc.) correctly identify gRPC and HTTP protocols on the local-traffic service.
+
 ## 3.174.0
 
 * Add Helm-Operator migration Kubernetes job. This feature is in preview ([#2319](https://github.com/DataDog/helm-charts/pull/2319)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.174.0
+version: 3.174.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.174.0](https://img.shields.io/badge/Version-3.174.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.174.1](https://img.shields.io/badge/Version-3.174.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/agent-services.yaml
+++ b/charts/datadog/templates/agent-services.yaml
@@ -93,12 +93,14 @@ spec:
       port: {{ .Values.datadog.otlp.receiver.protocols.grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
       targetPort: {{ .Values.datadog.otlp.receiver.protocols.grpc.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
       name: otlpgrpcport
+      appProtocol: grpc
 {{- end }}
 {{- if .Values.datadog.otlp.receiver.protocols.http.enabled }}
     - protocol: TCP
       port: {{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
       targetPort: {{ .Values.datadog.otlp.receiver.protocols.http.endpoint | regexFind ":[0-9]+$" | trimPrefix ":" }}
       name: otlphttpport
+      appProtocol: http
  {{- end }}
 {{- if eq (include "should-enable-otel-agent" .) "true" }}
 {{- range .Values.datadog.otelCollector.ports }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `appProtocol: grpc` and `appProtocol: http` to the OTLP receiver port entries (`otlpgrpcport` and `otlphttpport`) in the local-traffic agent service (`agent-services.yaml`).

Envoy-based service meshes (Istio sidecar/ambient, Gloo, etc.) rely on either port-name prefixes (`grpc-`, `http-`) or the `appProtocol` field to detect application-level protocols. Because `otlpgrpcport` doesn't match any recognized prefix, the proxy treats the port as plain TCP — breaking gRPC connectivity with:

```
upstream connect error or disconnect/reset before headers.
reset reason: protocol error
```

`appProtocol` is a stable Kubernetes field (GA since v1.20) and is the standard way to declare application-level protocols on service ports.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

- This is a non-breaking, additive-only change — `appProtocol` is ignored by components that don't inspect it.
- Verified that versions 3.154.1 through 3.174.0 do not set `appProtocol` on these ports.
- No new values.yaml parameters are introduced (the field is unconditionally set when the OTLP receiver is enabled).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits