### PR TITLE
[CASCL-864] Add RBAC for eks.amazonaws.com NodeClass CRD

### DIFF
--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -286,6 +286,7 @@ rules:
   - watch
 - apiGroups:
   - datadoghq.com
+  - eks.amazonaws.com
   - karpenter.azure.com
   resources:
   - '*'


### PR DESCRIPTION
#### What this PR does / why we need it:

Support AWS EKS auto-mode cluster in Datadog Kubernetes Autoscaling.
This PR add missing RBAC for the operator, to allow the creation of RBAC for the AWS EKS Karpenter CRDs collections with  orchestrator check that run either in the cluster-agent or cluster-check-runner.  

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - requires for [CASCL-864](https://datadoghq.atlassian.net/browse/CASCL-864)]

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits