### PR TITLE
WIP: Standalone helm

### DIFF
--- a/charts/datadog/templates/_container-host-profiler-standalone.yaml
+++ b/charts/datadog/templates/_container-host-profiler-standalone.yaml
@@ -1,0 +1,58 @@
+{{- define "container-host-profiler-standalone" -}}
+- name: host-profiler
+  image: "{{ include "ddot-ebpf-standalone-image" . }}"
+  imagePullPolicy: {{ .Values.datadog.hostProfilerStandalone.containers.hostProfiler.imagePullPolicy }}
+  command:
+    - "/opt/datadog-agent/embedded/bin/full-host-profiler"
+    - "run"
+  args:
+    {{- if .Values.datadog.hostProfilerStandalone.configMap.items }}
+    {{- range .Values.datadog.hostProfilerStandalone.configMap.items }}
+    - "--config={{ template "datadog.hostprofilerconfPath" $ }}/{{ .path }}"
+    {{- end }}
+    {{- else }}
+    - "--config={{ template "datadog.hostprofilerconfPath" . }}/host-profiler-config.yaml"
+    {{- end }}
+{{ include "generate-security-context" (dict "securityContext" .Values.datadog.hostProfilerStandalone.containers.hostProfiler.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | nindent 2 }}
+  resources:
+{{ toYaml .Values.datadog.hostProfilerStandalone.containers.hostProfiler.resources | indent 4 }}
+{{- if .Values.datadog.hostProfilerStandalone.containers.hostProfiler.envFrom }}
+  envFrom:
+{{ .Values.datadog.hostProfilerStandalone.containers.hostProfiler.envFrom | toYaml | indent 4 }}
+{{- end }}
+  env:
+    - name: DD_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ template "datadog.apiSecretName" . }}
+          key: api-key
+    - name: DD_HOSTNAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    {{- if .Values.datadog.site }}
+    - name: DD_SITE
+      value: {{ .Values.datadog.site | quote }}
+    {{- end }}
+    - name: DD_AGENT_IPC_PORT
+      value: "0"
+    - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+      value: "0"
+    - name: DD_LOG_LEVEL
+      value: {{ .Values.datadog.hostProfilerStandalone.containers.hostProfiler.logLevel | default .Values.datadog.logLevel | quote }}
+    {{- include "additional-env-entries" .Values.datadog.hostProfilerStandalone.containers.hostProfiler.env | indent 4 }}
+    {{- include "additional-env-dict-entries" .Values.datadog.hostProfilerStandalone.containers.hostProfiler.envDict | indent 4 }}
+  volumeMounts:
+    - name: tracingfs
+      mountPath: /sys/kernel/tracing
+      readOnly: false
+    - name: hostprofilerstandaloneconfig
+      mountPath: {{ template "datadog.hostprofilerconfPath" . }}
+      readOnly: true
+    - name: tmpdir
+      mountPath: /tmp
+      readOnly: false # Need RW for tmp directory
+    {{- if .Values.datadog.hostProfilerStandalone.containers.hostProfiler.volumeMounts }}
+{{ toYaml .Values.datadog.hostProfilerStandalone.containers.hostProfiler.volumeMounts | indent 4 }}
+    {{- end }}
+{{- end -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -178,6 +178,17 @@ false
 {{- end -}}
 
 {{/*
+Return true if the standalone Host Profiler DaemonSet needs to be deployed
+*/}}
+{{- define "should-enable-host-profiler-standalone" -}}
+{{- if and .Values.datadog.hostProfilerStandalone.enabled (eq .Values.targetSystem "linux") (not .Values.providers.gke.gdc) (not .Values.providers.gke.autopilot) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return true if Agent Data Plane needs to be deployed
 
 This considers both whether or not the Data Plane feature is enabled and whether or not there's at least one
@@ -909,6 +920,21 @@ datadog-agent-fips-config
 
 {{- define "agents-install-host-profiler-configmap-name" -}}
 {{ template "datadog.fullname" . }}-host-profiler-config
+{{- end -}}
+
+{{- define "agents-install-host-profiler-standalone-configmap-name" -}}
+{{ template "datadog.fullname" . }}-host-profiler-standalone-config
+{{- end -}}
+
+{{/*
+Return the ddot-ebpf standalone image path
+*/}}
+{{- define "ddot-ebpf-standalone-image" -}}
+{{- if .Values.datadog.hostProfilerStandalone.image -}}
+{{ .Values.datadog.hostProfilerStandalone.image }}
+{{- else -}}
+datadog/ddot-ebpf-dev:nightly-latest
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/datadog/templates/_host_profiler_config.yaml
+++ b/charts/datadog/templates/_host_profiler_config.yaml
@@ -1,3 +1,61 @@
+{{- define "host-profiler-standalone-config-configmap-content" -}}
+host-profiler-config.yaml: {{- if .Values.datadog.hostProfilerStandalone.config }} {{ toYaml .Values.datadog.hostProfilerStandalone.config | indent 4 }}
+  {{- else }} |
+    extensions:
+      ddprofiling/default:
+      hpflare/default:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+      hostprofiler:
+        symbol_uploader:
+          enabled: true
+    processors:
+    # infraattributes/default is automatically removed when the Agent Core is not available
+      infraattributes/default:
+        cardinality: 2 # HighCardinality
+        allow_hostname_override: true
+      cumulativetodelta: {}
+    # resourcedetection is automatically removed when the Agent Core is available
+      resourcedetection:
+        detectors: ["system"]
+        system:
+          # TODO: which resource attributes do we want as default?
+          # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/system/documentation.md
+          resource_attributes:
+            host.arch:
+              enabled: true
+            host.name:
+              enabled: false
+            os.type:
+              enabled: false
+
+    exporters:
+      debug: {}
+      otlphttp/metrics:
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        headers:
+          dd-api-key: ${env:DD_API_KEY}
+          dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
+    service:
+      extensions: [hpflare/default]
+      pipelines:
+        profiles:
+          receivers: [hostprofiler]
+          # infraattributes/default is automatically removed when the Agent Core is not available
+          # resourcedetection is automatically removed when the Agent Core is available
+          processors: [infraattributes/default, resourcedetection]
+          exporters: [debug]
+        metrics:
+          receivers: [otlp]
+          # infraattributes/default is automatically removed when the Agent Core is not available
+          processors: [cumulativetodelta, infraattributes/default]
+          exporters: [otlphttp/metrics]
+{{- end }}
+{{- end -}}
+
 {{- define "host-profiler-config-configmap-content" -}}
 host-profiler-config.yaml: {{- if .Values.datadog.hostProfiler.config }} {{ toYaml .Values.datadog.hostProfiler.config | indent 4 }}
   {{- else }} |

--- a/charts/datadog/templates/host-profiler-standalone-configmap.yaml
+++ b/charts/datadog/templates/host-profiler-standalone-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and (eq (include "should-enable-host-profiler-standalone" .) "true") (not .Values.datadog.hostProfilerStandalone.configMap.name) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agents-install-host-profiler-standalone-configmap-name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "datadog.labels" . | nindent 4 }}
+  annotations:
+    checksum/host-profiler-standalone-config: {{ printf "%s-%s" .Chart.Name .Chart.Version | sha256sum }}
+data: {{ include "host-profiler-standalone-config-configmap-content" . | nindent 2 }}
+{{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -737,6 +737,81 @@ datadog:
       # datadog.hostProfiler.configMap.key -- Key within the ConfigMap that contains the Host Profiler configuration (experimental)
       key: host-profiler-config.yaml
 
+  ## Host Profiler Standalone related configuration. Deploys a standalone DaemonSet with only the host-profiler container (no Agent). Mutually exclusive with datadog.hostProfiler.enabled. Note this is experimental and subject to change
+  hostProfilerStandalone:
+    # datadog.hostProfilerStandalone.enabled -- Enable the standalone Host Profiler DaemonSet. This feature is experimental and subject to change.
+    enabled: false
+    # datadog.hostProfilerStandalone.image -- Image for the standalone Host Profiler. This parameter is experimental and will be removed once official image is available.
+    image: ""
+    # datadog.hostProfilerStandalone.config -- Standalone Host Profiler configuration (experimental)
+    config: null
+    # datadog.hostProfilerStandalone.configMap -- Use an existing ConfigMap for standalone Host Profiler configuration (experimental)
+    configMap:
+      # datadog.hostProfilerStandalone.configMap.name -- Name of the existing ConfigMap that contains the standalone Host Profiler configuration (experimental)
+      name: null
+      # datadog.hostProfilerStandalone.configMap.items -- Items within the ConfigMap that contain standalone Host Profiler configuration (experimental)
+      items:
+      #   - key: host-profiler-config.yaml
+      #     path: host-profiler-config.yaml
+      #   - key: host-profiler-config-two.yaml
+      #     path: host-profiler-config-two.yaml
+      # datadog.hostProfilerStandalone.configMap.key -- Key within the ConfigMap that contains the standalone Host Profiler configuration (experimental)
+      key: host-profiler-config.yaml
+
+    # datadog.hostProfilerStandalone.tolerations -- Tolerations for the standalone host-profiler DaemonSet
+    tolerations: []
+
+    # datadog.hostProfilerStandalone.nodeSelector -- Additional node selector labels for the standalone host-profiler DaemonSet
+    nodeSelector: {}
+
+    # datadog.hostProfilerStandalone.volumes -- Additional volumes for the standalone host-profiler DaemonSet
+    volumes: []
+    #   - hostPath:
+    #       path: <HOST_PATH>
+    #     name: <VOLUME_NAME>
+
+    containers:
+      hostProfiler:
+        # datadog.hostProfilerStandalone.containers.hostProfiler.imagePullPolicy -- Image pull policy for the standalone host-profiler container
+        imagePullPolicy: IfNotPresent
+
+        # datadog.hostProfilerStandalone.containers.hostProfiler.env -- Additional environment variables for the standalone host-profiler container
+        env: []
+
+        # datadog.hostProfilerStandalone.containers.hostProfiler.envFrom -- Set environment variables for the standalone host-profiler from configMaps and/or secrets
+        envFrom: []
+        #   - configMapRef:
+        #       name: <CONFIGMAP_NAME>
+        #   - secretRef:
+        #       name: <SECRET_NAME>
+
+        # datadog.hostProfilerStandalone.containers.hostProfiler.envDict -- Set environment variables for the standalone host-profiler defined in a dict
+        envDict: {}
+        #   <ENV_VAR_NAME>: <ENV_VAR_VALUE>
+
+        # datadog.hostProfilerStandalone.containers.hostProfiler.resources -- Resource requests and limits for the standalone host-profiler container
+        resources: {}
+        #  requests:
+        #    cpu: 100m
+        #    memory: 200Mi
+        #  limits:
+        #    cpu: 100m
+        #    memory: 200Mi
+
+        # datadog.hostProfilerStandalone.containers.hostProfiler.securityContext -- SecurityContext for the standalone host-profiler container
+        securityContext:
+          readOnlyRootFilesystem: true
+          privileged: true
+
+        # datadog.hostProfilerStandalone.containers.hostProfiler.logLevel -- Log level for the standalone host-profiler container
+        logLevel: ""
+
+        # datadog.hostProfilerStandalone.containers.hostProfiler.volumeMounts -- Additional volume mounts for the standalone host-profiler container
+        volumeMounts: []
+        #   - name: <VOLUME_NAME>
+        #     mountPath: <CONTAINER_PATH>
+        #     readOnly: true
+
   ## OTel collector related configuration for the otel-agent in Agent Daemonset
   otelCollector:
     # datadog.otelCollector.enabled -- Enable the OTel Collector


### PR DESCRIPTION
#### What this PR does / why we need it:

Putting this on hold as we investigate using upstream helm charts for standalone mode instead.

#### Which issue this PR fixes
OTAGENT-887

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits