### PR TITLE
Remove optional run subcommand

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.201.1
+
+* Remove optional run subcommand ([#2547](https://github.com/DataDog/helm-charts/pull/2547)).
+
 ## 3.201.0
 
 * Remove collector config from host profiler ([#2535](https://github.com/DataDog/helm-charts/pull/2535)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.201.0
+version: 3.201.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.201.0](https://img.shields.io/badge/Version-3.201.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.201.1](https://img.shields.io/badge/Version-3.201.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_container-host-profiler.yaml
+++ b/charts/datadog/templates/_container-host-profiler.yaml
@@ -8,7 +8,6 @@
   {{- end }}
   command:
     - "/opt/datadog-agent/embedded/bin/full-host-profiler"
-    - "run"
     - "--core-config={{ template "datadog.confPath" .  }}/datadog.yaml"
 {{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.hostProfiler.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | nindent 2 }}
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove run subcommand from host profiler, this is now optional: https://github.com/DataDog/datadog-agent/pull/48197.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits