### PR TITLE
Allow specifying priorityClassName in datadog-operator

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.19.2
+* Add the ability to configure `priorityClassName` in the operator deployment
+
 ## 2.19.1
 
 * Extend `registryMigrationMode: "auto"` to also enable `DD_REGISTRY_OVERRIDE_EU`, migrating EU1 (`datadoghq.eu`) Agent image pulls to `registry.datadoghq.com`.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.19.1
+version: 2.19.2
 appVersion: 1.24.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.19.1](https://img.shields.io/badge/Version-2.19.1-informational?style=flat-square) ![AppVersion: 1.24.0](https://img.shields.io/badge/AppVersion-1.24.0-informational?style=flat-square)
+![Version: 2.19.2](https://img.shields.io/badge/Version-2.19.2-informational?style=flat-square) ![AppVersion: 1.24.0](https://img.shields.io/badge/AppVersion-1.24.0-informational?style=flat-square)
 
 ## Values
 
@@ -33,6 +33,7 @@
 | datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | deployment.annotations | object | `{}` | Allows setting additional annotations for the deployment resource |
+| deployment.priorityClassName | string | `nil` | Allows setting the priority class name for the deployment resource |
 | dnsConfig | object | `{}` | Specify DNS configuration options for Datadog Operator PODs |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |
 | fullnameOverride | string | `""` |  |

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -215,6 +215,9 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.deployment.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
       volumes:
       {{- if .Values.volumes }}
       {{- toYaml .Values.volumes | nindent 6 }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -118,6 +118,8 @@ registryMigrationMode: "auto"
 deployment:
   # deployment.annotations -- Allows setting additional annotations for the deployment resource
   annotations: {}
+  # deployment.priorityClassName -- Allows setting the priority class name for the deployment resource
+  priorityClassName:
 rbac:
   # rbac.create -- Specifies whether the RBAC resources should be created
   create: true

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.19.1
+    helm.sh/chart: datadog-operator-2.19.2
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.24.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows the end user to configure the priorityClassName in the datadog-operator deployment.

#### Which issue this PR fixes
#1413

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] All commits are signed (see: [signing commits][1])
- [X] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [X] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated 
- [X] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits