### PR TITLE
feat(datadog-crds): update datadog autoscaling CRDs

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.19.0
+
+* feat(datadog-crds): update datadog autoscaling CRDs ([#2560](https://github.com/DataDog/helm-charts/pull/2560)).
+
 ## 2.18.1
 
 Drop `description` fields from `datadogagentinternals` and `datadogagentprofiles`.

--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.19.0
 
-* feat(datadog-crds): update datadog autoscaling CRDs ([#2560](https://github.com/DataDog/helm-charts/pull/2560)).
+* Update DatadogPodAutoscaler CRD and add DatadogPodAutoscalerClusterProfile CRD.
 
 ## 2.18.1
 

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.18.1
+version: 2.19.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -29,7 +29,7 @@ But the recommended Kubernetes versions are `1.16+`.
 | crds.datadogGenericResources | bool | `false` | Set to true to deploy the DatadogGenericResources CRD |
 | crds.datadogMetrics | bool | `false` | Set to true to deploy the DatadogMetrics CRD |
 | crds.datadogMonitors | bool | `false` | Set to true to deploy the DatadogMonitors CRD |
-| crds.datadogPodAutoscalerClusterProfile | bool | `false` | Set to true to deploy the DatadogPodAutoscalerClusterProfiles CRD |
+| crds.datadogPodAutoscalerClusterProfiles | bool | `false` | Set to true to deploy the DatadogPodAutoscalerClusterProfiles CRD |
 | crds.datadogPodAutoscalers | bool | `false` | Set to true to deploy the DatadogPodAutoscalers CRD |
 | crds.datadogSLOs | bool | `false` | Set to true to deploy the DatadogSLO CRD |
 | fullnameOverride | string | `""` | Override the fully qualified app name |

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.18.1](https://img.shields.io/badge/Version-2.18.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.19.0](https://img.shields.io/badge/Version-2.19.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 
@@ -29,6 +29,7 @@ But the recommended Kubernetes versions are `1.16+`.
 | crds.datadogGenericResources | bool | `false` | Set to true to deploy the DatadogGenericResources CRD |
 | crds.datadogMetrics | bool | `false` | Set to true to deploy the DatadogMetrics CRD |
 | crds.datadogMonitors | bool | `false` | Set to true to deploy the DatadogMonitors CRD |
+| crds.datadogPodAutoscalerClusterProfile | bool | `false` | Set to true to deploy the DatadogPodAutoscalerClusterProfiles CRD |
 | crds.datadogPodAutoscalers | bool | `false` | Set to true to deploy the DatadogPodAutoscalers CRD |
 | crds.datadogSLOs | bool | `false` | Set to true to deploy the DatadogSLO CRD |
 | fullnameOverride | string | `""` | Override the fully qualified app name |

--- a/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalerclusterprofiles_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalerclusterprofiles_v1.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crds.datadogPodAutoscalerClusterProfile }}
+{{- if .Values.crds.datadogPodAutoscalerClusterProfiles }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalerclusterprofiles_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalerclusterprofiles_v1.yaml
@@ -1,0 +1,920 @@
+{{- if .Values.crds.datadogPodAutoscalerClusterProfile }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {{- if .Values.keepCrds }}
+    helm.sh/resource-policy: keep
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogpodautoscalerclusterprofiles.datadoghq.com
+  labels:
+    helm.sh/chart: '{{ include "datadog-crds.chart" . }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ include "datadog-crds.name" . }}'
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogPodAutoscalerClusterProfile
+    listKind: DatadogPodAutoscalerClusterProfileList
+    plural: datadogpodautoscalerclusterprofiles
+    shortNames:
+      - dpacp
+    singular: datadogpodautoscalerclusterprofile
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Valid')].status
+          name: Valid
+          type: string
+        - jsonPath: .status.controlledAutoscalers
+          name: Controlled Autoscalers
+          type: integer
+        - jsonPath: .spec.template.applyPolicy.mode
+          name: Apply Mode
+          type: string
+        - jsonPath: .spec.template.constraints.minReplicas
+          name: Min Replicas
+          type: integer
+        - jsonPath: .spec.template.constraints.maxReplicas
+          name: Max Replicas
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: DatadogPodAutoscalerClusterProfile is the Schema for the datadogpodautoscalerclusterprofiles API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogPodAutoscalerProfileSpec defines the desired state of DatadogPodAutoscalerProfile.
+              properties:
+                template:
+                  description: Template contains the autoscaling behavior configuration to apply to managed DatadogPodAutoscalers.
+                  properties:
+                    applyPolicy:
+                      default: {}
+                      description: ApplyPolicy defines how recommendations should be applied.
+                      properties:
+                        mode:
+                          default: Apply
+                          description: |-
+                            Mode determines recommendations that should be applied by the controller:
+                            - Apply: Apply all recommendations.
+                            - Preview: Recommendations are received and visible through .Status, but the controller does not apply them.
+                            It's also possible to selectively deactivate upscale, downscale or update actions thanks to the `ScaleUp`, `ScaleDown` and `Update` fields.
+                          enum:
+                            - Apply
+                            - Preview
+                          type: string
+                        scaleDown:
+                          description: ScaleDown defines the policy to scale down the target resource.
+                          properties:
+                            rules:
+                              description: |-
+                                Rules is a list of potential scaling polices which can be used during scaling.
+                                At least one policy must be specified, otherwise the DatadogPodAutoscalerScalingPolicy will be discarded as invalid
+                              items:
+                                description: DatadogPodAutoscalerScalingRule defines rules for horizontal scaling that should be true for a certain amount of time.
+                                properties:
+                                  periodSeconds:
+                                    description: |-
+                                      PeriodSeconds specifies the window of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
+                                    format: int32
+                                    maximum: 3600
+                                    minimum: 1
+                                    type: integer
+                                  type:
+                                    description: Type is used to specify the scaling policy.
+                                    enum:
+                                      - Pods
+                                      - Percent
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value contains the amount of change which is permitted by the policy.
+                                      Setting it to 0 will prevent any scaling in this direction.
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            stabilizationWindowSeconds:
+                              description: |-
+                                StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+                                before deciding to apply a new one. Defaults to 0.
+                              format: int32
+                              maximum: 3600
+                              minimum: 0
+                              type: integer
+                            strategy:
+                              description: |-
+                                Strategy is used to specify which policy should be used.
+                                If not set, the default value Max is used.
+                              enum:
+                                - Max
+                                - Min
+                                - Disabled
+                              type: string
+                          type: object
+                        scaleUp:
+                          description: ScaleUp defines the policy to scale up the target resource.
+                          properties:
+                            rules:
+                              description: |-
+                                Rules is a list of potential scaling polices which can be used during scaling.
+                                At least one policy must be specified, otherwise the DatadogPodAutoscalerScalingPolicy will be discarded as invalid
+                              items:
+                                description: DatadogPodAutoscalerScalingRule defines rules for horizontal scaling that should be true for a certain amount of time.
+                                properties:
+                                  periodSeconds:
+                                    description: |-
+                                      PeriodSeconds specifies the window of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
+                                    format: int32
+                                    maximum: 3600
+                                    minimum: 1
+                                    type: integer
+                                  type:
+                                    description: Type is used to specify the scaling policy.
+                                    enum:
+                                      - Pods
+                                      - Percent
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value contains the amount of change which is permitted by the policy.
+                                      Setting it to 0 will prevent any scaling in this direction.
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            stabilizationWindowSeconds:
+                              description: |-
+                                StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+                                before deciding to apply a new one. Defaults to 0.
+                              format: int32
+                              maximum: 3600
+                              minimum: 0
+                              type: integer
+                            strategy:
+                              description: |-
+                                Strategy is used to specify which policy should be used.
+                                If not set, the default value Max is used.
+                              enum:
+                                - Max
+                                - Min
+                                - Disabled
+                              type: string
+                          type: object
+                        update:
+                          description: Update defines the policy for updating the target resource.
+                          properties:
+                            resizePendingPeriod:
+                              description: |-
+                                Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.
+                                Must be greater than 0 and less than or equal to 3600 (1 hour).
+                              format: int32
+                              maximum: 3600
+                              minimum: 1
+                              type: integer
+                            rolloutFallbackDelay:
+                              description: |-
+                                Controls how long we wait before falling back to a full rollout when evictions are blocked.
+                                Must be greater than 0 and less than or equal to 3600 (1 hour).
+                              format: int32
+                              maximum: 3600
+                              minimum: 1
+                              type: integer
+                            strategy:
+                              description: Strategy defines the mode of the update policy.
+                              enum:
+                                - Auto
+                                - Disabled
+                                - TriggerRollout
+                              type: string
+                          type: object
+                      type: object
+                    constraints:
+                      description: Constraints defines constraints that should always be respected.
+                      properties:
+                        containers:
+                          description: Containers defines constraints for the containers.
+                          items:
+                            description: |-
+                              DatadogPodAutoscalerContainerConstraints defines constraints that should always be respected for a container.
+                              If no constraints are set, it enables resource scaling for all containers without any constraints.
+                            properties:
+                              controlledResources:
+                                description: |-
+                                  Specifies the resources for which recommendations will be computed.
+                                  If not specified, it defaults to CPU and Memory.
+                                  If an empty list is provided, no resource will be controlled (equivalent to Enabled=false).
+                                items:
+                                  description: ResourceName is the name identifying various resources in a ResourceList.
+                                  type: string
+                                type: array
+                              controlledValues:
+                                description: |-
+                                  Specifies whether recommendations are made to Requests and Limits (RequestsAndLimits) or Requests only (RequestsOnly).
+                                  The default is "RequestsAndLimits".
+                                enum:
+                                  - RequestsAndLimits
+                                  - RequestsOnly
+                                type: string
+                              enabled:
+                                description: Enabled, if false, allows one to disable resource autoscaling for the container. Defaults to true.
+                                type: boolean
+                              maxAllowed:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: MaxAllowed is the upper limit for the requests of the container.
+                                type: object
+                              minAllowed:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: MinAllowed is the lower limit for the requests of the container.
+                                type: object
+                              name:
+                                description: Name is the name of the container. Can be "*" to apply to all containers.
+                                type: string
+                              requests:
+                                description: |-
+                                  Requests defines the constraints for the requests of the container.
+                                  WARNING: Deprecated
+                                properties:
+                                  maxAllowed:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: MaxAllowed is the upper limit for the requests of the container.
+                                    type: object
+                                  minAllowed:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: MinAllowed is the lower limit for the requests of the container.
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        maxReplicas:
+                          description: MaxReplicas is the upper limit for the number of POD replicas. Needs to be >= minReplicas.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        minReplicas:
+                          description: MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 1. Defaults to 1.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                      type: object
+                    fallback:
+                      default: {}
+                      description: Fallback defines how recommendations should be applied when in fallback mode.
+                      properties:
+                        horizontal:
+                          default: {}
+                          description: Horizontal configures the behavior during horizontal fallback mode.
+                          properties:
+                            direction:
+                              default: ScaleUp
+                              description: Direction determines the direction that recommendations should be applied.
+                              enum:
+                                - ScaleUp
+                                - ScaleDown
+                                - All
+                              type: string
+                            enabled:
+                              default: true
+                              description: 'Enabled determines whether recommendations should be applied by the controller:'
+                              type: boolean
+                            objectives:
+                              description: |-
+                                Objectives are the objectives to reach and maintain for the target resource in fallback mode.
+                                If not set, the regular objectives will be used.
+                              items:
+                                description: DatadogPodAutoscalerObjective defines the objectives to reach and maintain for the target workload.
+                                properties:
+                                  containerResource:
+                                    description: ContainerResource allows to set a container-level resource objective.
+                                    properties:
+                                      container:
+                                        description: Container is the name of the container.
+                                        type: string
+                                      name:
+                                        description: Name is the name of the resource.
+                                        enum:
+                                          - cpu
+                                          - memory
+                                        type: string
+                                      value:
+                                        description: Value is the value of the objective
+                                        properties:
+                                          absoluteValue:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                              Use a plain number (e.g., "11" or "11.5").
+                                              Represented as a resource.Quantity to avoid floating point in CRDs.
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type:
+                                            description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                            enum:
+                                              - Utilization
+                                              - AbsoluteValue
+                                            type: string
+                                          utilization:
+                                            description: Utilization defines a percentage of the target compared to requested workload
+                                            format: int32
+                                            maximum: 100
+                                            minimum: 0
+                                            type: integer
+                                        required:
+                                          - type
+                                        type: object
+                                    required:
+                                      - container
+                                      - name
+                                      - value
+                                    type: object
+                                  customQuery:
+                                    description: CustomQuery allows to set a controller-level objective.
+                                    properties:
+                                      request:
+                                        description: Request is the timeseries query to use for the objective.
+                                        properties:
+                                          formula:
+                                            description: Formula to compute (optional).
+                                            type: string
+                                          queries:
+                                            description: |-
+                                              Queries is a list of timeseries queries to use for the objective.
+                                              At least one query must be specified
+                                            items:
+                                              description: TimeseriesQuery is a discriminated union. Only Metrics and APMMetrics are supported for autoscaling.
+                                              properties:
+                                                apmMetrics:
+                                                  description: ApmMetrics is allows to query APM metrics.
+                                                  properties:
+                                                    groupBy:
+                                                      description: GroupBy is the list of tags to group by.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    operationName:
+                                                      description: OperationName is the name of the operation to query.
+                                                      type: string
+                                                    queryFilter:
+                                                      description: QueryFilter is the filter to apply to the query.
+                                                      type: string
+                                                    resourceHash:
+                                                      description: ResourceHash is a fingerprint of the resource name that can be used to identify the resource instead of the resource name.
+                                                      type: string
+                                                    resourceName:
+                                                      description: ResourceName is the name of the resource to query.
+                                                      type: string
+                                                    service:
+                                                      description: Service is the name of the service to query.
+                                                      type: string
+                                                    spanKind:
+                                                      description: SpanKind is the kind of span to query.
+                                                      type: string
+                                                    stat:
+                                                      description: Stat defines the statistic to compute for the APM metrics query.
+                                                      enum:
+                                                        - error_rate
+                                                        - errors
+                                                        - errors_per_second
+                                                        - hits
+                                                        - hits_per_second
+                                                        - apdex
+                                                        - latency_avg
+                                                        - latency_max
+                                                        - latency_p50
+                                                        - latency_p75
+                                                        - latency_p90
+                                                        - latency_p95
+                                                        - latency_p99
+                                                        - latency_p999
+                                                        - latency_distribution
+                                                        - total_time
+                                                      type: string
+                                                  required:
+                                                    - stat
+                                                  type: object
+                                                metrics:
+                                                  description: Metrics is a standard Datadog metrics query.
+                                                  properties:
+                                                    query:
+                                                      description: Classic Datadog metrics query, e.g. "avg:system.cpu.user{*} by {env}".
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                    - query
+                                                  type: object
+                                                name:
+                                                  description: Optional variable name ("a", "b", etc.) to reference in formulas.
+                                                  type: string
+                                                source:
+                                                  description: Source defines the source of the timeseries query.
+                                                  enum:
+                                                    - Metrics
+                                                    - ApmMetrics
+                                                  type: string
+                                              required:
+                                                - source
+                                              type: object
+                                            minItems: 1
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - queries
+                                        type: object
+                                      value:
+                                        description: Value is the value of the objective
+                                        properties:
+                                          absoluteValue:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                              Use a plain number (e.g., "11" or "11.5").
+                                              Represented as a resource.Quantity to avoid floating point in CRDs.
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type:
+                                            description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                            enum:
+                                              - Utilization
+                                              - AbsoluteValue
+                                            type: string
+                                          utilization:
+                                            description: Utilization defines a percentage of the target compared to requested workload
+                                            format: int32
+                                            maximum: 100
+                                            minimum: 0
+                                            type: integer
+                                        required:
+                                          - type
+                                        type: object
+                                      window:
+                                        description: Window is the time duration over which the query is computed. It should contain at least one full sample.
+                                        type: string
+                                    required:
+                                      - request
+                                      - value
+                                      - window
+                                    type: object
+                                  podResource:
+                                    description: PodResource allows to set a pod-level resource objective.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the resource.
+                                        enum:
+                                          - cpu
+                                          - memory
+                                        type: string
+                                      value:
+                                        description: Value is the value of the objective.
+                                        properties:
+                                          absoluteValue:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                              Use a plain number (e.g., "11" or "11.5").
+                                              Represented as a resource.Quantity to avoid floating point in CRDs.
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type:
+                                            description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                            enum:
+                                              - Utilization
+                                              - AbsoluteValue
+                                            type: string
+                                          utilization:
+                                            description: Utilization defines a percentage of the target compared to requested workload
+                                            format: int32
+                                            maximum: 100
+                                            minimum: 0
+                                            type: integer
+                                        required:
+                                          - type
+                                        type: object
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type:
+                                    description: Type sets the type of the objective.
+                                    enum:
+                                      - PodResource
+                                      - ContainerResource
+                                      - CustomQuery
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            triggers:
+                              default: {}
+                              description: Triggers defines the triggers that will generate recommendations.
+                              properties:
+                                staleRecommendationThresholdSeconds:
+                                  default: 600
+                                  description: StaleRecommendationThresholdSeconds defines the time window the controller will wait after detecting an error before applying recommendations.
+                                  format: int32
+                                  maximum: 3600
+                                  minimum: 100
+                                  type: integer
+                              type: object
+                          type: object
+                      type: object
+                    objectives:
+                      description: |-
+                        Objectives are the objectives to reach and maintain for the target resource.
+                        Default to a single objective to maintain 80% POD CPU utilization.
+                      items:
+                        description: DatadogPodAutoscalerObjective defines the objectives to reach and maintain for the target workload.
+                        properties:
+                          containerResource:
+                            description: ContainerResource allows to set a container-level resource objective.
+                            properties:
+                              container:
+                                description: Container is the name of the container.
+                                type: string
+                              name:
+                                description: Name is the name of the resource.
+                                enum:
+                                  - cpu
+                                  - memory
+                                type: string
+                              value:
+                                description: Value is the value of the objective
+                                properties:
+                                  absoluteValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                      Use a plain number (e.g., "11" or "11.5").
+                                      Represented as a resource.Quantity to avoid floating point in CRDs.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                    enum:
+                                      - Utilization
+                                      - AbsoluteValue
+                                    type: string
+                                  utilization:
+                                    description: Utilization defines a percentage of the target compared to requested workload
+                                    format: int32
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - container
+                              - name
+                              - value
+                            type: object
+                          customQuery:
+                            description: CustomQuery allows to set a controller-level objective.
+                            properties:
+                              request:
+                                description: Request is the timeseries query to use for the objective.
+                                properties:
+                                  formula:
+                                    description: Formula to compute (optional).
+                                    type: string
+                                  queries:
+                                    description: |-
+                                      Queries is a list of timeseries queries to use for the objective.
+                                      At least one query must be specified
+                                    items:
+                                      description: TimeseriesQuery is a discriminated union. Only Metrics and APMMetrics are supported for autoscaling.
+                                      properties:
+                                        apmMetrics:
+                                          description: ApmMetrics is allows to query APM metrics.
+                                          properties:
+                                            groupBy:
+                                              description: GroupBy is the list of tags to group by.
+                                              items:
+                                                type: string
+                                              type: array
+                                            operationName:
+                                              description: OperationName is the name of the operation to query.
+                                              type: string
+                                            queryFilter:
+                                              description: QueryFilter is the filter to apply to the query.
+                                              type: string
+                                            resourceHash:
+                                              description: ResourceHash is a fingerprint of the resource name that can be used to identify the resource instead of the resource name.
+                                              type: string
+                                            resourceName:
+                                              description: ResourceName is the name of the resource to query.
+                                              type: string
+                                            service:
+                                              description: Service is the name of the service to query.
+                                              type: string
+                                            spanKind:
+                                              description: SpanKind is the kind of span to query.
+                                              type: string
+                                            stat:
+                                              description: Stat defines the statistic to compute for the APM metrics query.
+                                              enum:
+                                                - error_rate
+                                                - errors
+                                                - errors_per_second
+                                                - hits
+                                                - hits_per_second
+                                                - apdex
+                                                - latency_avg
+                                                - latency_max
+                                                - latency_p50
+                                                - latency_p75
+                                                - latency_p90
+                                                - latency_p95
+                                                - latency_p99
+                                                - latency_p999
+                                                - latency_distribution
+                                                - total_time
+                                              type: string
+                                          required:
+                                            - stat
+                                          type: object
+                                        metrics:
+                                          description: Metrics is a standard Datadog metrics query.
+                                          properties:
+                                            query:
+                                              description: Classic Datadog metrics query, e.g. "avg:system.cpu.user{*} by {env}".
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                            - query
+                                          type: object
+                                        name:
+                                          description: Optional variable name ("a", "b", etc.) to reference in formulas.
+                                          type: string
+                                        source:
+                                          description: Source defines the source of the timeseries query.
+                                          enum:
+                                            - Metrics
+                                            - ApmMetrics
+                                          type: string
+                                      required:
+                                        - source
+                                      type: object
+                                    minItems: 1
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - queries
+                                type: object
+                              value:
+                                description: Value is the value of the objective
+                                properties:
+                                  absoluteValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                      Use a plain number (e.g., "11" or "11.5").
+                                      Represented as a resource.Quantity to avoid floating point in CRDs.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                    enum:
+                                      - Utilization
+                                      - AbsoluteValue
+                                    type: string
+                                  utilization:
+                                    description: Utilization defines a percentage of the target compared to requested workload
+                                    format: int32
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                  - type
+                                type: object
+                              window:
+                                description: Window is the time duration over which the query is computed. It should contain at least one full sample.
+                                type: string
+                            required:
+                              - request
+                              - value
+                              - window
+                            type: object
+                          podResource:
+                            description: PodResource allows to set a pod-level resource objective.
+                            properties:
+                              name:
+                                description: Name is the name of the resource.
+                                enum:
+                                  - cpu
+                                  - memory
+                                type: string
+                              value:
+                                description: Value is the value of the objective.
+                                properties:
+                                  absoluteValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                      Use a plain number (e.g., "11" or "11.5").
+                                      Represented as a resource.Quantity to avoid floating point in CRDs.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                    enum:
+                                      - Utilization
+                                      - AbsoluteValue
+                                    type: string
+                                  utilization:
+                                    description: Utilization defines a percentage of the target compared to requested workload
+                                    format: int32
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type:
+                            description: Type sets the type of the objective.
+                            enum:
+                              - PodResource
+                              - ContainerResource
+                              - CustomQuery
+                            type: string
+                        required:
+                          - type
+                        type: object
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    options:
+                      description: Options defines optional behavior modifications for the autoscaler.
+                      properties:
+                        outOfMemory:
+                          description: OutOfMemory configures behavior when OOM events are detected.
+                          properties:
+                            bumpUpRatio:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                BumpUpRatio defines the ratio to multiply memory by when OOM is detected.
+                                For example, "1.2" means increase memory by 20%.
+                                Represented as a resource.Quantity to avoid floating point in CRDs.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                  type: object
+              required:
+                - template
+              type: object
+            status:
+              description: DatadogPodAutoscalerProfileStatus defines the observed state of DatadogPodAutoscalerProfile.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the profile's current state.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                controlledAutoscalers:
+                  description: ControlledAutoscalers is the number of DatadogPodAutoscaler objects managed by this profile.
+                  format: int32
+                  type: integer
+                templateHash:
+                  description: TemplateHash is the stored hash of the DatadogPodAutoscalerProfile template.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+{{- end }}

--- a/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogpodautoscalers_v1.yaml
@@ -261,11 +261,28 @@ spec:
                     update:
                       description: Update defines the policy to update target resource.
                       properties:
+                        resizePendingPeriod:
+                          description: |-
+                            Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.
+                            Must be greater than 0 and less than or equal to 3600 (1 hour).
+                          format: int32
+                          maximum: 3600
+                          minimum: 1
+                          type: integer
+                        rolloutFallbackDelay:
+                          description: |-
+                            Controls how long we wait before falling back to a full rollout when evictions are blocked.
+                            Must be greater than 0 and less than or equal to 3600 (1 hour).
+                          format: int32
+                          maximum: 3600
+                          minimum: 1
+                          type: integer
                         strategy:
                           description: Strategy defines the mode of the update policy.
                           enum:
                             - Auto
                             - Disabled
+                            - TriggerRollout
                           type: string
                       type: object
                     upscale:
@@ -745,6 +762,12 @@ spec:
                               - name
                             type: object
                           type: array
+                        evicted:
+                          description: |-
+                            Evicted is the number of pods evicted as an in-place resize fallback during the
+                            current recommendation cycle. Resets when the recommendation changes.
+                          format: int32
+                          type: integer
                         generatedAt:
                           description: GeneratedAt is the timestamp at which the recommendation was generated
                           format: date-time
@@ -979,11 +1002,28 @@ spec:
                     update:
                       description: Update defines the policy for updating the target resource.
                       properties:
+                        resizePendingPeriod:
+                          description: |-
+                            Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.
+                            Must be greater than 0 and less than or equal to 3600 (1 hour).
+                          format: int32
+                          maximum: 3600
+                          minimum: 1
+                          type: integer
+                        rolloutFallbackDelay:
+                          description: |-
+                            Controls how long we wait before falling back to a full rollout when evictions are blocked.
+                            Must be greater than 0 and less than or equal to 3600 (1 hour).
+                          format: int32
+                          maximum: 3600
+                          minimum: 1
+                          type: integer
                         strategy:
                           description: Strategy defines the mode of the update policy.
                           enum:
                             - Auto
                             - Disabled
+                            - TriggerRollout
                           type: string
                       type: object
                   type: object
@@ -1792,6 +1832,12 @@ spec:
                               - name
                             type: object
                           type: array
+                        evicted:
+                          description: |-
+                            Evicted is the number of pods evicted as an in-place resize fallback during the
+                            current recommendation cycle. Resets when the recommendation changes.
+                          format: int32
+                          type: integer
                         generatedAt:
                           description: GeneratedAt is the timestamp at which the recommendation was generated
                           format: date-time

--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -56,6 +56,7 @@ download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogmonitors da
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogslos datadogSLOs v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogagentprofiles datadogAgentProfiles v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogpodautoscalers datadogPodAutoscalers v1
+download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogpodautoscalerclusterprofiles datadogPodAutoscalerClusterProfile v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogdashboards datadogDashboards v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadoggenericresources datadogGenericResources v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogagentinternals datadogAgentInternals v1

--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -56,7 +56,7 @@ download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogmonitors da
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogslos datadogSLOs v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogagentprofiles datadogAgentProfiles v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogpodautoscalers datadogPodAutoscalers v1
-download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogpodautoscalerclusterprofiles datadogPodAutoscalerClusterProfile v1
+download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogpodautoscalerclusterprofiles datadogPodAutoscalerClusterProfiles v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogdashboards datadogDashboards v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadoggenericresources datadogGenericResources v1
 download_crd "$DATADOG_OPERATOR_REPO" "$DATADOG_OPERATOR_TAG" datadogagentinternals datadogAgentInternals v1

--- a/charts/datadog-crds/values.yaml
+++ b/charts/datadog-crds/values.yaml
@@ -13,8 +13,8 @@ crds:
   datadogSLOs: false
   # crds.datadogAgentProfiles -- Set to true to deploy the DatadogAgentProfiles CRD
   datadogAgentProfiles: false
-  # crds.datadogPodAutoscalerClusterProfile -- Set to true to deploy the DatadogPodAutoscalerClusterProfiles CRD
-  datadogPodAutoscalerClusterProfile: false
+  # crds.datadogPodAutoscalerClusterProfiles -- Set to true to deploy the DatadogPodAutoscalerClusterProfiles CRD
+  datadogPodAutoscalerClusterProfiles: false
   # crds.datadogPodAutoscalers -- Set to true to deploy the DatadogPodAutoscalers CRD
   datadogPodAutoscalers: false
   # crds.datadogDashboards -- Set to true to deploy the DatadogDashboards CRD

--- a/charts/datadog-crds/values.yaml
+++ b/charts/datadog-crds/values.yaml
@@ -13,6 +13,8 @@ crds:
   datadogSLOs: false
   # crds.datadogAgentProfiles -- Set to true to deploy the DatadogAgentProfiles CRD
   datadogAgentProfiles: false
+  # crds.datadogPodAutoscalerClusterProfile -- Set to true to deploy the DatadogPodAutoscalerClusterProfiles CRD
+  datadogPodAutoscalerClusterProfile: false
   # crds.datadogPodAutoscalers -- Set to true to deploy the DatadogPodAutoscalers CRD
   datadogPodAutoscalers: false
   # crds.datadogDashboards -- Set to true to deploy the DatadogDashboards CRD

--- a/crds/datadoghq.com_datadogpodautoscalerclusterprofiles.yaml
+++ b/crds/datadoghq.com_datadogpodautoscalerclusterprofiles.yaml
@@ -1,0 +1,910 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datadogpodautoscalerclusterprofiles.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogPodAutoscalerClusterProfile
+    listKind: DatadogPodAutoscalerClusterProfileList
+    plural: datadogpodautoscalerclusterprofiles
+    shortNames:
+      - dpacp
+    singular: datadogpodautoscalerclusterprofile
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Valid')].status
+          name: Valid
+          type: string
+        - jsonPath: .status.controlledAutoscalers
+          name: Controlled Autoscalers
+          type: integer
+        - jsonPath: .spec.template.applyPolicy.mode
+          name: Apply Mode
+          type: string
+        - jsonPath: .spec.template.constraints.minReplicas
+          name: Min Replicas
+          type: integer
+        - jsonPath: .spec.template.constraints.maxReplicas
+          name: Max Replicas
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: DatadogPodAutoscalerClusterProfile is the Schema for the datadogpodautoscalerclusterprofiles API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DatadogPodAutoscalerProfileSpec defines the desired state of DatadogPodAutoscalerProfile.
+              properties:
+                template:
+                  description: Template contains the autoscaling behavior configuration to apply to managed DatadogPodAutoscalers.
+                  properties:
+                    applyPolicy:
+                      default: {}
+                      description: ApplyPolicy defines how recommendations should be applied.
+                      properties:
+                        mode:
+                          default: Apply
+                          description: |-
+                            Mode determines recommendations that should be applied by the controller:
+                            - Apply: Apply all recommendations.
+                            - Preview: Recommendations are received and visible through .Status, but the controller does not apply them.
+                            It's also possible to selectively deactivate upscale, downscale or update actions thanks to the `ScaleUp`, `ScaleDown` and `Update` fields.
+                          enum:
+                            - Apply
+                            - Preview
+                          type: string
+                        scaleDown:
+                          description: ScaleDown defines the policy to scale down the target resource.
+                          properties:
+                            rules:
+                              description: |-
+                                Rules is a list of potential scaling polices which can be used during scaling.
+                                At least one policy must be specified, otherwise the DatadogPodAutoscalerScalingPolicy will be discarded as invalid
+                              items:
+                                description: DatadogPodAutoscalerScalingRule defines rules for horizontal scaling that should be true for a certain amount of time.
+                                properties:
+                                  periodSeconds:
+                                    description: |-
+                                      PeriodSeconds specifies the window of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
+                                    format: int32
+                                    maximum: 3600
+                                    minimum: 1
+                                    type: integer
+                                  type:
+                                    description: Type is used to specify the scaling policy.
+                                    enum:
+                                      - Pods
+                                      - Percent
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value contains the amount of change which is permitted by the policy.
+                                      Setting it to 0 will prevent any scaling in this direction.
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            stabilizationWindowSeconds:
+                              description: |-
+                                StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+                                before deciding to apply a new one. Defaults to 0.
+                              format: int32
+                              maximum: 3600
+                              minimum: 0
+                              type: integer
+                            strategy:
+                              description: |-
+                                Strategy is used to specify which policy should be used.
+                                If not set, the default value Max is used.
+                              enum:
+                                - Max
+                                - Min
+                                - Disabled
+                              type: string
+                          type: object
+                        scaleUp:
+                          description: ScaleUp defines the policy to scale up the target resource.
+                          properties:
+                            rules:
+                              description: |-
+                                Rules is a list of potential scaling polices which can be used during scaling.
+                                At least one policy must be specified, otherwise the DatadogPodAutoscalerScalingPolicy will be discarded as invalid
+                              items:
+                                description: DatadogPodAutoscalerScalingRule defines rules for horizontal scaling that should be true for a certain amount of time.
+                                properties:
+                                  periodSeconds:
+                                    description: |-
+                                      PeriodSeconds specifies the window of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
+                                    format: int32
+                                    maximum: 3600
+                                    minimum: 1
+                                    type: integer
+                                  type:
+                                    description: Type is used to specify the scaling policy.
+                                    enum:
+                                      - Pods
+                                      - Percent
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value contains the amount of change which is permitted by the policy.
+                                      Setting it to 0 will prevent any scaling in this direction.
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            stabilizationWindowSeconds:
+                              description: |-
+                                StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+                                before deciding to apply a new one. Defaults to 0.
+                              format: int32
+                              maximum: 3600
+                              minimum: 0
+                              type: integer
+                            strategy:
+                              description: |-
+                                Strategy is used to specify which policy should be used.
+                                If not set, the default value Max is used.
+                              enum:
+                                - Max
+                                - Min
+                                - Disabled
+                              type: string
+                          type: object
+                        update:
+                          description: Update defines the policy for updating the target resource.
+                          properties:
+                            resizePendingPeriod:
+                              description: |-
+                                Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.
+                                Must be greater than 0 and less than or equal to 3600 (1 hour).
+                              format: int32
+                              maximum: 3600
+                              minimum: 1
+                              type: integer
+                            rolloutFallbackDelay:
+                              description: |-
+                                Controls how long we wait before falling back to a full rollout when evictions are blocked.
+                                Must be greater than 0 and less than or equal to 3600 (1 hour).
+                              format: int32
+                              maximum: 3600
+                              minimum: 1
+                              type: integer
+                            strategy:
+                              description: Strategy defines the mode of the update policy.
+                              enum:
+                                - Auto
+                                - Disabled
+                                - TriggerRollout
+                              type: string
+                          type: object
+                      type: object
+                    constraints:
+                      description: Constraints defines constraints that should always be respected.
+                      properties:
+                        containers:
+                          description: Containers defines constraints for the containers.
+                          items:
+                            description: |-
+                              DatadogPodAutoscalerContainerConstraints defines constraints that should always be respected for a container.
+                              If no constraints are set, it enables resource scaling for all containers without any constraints.
+                            properties:
+                              controlledResources:
+                                description: |-
+                                  Specifies the resources for which recommendations will be computed.
+                                  If not specified, it defaults to CPU and Memory.
+                                  If an empty list is provided, no resource will be controlled (equivalent to Enabled=false).
+                                items:
+                                  description: ResourceName is the name identifying various resources in a ResourceList.
+                                  type: string
+                                type: array
+                              controlledValues:
+                                description: |-
+                                  Specifies whether recommendations are made to Requests and Limits (RequestsAndLimits) or Requests only (RequestsOnly).
+                                  The default is "RequestsAndLimits".
+                                enum:
+                                  - RequestsAndLimits
+                                  - RequestsOnly
+                                type: string
+                              enabled:
+                                description: Enabled, if false, allows one to disable resource autoscaling for the container. Defaults to true.
+                                type: boolean
+                              maxAllowed:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: MaxAllowed is the upper limit for the requests of the container.
+                                type: object
+                              minAllowed:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: MinAllowed is the lower limit for the requests of the container.
+                                type: object
+                              name:
+                                description: Name is the name of the container. Can be "*" to apply to all containers.
+                                type: string
+                              requests:
+                                description: |-
+                                  Requests defines the constraints for the requests of the container.
+                                  WARNING: Deprecated
+                                properties:
+                                  maxAllowed:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: MaxAllowed is the upper limit for the requests of the container.
+                                    type: object
+                                  minAllowed:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: MinAllowed is the lower limit for the requests of the container.
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        maxReplicas:
+                          description: MaxReplicas is the upper limit for the number of POD replicas. Needs to be >= minReplicas.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        minReplicas:
+                          description: MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 1. Defaults to 1.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                      type: object
+                    fallback:
+                      default: {}
+                      description: Fallback defines how recommendations should be applied when in fallback mode.
+                      properties:
+                        horizontal:
+                          default: {}
+                          description: Horizontal configures the behavior during horizontal fallback mode.
+                          properties:
+                            direction:
+                              default: ScaleUp
+                              description: Direction determines the direction that recommendations should be applied.
+                              enum:
+                                - ScaleUp
+                                - ScaleDown
+                                - All
+                              type: string
+                            enabled:
+                              default: true
+                              description: 'Enabled determines whether recommendations should be applied by the controller:'
+                              type: boolean
+                            objectives:
+                              description: |-
+                                Objectives are the objectives to reach and maintain for the target resource in fallback mode.
+                                If not set, the regular objectives will be used.
+                              items:
+                                description: DatadogPodAutoscalerObjective defines the objectives to reach and maintain for the target workload.
+                                properties:
+                                  containerResource:
+                                    description: ContainerResource allows to set a container-level resource objective.
+                                    properties:
+                                      container:
+                                        description: Container is the name of the container.
+                                        type: string
+                                      name:
+                                        description: Name is the name of the resource.
+                                        enum:
+                                          - cpu
+                                          - memory
+                                        type: string
+                                      value:
+                                        description: Value is the value of the objective
+                                        properties:
+                                          absoluteValue:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                              Use a plain number (e.g., "11" or "11.5").
+                                              Represented as a resource.Quantity to avoid floating point in CRDs.
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type:
+                                            description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                            enum:
+                                              - Utilization
+                                              - AbsoluteValue
+                                            type: string
+                                          utilization:
+                                            description: Utilization defines a percentage of the target compared to requested workload
+                                            format: int32
+                                            maximum: 100
+                                            minimum: 0
+                                            type: integer
+                                        required:
+                                          - type
+                                        type: object
+                                    required:
+                                      - container
+                                      - name
+                                      - value
+                                    type: object
+                                  customQuery:
+                                    description: CustomQuery allows to set a controller-level objective.
+                                    properties:
+                                      request:
+                                        description: Request is the timeseries query to use for the objective.
+                                        properties:
+                                          formula:
+                                            description: Formula to compute (optional).
+                                            type: string
+                                          queries:
+                                            description: |-
+                                              Queries is a list of timeseries queries to use for the objective.
+                                              At least one query must be specified
+                                            items:
+                                              description: TimeseriesQuery is a discriminated union. Only Metrics and APMMetrics are supported for autoscaling.
+                                              properties:
+                                                apmMetrics:
+                                                  description: ApmMetrics is allows to query APM metrics.
+                                                  properties:
+                                                    groupBy:
+                                                      description: GroupBy is the list of tags to group by.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    operationName:
+                                                      description: OperationName is the name of the operation to query.
+                                                      type: string
+                                                    queryFilter:
+                                                      description: QueryFilter is the filter to apply to the query.
+                                                      type: string
+                                                    resourceHash:
+                                                      description: ResourceHash is a fingerprint of the resource name that can be used to identify the resource instead of the resource name.
+                                                      type: string
+                                                    resourceName:
+                                                      description: ResourceName is the name of the resource to query.
+                                                      type: string
+                                                    service:
+                                                      description: Service is the name of the service to query.
+                                                      type: string
+                                                    spanKind:
+                                                      description: SpanKind is the kind of span to query.
+                                                      type: string
+                                                    stat:
+                                                      description: Stat defines the statistic to compute for the APM metrics query.
+                                                      enum:
+                                                        - error_rate
+                                                        - errors
+                                                        - errors_per_second
+                                                        - hits
+                                                        - hits_per_second
+                                                        - apdex
+                                                        - latency_avg
+                                                        - latency_max
+                                                        - latency_p50
+                                                        - latency_p75
+                                                        - latency_p90
+                                                        - latency_p95
+                                                        - latency_p99
+                                                        - latency_p999
+                                                        - latency_distribution
+                                                        - total_time
+                                                      type: string
+                                                  required:
+                                                    - stat
+                                                  type: object
+                                                metrics:
+                                                  description: Metrics is a standard Datadog metrics query.
+                                                  properties:
+                                                    query:
+                                                      description: Classic Datadog metrics query, e.g. "avg:system.cpu.user{*} by {env}".
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                    - query
+                                                  type: object
+                                                name:
+                                                  description: Optional variable name ("a", "b", etc.) to reference in formulas.
+                                                  type: string
+                                                source:
+                                                  description: Source defines the source of the timeseries query.
+                                                  enum:
+                                                    - Metrics
+                                                    - ApmMetrics
+                                                  type: string
+                                              required:
+                                                - source
+                                              type: object
+                                            minItems: 1
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - queries
+                                        type: object
+                                      value:
+                                        description: Value is the value of the objective
+                                        properties:
+                                          absoluteValue:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                              Use a plain number (e.g., "11" or "11.5").
+                                              Represented as a resource.Quantity to avoid floating point in CRDs.
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type:
+                                            description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                            enum:
+                                              - Utilization
+                                              - AbsoluteValue
+                                            type: string
+                                          utilization:
+                                            description: Utilization defines a percentage of the target compared to requested workload
+                                            format: int32
+                                            maximum: 100
+                                            minimum: 0
+                                            type: integer
+                                        required:
+                                          - type
+                                        type: object
+                                      window:
+                                        description: Window is the time duration over which the query is computed. It should contain at least one full sample.
+                                        type: string
+                                    required:
+                                      - request
+                                      - value
+                                      - window
+                                    type: object
+                                  podResource:
+                                    description: PodResource allows to set a pod-level resource objective.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the resource.
+                                        enum:
+                                          - cpu
+                                          - memory
+                                        type: string
+                                      value:
+                                        description: Value is the value of the objective.
+                                        properties:
+                                          absoluteValue:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                              Use a plain number (e.g., "11" or "11.5").
+                                              Represented as a resource.Quantity to avoid floating point in CRDs.
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type:
+                                            description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                            enum:
+                                              - Utilization
+                                              - AbsoluteValue
+                                            type: string
+                                          utilization:
+                                            description: Utilization defines a percentage of the target compared to requested workload
+                                            format: int32
+                                            maximum: 100
+                                            minimum: 0
+                                            type: integer
+                                        required:
+                                          - type
+                                        type: object
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type:
+                                    description: Type sets the type of the objective.
+                                    enum:
+                                      - PodResource
+                                      - ContainerResource
+                                      - CustomQuery
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            triggers:
+                              default: {}
+                              description: Triggers defines the triggers that will generate recommendations.
+                              properties:
+                                staleRecommendationThresholdSeconds:
+                                  default: 600
+                                  description: StaleRecommendationThresholdSeconds defines the time window the controller will wait after detecting an error before applying recommendations.
+                                  format: int32
+                                  maximum: 3600
+                                  minimum: 100
+                                  type: integer
+                              type: object
+                          type: object
+                      type: object
+                    objectives:
+                      description: |-
+                        Objectives are the objectives to reach and maintain for the target resource.
+                        Default to a single objective to maintain 80% POD CPU utilization.
+                      items:
+                        description: DatadogPodAutoscalerObjective defines the objectives to reach and maintain for the target workload.
+                        properties:
+                          containerResource:
+                            description: ContainerResource allows to set a container-level resource objective.
+                            properties:
+                              container:
+                                description: Container is the name of the container.
+                                type: string
+                              name:
+                                description: Name is the name of the resource.
+                                enum:
+                                  - cpu
+                                  - memory
+                                type: string
+                              value:
+                                description: Value is the value of the objective
+                                properties:
+                                  absoluteValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                      Use a plain number (e.g., "11" or "11.5").
+                                      Represented as a resource.Quantity to avoid floating point in CRDs.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                    enum:
+                                      - Utilization
+                                      - AbsoluteValue
+                                    type: string
+                                  utilization:
+                                    description: Utilization defines a percentage of the target compared to requested workload
+                                    format: int32
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - container
+                              - name
+                              - value
+                            type: object
+                          customQuery:
+                            description: CustomQuery allows to set a controller-level objective.
+                            properties:
+                              request:
+                                description: Request is the timeseries query to use for the objective.
+                                properties:
+                                  formula:
+                                    description: Formula to compute (optional).
+                                    type: string
+                                  queries:
+                                    description: |-
+                                      Queries is a list of timeseries queries to use for the objective.
+                                      At least one query must be specified
+                                    items:
+                                      description: TimeseriesQuery is a discriminated union. Only Metrics and APMMetrics are supported for autoscaling.
+                                      properties:
+                                        apmMetrics:
+                                          description: ApmMetrics is allows to query APM metrics.
+                                          properties:
+                                            groupBy:
+                                              description: GroupBy is the list of tags to group by.
+                                              items:
+                                                type: string
+                                              type: array
+                                            operationName:
+                                              description: OperationName is the name of the operation to query.
+                                              type: string
+                                            queryFilter:
+                                              description: QueryFilter is the filter to apply to the query.
+                                              type: string
+                                            resourceHash:
+                                              description: ResourceHash is a fingerprint of the resource name that can be used to identify the resource instead of the resource name.
+                                              type: string
+                                            resourceName:
+                                              description: ResourceName is the name of the resource to query.
+                                              type: string
+                                            service:
+                                              description: Service is the name of the service to query.
+                                              type: string
+                                            spanKind:
+                                              description: SpanKind is the kind of span to query.
+                                              type: string
+                                            stat:
+                                              description: Stat defines the statistic to compute for the APM metrics query.
+                                              enum:
+                                                - error_rate
+                                                - errors
+                                                - errors_per_second
+                                                - hits
+                                                - hits_per_second
+                                                - apdex
+                                                - latency_avg
+                                                - latency_max
+                                                - latency_p50
+                                                - latency_p75
+                                                - latency_p90
+                                                - latency_p95
+                                                - latency_p99
+                                                - latency_p999
+                                                - latency_distribution
+                                                - total_time
+                                              type: string
+                                          required:
+                                            - stat
+                                          type: object
+                                        metrics:
+                                          description: Metrics is a standard Datadog metrics query.
+                                          properties:
+                                            query:
+                                              description: Classic Datadog metrics query, e.g. "avg:system.cpu.user{*} by {env}".
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                            - query
+                                          type: object
+                                        name:
+                                          description: Optional variable name ("a", "b", etc.) to reference in formulas.
+                                          type: string
+                                        source:
+                                          description: Source defines the source of the timeseries query.
+                                          enum:
+                                            - Metrics
+                                            - ApmMetrics
+                                          type: string
+                                      required:
+                                        - source
+                                      type: object
+                                    minItems: 1
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - queries
+                                type: object
+                              value:
+                                description: Value is the value of the objective
+                                properties:
+                                  absoluteValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                      Use a plain number (e.g., "11" or "11.5").
+                                      Represented as a resource.Quantity to avoid floating point in CRDs.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                    enum:
+                                      - Utilization
+                                      - AbsoluteValue
+                                    type: string
+                                  utilization:
+                                    description: Utilization defines a percentage of the target compared to requested workload
+                                    format: int32
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                  - type
+                                type: object
+                              window:
+                                description: Window is the time duration over which the query is computed. It should contain at least one full sample.
+                                type: string
+                            required:
+                              - request
+                              - value
+                              - window
+                            type: object
+                          podResource:
+                            description: PodResource allows to set a pod-level resource objective.
+                            properties:
+                              name:
+                                description: Name is the name of the resource.
+                                enum:
+                                  - cpu
+                                  - memory
+                                type: string
+                              value:
+                                description: Value is the value of the objective.
+                                properties:
+                                  absoluteValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                      Use a plain number (e.g., "11" or "11.5").
+                                      Represented as a resource.Quantity to avoid floating point in CRDs.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description: 'Type specifies how the value is expressed (possible values: Utilization, AbsoluteValue).'
+                                    enum:
+                                      - Utilization
+                                      - AbsoluteValue
+                                    type: string
+                                  utilization:
+                                    description: Utilization defines a percentage of the target compared to requested workload
+                                    format: int32
+                                    maximum: 100
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type:
+                            description: Type sets the type of the objective.
+                            enum:
+                              - PodResource
+                              - ContainerResource
+                              - CustomQuery
+                            type: string
+                        required:
+                          - type
+                        type: object
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    options:
+                      description: Options defines optional behavior modifications for the autoscaler.
+                      properties:
+                        outOfMemory:
+                          description: OutOfMemory configures behavior when OOM events are detected.
+                          properties:
+                            bumpUpRatio:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                BumpUpRatio defines the ratio to multiply memory by when OOM is detected.
+                                For example, "1.2" means increase memory by 20%.
+                                Represented as a resource.Quantity to avoid floating point in CRDs.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                  type: object
+              required:
+                - template
+              type: object
+            status:
+              description: DatadogPodAutoscalerProfileStatus defines the observed state of DatadogPodAutoscalerProfile.
+              properties:
+                conditions:
+                  description: Conditions represents the latest available observations of the profile's current state.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                controlledAutoscalers:
+                  description: ControlledAutoscalers is the number of DatadogPodAutoscaler objects managed by this profile.
+                  format: int32
+                  type: integer
+                templateHash:
+                  description: TemplateHash is the stored hash of the DatadogPodAutoscalerProfile template.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/crds/datadoghq.com_datadogpodautoscalers.yaml
+++ b/crds/datadoghq.com_datadogpodautoscalers.yaml
@@ -252,11 +252,28 @@ spec:
                     update:
                       description: Update defines the policy to update target resource.
                       properties:
+                        resizePendingPeriod:
+                          description: |-
+                            Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.
+                            Must be greater than 0 and less than or equal to 3600 (1 hour).
+                          format: int32
+                          maximum: 3600
+                          minimum: 1
+                          type: integer
+                        rolloutFallbackDelay:
+                          description: |-
+                            Controls how long we wait before falling back to a full rollout when evictions are blocked.
+                            Must be greater than 0 and less than or equal to 3600 (1 hour).
+                          format: int32
+                          maximum: 3600
+                          minimum: 1
+                          type: integer
                         strategy:
                           description: Strategy defines the mode of the update policy.
                           enum:
                             - Auto
                             - Disabled
+                            - TriggerRollout
                           type: string
                       type: object
                     upscale:
@@ -736,6 +753,12 @@ spec:
                               - name
                             type: object
                           type: array
+                        evicted:
+                          description: |-
+                            Evicted is the number of pods evicted as an in-place resize fallback during the
+                            current recommendation cycle. Resets when the recommendation changes.
+                          format: int32
+                          type: integer
                         generatedAt:
                           description: GeneratedAt is the timestamp at which the recommendation was generated
                           format: date-time
@@ -970,11 +993,28 @@ spec:
                     update:
                       description: Update defines the policy for updating the target resource.
                       properties:
+                        resizePendingPeriod:
+                          description: |-
+                            Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.
+                            Must be greater than 0 and less than or equal to 3600 (1 hour).
+                          format: int32
+                          maximum: 3600
+                          minimum: 1
+                          type: integer
+                        rolloutFallbackDelay:
+                          description: |-
+                            Controls how long we wait before falling back to a full rollout when evictions are blocked.
+                            Must be greater than 0 and less than or equal to 3600 (1 hour).
+                          format: int32
+                          maximum: 3600
+                          minimum: 1
+                          type: integer
                         strategy:
                           description: Strategy defines the mode of the update policy.
                           enum:
                             - Auto
                             - Disabled
+                            - TriggerRollout
                           type: string
                       type: object
                   type: object
@@ -1783,6 +1823,12 @@ spec:
                               - name
                             type: object
                           type: array
+                        evicted:
+                          description: |-
+                            Evicted is the number of pods evicted as an in-place resize fallback during the
+                            current recommendation cycle. Resets when the recommendation changes.
+                          format: int32
+                          type: integer
                         generatedAt:
                           description: GeneratedAt is the timestamp at which the recommendation was generated
                           format: date-time


### PR DESCRIPTION
#### What this PR does / why we need it:

We need to have the new autoscaling CRD for the agent/cluster-agent release 7.78.0 
* Add datadogpodautoscalerclusterprofiles CRD
* Update datadogpodautoscalercCRD
Both change are backward compatible

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits