### PR TITLE
[BARX-1655] Extend AP1 registry migration to all users

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.183.0
+
+* Extend `registryMigrationMode: "auto"` to all AP1 (`ap1.datadoghq.com`) users regardless of APM configuration.
+
 ## 3.182.0
 
 * Add `registryMigrationMode` to control gradual migration of default image registry to `registry.datadoghq.com`, replacing site-specific regional mirrors (GCR, ACR). Defaults to `"auto"`, which currently enables `registry.datadoghq.com` for the AP1 site (`ap1.datadoghq.com`) when `datadog.apm.enabled` is `false` (the default). More sites will be enabled in future releases. Set to `""` to disable. GKE Autopilot, GKE GDC, US1-FED, and US3 clusters are excluded.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.182.0
+version: 3.183.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.182.0](https://img.shields.io/badge/Version-3.182.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.183.0](https://img.shields.io/badge/Version-3.183.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -952,7 +952,7 @@ Learn more about Private Action Runner: https://docs.datadoghq.com/actions/priva
 {{- if eq $migrationMode "all" -}}
 {{- $migratedSite = true -}}
 {{- else if eq $migrationMode "auto" -}}
-{{- if and (eq $site "ap1.datadoghq.com") (not .Values.datadog.apm.enabled) -}}
+{{- if eq $site "ap1.datadoghq.com" -}}
 {{- $migratedSite = true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -471,7 +471,7 @@ datadoghq.azurecr.io
 {{- if eq $migrationMode "all" -}}
 {{- $migratedSite = true -}}
 {{- else if eq $migrationMode "auto" -}}
-{{- if and (eq $site "ap1.datadoghq.com") (not .datadog.apm.enabled) -}}
+{{- if eq $site "ap1.datadoghq.com" -}}
 {{- $migratedSite = true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -43,7 +43,7 @@ registry:  # gcr.io/datadoghq
 # US3 (us3.datadoghq.com) is excluded and always uses datadoghq.azurecr.io.
 
 ## "auto" (default): enable registry.datadoghq.com for sites where migration is rolled out.
-##   Currently enabled: AP1 (ap1.datadoghq.com) when datadog.apm.enabled is false (the default).
+##   Currently enabled: AP1 (ap1.datadoghq.com).
 ## "all": enable registry.datadoghq.com for all sites (AP1, AP2, EU, US1, US5).
 ## "": disable migration, keeping site-specific registries.
 registryMigrationMode: "auto"

--- a/test/datadog/registry_migration_test.go
+++ b/test/datadog/registry_migration_test.go
@@ -126,8 +126,8 @@ func TestRegistryMigration(t *testing.T) {
 		assert.Contains(t, err.Error(), "registryMigrationMode")
 	})
 
-	// APM gating: auto mode on AP1 only migrates when apm.enabled is false (the default).
-	t.Run("AP1/auto/apm-enabled: no migration", func(t *testing.T) {
+	// AP1 auto migration applies regardless of APM configuration.
+	t.Run("AP1/auto/apm-enabled: migrates", func(t *testing.T) {
 		registry := renderAndExtractRegistry(t, map[string]string{
 			"datadog.apiKeyExistingSecret": "datadog-secret",
 			"datadog.appKeyExistingSecret": "datadog-secret",
@@ -135,7 +135,7 @@ func TestRegistryMigration(t *testing.T) {
 			"datadog.apm.enabled":          "true",
 			"registryMigrationMode":        "auto",
 		})
-		assert.Equal(t, "asia.gcr.io/datadoghq", registry)
+		assert.Equal(t, "registry.datadoghq.com", registry)
 	})
 
 	// Explicit registry always takes precedence over migration.


### PR DESCRIPTION
#### What this PR does / why we need it:

Follow-up to #2438. Removes the `datadog.apm.enabled` gate from `registryMigrationMode: "auto"` so that **all AP1** (`ap1.datadoghq.com`) users are migrated to `registry.datadoghq.com`, regardless of APM configuration.

Previously, auto mode only migrated AP1 users when `datadog.apm.enabled` was `false` (the default). This PR removes that condition.

#### Which issue this PR fixes

- Part of https://datadoghq.atlassian.net/browse/BARX-1655
- Follow-up to #2438

#### Special notes for your reviewer:

Single-line change in the `registry` helper and `NOTES.txt` — removes `(not .datadog.apm.enabled)` from the AP1 auto condition.

#### Checklist
- [x] All commits are signed (see: [signing commits][1])
- [x] Chart Version semver bump label has been added
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits