### PR TITLE
Add RBAC for network topology CRD collection

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.202.0
+
+* Add RBAC rules for Gateway API, service mesh, and ingress controller CRDs used by the orchestrator explorer for internet-reachability analysis. Opt-in via `datadog.orchestratorExplorer.networkCRDs.enabled` (default: `false`).
+
 ## 3.201.0
 
 * Remove collector config from host profiler ([#2535](https://github.com/DataDog/helm-charts/pull/2535)).

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -111,6 +111,87 @@
 
 ## 3.208.0
 
+* Add cluster autoscaling RBAC permissions.
+
+## 3.207.0
+
+* Add cluster agent RBAC permissions required for cluster-profile-aware workload autoscaling: `datadogpodautoscalerclusterprofiles` CRD access for reading and writing cluster-wide scaling profiles; `statefulsets` and `argoproj.io/rollouts` get/list/watch/patch to read workload metadata and trigger rollouts; `namespaces` get/list/watch to resolve namespace-scoped profiles.
+
+## 3.206.0
+
+* Bump Datadog Operator chart dependency to 2.22.0.
+* Bump Datadog CRD chart dependency to 2.20.0.
+* Bump Operator image tag to 1.26.0.
+
+## 3.205.0
+
+* enable discovery by default on supported agent versions ([#2598](https://github.com/DataDog/helm-charts/pull/2598)).
+
+## 3.204.0
+
+* Add `pods/resize`, `pods/eviction` roles to the cluster agent deployment when autoscaling workloads is enabled.
+
+## 3.203.0
+
+* Add `datadog.sbom.enrichment.usage.enabled` to enable runtime "package in use" SBOM enrichment via system-probe (Agent 7.79.0+).
+
+## 3.202.6
+
+* Update `fips.image.tag` to `1.1.23` fixing CVEs and updating packages.
+
+## 3.202.5
+
+* Default `datadog.dataPlane.dogstatsd.enabled` to `true` so that setting `datadog.dataPlane.enabled: true` is sufficient to route DogStatsD to ADP ([#2604](https://github.com/DataDog/helm-charts/pull/2604)).
+
+## 3.202.4
+
+* TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).
+
+## 3.202.3
+
+* [CSPM] add new configuration to run CSPM within system-probe
+
+## 3.202.2
+
+* Use the standard Agent image for the `agent-data-plane` container instead of the dedicated `agent-data-plane` image, matching the Datadog Operator behavior.
+
+## 3.202.1
+
+* Update datadog-csi-driver chart dependency version to fix a CSI Driver startup failure bug on gke autopilot. [Release v1.2.2](https://github.com/DataDog/datadog-csi-driver/pull/78)
+
+## 3.202.0
+
+* Add `clusterAgent.privateActionRunner.k8sRemediationEnabled` to create the ClusterRole and ClusterRoleBinding required for k8s remediation actions ([#2592](https://github.com/DataDog/helm-charts/pull/2592)).
+
+## 3.201.8
+
+* Fix deployment issues when using an agent image tag that contains the string `latest` when `doNotCheckTag` is not set due to the semverCompare for `controllerrevisions` in `kube-state-metrics-core-rbac.yaml`.
+
+## 3.201.7
+
+* [CONS-8251] Service is not needed when node agent is disabled ([#2575](https://github.com/DataDog/helm-charts/pull/2575)).
+* [PROF-14062] Rename the profiler in the datadog-agent, helm, operator ([#2568](https://github.com/DataDog/helm-charts/pull/2568)).
+
+## 3.201.5
+
+* Update Default Agent Version to 7.78.0.
+
+## 3.201.4
+
+* Update `check-cluster-name` pre-install hook regex to allow cluster names containing underscores or starting with a digit, and improve the failure message ([#2428](https://github.com/DataDog/helm-charts/pull/2428)).
+
+## 3.201.3
+
+* Update `fips.image.tag` to `1.1.22` fixing CVEs and updating packages.
+
+## 3.201.2
+
+* [OTAGENT-920] Set DD_OTELCOLLECTOR_INSTALLATION_METHOD on otel-agent container ([#2528](https://github.com/DataDog/helm-charts/pull/2528)).
+
+## 3.201.1
+
+* Remove optional run subcommand ([#2547](https://github.com/DataDog/helm-charts/pull/2547)).
+
 ## 3.201.0
 
 * Remove collector config from host profiler ([#2535](https://github.com/DataDog/helm-charts/pull/2535)).

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.222.0
+
+* Add RBAC rules for Gateway API, service mesh, and ingress controller CRD collection, gated behind `datadog.orchestratorExplorer.networkCRDs.enabled`.
+
 ## 3.221.0
 
 * Bump Datadog Operator chart dependency to 2.23.0.
@@ -58,7 +62,7 @@
 
 ## 3.214.1
 
-* Update `fips.image.tag` to `1.1.25` fixing CVEs and updating packages.
+ * Update `fips.image.tag` to `1.1.25` fixing CVEs and updating packages.
 
 ## 3.214.0
 
@@ -106,87 +110,6 @@
 * Allow `writev`, `shutdown`, and `chown` syscalls in the system-probe seccomp profile, required by `system-probe-lite`.
 
 ## 3.208.0
-
-* Add cluster autoscaling RBAC permissions.
-
-## 3.207.0
-
-* Add cluster agent RBAC permissions required for cluster-profile-aware workload autoscaling: `datadogpodautoscalerclusterprofiles` CRD access for reading and writing cluster-wide scaling profiles; `statefulsets` and `argoproj.io/rollouts` get/list/watch/patch to read workload metadata and trigger rollouts; `namespaces` get/list/watch to resolve namespace-scoped profiles.
-
-## 3.206.0
-
-* Bump Datadog Operator chart dependency to 2.22.0.
-* Bump Datadog CRD chart dependency to 2.20.0.
-* Bump Operator image tag to 1.26.0.
-
-## 3.205.0
-
-* enable discovery by default on supported agent versions ([#2598](https://github.com/DataDog/helm-charts/pull/2598)).
-
-## 3.204.0
-
-* Add `pods/resize`, `pods/eviction` roles to the cluster agent deployment when autoscaling workloads is enabled.
-
-## 3.203.0
-
-* Add `datadog.sbom.enrichment.usage.enabled` to enable runtime "package in use" SBOM enrichment via system-probe (Agent 7.79.0+).
-
-## 3.202.6
-
-* Update `fips.image.tag` to `1.1.23` fixing CVEs and updating packages.
-
-## 3.202.5
-
-* Default `datadog.dataPlane.dogstatsd.enabled` to `true` so that setting `datadog.dataPlane.enabled: true` is sufficient to route DogStatsD to ADP ([#2604](https://github.com/DataDog/helm-charts/pull/2604)).
-
-## 3.202.4
-
-* TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).
-
-## 3.202.3
-
-* [CSPM] add new configuration to run CSPM within system-probe
-
-## 3.202.2
-
-* Use the standard Agent image for the `agent-data-plane` container instead of the dedicated `agent-data-plane` image, matching the Datadog Operator behavior.
-
-## 3.202.1
-
-* Update datadog-csi-driver chart dependency version to fix a CSI Driver startup failure bug on gke autopilot. [Release v1.2.2](https://github.com/DataDog/datadog-csi-driver/pull/78)
-
-## 3.202.0
-
-* Add `clusterAgent.privateActionRunner.k8sRemediationEnabled` to create the ClusterRole and ClusterRoleBinding required for k8s remediation actions ([#2592](https://github.com/DataDog/helm-charts/pull/2592)).
-
-## 3.201.8
-
-* Fix deployment issues when using an agent image tag that contains the string `latest` when `doNotCheckTag` is not set due to the semverCompare for `controllerrevisions` in `kube-state-metrics-core-rbac.yaml`.
-
-## 3.201.7
-
-* [CONS-8251] Service is not needed when node agent is disabled ([#2575](https://github.com/DataDog/helm-charts/pull/2575)).
-* [PROF-14062] Rename the profiler in the datadog-agent, helm, operator ([#2568](https://github.com/DataDog/helm-charts/pull/2568)).
-
-## 3.201.5
-
-* Update Default Agent Version to 7.78.0.
-
-## 3.201.4
-
-* Update `check-cluster-name` pre-install hook regex to allow cluster names containing underscores or starting with a digit, and improve the failure message ([#2428](https://github.com/DataDog/helm-charts/pull/2428)).
-
-## 3.201.3
-
-* Update `fips.image.tag` to `1.1.22` fixing CVEs and updating packages.
-
-## 3.201.2
-
-* [OTAGENT-920] Set DD_OTELCOLLECTOR_INSTALLATION_METHOD on otel-agent container ([#2528](https://github.com/DataDog/helm-charts/pull/2528)).
-
-## 3.201.1
-
-* Remove optional run subcommand ([#2547](https://github.com/DataDog/helm-charts/pull/2547)).
 
 ## 3.201.0
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.201.0
+version: 3.202.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.221.0
+version: 3.222.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.201.0](https://img.shields.io/badge/Version-3.201.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.202.0](https://img.shields.io/badge/Version-3.202.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -913,6 +913,7 @@ helm install <RELEASE_NAME> \
 | datadog.orchestratorExplorer.customResources | list | `[]` | Defines custom resources for the orchestrator explorer to collect |
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
 | datadog.orchestratorExplorer.kubelet_configuration_check.enabled | bool | `true` | Enable the orchestrator kubelet configuration check |
+| datadog.orchestratorExplorer.networkCRDs.enabled | bool | `false` | Enable RBAC for Gateway API, service mesh, and ingress controller CRD collection Set to true to add RBAC rules for these resources to the cluster agent |
 | datadog.originDetectionUnified.enabled | bool | `false` | Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+). |
 | datadog.osReleasePath | string | `"/etc/os-release"` | Specify the path to your os-release file |
 | datadog.otelCollector.config | string | `nil` | OTel collector configuration |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.221.0](https://img.shields.io/badge/Version-3.221.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.222.0](https://img.shields.io/badge/Version-3.222.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -917,6 +917,7 @@ helm install <RELEASE_NAME> \
 | datadog.orchestratorExplorer.customResources | list | `[]` | Defines custom resources for the orchestrator explorer to collect |
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
 | datadog.orchestratorExplorer.kubelet_configuration_check.enabled | bool | `true` | Enable the orchestrator kubelet configuration check |
+| datadog.orchestratorExplorer.networkCRDs.enabled | bool | `false` | Enable RBAC for Gateway API, service mesh, and ingress controller CRD collection Set to true to add RBAC rules for these resources to the orchestrator explorer ClusterRole |
 | datadog.orchestratorExplorer.rbac.create | bool | `true` | If true, create & use a dedicated ClusterRole and ClusterRoleBinding for orchestrator explorer permissions |
 | datadog.orchestratorExplorer.useClusterCheckRunners | bool | `false` | For clusters where orchestrator explorer checks run on dedicated Cluster Checks Runners instead of the Cluster Agent. |
 | datadog.originDetectionUnified.enabled | bool | `false` | Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+). |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -917,7 +917,7 @@ helm install <RELEASE_NAME> \
 | datadog.orchestratorExplorer.customResources | list | `[]` | Defines custom resources for the orchestrator explorer to collect |
 | datadog.orchestratorExplorer.enabled | bool | `true` | Set this to false to disable the orchestrator explorer |
 | datadog.orchestratorExplorer.kubelet_configuration_check.enabled | bool | `true` | Enable the orchestrator kubelet configuration check |
-| datadog.orchestratorExplorer.networkCRDs.enabled | bool | `false` | Enable RBAC for Gateway API, service mesh, and ingress controller CRD collection Set to true to add RBAC rules for these resources to the orchestrator explorer ClusterRole |
+| datadog.orchestratorExplorer.networkCRDs.enabled | bool | `false` | Enable RBAC for Gateway API, service mesh, and ingress controller CRD collection. Set to true to add RBAC rules for these resources to the orchestrator explorer ClusterRole |
 | datadog.orchestratorExplorer.rbac.create | bool | `true` | If true, create & use a dedicated ClusterRole and ClusterRoleBinding for orchestrator explorer permissions |
 | datadog.orchestratorExplorer.useClusterCheckRunners | bool | `false` | For clusters where orchestrator explorer checks run on dedicated Cluster Checks Runners instead of the Cluster Agent. |
 | datadog.originDetectionUnified.enabled | bool | `false` | Enabled enables unified mechanism for origin detection. Default: false. (Requires Agent 7.54.0+). |

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -451,6 +451,14 @@ spec:
           - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
             value: {{ .Values.datadog.orchestratorExplorer.container_scrubbing.enabled | quote }}
           {{- end }}
+          {{- if .Values.datadog.orchestratorExplorer.networkCRDs.enabled }}
+          - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_RESOURCES_OOTB_GATEWAY_API
+            value: "true"
+          - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_RESOURCES_OOTB_SERVICE_MESH
+            value: "true"
+          - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_RESOURCES_OOTB_INGRESS_CONTROLLERS
+            value: "true"
+          {{- end }}
           - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
             value: {{ include "language-detection-enabled" .  | quote }}
           {{- if eq  (include "should-enable-security-agent" .) "true" }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -455,6 +455,14 @@ spec:
           - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
             value: {{ .Values.datadog.orchestratorExplorer.container_scrubbing.enabled | quote }}
           {{- end }}
+          {{- if .Values.datadog.orchestratorExplorer.networkCRDs.enabled }}
+          - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_RESOURCES_OOTB_GATEWAY_API
+            value: "true"
+          - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_RESOURCES_OOTB_SERVICE_MESH
+            value: "true"
+          - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_RESOURCES_OOTB_INGRESS_CONTROLLERS
+            value: "true"
+          {{- end }}
           - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
             value: {{ include "language-detection-enabled" .  | quote }}
           {{- if eq  (include "should-enable-security-agent" .) "true" }}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -391,6 +391,72 @@ rules:
   - list
   - watch
   - get
+{{- if .Values.datadog.orchestratorExplorer.networkCRDs.enabled }}
+# Gateway API, service mesh, and ingress controller CRDs for internet-reachability analysis
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  - httproutes
+  - grpcroutes
+  - tlsroutes
+  - listenersets
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  - gateways
+  - destinationrules
+  - serviceentries
+  - sidecars
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - gateway.envoyproxy.io
+  - traefik.containo.us
+  - policy.linkerd.io
+  - consul.hashicorp.com
+  - mesh.consul.hashicorp.com
+  - kuma.io
+  resources:
+  - "*"
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - k8s.nginx.org
+  resources:
+  - virtualservers
+  - virtualserverroutes
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - traefik.io
+  resources:
+  - ingressroutes
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - configuration.konghq.com
+  - core.haproxy.org
+  - ingress.v1.haproxy.org
+  - ingress.v3.haproxy.org
+  resources:
+  - "*"
+  verbs:
+  - list
+  - watch
+{{- end }}
 {{- include "orchestratorExplorer-config-crs" . }}
 {{- end }}
 {{- if .Values.datadog.appsec.injector.enabled }}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -429,6 +429,7 @@ rules:
   verbs:
   - list
   - watch
+  - get
 - apiGroups:
   - k8s.nginx.org
   resources:
@@ -456,6 +457,7 @@ rules:
   verbs:
   - list
   - watch
+  - get
 {{- end }}
 {{- include "orchestratorExplorer-config-crs" . }}
 {{- end }}

--- a/charts/datadog/templates/orchestrator-explorer-rbac.yaml
+++ b/charts/datadog/templates/orchestrator-explorer-rbac.yaml
@@ -167,6 +167,75 @@ rules:
   - list
   - watch
   - get
+{{- if .Values.datadog.orchestratorExplorer.networkCRDs.enabled }}
+# Gateway API, service mesh, and ingress controller CRDs for internet-reachability analysis
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  - httproutes
+  - grpcroutes
+  - tlsroutes
+  - listenersets
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  - gateways
+  - destinationrules
+  - serviceentries
+  - sidecars
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - gateway.envoyproxy.io
+  - traefik.containo.us
+  - policy.linkerd.io
+  - consul.hashicorp.com
+  - mesh.consul.hashicorp.com
+  - kuma.io
+  resources:
+  - "*"
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - k8s.nginx.org
+  resources:
+  - virtualservers
+  - virtualserverroutes
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - traefik.io
+  resources:
+  - ingressroutes
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - configuration.konghq.com
+  - core.haproxy.org
+  - ingress.v1.haproxy.org
+  - ingress.v3.haproxy.org
+  resources:
+  - "*"
+  verbs:
+  - list
+  - watch
+  - get
+{{- end }}
 {{- include "orchestratorExplorer-config-crs" . }}
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1069,6 +1069,11 @@ datadog:
     #   - datadoghq.com/v1alpha1/watermarkpodautoscalers
     customResources: []
 
+    # datadog.orchestratorExplorer.networkCRDs.enabled -- Enable RBAC for Gateway API, service mesh, and ingress controller CRD collection
+    # Set to true to add RBAC rules for these resources to the cluster agent
+    networkCRDs:
+      enabled: false
+
   helmCheck:
     # datadog.helmCheck.enabled -- Set this to true to enable the Helm check (Requires Agent 7.35.0+ and Cluster Agent 1.19.0+)
     # This requires clusterAgent.enabled to be set to true

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1096,7 +1096,7 @@ datadog:
     # datadog.orchestratorExplorer.rbac.create -- If true, create & use a dedicated ClusterRole and ClusterRoleBinding for orchestrator explorer permissions
       create: true
 
-    # datadog.orchestratorExplorer.networkCRDs.enabled -- Enable RBAC for Gateway API, service mesh, and ingress controller CRD collection
+    # datadog.orchestratorExplorer.networkCRDs.enabled -- Enable RBAC for Gateway API, service mesh, and ingress controller CRD collection.
     # Set to true to add RBAC rules for these resources to the orchestrator explorer ClusterRole
     networkCRDs:
       enabled: false

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1096,6 +1096,11 @@ datadog:
     # datadog.orchestratorExplorer.rbac.create -- If true, create & use a dedicated ClusterRole and ClusterRoleBinding for orchestrator explorer permissions
       create: true
 
+    # datadog.orchestratorExplorer.networkCRDs.enabled -- Enable RBAC for Gateway API, service mesh, and ingress controller CRD collection
+    # Set to true to add RBAC rules for these resources to the orchestrator explorer ClusterRole
+    networkCRDs:
+      enabled: false
+
     # datadog.orchestratorExplorer.useClusterCheckRunners -- For clusters where orchestrator explorer checks run on dedicated Cluster Checks Runners instead of the Cluster Agent.
 
     ## When enabled, the orchestrator explorer RBAC is bound to the Cluster Checks Runner ServiceAccount instead of the Cluster Agent.


### PR DESCRIPTION
### What does this PR do?

Adds list/watch RBAC permissions for 14 new API groups to the cluster agent ClusterRole, enabling OOTB collection of network topology CRDs for Cloud Security internet-reachability analysis.

Gated behind `datadog.orchestratorExplorer.networkCRDs.enabled` (default: `false`, **opt-in**).

**New API groups:**
- **Gateway API**: `gateway.networking.k8s.io` (resource-specific)
- **Service mesh**: `networking.istio.io` (resource-specific), `gateway.envoyproxy.io`, `traefik.containo.us`, `policy.linkerd.io`, `consul.hashicorp.com`, `mesh.consul.hashicorp.com`, `kuma.io`
- **Ingress controllers**: `k8s.nginx.org`, `traefik.io` (resource-specific), `configuration.konghq.com`, `core.haproxy.org`, `ingress.v1.haproxy.org`, `ingress.v3.haproxy.org`

### Motivation

The Datadog Agent is adding OOTB collection of these CRDs for Cloud Security internet-reachability analysis. The cluster agent needs RBAC permissions to list/watch these resources.

RFC: https://datadoghq.atlassian.net/wiki/x/4IOyfAE

### Describe how you validated your changes

- RBAC rules follow the same pattern as existing karpenter/argoproj/fluxcd entries
- Resource-specific entries for high-volume vendors (Istio, NGINX, Traefik, Gateway API)
- Group-level (`"*"` resources) for less common vendors
- Baseline test manifests regenerated

### Additional Notes

This PR should be merged before the corresponding agent PR. Collection is **opt-in** — both the Helm value and the agent-side flags must be enabled.

## Related PRs

| Repo | PR | Purpose |
|------|----|---------|
| DataDog/datadog-agent | DataDog/datadog-agent#48966 | Agent collection (merge AFTER) |
| DataDog/dd-go | DataDog/dd-go#230589 | Backend allowlist (deploy FIRST) |
| DataDog/datadog-operator | DataDog/datadog-operator#2874 | Operator RBAC |