### PR TITLE
[datadog-operator] 2.19.1: rollback registryMigrationMode and operator image registry

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.19.1
+
+* Rollback: disable `registryMigrationMode` (set default to `""`) and revert operator image repository to `gcr.io/datadoghq/operator`.
+
 ## 2.19.0-dev.8
 
 * Switch operator image to registry.datadoghq.com ([#2430](https://github.com/DataDog/helm-charts/pull/2430)).

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.19.0
+version: 2.19.1
 appVersion: 1.24.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.19.0](https://img.shields.io/badge/Version-2.19.0-informational?style=flat-square) ![AppVersion: 1.24.0](https://img.shields.io/badge/AppVersion-1.24.0-informational?style=flat-square)
+![Version: 2.19.1](https://img.shields.io/badge/Version-2.19.1-informational?style=flat-square) ![AppVersion: 1.24.0](https://img.shields.io/badge/AppVersion-1.24.0-informational?style=flat-square)
 
 ## Values
 
@@ -38,7 +38,7 @@
 | fullnameOverride | string | `""` |  |
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
-| image.repository | string | `"registry.datadoghq.com/operator"` | Repository to use for Datadog Operator image |
+| image.repository | string | `"gcr.io/datadoghq/operator"` | Repository to use for Datadog Operator image |
 | image.tag | string | `"1.24.0"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
@@ -53,7 +53,7 @@
 | podAnnotations | object | `{}` | Allows setting additional annotations for Datadog Operator PODs |
 | podLabels | object | `{}` | Allows setting additional labels for for Datadog Operator PODs |
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |
-| registryMigrationMode | string | `"auto"` | Controls gradual migration of Agent image pulls to registry.datadoghq.com. When enabled, DD_REGISTRY_OVERRIDE_* environment variables are added to the Datadog Operator deployment to pull Agent images from the global CDN-backed registry.datadoghq.com based on the global.site setting, unless global.registry is specified in the DatadogAgent custom resource (which takes precedence). This has no effect on sites not covered by the active overrides. More sites will be enabled by default in future helm-chart releases. "auto" (default): enable overrides for sites where migration is rolled out.   Currently enabled: AP1 (ap1.datadoghq.com). "all": enable all per-site overrides (AP1, US1, EU1, US3). "" or unset: disable all overrides. |
+| registryMigrationMode | string | `""` | Controls gradual migration of Agent image pulls to registry.datadoghq.com. When enabled, DD_REGISTRY_OVERRIDE_* environment variables are added to the Datadog Operator deployment to pull Agent images from the global CDN-backed registry.datadoghq.com based on the global.site setting, unless global.registry is specified in the DatadogAgent custom resource (which takes precedence). This has no effect on sites not covered by the active overrides. More sites will be enabled by default in future helm-chart releases. "auto" (default): enable overrides for sites where migration is rolled out.   Currently enabled: AP1 (ap1.datadoghq.com). "all": enable all per-site overrides (AP1, US1, EU1, US3). "" or unset: disable all overrides. |
 | remoteConfiguration.enabled | bool | `false` | If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set. |
 | replicaCount | int | `1` | Number of instances of Datadog Operator |
 | resources | object | `{}` | Set resources requests/limits for Datadog Operator PODs |

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -45,7 +45,7 @@ appKeyExistingSecret:  # <DATADOG_APP_KEY_SECRET>
 
 image:
   # image.repository -- Repository to use for Datadog Operator image
-  repository: registry.datadoghq.com/operator
+  repository: gcr.io/datadoghq/operator
   # image.tag -- Define the Datadog Operator version to use
   tag: 1.24.0
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
@@ -113,7 +113,7 @@ remoteConfiguration:
 #   Currently enabled: AP1 (ap1.datadoghq.com).
 # "all": enable all per-site overrides (AP1, US1, EU1, US3).
 # "" or unset: disable all overrides.
-registryMigrationMode: "auto"
+registryMigrationMode: ""
 
 deployment:
   # deployment.annotations -- Allows setting additional annotations for the deployment resource

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.19.0
+    helm.sh/chart: datadog-operator-2.19.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.24.0"
     app.kubernetes.io/managed-by: Helm
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "registry.datadoghq.com/operator:1.24.0"
+          image: "gcr.io/datadoghq/operator:1.24.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -56,8 +56,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-            - name: DD_REGISTRY_OVERRIDE_ASIA
-              value: "true"
           args:
             - "-supportExtendedDaemonset=false"
             - "-logEncoder=json"

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -183,7 +183,7 @@ func Test_operator_chart(t *testing.T) {
 				common.Unmarshal(t, manifest, &deployment)
 				assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
-				assert.Equal(t, "registry.datadoghq.com/operator:1.18.0@sha256:0000", operatorContainer.Image)
+				assert.Equal(t, "gcr.io/datadoghq/operator:1.18.0@sha256:0000", operatorContainer.Image)
 				installToolEnv := FindEnvVarByName(operatorContainer.Env, "DD_TOOL_VERSION")
 				assert.Equal(t, "unknown", installToolEnv.Value)
 			},
@@ -208,7 +208,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "registry.datadoghq.com/operator:1.24.0", operatorContainer.Image)
+	assert.Equal(t, "gcr.io/datadoghq/operator:1.24.0", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

**Precautionary rollback — do not merge unless the registry migration (PRs #2421 / #2430) needs to be reverted.**

This PR is prepared in advance as a break-glass option. It should remain as a draft and only be merged if something goes wrong with the BARX-1655 registry migration rollout.

Changes:
- Sets `registryMigrationMode: ""` (disabled — no `DD_REGISTRY_OVERRIDE_*` env vars injected)
- Reverts operator image repository to `gcr.io/datadoghq/operator`
- Bumps chart version to `2.19.1` so it is picked up as the latest stable release without `--devel`

The `registryMigrationMode` value and helper template are kept in place (not removed), so re-enabling the migration is a one-line change when ready.

#### Which issue this PR fixes
  - Related to https://datadoghq.atlassian.net/browse/BARX-1655

#### Special notes for your reviewer:

Rollback of #2421 and #2430. **Do not merge unless the registry migration needs to be reverted.**

#### Checklist
- [x] All commits are signed (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (`datadog-operator/patch-version`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits