### PR TITLE
Extend registry migration auto mode to all EU1 users

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 * Add log volume to full host profiler ([#2461](https://github.com/DataDog/helm-charts/pull/2461)).
 
+## 3.191.0
+
+* Extend `registryMigrationMode: "auto"` to all EU1 (`datadoghq.eu`) users regardless of APM configuration. If you experience image pull issues, set `registryMigrationMode: ""` to revert to the previous registry.
+
 ## 3.190.0
 
 * Extend `registryMigrationMode: "auto"` to EU1 (`datadoghq.eu`) users with `datadog.apm.enabled: false` (the default). If you experience image pull issues, set `registryMigrationMode: ""` to revert to the previous registry.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.190.1
+version: 3.191.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.190.1](https://img.shields.io/badge/Version-3.190.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.191.0](https://img.shields.io/badge/Version-3.191.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -952,9 +952,7 @@ Learn more about Private Action Runner: https://docs.datadoghq.com/actions/priva
 {{- if eq $migrationMode "all" -}}
 {{- $migratedSite = true -}}
 {{- else if eq $migrationMode "auto" -}}
-{{- if or (eq $site "ap1.datadoghq.com") (eq $site "ap2.datadoghq.com") (eq $site "us5.datadoghq.com") -}}
-{{- $migratedSite = true -}}
-{{- else if and (eq $site "datadoghq.eu") (not .Values.datadog.apm.enabled) -}}
+{{- if or (eq $site "ap1.datadoghq.com") (eq $site "ap2.datadoghq.com") (eq $site "us5.datadoghq.com") (eq $site "datadoghq.eu") -}}
 {{- $migratedSite = true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -471,9 +471,7 @@ datadoghq.azurecr.io
 {{- if eq $migrationMode "all" -}}
 {{- $migratedSite = true -}}
 {{- else if eq $migrationMode "auto" -}}
-{{- if or (eq $site "ap1.datadoghq.com") (eq $site "ap2.datadoghq.com") (eq $site "us5.datadoghq.com") -}}
-{{- $migratedSite = true -}}
-{{- else if and (eq $site "datadoghq.eu") (not .datadog.apm.enabled) -}}
+{{- if or (eq $site "ap1.datadoghq.com") (eq $site "ap2.datadoghq.com") (eq $site "us5.datadoghq.com") (eq $site "datadoghq.eu") -}}
 {{- $migratedSite = true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -43,7 +43,7 @@ registry:  # gcr.io/datadoghq
 # US3 (us3.datadoghq.com) is excluded and always uses datadoghq.azurecr.io.
 
 ## "auto" (default): enable registry.datadoghq.com for sites where migration is rolled out.
-##   Currently enabled: AP1 (ap1.datadoghq.com), AP2 (ap2.datadoghq.com), US5 (us5.datadoghq.com), EU1 (datadoghq.eu, when datadog.apm.enabled is false).
+##   Currently enabled: AP1 (ap1.datadoghq.com), AP2 (ap2.datadoghq.com), US5 (us5.datadoghq.com), EU1 (datadoghq.eu).
 ## "all": enable registry.datadoghq.com for all sites (AP1, AP2, EU, US1, US5).
 ## "": disable migration, keeping site-specific registries.
 registryMigrationMode: "auto"

--- a/test/datadog/registry_migration_test.go
+++ b/test/datadog/registry_migration_test.go
@@ -43,7 +43,6 @@ func TestRegistryMigration(t *testing.T) {
 			wantDisabled: "gcr.io/datadoghq",
 		},
 		{
-			// apm.enabled defaults to false, so auto mode migrates EU1.
 			name:         "EU1",
 			site:         "datadoghq.eu",
 			wantAuto:     "registry.datadoghq.com",
@@ -137,18 +136,6 @@ func TestRegistryMigration(t *testing.T) {
 			"registryMigrationMode":        "auto",
 		})
 		assert.Equal(t, "registry.datadoghq.com", registry)
-	})
-
-	// EU1 auto migration is gated on APM being disabled.
-	t.Run("EU1/auto/apm-enabled: does not migrate", func(t *testing.T) {
-		registry := renderAndExtractRegistry(t, map[string]string{
-			"datadog.apiKeyExistingSecret": "datadog-secret",
-			"datadog.appKeyExistingSecret": "datadog-secret",
-			"datadog.site":                 "datadoghq.eu",
-			"datadog.apm.enabled":          "true",
-			"registryMigrationMode":        "auto",
-		})
-		assert.Equal(t, "eu.gcr.io/datadoghq", registry)
 	})
 
 	// Explicit registry always takes precedence over migration.


### PR DESCRIPTION
## Summary

- Removes the `datadog.apm.enabled` gate for EU1 (`datadoghq.eu`), migrating all EU1 users to `registry.datadoghq.com`
- Previously only EU1 users with APM disabled were migrated (#2477)
- Bumps chart version to `3.191.0`

## Rollback

If you experience image pull issues after upgrading, set `registryMigrationMode: ""` to revert to the previous registry.

## Test plan

- [x] Unit tests pass (`make unit-test-datadog`)
- [x] Baseline manifests updated
- [x] README regenerated via helm-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)