### PR TITLE
Extend registry migration auto mode to US1 (APM disabled)

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.195.0
+
+* Extend `registryMigrationMode: "auto"` to US1 (`datadoghq.com`) users with APM disabled (the default). If you experience image pull issues, set `registryMigrationMode: ""` to revert to the previous registry.
+
 ## 3.194.0
 
 * [CONTP-1361] add admission controller probe configuration ([#2449](https://github.com/DataDog/helm-charts/pull/2449)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.194.0
+version: 3.195.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.194.0](https://img.shields.io/badge/Version-3.194.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.195.0](https://img.shields.io/badge/Version-3.195.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -1002,6 +1002,8 @@ Learn more about Private Action Runner: https://docs.datadoghq.com/actions/priva
 {{- else if eq $migrationMode "auto" -}}
 {{- if or (eq $site "ap1.datadoghq.com") (eq $site "ap2.datadoghq.com") (eq $site "us5.datadoghq.com") (eq $site "datadoghq.eu") -}}
 {{- $migratedSite = true -}}
+{{- else if and (eq $site "datadoghq.com") (not (or .Values.datadog.apm.enabled .Values.datadog.apm.portEnabled)) -}}
+{{- $migratedSite = true -}}
 {{- end -}}
 {{- end -}}
 {{- if and $migratedSite (not .Values.registry) (ne $site "ddog-gov.com") (ne $site "us3.datadoghq.com") (not (or .Values.providers.gke.autopilot .Values.providers.gke.gdc)) }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -473,6 +473,8 @@ datadoghq.azurecr.io
 {{- else if eq $migrationMode "auto" -}}
 {{- if or (eq $site "ap1.datadoghq.com") (eq $site "ap2.datadoghq.com") (eq $site "us5.datadoghq.com") (eq $site "datadoghq.eu") -}}
 {{- $migratedSite = true -}}
+{{- else if and (eq $site "datadoghq.com") (not (or .datadog.apm.enabled .datadog.apm.portEnabled)) -}}
+{{- $migratedSite = true -}}
 {{- end -}}
 {{- end -}}
 {{- if and $migratedSite (not (or .providers.gke.autopilot .providers.gke.gdc)) -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -43,7 +43,7 @@ registry:  # gcr.io/datadoghq
 # US3 (us3.datadoghq.com) is excluded and always uses datadoghq.azurecr.io.
 
 ## "auto" (default): enable registry.datadoghq.com for sites where migration is rolled out.
-##   Currently enabled: AP1 (ap1.datadoghq.com), AP2 (ap2.datadoghq.com), US5 (us5.datadoghq.com), EU1 (datadoghq.eu).
+##   Currently enabled: AP1 (ap1.datadoghq.com), AP2 (ap2.datadoghq.com), US5 (us5.datadoghq.com), EU1 (datadoghq.eu), US1 (datadoghq.com, when APM is disabled).
 ## "all": enable registry.datadoghq.com for all sites (AP1, AP2, EU, US1, US5).
 ## "": disable migration, keeping site-specific registries.
 registryMigrationMode: "auto"

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -1451,7 +1451,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.74.0
+          image: registry.datadoghq.com/agent:7.74.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1593,7 +1593,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.74.0
+          image: registry.datadoghq.com/agent:7.74.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1682,7 +1682,7 @@ spec:
               value: "true"
             - name: DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR
               value: tcp://127.0.0.1:5102
-          image: gcr.io/datadoghq/agent-data-plane:0.1.30
+          image: registry.datadoghq.com/agent-data-plane:0.1.30
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 12
@@ -1742,7 +1742,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.74.0
+          image: registry.datadoghq.com/agent:7.74.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1781,7 +1781,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.74.0
+          image: registry.datadoghq.com/agent:7.74.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2048,7 +2048,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2113,7 +2113,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2186,7 +2186,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -1449,7 +1449,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.75.0
+          image: registry.datadoghq.com/agent:7.75.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1593,7 +1593,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.75.0
+          image: registry.datadoghq.com/agent:7.75.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1682,7 +1682,7 @@ spec:
               value: "true"
             - name: DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR
               value: tcp://127.0.0.1:5102
-          image: gcr.io/datadoghq/agent-data-plane:0.1.30
+          image: registry.datadoghq.com/agent-data-plane:0.1.30
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 12
@@ -1742,7 +1742,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.75.0
+          image: registry.datadoghq.com/agent:7.75.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1781,7 +1781,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.75.0
+          image: registry.datadoghq.com/agent:7.75.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2048,7 +2048,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2113,7 +2113,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2186,7 +2186,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -1468,7 +1468,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1615,7 +1615,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1666,7 +1666,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1705,7 +1705,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1971,7 +1971,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2028,7 +2028,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2041,7 +2041,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2173,7 +2173,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2240,7 +2240,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2313,7 +2313,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -1435,7 +1435,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1584,7 +1584,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1635,7 +1635,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1676,7 +1676,7 @@ spec:
               value: '[{"products":["global"],"rules":{"containers":["container.name == \"redis\""]}},{"products":["logs","metrics"],"rules":{"pods":["pod.name.startsWith(''nginx'')"]}}]'
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1943,7 +1943,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2008,7 +2008,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2081,7 +2081,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -1493,7 +1493,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -1558,7 +1558,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1631,7 +1631,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -1493,7 +1493,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_ENABLED
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_CLUSTER_AGENT_ENABLED
@@ -1572,7 +1572,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1645,7 +1645,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -1493,7 +1493,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_ENABLED
               value: "true"
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_CLUSTER_AGENT_ENABLED
@@ -1568,7 +1568,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1641,7 +1641,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -1495,7 +1495,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -1560,7 +1560,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1633,7 +1633,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -1504,7 +1504,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1651,7 +1651,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1702,7 +1702,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1741,7 +1741,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2013,7 +2013,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2070,7 +2070,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2083,7 +2083,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2215,7 +2215,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2282,7 +2282,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2355,7 +2355,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -1433,7 +1433,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1580,7 +1580,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1631,7 +1631,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1670,7 +1670,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1937,7 +1937,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2002,7 +2002,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2075,7 +2075,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -1433,7 +1433,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1580,7 +1580,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1631,7 +1631,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1670,7 +1670,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1937,7 +1937,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2002,7 +2002,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2075,7 +2075,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -908,7 +908,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1013,7 +1013,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1039,7 +1039,7 @@ spec:
           command:
             - pwsh
             - -Command
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1081,7 +1081,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1230,7 +1230,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -1295,7 +1295,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1368,7 +1368,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -1697,7 +1697,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1859,7 +1859,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1938,7 +1938,7 @@ spec:
               value: /host/root
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2026,7 +2026,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2065,7 +2065,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2092,7 +2092,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2391,7 +2391,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2456,7 +2456,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2529,7 +2529,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -1498,7 +1498,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1645,7 +1645,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1696,7 +1696,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1735,7 +1735,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2002,7 +2002,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2067,7 +2067,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2140,7 +2140,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1689,7 +1689,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1843,7 +1843,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1945,7 +1945,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2023,7 +2023,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2102,7 +2102,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2141,7 +2141,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2168,7 +2168,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2457,7 +2457,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2522,7 +2522,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2595,7 +2595,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -1522,7 +1522,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1669,7 +1669,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1762,7 +1762,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.76.1
+          image: registry.datadoghq.com/ddot-collector:7.76.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1819,7 +1819,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1858,7 +1858,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2131,7 +2131,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2196,7 +2196,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2269,7 +2269,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -1447,7 +1447,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1594,7 +1594,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1687,7 +1687,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.76.1
+          image: registry.datadoghq.com/ddot-collector:7.76.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1738,7 +1738,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1777,7 +1777,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2050,7 +2050,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2115,7 +2115,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2188,7 +2188,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -1518,7 +1518,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1665,7 +1665,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1758,7 +1758,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.76.1
+          image: registry.datadoghq.com/ddot-collector:7.76.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1813,7 +1813,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1852,7 +1852,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2125,7 +2125,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2190,7 +2190,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2263,7 +2263,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1470,7 +1470,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1617,7 +1617,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1710,7 +1710,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.76.1
+          image: registry.datadoghq.com/ddot-collector:7.76.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1773,7 +1773,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1812,7 +1812,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2094,7 +2094,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2159,7 +2159,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2232,7 +2232,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -1518,7 +1518,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1665,7 +1665,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1758,7 +1758,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.76.1
+          image: registry.datadoghq.com/ddot-collector:7.76.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1812,7 +1812,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1851,7 +1851,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2127,7 +2127,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2192,7 +2192,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2265,7 +2265,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -1518,7 +1518,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1665,7 +1665,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1758,7 +1758,7 @@ spec:
               value: "true"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.76.1
+          image: registry.datadoghq.com/ddot-collector:7.76.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1809,7 +1809,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1848,7 +1848,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2121,7 +2121,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2186,7 +2186,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2259,7 +2259,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -1433,7 +1433,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1580,7 +1580,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1631,7 +1631,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1670,7 +1670,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1937,7 +1937,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2002,7 +2002,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2075,7 +2075,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -1447,7 +1447,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1626,7 +1626,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1677,7 +1677,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1716,7 +1716,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2013,7 +2013,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2078,7 +2078,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2151,7 +2151,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -1466,7 +1466,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1615,7 +1615,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1671,7 +1671,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1716,7 +1716,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1987,7 +1987,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2044,7 +2044,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2063,7 +2063,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2205,7 +2205,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2272,7 +2272,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2349,7 +2349,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           securityContext:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1689,7 +1689,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1843,7 +1843,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1945,7 +1945,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2025,7 +2025,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2196,7 +2196,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -2239,7 +2239,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2278,7 +2278,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2305,7 +2305,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2635,7 +2635,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2702,7 +2702,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2775,7 +2775,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1689,7 +1689,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1843,7 +1843,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1945,7 +1945,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2023,7 +2023,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2138,7 +2138,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2177,7 +2177,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2204,7 +2204,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2528,7 +2528,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2593,7 +2593,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2666,7 +2666,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -1685,7 +1685,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1839,7 +1839,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1916,7 +1916,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2047,7 +2047,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -2090,7 +2090,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2129,7 +2129,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2156,7 +2156,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2448,7 +2448,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2515,7 +2515,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2588,7 +2588,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -1685,7 +1685,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1839,7 +1839,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1916,7 +1916,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2001,7 +2001,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2040,7 +2040,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2067,7 +2067,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.76.1
+          image: registry.datadoghq.com/agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2356,7 +2356,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_PORT
               value: "8000"
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
-              value: gcr.io/datadoghq
+              value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2421,7 +2421,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2494,7 +2494,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.76.1
+          image: registry.datadoghq.com/cluster-agent:7.76.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/otel_agent_test.go
+++ b/test/datadog/otel_agent_test.go
@@ -99,8 +99,8 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 			expectError: false,
 			assertion: func(t *testing.T, manifest string) {
-				verifyAgentImage(t, manifest, "gcr.io/datadoghq/agent:7.67.0")
-				verifyOtelImage(t, manifest, "gcr.io/datadoghq/ddot-collector:7.67.0")
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7.67.0")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7.67.0")
 			},
 		},
 		{
@@ -120,8 +120,8 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 			expectError: false,
 			assertion: func(t *testing.T, manifest string) {
-				verifyAgentImage(t, manifest, "gcr.io/datadoghq/agent:7.68.0")
-				verifyOtelImage(t, manifest, "gcr.io/datadoghq/ddot-collector:7.68.0")
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7.68.0")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7.68.0")
 			},
 		},
 		{
@@ -160,8 +160,8 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 			expectError: false,
 			assertion: func(t *testing.T, manifest string) {
-				verifyAgentImage(t, manifest, "gcr.io/datadoghq/agent:7.67.0-full")
-				verifyOtelImage(t, manifest, "gcr.io/datadoghq/ddot-collector:7.67.0")
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7.67.0-full")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7.67.0")
 			},
 		},
 		{
@@ -182,8 +182,8 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 			expectError: false,
 			assertion: func(t *testing.T, manifest string) {
-				verifyAgentImage(t, manifest, "gcr.io/datadoghq/agent:7.66.0-full")
-				verifyOtelImage(t, manifest, "gcr.io/datadoghq/agent:7.66.0-full")
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7.66.0-full")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/agent:7.66.0-full")
 			},
 		},
 		{
@@ -203,8 +203,8 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 			expectError: false,
 			assertion: func(t *testing.T, manifest string) {
-				verifyAgentImage(t, manifest, "gcr.io/datadoghq/agent:7.67.0")
-				verifyOtelImage(t, manifest, "gcr.io/datadoghq/agent:7.67.0")
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7.67.0")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/agent:7.67.0")
 			},
 		},
 		{
@@ -225,8 +225,8 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 			expectError: false,
 			assertion: func(t *testing.T, manifest string) {
-				verifyAgentImage(t, manifest, "gcr.io/datadoghq/agent:7.66.0-full")
-				verifyOtelImage(t, manifest, "gcr.io/datadoghq/agent:7.66.0-full")
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7.66.0-full")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/agent:7.66.0-full")
 			},
 		},
 		{
@@ -246,8 +246,8 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 			expectError: false,
 			assertion: func(t *testing.T, manifest string) {
-				verifyAgentImage(t, manifest, "gcr.io/datadoghq/agent:7.67.0-full")
-				verifyOtelImage(t, manifest, "gcr.io/datadoghq/agent:7.67.0-full")
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7.67.0-full")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/agent:7.67.0-full")
 			},
 		},
 		{
@@ -285,8 +285,8 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 			expectError: false,
 			assertion: func(t *testing.T, manifest string) {
-				verifyAgentImage(t, manifest, "gcr.io/datadoghq/agent:7.66.0-full")
-				verifyOtelImage(t, manifest, "gcr.io/datadoghq/agent:7.66.0-full")
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7.66.0-full")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/agent:7.66.0-full")
 			},
 		},
 	}

--- a/test/datadog/registry_migration_test.go
+++ b/test/datadog/registry_migration_test.go
@@ -23,8 +23,9 @@ func TestRegistryMigration(t *testing.T) {
 		wantDisabled string
 	}{
 		{
+			// apm.enabled defaults to false, so auto mode migrates US1.
 			name:         "US1 (default)",
-			wantAuto:     "gcr.io/datadoghq",
+			wantAuto:     "registry.datadoghq.com",
 			wantAll:      "registry.datadoghq.com",
 			wantDisabled: "gcr.io/datadoghq",
 		},
@@ -136,6 +137,27 @@ func TestRegistryMigration(t *testing.T) {
 			"registryMigrationMode":        "auto",
 		})
 		assert.Equal(t, "registry.datadoghq.com", registry)
+	})
+
+	// US1 auto migration is gated on APM being disabled (both legacy and modern fields).
+	t.Run("US1/auto/apm-enabled: does not migrate", func(t *testing.T) {
+		registry := renderAndExtractRegistry(t, map[string]string{
+			"datadog.apiKeyExistingSecret": "datadog-secret",
+			"datadog.appKeyExistingSecret": "datadog-secret",
+			"datadog.apm.enabled":          "true",
+			"registryMigrationMode":        "auto",
+		})
+		assert.Equal(t, "gcr.io/datadoghq", registry)
+	})
+
+	t.Run("US1/auto/apm-portEnabled: does not migrate", func(t *testing.T) {
+		registry := renderAndExtractRegistry(t, map[string]string{
+			"datadog.apiKeyExistingSecret": "datadog-secret",
+			"datadog.appKeyExistingSecret": "datadog-secret",
+			"datadog.apm.portEnabled":      "true",
+			"registryMigrationMode":        "auto",
+		})
+		assert.Equal(t, "gcr.io/datadoghq", registry)
 	})
 
 	// Explicit registry always takes precedence over migration.


### PR DESCRIPTION
## Summary

- Adds `datadoghq.com` (US1) to `registryMigrationMode: "auto"` rollout, gated on APM being disabled (both `datadog.apm.enabled` and `datadog.apm.portEnabled` must be `false`)
- US1 users with APM enabled via either field are unaffected and continue using `gcr.io/datadoghq`
- Bumps chart version to `3.192.0`

**Note:** `datadog.apm.enabled` is deprecated in favor of `datadog.apm.portEnabled`. The gate checks both fields to avoid accidentally migrating users who enabled APM via the modern `portEnabled` field.

## Rollback

If you experience image pull issues after upgrading, set `registryMigrationMode: ""` to revert to the previous registry.

## Test plan

- [x] Unit tests pass
- [x] New test cases: `US1/auto/apm-enabled: does not migrate` and `US1/auto/apm-portEnabled: does not migrate`
- [x] Updated `Test_ddotCollectorImage` expected registries (default site now uses `registry.datadoghq.com`)
- [x] Baseline manifests updated
- [x] README regenerated via helm-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)