### PR TITLE
chore(datadog): Fix Linting Issue with MaxEventsPerRun

### DIFF
--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -494,9 +494,9 @@ datadog:
         reasons:
           - SawCompletedJob
     # datadog.kubernetesEvents.maxEventsPerRun -- Maximum number of events you wish to collect per check run.
-    maxEventsPerRun: 
+    maxEventsPerRun:
     # datadog.kubernetesEvents.kubernetesEventResyncPeriodS -- Specify the frequency in seconds at which the Agent should list all events to re-sync following the informer pattern
-    kubernetesEventResyncPeriodS: 
+    kubernetesEventResyncPeriodS:
 
   clusterTagger:
     # datadog.clusterTagger.collectKubernetesTags -- Enables Kubernetes resources tags collection.


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

Fixes linting issue from https://github.com/DataDog/helm-charts/pull/2485

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits