### PR TITLE
[devel][datadog-operator] Update Operator RBACs for v1.24.0-rc.2

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.19.0-dev.5
+
+* Update Datadog Operator chart for RBACs for 1.24.0-rc.2.
+
 ## 2.19.0-dev.4
 
 * Update Datadog Operator chart for 1.24.0-rc.2.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.19.0-dev.4
+version: 2.19.0-dev.5
 appVersion: 1.24.0-rc.2
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.19.0-dev.4](https://img.shields.io/badge/Version-2.19.0--dev.4-informational?style=flat-square) ![AppVersion: 1.24.0-rc.2](https://img.shields.io/badge/AppVersion-1.24.0--rc.2-informational?style=flat-square)
+![Version: 2.19.0-dev.5](https://img.shields.io/badge/Version-2.19.0--dev.5-informational?style=flat-square) ![AppVersion: 1.24.0-rc.2](https://img.shields.io/badge/AppVersion-1.24.0--rc.2-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -286,6 +286,7 @@ rules:
   - watch
 - apiGroups:
   - datadoghq.com
+  - eks.amazonaws.com
   - karpenter.azure.com
   resources:
   - '*'

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.19.0-dev.4
+    helm.sh/chart: datadog-operator-2.19.0-dev.5
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.24.0-rc.2"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the public Operator helm chart RBACs for new features included in rc2

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits