### PR TITLE
chore(opw): remove deprecated workerAPI.playground config

### DIFF
--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.15.1
+
+- Remove deprecated `datadog.workerAPI.playground` config (GraphQL API replaced by gRPC)
+
 ## 2.15.0
 
 - Official image `2.15.0`

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: 2.15.0
+version: 2.15.1
 description: Observability Pipelines Worker
 type: application
 keywords:

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.15.0](https://img.shields.io/badge/Version-2.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
+![Version: 2.15.1](https://img.shields.io/badge/Version-2.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.0](https://img.shields.io/badge/AppVersion-2.15.0-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -99,7 +99,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | datadog.site | string | `"datadoghq.com"` | The [site](https://docs.datadoghq.com/getting_started/site/) of the Datadog intake to send data to. |
 | datadog.workerAPI.address | string | `"0.0.0.0:8686"` | Local address to bind the Worker's API to. if you change this port, you'll need to update the livenessProbe and readinessProbe |
 | datadog.workerAPI.enabled | bool | `true` | Whether to enable the Worker's API. |
-| datadog.workerAPI.playground | bool | `false` | Whether to enable the Worker's API GraphQL playground. |
 | dnsConfig | object | `{}` | Specify the [dnsConfig](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config). |
 | dnsPolicy | string | `"ClusterFirst"` | Specify the [dnsPolicy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy). |
 | env | list | `[]` | Define environment variables. |

--- a/charts/observability-pipelines-worker/ci/api-values.yaml
+++ b/charts/observability-pipelines-worker/ci/api-values.yaml
@@ -2,7 +2,6 @@ datadog:
   pipelineId: "8799b5cc-c2c9-4be5-9660-f97a4eede7f7"
   workerAPI:
     enabled: true
-    playground: false
     address: "0.0.0.0:8686"
 
 args:

--- a/charts/observability-pipelines-worker/templates/_pod.tpl
+++ b/charts/observability-pipelines-worker/templates/_pod.tpl
@@ -59,8 +59,6 @@ containers:
       {{- end }}
       - name: DD_OP_API_ENABLED
         value: {{ .Values.datadog.workerAPI.enabled | quote }}
-      - name: DD_OP_API_PLAYGROUND
-        value: {{ .Values.datadog.workerAPI.playground | quote }}
       - name: DD_OP_API_ADDRESS
         value: {{ .Values.datadog.workerAPI.address | quote }}
 {{- if .Values.env }}

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -33,8 +33,6 @@ datadog:
   workerAPI:
     # datadog.workerAPI.enabled -- Whether to enable the Worker's API.
     enabled: true
-    # datadog.workerAPI.playground -- Whether to enable the Worker's API GraphQL playground.
-    playground: false
     # datadog.workerAPI.address -- Local address to bind the Worker's API to.
     # if you change this port, you'll need to update the livenessProbe and readinessProbe
     address: "0.0.0.0:8686"


### PR DESCRIPTION
## Summary

- Removes `datadog.workerAPI.playground` value and `DD_OP_API_PLAYGROUND` env var injection
- The GraphQL API was replaced by gRPC in upstream Vector (vectordotdev/vector#24364), so the playground option no longer exists

## Test plan

- [ ] Helm template renders without `DD_OP_API_PLAYGROUND` env var
- [ ] Existing deployments that have `workerAPI.playground` set in their values will get a helm warning about unknown value (standard helm behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)