### PR TITLE
[BARX-1655] Extend registry migration auto mode to US5

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.187.0
+
+* Extend `registryMigrationMode: "auto"` to US5 (`us5.datadoghq.com`) users. If you experience image pull issues, set `registryMigrationMode: ""` to revert to the previous registry.
+
 ## 3.186.0
 
 * Add liveness and readiness probes to the OTel Agent Gateway deployment. Probes are **opt-in** (`enabled: false` by default). Set `otelAgentGateway.containers.otelAgent.livenessProbe.enabled: true` and/or `otelAgentGateway.containers.otelAgent.readinessProbe.enabled: true` to activate. When enabled, probes perform an HTTP GET on `healthPort` (default 13133, configurable via `otelAgentGateway.containers.otelAgent.healthPort`). The OTel config must expose the `health_check` extension on that port; the generated default config (used when `otelAgentGateway.config` and `otelAgentGateway.configMap` are unset) does this automatically.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.186.0
+version: 3.187.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.186.0](https://img.shields.io/badge/Version-3.186.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.187.0](https://img.shields.io/badge/Version-3.187.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -952,7 +952,7 @@ Learn more about Private Action Runner: https://docs.datadoghq.com/actions/priva
 {{- if eq $migrationMode "all" -}}
 {{- $migratedSite = true -}}
 {{- else if eq $migrationMode "auto" -}}
-{{- if or (eq $site "ap1.datadoghq.com") (eq $site "ap2.datadoghq.com") -}}
+{{- if or (eq $site "ap1.datadoghq.com") (eq $site "ap2.datadoghq.com") (eq $site "us5.datadoghq.com") -}}
 {{- $migratedSite = true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -471,7 +471,7 @@ datadoghq.azurecr.io
 {{- if eq $migrationMode "all" -}}
 {{- $migratedSite = true -}}
 {{- else if eq $migrationMode "auto" -}}
-{{- if or (eq $site "ap1.datadoghq.com") (eq $site "ap2.datadoghq.com") -}}
+{{- if or (eq $site "ap1.datadoghq.com") (eq $site "ap2.datadoghq.com") (eq $site "us5.datadoghq.com") -}}
 {{- $migratedSite = true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -43,7 +43,7 @@ registry:  # gcr.io/datadoghq
 # US3 (us3.datadoghq.com) is excluded and always uses datadoghq.azurecr.io.
 
 ## "auto" (default): enable registry.datadoghq.com for sites where migration is rolled out.
-##   Currently enabled: AP1 (ap1.datadoghq.com), AP2 (ap2.datadoghq.com).
+##   Currently enabled: AP1 (ap1.datadoghq.com), AP2 (ap2.datadoghq.com), US5 (us5.datadoghq.com).
 ## "all": enable registry.datadoghq.com for all sites (AP1, AP2, EU, US1, US5).
 ## "": disable migration, keeping site-specific registries.
 registryMigrationMode: "auto"

--- a/test/datadog/registry_migration_test.go
+++ b/test/datadog/registry_migration_test.go
@@ -38,7 +38,7 @@ func TestRegistryMigration(t *testing.T) {
 		{
 			name:         "US5",
 			site:         "us5.datadoghq.com",
-			wantAuto:     "gcr.io/datadoghq",
+			wantAuto:     "registry.datadoghq.com",
 			wantAll:      "registry.datadoghq.com",
 			wantDisabled: "gcr.io/datadoghq",
 		},


### PR DESCRIPTION
## Summary

- Adds `us5.datadoghq.com` to the `registryMigrationMode: "auto"` rollout
- US5 users will now use `registry.datadoghq.com` instead of `gcr.io/datadoghq`
- Bumps chart version to `3.185.0`

## Rollback

If you experience image pull issues after upgrading, set `registryMigrationMode: ""` to revert to the previous registry.

## Test plan

- [x] Unit tests pass (`make unit-test-datadog`)
- [x] Baseline manifests updated
- [x] README regenerated via helm-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)