### PR TITLE
Drop `description` fields from `datadogcsidrivers`

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.20.0-dev.2
+
+* Drop `description` fields from `datadogcsidrivers` ([#2563](https://github.com/DataDog/helm-charts/pull/2563)).
+
 ## 2.20.0-dev.1
 
 * Update CRDs from Datadog Operator v1.26.0-rc.1 release candidate tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.20.0-dev.1
+version: 2.20.0-dev.2
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.20.0-dev.1](https://img.shields.io/badge/Version-2.20.0--dev.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.20.0-dev.2](https://img.shields.io/badge/Version-2.20.0--dev.2-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogcsidrivers_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogcsidrivers_v1.yaml
@@ -38,137 +38,56 @@ spec:
           description: DatadogCSIDriver is the Schema for the datadogcsidrivers API
           properties:
             apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              description: DatadogCSIDriverSpec defines the desired state of DatadogCSIDriver
               properties:
                 apmSocketPath:
-                  description: |-
-                    APMSocketPath is the host path to the APM socket.
-                    Default: /var/run/datadog/apm.socket
                   type: string
                 csiDriverImage:
-                  description: |-
-                    CSIDriverImage is the image configuration for the main CSI node driver container.
-                    Default image: gcr.io/datadoghq/csi-driver:1.2.1
                   properties:
                     jmxEnabled:
-                      description: |-
-                        Define whether the Agent image should support JMX.
-                        To be used if the `Name` field does not correspond to a full image string.
                       type: boolean
                     name:
-                      description: |-
-                        Defines the Agent image name for the pod. You can provide this as:
-                        * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
-                        for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
-                        * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
-                        and `[key].image.jmxEnabled` are ignored.
-                        * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
-                          like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
                       type: string
                     pullPolicy:
-                      description: |-
-                        The Kubernetes pull policy:
-                        Use `Always`, `Never`, or `IfNotPresent`.
                       type: string
                     pullSecrets:
-                      description: |-
-                        It is possible to specify Docker registry credentials.
-                        See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
                       items:
-                        description: |-
-                          LocalObjectReference contains enough information to let you locate the
-                          referenced object inside the same namespace.
                         properties:
                           name:
                             default: ""
-                            description: |-
-                              Name of the referent.
-                              This field is effectively required, but due to backwards compatibility is
-                              allowed to be empty. Instances of this type with an empty value here are
-                              almost certainly wrong.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
                       type: array
                     tag:
-                      description: |-
-                        Define the image tag to use.
-                        To be used if the `Name` field does not correspond to a full image string.
                       type: string
                   type: object
                 dsdSocketPath:
-                  description: |-
-                    DSDSocketPath is the host path to the DogStatsD socket.
-                    Default: /var/run/datadog/dsd.socket
                   type: string
                 override:
-                  description: Override allows customization of the CSI driver DaemonSet pod template.
                   properties:
                     affinity:
-                      description: Affinity specifies the pod's scheduling constraints.
                       properties:
                         nodeAffinity:
-                          description: Describes node affinity scheduling rules for the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                The scheduler will prefer to schedule pods to nodes that satisfy
-                                the affinity expressions specified by this field, but it may choose
-                                a node that violates one or more of the expressions. The node that is
-                                most preferred is the one with the greatest sum of weights, i.e.
-                                for each node that meets all of the scheduling requirements (resource
-                                request, requiredDuringScheduling affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field and adding
-                                "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                node(s) with the highest sum are the most preferred.
                               items:
-                                description: |-
-                                  An empty preferred scheduling term matches all objects with implicit weight 0
-                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -180,27 +99,13 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -214,7 +119,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   weight:
-                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -224,43 +128,18 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                If the affinity requirements specified by this field are not met at
-                                scheduling time, the pod will not be scheduled onto the node.
-                                If the affinity requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from its node.
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: |-
-                                      A null or empty node selector term matches no objects. The requirements of
-                                      them are ANDed.
-                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -272,27 +151,13 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -313,51 +178,22 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                The scheduler will prefer to schedule pods to nodes that satisfy
-                                the affinity expressions specified by this field, but it may choose
-                                a node that violates one or more of the expressions. The node that is
-                                most preferred is the one with the greatest sum of weights, i.e.
-                                for each node that meets all of the scheduling requirements (resource
-                                request, requiredDuringScheduling affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field and adding
-                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                node(s) with the highest sum are the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: |-
-                                          A label query over a set of resources, in this case pods.
-                                          If it's null, this PodAffinityTerm matches with no Pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -371,70 +207,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: |-
-                                          MatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: |-
-                                          MismatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: |-
-                                          A label query over the set of namespaces that the term applies to.
-                                          The term is applied to the union of the namespaces selected by this field
-                                          and the ones listed in the namespaces field.
-                                          null selector and null or empty namespaces list means "this pod's namespace".
-                                          An empty selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -448,38 +243,20 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: |-
-                                          namespaces specifies a static list of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces listed in this field
-                                          and the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       topologyKey:
-                                        description: |-
-                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches that of any node on which any of the
-                                          selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: |-
-                                      weight associated with matching the corresponding podAffinityTerm,
-                                      in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -489,49 +266,18 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                If the affinity requirements specified by this field are not met at
-                                scheduling time, the pod will not be scheduled onto the node.
-                                If the affinity requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod label update), the
-                                system may or may not try to eventually evict the pod from its node.
-                                When there are multiple elements, the lists of nodes corresponding to each
-                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: |-
-                                  Defines a set of pods (namely those matching the labelSelector
-                                  relative to the given namespace(s)) that this pod should be
-                                  co-located (affinity) or not co-located (anti-affinity) with,
-                                  where co-located is defined as running on a node whose value of
-                                  the label with key <topologyKey> matches that of any node on which
-                                  a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      A label query over a set of resources, in this case pods.
-                                      If it's null, this PodAffinityTerm matches with no Pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -545,70 +291,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: |-
-                                      MismatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: |-
-                                      A label query over the set of namespaces that the term applies to.
-                                      The term is applied to the union of the namespaces selected by this field
-                                      and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list means "this pod's namespace".
-                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -622,30 +327,15 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: |-
-                                      namespaces specifies a static list of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces listed in this field
-                                      and the ones selected by namespaceSelector.
-                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   topologyKey:
-                                    description: |-
-                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey matches that of any node on which any of the
-                                      selected pods is running.
-                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -654,51 +344,22 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                The scheduler will prefer to schedule pods to nodes that satisfy
-                                the anti-affinity expressions specified by this field, but it may choose
-                                a node that violates one or more of the expressions. The node that is
-                                most preferred is the one with the greatest sum of weights, i.e.
-                                for each node that meets all of the scheduling requirements (resource
-                                request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field and subtracting
-                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                node(s) with the highest sum are the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: |-
-                                          A label query over a set of resources, in this case pods.
-                                          If it's null, this PodAffinityTerm matches with no Pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -712,70 +373,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: |-
-                                          MatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: |-
-                                          MismatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: |-
-                                          A label query over the set of namespaces that the term applies to.
-                                          The term is applied to the union of the namespaces selected by this field
-                                          and the ones listed in the namespaces field.
-                                          null selector and null or empty namespaces list means "this pod's namespace".
-                                          An empty selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -789,38 +409,20 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: |-
-                                          namespaces specifies a static list of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces listed in this field
-                                          and the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       topologyKey:
-                                        description: |-
-                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches that of any node on which any of the
-                                          selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: |-
-                                      weight associated with matching the corresponding podAffinityTerm,
-                                      in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -830,49 +432,18 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                If the anti-affinity requirements specified by this field are not met at
-                                scheduling time, the pod will not be scheduled onto the node.
-                                If the anti-affinity requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod label update), the
-                                system may or may not try to eventually evict the pod from its node.
-                                When there are multiple elements, the lists of nodes corresponding to each
-                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: |-
-                                  Defines a set of pods (namely those matching the labelSelector
-                                  relative to the given namespace(s)) that this pod should be
-                                  co-located (affinity) or not co-located (anti-affinity) with,
-                                  where co-located is defined as running on a node whose value of
-                                  the label with key <topologyKey> matches that of any node on which
-                                  a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      A label query over a set of resources, in this case pods.
-                                      If it's null, this PodAffinityTerm matches with no Pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -886,70 +457,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: |-
-                                      MismatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: |-
-                                      A label query over the set of namespaces that the term applies to.
-                                      The term is applied to the union of the namespaces selected by this field
-                                      and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list means "this pod's namespace".
-                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -963,30 +493,15 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: |-
-                                      namespaces specifies a static list of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces listed in this field
-                                      and the ones selected by namespaceSelector.
-                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   topologyKey:
-                                    description: |-
-                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey matches that of any node on which any of the
-                                      selected pods is running.
-                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -998,120 +513,64 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: Annotations provides annotations that are added to the CSI driver DaemonSet pods.
                       type: object
                     containers:
                       additionalProperties:
-                        description: DatadogAgentGenericContainer is the generic structure describing any container's common configuration.
                         properties:
                           appArmorProfileName:
-                            description: AppArmorProfileName specifies an apparmor profile.
                             type: string
                           args:
-                            description: Args allows the specification of extra args to the `Command` parameter
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           command:
-                            description: Command allows the specification of a custom entrypoint for container
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           env:
-                            description: |-
-                              Specify additional environment variables in the container.
-                              See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables
                             items:
-                              description: EnvVar represents an environment variable present in a Container.
                               properties:
                                 name:
-                                  description: |-
-                                    Name of the environment variable.
-                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fileKeyRef:
-                                      description: |-
-                                        FileKeyRef selects a key of the env file.
-                                        Requires the EnvFiles feature gate to be enabled.
                                       properties:
                                         key:
-                                          description: |-
-                                            The key within the env file. An invalid key will prevent the pod from starting.
-                                            The keys defined within a source may consist of any printable ASCII characters except '='.
-                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
                                           type: string
                                         optional:
                                           default: false
-                                          description: |-
-                                            Specify whether the file or its key must be defined. If the file or key
-                                            does not exist, then the env var is not published.
-                                            If optional is set to true and the specified key does not exist,
-                                            the environment variable will not be set in the Pod's containers.
-
-                                            If optional is set to false and the specified key does not exist,
-                                            an error will be returned during Pod creation.
                                           type: boolean
                                         path:
-                                          description: |-
-                                            The path within the volume from which to select the file.
-                                            Must be relative and may not contain the '..' path or start with '..'.
                                           type: string
                                         volumeName:
-                                          description: The name of the volume mount containing the env file.
                                           type: string
                                       required:
                                         - key
@@ -1120,44 +579,29 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -1172,73 +616,42 @@ spec:
                               - name
                             x-kubernetes-list-type: map
                           healthPort:
-                            description: |-
-                              HealthPort of the container for the internal liveness probe.
-                              Must be the same as the Liveness/Readiness probes.
                             format: int32
                             type: integer
                           livenessProbe:
-                            description: Configure the Liveness Probe of the container
                             properties:
                               exec:
-                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
-                                    description: |-
-                                      Command is the command line to execute inside the container, the working directory for the
-                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                      a shell, you need to explicitly call out to that shell.
-                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
                               failureThreshold:
-                                description: |-
-                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
-                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                     format: int32
                                     type: integer
                                   service:
                                     default: ""
-                                    description: |-
-                                      Service is the name of the service to place in the gRPC HealthCheckRequest
-                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-                                      If this is not specified, the default behavior is defined by gRPC.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
-                                    description: |-
-                                      Host name to connect to, defaults to the pod IP. You probably want to set
-                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: |-
-                                            The header field name.
-                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1247,128 +660,64 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Name or number of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: |-
-                                      Scheme to use for connecting to the host.
-                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: |-
-                                  Number of seconds after the container has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: |-
-                                  How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: |-
-                                  Minimum consecutive successes for the probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies a connection to a TCP port.
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Number or name of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: |-
-                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                  The grace period is the duration in seconds after the processes running in the pod are sent
-                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                  Set this value longer than the expected cleanup time for your process.
-                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                  value overrides the value provided by the pod spec.
-                                  Value must be non-negative integer. The value zero indicates stop immediately via
-                                  the kill signal (no opportunity to shut down).
-                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: |-
-                                  Number of seconds after which the probe times out.
-                                  Defaults to 1 second. Minimum value is 1.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                             type: object
                           logLevel:
-                            description: |-
-                              LogLevel sets logging verbosity (overrides global setting).
-                              Valid log levels are: trace, debug, info, warn, error, critical, and off.
-                              Default: 'info'
                             type: string
                           name:
-                            description: Name of the container that is overridden
                             type: string
                           ports:
-                            description: |-
-                              Specify additional ports to be exposed by the container. Not specifying a port here
-                              DOES NOT prevent that port from being exposed.
-                              See https://pkg.go.dev/k8s.io/api/core/v1#Container documentation for more details.
                             items:
-                              description: ContainerPort represents a network port in a single container.
                               properties:
                                 containerPort:
-                                  description: |-
-                                    Number of port to expose on the pod's IP address.
-                                    This must be a valid port number, 0 < x < 65536.
                                   format: int32
                                   type: integer
                                 hostIP:
-                                  description: What host IP to bind the external port to.
                                   type: string
                                 hostPort:
-                                  description: |-
-                                    Number of port to expose on the host.
-                                    If specified, this must be a valid port number, 0 < x < 65536.
-                                    If HostNetwork is specified, this must match ContainerPort.
-                                    Most containers do not need this.
                                   format: int32
                                   type: integer
                                 name:
-                                  description: |-
-                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                                    named port in a pod must have a unique name. Name for the port that can be
-                                    referred to by services.
                                   type: string
                                 protocol:
                                   default: TCP
-                                  description: |-
-                                    Protocol for port. Must be UDP, TCP, or SCTP.
-                                    Defaults to "TCP".
                                   type: string
                               required:
                                 - containerPort
@@ -1376,67 +725,39 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           readinessProbe:
-                            description: Configure the Readiness Probe of the container
                             properties:
                               exec:
-                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
-                                    description: |-
-                                      Command is the command line to execute inside the container, the working directory for the
-                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                      a shell, you need to explicitly call out to that shell.
-                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
                               failureThreshold:
-                                description: |-
-                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
-                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                     format: int32
                                     type: integer
                                   service:
                                     default: ""
-                                    description: |-
-                                      Service is the name of the service to place in the gRPC HealthCheckRequest
-                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-                                      If this is not specified, the default behavior is defined by gRPC.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
-                                    description: |-
-                                      Host name to connect to, defaults to the pod IP. You probably want to set
-                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: |-
-                                            The header field name.
-                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1445,112 +766,53 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Name or number of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: |-
-                                      Scheme to use for connecting to the host.
-                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: |-
-                                  Number of seconds after the container has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: |-
-                                  How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: |-
-                                  Minimum consecutive successes for the probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies a connection to a TCP port.
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Number or name of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: |-
-                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                  The grace period is the duration in seconds after the processes running in the pod are sent
-                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                  Set this value longer than the expected cleanup time for your process.
-                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                  value overrides the value provided by the pod spec.
-                                  Value must be non-negative integer. The value zero indicates stop immediately via
-                                  the kill signal (no opportunity to shut down).
-                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: |-
-                                  Number of seconds after which the probe times out.
-                                  Defaults to 1 second. Minimum value is 1.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: |-
-                              Specify the Request and Limits of the pods
-                              To get guaranteed QoS class, specify requests and limits equal.
-                              See also: http://kubernetes.io/docs/user-guide/compute-resources/
                             properties:
                               claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-                                  This field depends on the
-                                  DynamicResourceAllocation feature gate.
-
-                                  This field is immutable. It can only be set for containers.
                                 items:
-                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
                                       type: string
                                     request:
-                                      description: |-
-                                        Request is the name chosen for a request in the referenced claim.
-                                        If empty, everything from the claim is made available, otherwise
-                                        only the result of this request.
                                       type: string
                                   required:
                                     - name
@@ -1566,9 +828,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1577,54 +836,25 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           seccompConfig:
-                            description: |-
-                              Seccomp configurations to override Operator actions. For all other Seccomp Profile manipulation,
-                              use SecurityContext.
                             properties:
                               customProfile:
-                                description: |-
-                                  CustomProfile specifies a ConfigMap containing a custom Seccomp Profile.
-                                  ConfigMap data must either have the key `system-probe-seccomp.json` or CustomProfile.Items
-                                  must include a corev1.KeytoPath that maps the key to the path `system-probe-seccomp.json`.
                                 properties:
                                   configData:
-                                    description: ConfigData corresponds to the configuration file content.
                                     type: string
                                   configMap:
-                                    description: ConfigMap references an existing ConfigMap with the configuration file content.
                                     properties:
                                       items:
-                                        description: Items maps a ConfigMap data `key` to a file `path` mount.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: |-
-                                                mode is Optional: mode bits used to set permissions on this file.
-                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                If not specified, the volume defaultMode will be used.
-                                                This might be in conflict with other options that affect the file
-                                                mode, like fsGroup, and the result can be other mode bits set.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: |-
-                                                path is the relative path of the file to map the key to.
-                                                May not be an absolute path.
-                                                May not contain the path element '..'.
-                                                May not start with the string '..'.
                                               type: string
                                           required:
                                             - key
@@ -1635,261 +865,118 @@ spec:
                                           - key
                                         x-kubernetes-list-type: map
                                       name:
-                                        description: Name is the name of the ConfigMap.
                                         type: string
                                     type: object
                                 type: object
                               customRootPath:
-                                description: CustomRootPath specifies a custom Seccomp Profile root location.
                                 type: string
                             type: object
                           securityContext:
-                            description: Container-level SecurityContext.
                             properties:
                               allowPrivilegeEscalation:
-                                description: |-
-                                  AllowPrivilegeEscalation controls whether a process can gain more
-                                  privileges than its parent process. This bool directly controls if
-                                  the no_new_privs flag will be set on the container process.
-                                  AllowPrivilegeEscalation is true always when the container is:
-                                  1) run as Privileged
-                                  2) has CAP_SYS_ADMIN
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: boolean
                               appArmorProfile:
-                                description: |-
-                                  appArmorProfile is the AppArmor options to use by this container. If set, this profile
-                                  overrides the pod's appArmorProfile.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   localhostProfile:
-                                    description: |-
-                                      localhostProfile indicates a profile loaded on the node that should be used.
-                                      The profile must be preconfigured on the node to work.
-                                      Must match the loaded name of the profile.
-                                      Must be set if and only if type is "Localhost".
                                     type: string
                                   type:
-                                    description: |-
-                                      type indicates which kind of AppArmor profile will be applied.
-                                      Valid options are:
-                                        Localhost - a profile pre-loaded on the node.
-                                        RuntimeDefault - the container runtime's default profile.
-                                        Unconfined - no AppArmor enforcement.
                                     type: string
                                 required:
                                   - type
                                 type: object
                               capabilities:
-                                description: |-
-                                  The capabilities to add/drop when running containers.
-                                  Defaults to the default set of capabilities granted by the container runtime.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   add:
-                                    description: Added capabilities
                                     items:
-                                      description: Capability represent POSIX capabilities type
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   drop:
-                                    description: Removed capabilities
                                     items:
-                                      description: Capability represent POSIX capabilities type
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
                               privileged:
-                                description: |-
-                                  Run container in privileged mode.
-                                  Processes in privileged containers are essentially equivalent to root on the host.
-                                  Defaults to false.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: boolean
                               procMount:
-                                description: |-
-                                  procMount denotes the type of proc mount to use for the containers.
-                                  The default value is Default which uses the container runtime defaults for
-                                  readonly paths and masked paths.
-                                  This requires the ProcMountType feature flag to be enabled.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: string
                               readOnlyRootFilesystem:
-                                description: |-
-                                  Whether this container has a read-only root filesystem.
-                                  Default is false.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: boolean
                               runAsGroup:
-                                description: |-
-                                  The GID to run the entrypoint of the container process.
-                                  Uses runtime default if unset.
-                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               runAsNonRoot:
-                                description: |-
-                                  Indicates that the container must run as a non-root user.
-                                  If true, the Kubelet will validate the image at runtime to ensure that it
-                                  does not run as UID 0 (root) and fail to start the container if it does.
-                                  If unset or false, no such validation will be performed.
-                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: boolean
                               runAsUser:
-                                description: |-
-                                  The UID to run the entrypoint of the container process.
-                                  Defaults to user specified in image metadata if unspecified.
-                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               seLinuxOptions:
-                                description: |-
-                                  The SELinux context to be applied to the container.
-                                  If unspecified, the container runtime will allocate a random SELinux context for each
-                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   level:
-                                    description: Level is SELinux level label that applies to the container.
                                     type: string
                                   role:
-                                    description: Role is a SELinux role label that applies to the container.
                                     type: string
                                   type:
-                                    description: Type is a SELinux type label that applies to the container.
                                     type: string
                                   user:
-                                    description: User is a SELinux user label that applies to the container.
                                     type: string
                                 type: object
                               seccompProfile:
-                                description: |-
-                                  The seccomp options to use by this container. If seccomp options are
-                                  provided at both the pod & container level, the container options
-                                  override the pod options.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   localhostProfile:
-                                    description: |-
-                                      localhostProfile indicates a profile defined in a file on the node should be used.
-                                      The profile must be preconfigured on the node to work.
-                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                      Must be set if type is "Localhost". Must NOT be set for any other type.
                                     type: string
                                   type:
-                                    description: |-
-                                      type indicates which kind of seccomp profile will be applied.
-                                      Valid options are:
-
-                                      Localhost - a profile defined in a file on the node should be used.
-                                      RuntimeDefault - the container runtime default profile should be used.
-                                      Unconfined - no profile should be applied.
                                     type: string
                                 required:
                                   - type
                                 type: object
                               windowsOptions:
-                                description: |-
-                                  The Windows specific settings applied to all containers.
-                                  If unspecified, the options from the PodSecurityContext will be used.
-                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name is linux.
                                 properties:
                                   gmsaCredentialSpec:
-                                    description: |-
-                                      GMSACredentialSpec is where the GMSA admission webhook
-                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                      GMSA credential spec named by the GMSACredentialSpecName field.
                                     type: string
                                   gmsaCredentialSpecName:
-                                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                     type: string
                                   hostProcess:
-                                    description: |-
-                                      HostProcess determines if a container should be run as a 'Host Process' container.
-                                      All of a Pod's containers must have the same effective HostProcess value
-                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
                                     type: boolean
                                   runAsUserName:
-                                    description: |-
-                                      The UserName in Windows to run the entrypoint of the container process.
-                                      Defaults to the user specified in image metadata if unspecified.
-                                      May also be set in PodSecurityContext. If set in both SecurityContext and
-                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: string
                                 type: object
                             type: object
                           startupProbe:
-                            description: Configure the Startup Probe of the container
                             properties:
                               exec:
-                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
-                                    description: |-
-                                      Command is the command line to execute inside the container, the working directory for the
-                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                      a shell, you need to explicitly call out to that shell.
-                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
                               failureThreshold:
-                                description: |-
-                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
-                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                     format: int32
                                     type: integer
                                   service:
                                     default: ""
-                                    description: |-
-                                      Service is the name of the service to place in the gRPC HealthCheckRequest
-                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-                                      If this is not specified, the default behavior is defined by gRPC.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
-                                    description: |-
-                                      Host name to connect to, defaults to the pod IP. You probably want to set
-                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: |-
-                                            The header field name.
-                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1898,140 +985,61 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Name or number of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: |-
-                                      Scheme to use for connecting to the host.
-                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: |-
-                                  Number of seconds after the container has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: |-
-                                  How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: |-
-                                  Minimum consecutive successes for the probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies a connection to a TCP port.
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Number or name of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: |-
-                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                  The grace period is the duration in seconds after the processes running in the pod are sent
-                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                  Set this value longer than the expected cleanup time for your process.
-                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                  value overrides the value provided by the pod spec.
-                                  Value must be non-negative integer. The value zero indicates stop immediately via
-                                  the kill signal (no opportunity to shut down).
-                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: |-
-                                  Number of seconds after which the probe times out.
-                                  Defaults to 1 second. Minimum value is 1.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
-                            description: Specify additional volume mounts in the container.
                             items:
-                              description: VolumeMount describes a mounting of a Volume within a container.
                               properties:
                                 mountPath:
-                                  description: |-
-                                    Path within the container at which the volume should be mounted.  Must
-                                    not contain ':'.
                                   type: string
                                 mountPropagation:
-                                  description: |-
-                                    mountPropagation determines how mounts are propagated from the host
-                                    to container and the other way around.
-                                    When not set, MountPropagationNone is used.
-                                    This field is beta in 1.10.
-                                    When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
-                                    (which defaults to None).
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    Mounted read-only if true, read-write otherwise (false or unspecified).
-                                    Defaults to false.
                                   type: boolean
                                 recursiveReadOnly:
-                                  description: |-
-                                    RecursiveReadOnly specifies whether read-only mounts should be handled
-                                    recursively.
-
-                                    If ReadOnly is false, this field has no meaning and must be unspecified.
-
-                                    If ReadOnly is true, and this field is set to Disabled, the mount is not made
-                                    recursively read-only.  If this field is set to IfPossible, the mount is made
-                                    recursively read-only, if it is supported by the container runtime.  If this
-                                    field is set to Enabled, the mount is made recursively read-only if it is
-                                    supported by the container runtime, otherwise the pod will not be started and
-                                    an error will be generated to indicate the reason.
-
-                                    If this field is set to IfPossible or Enabled, MountPropagation must be set to
-                                    None (or be unspecified, which defaults to None).
-
-                                    If this field is not specified, it is treated as an equivalent of Disabled.
                                   type: string
                                 subPath:
-                                  description: |-
-                                    Path within the volume from which the container's volume should be mounted.
-                                    Defaults to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: |-
-                                    Expanded path within the volume from which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                    Defaults to "" (volume's root).
-                                    SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -2043,101 +1051,49 @@ spec:
                               - mountPath
                             x-kubernetes-list-type: map
                         type: object
-                      description: |-
-                        Containers allows overriding container-level configuration for the CSI driver containers.
-                        Valid keys are: "csi-node-driver" and "csi-node-driver-registrar".
                       type: object
                     env:
-                      description: Env specifies additional environment variables for all containers.
                       items:
-                        description: EnvVar represents an environment variable present in a Container.
                         properties:
                           name:
-                            description: |-
-                              Name of the environment variable.
-                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
-                            description: |-
-                              Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in the container and
-                              any service environment variables. If a variable cannot be resolved,
-                              the reference in the input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                              Escaped references will never be expanded, regardless of whether the variable
-                              exists or not.
-                              Defaults to "".
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value. Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
-                                    description: The key to select.
                                     type: string
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
-                                description: |-
-                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fileKeyRef:
-                                description: |-
-                                  FileKeyRef selects a key of the env file.
-                                  Requires the EnvFiles feature gate to be enabled.
                                 properties:
                                   key:
-                                    description: |-
-                                      The key within the env file. An invalid key will prevent the pod from starting.
-                                      The keys defined within a source may consist of any printable ASCII characters except '='.
-                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
                                     type: string
                                   optional:
                                     default: false
-                                    description: |-
-                                      Specify whether the file or its key must be defined. If the file or key
-                                      does not exist, then the env var is not published.
-                                      If optional is set to true and the specified key does not exist,
-                                      the environment variable will not be set in the Pod's containers.
-
-                                      If optional is set to false and the specified key does not exist,
-                                      an error will be returned during Pod creation.
                                     type: boolean
                                   path:
-                                    description: |-
-                                      The path within the volume from which to select the file.
-                                      Must be relative and may not contain the '..' path or start with '..'.
                                     type: string
                                   volumeName:
-                                    description: The name of the volume mount containing the env file.
                                     type: string
                                 required:
                                   - key
@@ -2146,44 +1102,29 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes, optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Specifies the output format of the exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -2200,206 +1141,73 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: AdditionalLabels provides labels that are added to the CSI driver DaemonSet pods.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: |-
-                        NodeSelector is a map of key-value pairs. For the CSI driver pod to run on a
-                        specific node, the node must have these key-value pairs as labels.
                       type: object
                     priorityClassName:
-                      description: PriorityClassName indicates the pod's priority.
                       type: string
                     securityContext:
-                      description: SecurityContext holds pod-level security attributes.
                       properties:
                         appArmorProfile:
-                          description: |-
-                            appArmorProfile is the AppArmor options to use by the containers in this pod.
-                            Note that this field cannot be set when spec.os.name is windows.
                           properties:
                             localhostProfile:
-                              description: |-
-                                localhostProfile indicates a profile loaded on the node that should be used.
-                                The profile must be preconfigured on the node to work.
-                                Must match the loaded name of the profile.
-                                Must be set if and only if type is "Localhost".
                               type: string
                             type:
-                              description: |-
-                                type indicates which kind of AppArmor profile will be applied.
-                                Valid options are:
-                                  Localhost - a profile pre-loaded on the node.
-                                  RuntimeDefault - the container runtime's default profile.
-                                  Unconfined - no AppArmor enforcement.
                               type: string
                           required:
                             - type
                           type: object
                         fsGroup:
-                          description: |-
-                            A special supplemental group that applies to all containers in a pod.
-                            Some volume types allow the Kubelet to change the ownership of that volume
-                            to be owned by the pod:
-
-                            1. The owning GID will be the FSGroup
-                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
-                            3. The permission bits are OR'd with rw-rw----
-
-                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
-                            Note that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
-                          description: |-
-                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
-                            before being exposed inside Pod. This field will only apply to
-                            volume types which support fsGroup based ownership(and permissions).
-                            It will have no effect on ephemeral volume types such as: secret, configmaps
-                            and emptydir.
-                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
-                            Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         runAsGroup:
-                          description: |-
-                            The GID to run the entrypoint of the container process.
-                            Uses runtime default if unset.
-                            May also be set in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence
-                            for that container.
-                            Note that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: |-
-                            Indicates that the container must run as a non-root user.
-                            If true, the Kubelet will validate the image at runtime to ensure that it
-                            does not run as UID 0 (root) and fail to start the container if it does.
-                            If unset or false, no such validation will be performed.
-                            May also be set in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: |-
-                            The UID to run the entrypoint of the container process.
-                            Defaults to user specified in image metadata if unspecified.
-                            May also be set in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence
-                            for that container.
-                            Note that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         seLinuxChangePolicy:
-                          description: |-
-                            seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
-                            It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
-                            Valid values are "MountOption" and "Recursive".
-
-                            "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
-                            This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
-
-                            "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
-                            This requires all Pods that share the same volume to use the same SELinux label.
-                            It is not possible to share the same volume among privileged and unprivileged Pods.
-                            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
-                            whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
-                            CSIDriver instance. Other volumes are always re-labelled recursively.
-                            "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
-
-                            If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                            If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                            and "Recursive" for all other volumes.
-
-                            This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
-
-                            All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
-                            Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         seLinuxOptions:
-                          description: |-
-                            The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random SELinux context for each
-                            container.  May also be set in SecurityContext.  If set in
-                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                            Note that this field cannot be set when spec.os.name is windows.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies to the container.
                               type: string
                           type: object
                         seccompProfile:
-                          description: |-
-                            The seccomp options to use by the containers in this pod.
-                            Note that this field cannot be set when spec.os.name is windows.
                           properties:
                             localhostProfile:
-                              description: |-
-                                localhostProfile indicates a profile defined in a file on the node should be used.
-                                The profile must be preconfigured on the node to work.
-                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                Must be set if type is "Localhost". Must NOT be set for any other type.
                               type: string
                             type:
-                              description: |-
-                                type indicates which kind of seccomp profile will be applied.
-                                Valid options are:
-
-                                Localhost - a profile defined in a file on the node should be used.
-                                RuntimeDefault - the container runtime default profile should be used.
-                                Unconfined - no profile should be applied.
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
-                          description: |-
-                            A list of groups applied to the first process run in each container, in
-                            addition to the container's primary GID and fsGroup (if specified).  If
-                            the SupplementalGroupsPolicy feature is enabled, the
-                            supplementalGroupsPolicy field determines whether these are in addition
-                            to or instead of any group memberships defined in the container image.
-                            If unspecified, no additional groups are added, though group memberships
-                            defined in the container image may still be used, depending on the
-                            supplementalGroupsPolicy field.
-                            Note that this field cannot be set when spec.os.name is windows.
                           items:
                             format: int64
                             type: integer
                           type: array
                           x-kubernetes-list-type: atomic
                         supplementalGroupsPolicy:
-                          description: |-
-                            Defines how supplemental groups of the first container processes are calculated.
-                            Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
-                            (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
-                            and the container runtime must implement support for this feature.
-                            Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         sysctls:
-                          description: |-
-                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
-                            sysctls (by the container runtime) might fail to launch.
-                            Note that this field cannot be set when spec.os.name is windows.
                           items:
-                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
-                                description: Name of a property to set
                                 type: string
                               value:
-                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -2408,348 +1216,160 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         windowsOptions:
-                          description: |-
-                            The Windows specific settings applied to all containers.
-                            If unspecified, the options within a container's SecurityContext will be used.
-                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                            Note that this field cannot be set when spec.os.name is linux.
                           properties:
                             gmsaCredentialSpec:
-                              description: |-
-                                GMSACredentialSpec is where the GMSA admission webhook
-                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                GMSA credential spec named by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                               type: string
                             hostProcess:
-                              description: |-
-                                HostProcess determines if a container should be run as a 'Host Process' container.
-                                All of a Pod's containers must have the same effective HostProcess value
-                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                In addition, if HostProcess is true then HostNetwork must also be set to true.
                               type: boolean
                             runAsUserName:
-                              description: |-
-                                The UserName in Windows to run the entrypoint of the container process.
-                                Defaults to the user specified in image metadata if unspecified.
-                                May also be set in PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
-                      description: ServiceAccountName sets the ServiceAccount used by the CSI driver DaemonSet.
                       type: string
                     tolerations:
-                      description: Tolerations configure the CSI driver DaemonSet pod tolerations.
                       items:
-                        description: |-
-                          The pod this Toleration is attached to tolerates any taint that matches
-                          the triple <key,value,effect> using the matching operator <operator>.
                         properties:
                           effect:
-                            description: |-
-                              Effect indicates the taint effect to match. Empty means match all taint effects.
-                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
-                            description: |-
-                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                             type: string
                           operator:
-                            description: |-
-                              Operator represents a key's relationship to the value.
-                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                              Exists is equivalent to wildcard for value, so that a pod can
-                              tolerate all taints of a particular category.
-                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                             type: string
                           tolerationSeconds:
-                            description: |-
-                              TolerationSeconds represents the period of time the toleration (which must be
-                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                              it is not set, which means tolerate the taint forever (do not evict). Zero and
-                              negative values will be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
-                            description: |-
-                              Value is the taint value the toleration matches to.
-                              If the operator is Exists, the value should be empty, otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                       x-kubernetes-list-type: atomic
                     updateStrategy:
-                      description: UpdateStrategy is the DaemonSet update strategy configuration.
                       properties:
                         rollingUpdate:
-                          description: Configure the rolling update strategy of the Deployment or DaemonSet.
                           properties:
                             maxSurge:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: |-
-                                MaxSurge behaves differently based on the Kubernetes resource. Refer to the
-                                Kubernetes API documentation for additional details.
                               x-kubernetes-int-or-string: true
                             maxUnavailable:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: |-
-                                The maximum number of pods that can be unavailable during the update.
-                                Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                                Refer to the Kubernetes API documentation for additional details..
                               x-kubernetes-int-or-string: true
                           type: object
                         type:
-                          description: |-
-                            Type can be "RollingUpdate" or "OnDelete" for DaemonSets and "RollingUpdate"
-                            or "Recreate" for Deployments
                           type: string
                       type: object
                     volumes:
-                      description: Volumes specifies additional volumes to add to the CSI driver DaemonSet pods.
                       items:
-                        description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                         properties:
                           awsElasticBlockStore:
-                            description: |-
-                              awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                              kubelet's host machine and then exposed to the pod.
-                              Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
-                              awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type of the volume that you want to mount.
-                                  Tip: Ensure that the filesystem type is supported by the host operating system.
-                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 type: string
                               partition:
-                                description: |-
-                                  partition is the partition in the volume that you want to mount.
-                                  If omitted, the default is to mount by volume name.
-                                  Examples: For volume /dev/sda1, you specify the partition as "1".
-                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                 format: int32
                                 type: integer
                               readOnly:
-                                description: |-
-                                  readOnly value true will force the readOnly setting in VolumeMounts.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 type: boolean
                               volumeID:
-                                description: |-
-                                  volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 type: string
                             required:
                               - volumeID
                             type: object
                           azureDisk:
-                            description: |-
-                              azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
-                              Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
-                              are redirected to the disk.csi.azure.com CSI driver.
                             properties:
                               cachingMode:
-                                description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                 type: string
                               diskName:
-                                description: diskName is the Name of the data disk in the blob storage
                                 type: string
                               diskURI:
-                                description: diskURI is the URI of data disk in the blob storage
                                 type: string
                               fsType:
                                 default: ext4
-                                description: |-
-                                  fsType is Filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               kind:
-                                description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                 type: string
                               readOnly:
                                 default: false
-                                description: |-
-                                  readOnly Defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                             required:
                               - diskName
                               - diskURI
                             type: object
                           azureFile:
-                            description: |-
-                              azureFile represents an Azure File Service mount on the host and bind mount to the pod.
-                              Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
-                              are redirected to the file.csi.azure.com CSI driver.
                             properties:
                               readOnly:
-                                description: |-
-                                  readOnly defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretName:
-                                description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                 type: string
                               shareName:
-                                description: shareName is the azure share Name
                                 type: string
                             required:
                               - secretName
                               - shareName
                             type: object
                           cephfs:
-                            description: |-
-                              cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
-                              Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                             properties:
                               monitors:
-                                description: |-
-                                  monitors is Required: Monitors is a collection of Ceph monitors
-                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               path:
-                                description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
-                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                 type: boolean
                               secretFile:
-                                description: |-
-                                  secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                 type: string
                               secretRef:
-                                description: |-
-                                  secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
-                                description: |-
-                                  user is optional: User is the rados user name, default is admin
-                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                 type: string
                             required:
                               - monitors
                             type: object
                           cinder:
-                            description: |-
-                              cinder represents a cinder volume attached and mounted on kubelets host machine.
-                              Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
-                              are redirected to the cinder.csi.openstack.org CSI driver.
-                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
-                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                 type: boolean
                               secretRef:
-                                description: |-
-                                  secretRef is optional: points to a secret object containing parameters used to connect
-                                  to OpenStack.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               volumeID:
-                                description: |-
-                                  volumeID used to identify the volume in cinder.
-                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                 type: string
                             required:
                               - volumeID
                             type: object
                           configMap:
-                            description: configMap represents a configMap that should populate this volume
                             properties:
                               defaultMode:
-                                description: |-
-                                  defaultMode is optional: mode bits used to set permissions on created files by default.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  Defaults to 0644.
-                                  Directories within the path are not affected by this setting.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               items:
-                                description: |-
-                                  items if unspecified, each key-value pair in the Data field of the referenced
-                                  ConfigMap will be projected into the volume as a file whose name is the
-                                  key and content is the value. If specified, the listed keys will be
-                                  projected into the specified paths, and unlisted keys will not be
-                                  present. If a key is specified which is not present in the ConfigMap,
-                                  the volume setup will error unless it is marked optional. Paths must be
-                                  relative and may not contain the '..' path or start with '..'.
                                 items:
-                                  description: Maps a string key to a path within a volume.
                                   properties:
                                     key:
-                                      description: key is the key to project.
                                       type: string
                                     mode:
-                                      description: |-
-                                        mode is Optional: mode bits used to set permissions on this file.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        If not specified, the volume defaultMode will be used.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     path:
-                                      description: |-
-                                        path is the relative path of the file to map the key to.
-                                        May not be an absolute path.
-                                        May not contain the path element '..'.
-                                        May not start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -2759,129 +1379,67 @@ spec:
                                 x-kubernetes-list-type: atomic
                               name:
                                 default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               optional:
-                                description: optional specify whether the ConfigMap or its keys must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           csi:
-                            description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                             properties:
                               driver:
-                                description: |-
-                                  driver is the name of the CSI driver that handles this volume.
-                                  Consult with your admin for the correct name as registered in the cluster.
                                 type: string
                               fsType:
-                                description: |-
-                                  fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                  If not provided, the empty value is passed to the associated CSI driver
-                                  which will determine the default filesystem to apply.
                                 type: string
                               nodePublishSecretRef:
-                                description: |-
-                                  nodePublishSecretRef is a reference to the secret object containing
-                                  sensitive information to pass to the CSI driver to complete the CSI
-                                  NodePublishVolume and NodeUnpublishVolume calls.
-                                  This field is optional, and  may be empty if no secret is required. If the
-                                  secret object contains more than one secret, all secret references are passed.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               readOnly:
-                                description: |-
-                                  readOnly specifies a read-only configuration for the volume.
-                                  Defaults to false (read/write).
                                 type: boolean
                               volumeAttributes:
                                 additionalProperties:
                                   type: string
-                                description: |-
-                                  volumeAttributes stores driver-specific properties that are passed to the CSI
-                                  driver. Consult your driver's documentation for supported values.
                                 type: object
                             required:
                               - driver
                             type: object
                           downwardAPI:
-                            description: downwardAPI represents downward API about the pod that should populate this volume
                             properties:
                               defaultMode:
-                                description: |-
-                                  Optional: mode bits to use on created files by default. Must be a
-                                  Optional: mode bits used to set permissions on created files by default.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  Defaults to 0644.
-                                  Directories within the path are not affected by this setting.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               items:
-                                description: Items is a list of downward API volume file
                                 items:
-                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                   properties:
                                     fieldRef:
-                                      description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     mode:
-                                      description: |-
-                                        Optional: mode bits used to set permissions on this file, must be an octal value
-                                        between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        If not specified, the volume defaultMode will be used.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     path:
-                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                       type: string
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
@@ -2894,125 +1452,36 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                           emptyDir:
-                            description: |-
-                              emptyDir represents a temporary directory that shares a pod's lifetime.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                             properties:
                               medium:
-                                description: |-
-                                  medium represents what type of storage medium should back this directory.
-                                  The default is "" which means to use the node's default medium.
-                                  Must be an empty string (default) or Memory.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                 type: string
                               sizeLimit:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: |-
-                                  sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                  The size limit is also applicable for memory medium.
-                                  The maximum usage on memory medium EmptyDir would be the minimum value between
-                                  the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                  The default is nil which means that the limit is undefined.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
                             type: object
                           ephemeral:
-                            description: |-
-                              ephemeral represents a volume that is handled by a cluster storage driver.
-                              The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                              and deleted when the pod is removed.
-
-                              Use this if:
-                              a) the volume is only needed while the pod runs,
-                              b) features of normal volumes like restoring from snapshot or capacity
-                                 tracking are needed,
-                              c) the storage driver is specified through a storage class, and
-                              d) the storage driver supports dynamic volume provisioning through
-                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                 information on the connection between this volume type
-                                 and PersistentVolumeClaim).
-
-                              Use PersistentVolumeClaim or one of the vendor-specific
-                              APIs for volumes that persist for longer than the lifecycle
-                              of an individual pod.
-
-                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                              be used that way - see the documentation of the driver for
-                              more information.
-
-                              A pod can use both types of ephemeral volumes and
-                              persistent volumes at the same time.
                             properties:
                               volumeClaimTemplate:
-                                description: |-
-                                  Will be used to create a stand-alone PVC to provision the volume.
-                                  The pod in which this EphemeralVolumeSource is embedded will be the
-                                  owner of the PVC, i.e. the PVC will be deleted together with the
-                                  pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                  `<volume name>` is the name from the `PodSpec.Volumes` array
-                                  entry. Pod validation will reject the pod if the concatenated name
-                                  is not valid for a PVC (for example, too long).
-
-                                  An existing PVC with that name that is not owned by the pod
-                                  will *not* be used for the pod to avoid using an unrelated
-                                  volume by mistake. Starting the pod is then blocked until
-                                  the unrelated PVC is removed. If such a pre-created PVC is
-                                  meant to be used by the pod, the PVC has to updated with an
-                                  owner reference to the pod once the pod exists. Normally
-                                  this should not be necessary, but it may be useful when
-                                  manually reconstructing a broken cluster.
-
-                                  This field is read-only and no changes will be made by Kubernetes
-                                  to the PVC after it has been created.
-
-                                  Required, must not be nil.
                                 properties:
                                   metadata:
-                                    description: |-
-                                      May contain labels and annotations that will be copied into the PVC
-                                      when creating it. No other fields are allowed and will be rejected during
-                                      validation.
                                     type: object
                                   spec:
-                                    description: |-
-                                      The specification for the PersistentVolumeClaim. The entire content is
-                                      copied unchanged into the PVC that gets created from this
-                                      template. The same fields as in a PersistentVolumeClaim
-                                      are also valid here.
                                     properties:
                                       accessModes:
-                                        description: |-
-                                          accessModes contains the desired access modes the volume should have.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       dataSource:
-                                        description: |-
-                                          dataSource field can be used to specify either:
-                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                          * An existing PVC (PersistentVolumeClaim)
-                                          If the provisioner or an external controller can support the specified data source,
-                                          it will create a new volume based on the contents of the specified data source.
-                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                         properties:
                                           apiGroup:
-                                            description: |-
-                                              APIGroup is the group for the resource being referenced.
-                                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                                              For any other third-party types, APIGroup is required.
                                             type: string
                                           kind:
-                                            description: Kind is the type of resource being referenced
                                             type: string
                                           name:
-                                            description: Name is the name of resource being referenced
                                             type: string
                                         required:
                                           - kind
@@ -3020,60 +1489,20 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       dataSourceRef:
-                                        description: |-
-                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                          volume is desired. This may be any object from a non-empty API group (non
-                                          core object) or a PersistentVolumeClaim object.
-                                          When this field is specified, volume binding will only succeed if the type of
-                                          the specified object matches some installed volume populator or dynamic
-                                          provisioner.
-                                          This field will replace the functionality of the dataSource field and as such
-                                          if both fields are non-empty, they must have the same value. For backwards
-                                          compatibility, when namespace isn't specified in dataSourceRef,
-                                          both fields (dataSource and dataSourceRef) will be set to the same
-                                          value automatically if one of them is empty and the other is non-empty.
-                                          When namespace is specified in dataSourceRef,
-                                          dataSource isn't set to the same value and must be empty.
-                                          There are three important differences between dataSource and dataSourceRef:
-                                          * While dataSource only allows two specific types of objects, dataSourceRef
-                                            allows any non-core object, as well as PersistentVolumeClaim objects.
-                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                            preserves all values, and generates an error if a disallowed value is
-                                            specified.
-                                          * While dataSource only allows local objects, dataSourceRef allows objects
-                                            in any namespaces.
-                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                         properties:
                                           apiGroup:
-                                            description: |-
-                                              APIGroup is the group for the resource being referenced.
-                                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                                              For any other third-party types, APIGroup is required.
                                             type: string
                                           kind:
-                                            description: Kind is the type of resource being referenced
                                             type: string
                                           name:
-                                            description: Name is the name of resource being referenced
                                             type: string
                                           namespace:
-                                            description: |-
-                                              Namespace is the namespace of resource being referenced
-                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                             type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
-                                        description: |-
-                                          resources represents the minimum resources the volume should have.
-                                          Users are allowed to specify resource requirements
-                                          that are lower than previous value but must still be higher than capacity recorded in the
-                                          status field of the claim.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -3082,9 +1511,6 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Limits describes the maximum amount of compute resources allowed.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -3093,37 +1519,18 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Requests describes the minimum amount of compute resources required.
-                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                         type: object
                                       selector:
-                                        description: selector is a label query over volumes to consider for binding.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -3137,38 +1544,16 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       storageClassName:
-                                        description: |-
-                                          storageClassName is the name of the StorageClass required by the claim.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                         type: string
                                       volumeAttributesClassName:
-                                        description: |-
-                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                          If specified, the CSI driver will create or update the volume with the attributes defined
-                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                          it can be changed after the claim is created. An empty string or nil value indicates that no
-                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                          this field can be reset to its previous value (including nil) to cancel the modification.
-                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                          exists.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
                                         type: string
                                       volumeMode:
-                                        description: |-
-                                          volumeMode defines what type of volume is required by the claim.
-                                          Value of Filesystem is implied when not included in claim spec.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                         type: string
                                     type: object
                                 required:
@@ -3176,79 +1561,41 @@ spec:
                                 type: object
                             type: object
                           fc:
-                            description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               lun:
-                                description: 'lun is Optional: FC target lun number'
                                 format: int32
                                 type: integer
                               readOnly:
-                                description: |-
-                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               targetWWNs:
-                                description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               wwids:
-                                description: |-
-                                  wwids Optional: FC volume world wide identifiers (wwids)
-                                  Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                             type: object
                           flexVolume:
-                            description: |-
-                              flexVolume represents a generic volume resource that is
-                              provisioned/attached using an exec based plugin.
-                              Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                             properties:
                               driver:
-                                description: driver is the name of the driver to use for this volume.
                                 type: string
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                 type: string
                               options:
                                 additionalProperties:
                                   type: string
-                                description: 'options is Optional: this field holds extra command options if any.'
                                 type: object
                               readOnly:
-                                description: |-
-                                  readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretRef:
-                                description: |-
-                                  secretRef is Optional: secretRef is reference to the secret object containing
-                                  sensitive information to pass to the plugin scripts. This may be
-                                  empty if no secret object is specified. If the secret object
-                                  contains more than one secret, all secrets are passed to the plugin
-                                  scripts.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -3256,230 +1603,98 @@ spec:
                               - driver
                             type: object
                           flocker:
-                            description: |-
-                              flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
-                              Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                             properties:
                               datasetName:
-                                description: |-
-                                  datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                  should be considered as deprecated
                                 type: string
                               datasetUUID:
-                                description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                 type: string
                             type: object
                           gcePersistentDisk:
-                            description: |-
-                              gcePersistentDisk represents a GCE Disk resource that is attached to a
-                              kubelet's host machine and then exposed to the pod.
-                              Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
-                              gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is filesystem type of the volume that you want to mount.
-                                  Tip: Ensure that the filesystem type is supported by the host operating system.
-                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 type: string
                               partition:
-                                description: |-
-                                  partition is the partition in the volume that you want to mount.
-                                  If omitted, the default is to mount by volume name.
-                                  Examples: For volume /dev/sda1, you specify the partition as "1".
-                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 format: int32
                                 type: integer
                               pdName:
-                                description: |-
-                                  pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly here will force the ReadOnly setting in VolumeMounts.
-                                  Defaults to false.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 type: boolean
                             required:
                               - pdName
                             type: object
                           gitRepo:
-                            description: |-
-                              gitRepo represents a git repository at a particular revision.
-                              Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
-                              EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                              into the Pod's container.
                             properties:
                               directory:
-                                description: |-
-                                  directory is the target directory name.
-                                  Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                  git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                  the subdirectory with the given name.
                                 type: string
                               repository:
-                                description: repository is the URL
                                 type: string
                               revision:
-                                description: revision is the commit hash for the specified revision.
                                 type: string
                             required:
                               - repository
                             type: object
                           glusterfs:
-                            description: |-
-                              glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                              Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                             properties:
                               endpoints:
-                                description: endpoints is the endpoint name that details Glusterfs topology.
                                 type: string
                               path:
-                                description: |-
-                                  path is the Glusterfs volume path.
-                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                  Defaults to false.
-                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                 type: boolean
                             required:
                               - endpoints
                               - path
                             type: object
                           hostPath:
-                            description: |-
-                              hostPath represents a pre-existing file or directory on the host
-                              machine that is directly exposed to the container. This is generally
-                              used for system agents or other privileged things that are allowed
-                              to see the host machine. Most containers will NOT need this.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                             properties:
                               path:
-                                description: |-
-                                  path of the directory on the host.
-                                  If the path is a symlink, it will follow the link to the real path.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                 type: string
                               type:
-                                description: |-
-                                  type for HostPath Volume
-                                  Defaults to ""
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                 type: string
                             required:
                               - path
                             type: object
                           image:
-                            description: |-
-                              image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
-                              The volume is resolved at pod startup depending on which PullPolicy value is provided:
-
-                              - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-                              - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-                              - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
-
-                              The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
-                              A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
-                              The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
-                              The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                              The volume will be mounted read-only (ro) and non-executable files (noexec).
-                              Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
-                              The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                             properties:
                               pullPolicy:
-                                description: |-
-                                  Policy for pulling OCI objects. Possible values are:
-                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
-                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
                                 type: string
                               reference:
-                                description: |-
-                                  Required: Image or artifact reference to be used.
-                                  Behaves in the same way as pod.spec.containers[*].image.
-                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
-                                  More info: https://kubernetes.io/docs/concepts/containers/images
-                                  This field is optional to allow higher level config management to default or override
-                                  container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                             type: object
                           iscsi:
-                            description: |-
-                              iscsi represents an ISCSI Disk resource that is attached to a
-                              kubelet's host machine and then exposed to the pod.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                             properties:
                               chapAuthDiscovery:
-                                description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                 type: boolean
                               chapAuthSession:
-                                description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                 type: boolean
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type of the volume that you want to mount.
-                                  Tip: Ensure that the filesystem type is supported by the host operating system.
-                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                 type: string
                               initiatorName:
-                                description: |-
-                                  initiatorName is the custom iSCSI Initiator Name.
-                                  If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                  <target portal>:<volume name> will be created for the connection.
                                 type: string
                               iqn:
-                                description: iqn is the target iSCSI Qualified Name.
                                 type: string
                               iscsiInterface:
                                 default: default
-                                description: |-
-                                  iscsiInterface is the interface Name that uses an iSCSI transport.
-                                  Defaults to 'default' (tcp).
                                 type: string
                               lun:
-                                description: lun represents iSCSI Target Lun number.
                                 format: int32
                                 type: integer
                               portals:
-                                description: |-
-                                  portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                  is other than default (typically TCP ports 860 and 3260).
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               readOnly:
-                                description: |-
-                                  readOnly here will force the ReadOnly setting in VolumeMounts.
-                                  Defaults to false.
                                 type: boolean
                               secretRef:
-                                description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               targetPortal:
-                                description: |-
-                                  targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                  is other than default (typically TCP ports 860 and 3260).
                                 type: string
                             required:
                               - iqn
@@ -3487,162 +1702,68 @@ spec:
                               - targetPortal
                             type: object
                           name:
-                            description: |-
-                              name of the volume.
-                              Must be a DNS_LABEL and unique within the pod.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                           nfs:
-                            description: |-
-                              nfs represents an NFS mount on the host that shares a pod's lifetime
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                             properties:
                               path:
-                                description: |-
-                                  path that is exported by the NFS server.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly here will force the NFS export to be mounted with read-only permissions.
-                                  Defaults to false.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                 type: boolean
                               server:
-                                description: |-
-                                  server is the hostname or IP address of the NFS server.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                 type: string
                             required:
                               - path
                               - server
                             type: object
                           persistentVolumeClaim:
-                            description: |-
-                              persistentVolumeClaimVolumeSource represents a reference to a
-                              PersistentVolumeClaim in the same namespace.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                             properties:
                               claimName:
-                                description: |-
-                                  claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly Will force the ReadOnly setting in VolumeMounts.
-                                  Default false.
                                 type: boolean
                             required:
                               - claimName
                             type: object
                           photonPersistentDisk:
-                            description: |-
-                              photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
-                              Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               pdID:
-                                description: pdID is the ID that identifies Photon Controller persistent disk
                                 type: string
                             required:
                               - pdID
                             type: object
                           portworxVolume:
-                            description: |-
-                              portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
-                              Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                              are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                              is on.
                             properties:
                               fsType:
-                                description: |-
-                                  fSType represents the filesystem type to mount
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               volumeID:
-                                description: volumeID uniquely identifies a Portworx volume
                                 type: string
                             required:
                               - volumeID
                             type: object
                           projected:
-                            description: projected items for all in one resources secrets, configmaps, and downward API
                             properties:
                               defaultMode:
-                                description: |-
-                                  defaultMode are the mode bits used to set permissions on created files by default.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  Directories within the path are not affected by this setting.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               sources:
-                                description: |-
-                                  sources is the list of volume projections. Each entry in this list
-                                  handles one source.
                                 items:
-                                  description: |-
-                                    Projection that may be projected along with other supported volume types.
-                                    Exactly one of these fields must be set.
                                   properties:
                                     clusterTrustBundle:
-                                      description: |-
-                                        ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                        of ClusterTrustBundle objects in an auto-updating file.
-
-                                        Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-                                        ClusterTrustBundle objects can either be selected by name, or by the
-                                        combination of signer name and a label selector.
-
-                                        Kubelet performs aggressive normalization of the PEM contents written
-                                        into the pod filesystem.  Esoteric PEM features such as inter-block
-                                        comments and block headers are stripped.  Certificates are deduplicated.
-                                        The ordering of certificates within the file is arbitrary, and Kubelet
-                                        may change the order over time.
                                       properties:
                                         labelSelector:
-                                          description: |-
-                                            Select all ClusterTrustBundles that match this label selector.  Only has
-                                            effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                            interpreted as "match nothing".  If set but empty, interpreted as "match
-                                            everything".
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3656,72 +1777,31 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         name:
-                                          description: |-
-                                            Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                            with signerName and labelSelector.
                                           type: string
                                         optional:
-                                          description: |-
-                                            If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                            aren't available.  If using name, then the named ClusterTrustBundle is
-                                            allowed not to exist.  If using signerName, then the combination of
-                                            signerName and labelSelector is allowed to match zero
-                                            ClusterTrustBundles.
                                           type: boolean
                                         path:
-                                          description: Relative path from the volume root to write the bundle.
                                           type: string
                                         signerName:
-                                          description: |-
-                                            Select all ClusterTrustBundles that match this signer name.
-                                            Mutually-exclusive with name.  The contents of all selected
-                                            ClusterTrustBundles will be unified and deduplicated.
                                           type: string
                                       required:
                                         - path
                                       type: object
                                     configMap:
-                                      description: configMap information about the configMap data to project
                                       properties:
                                         items:
-                                          description: |-
-                                            items if unspecified, each key-value pair in the Data field of the referenced
-                                            ConfigMap will be projected into the volume as a file whose name is the
-                                            key and content is the value. If specified, the listed keys will be
-                                            projected into the specified paths, and unlisted keys will not be
-                                            present. If a key is specified which is not present in the ConfigMap,
-                                            the volume setup will error unless it is marked optional. Paths must be
-                                            relative and may not contain the '..' path or start with '..'.
                                           items:
-                                            description: Maps a string key to a path within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: |-
-                                                  mode is Optional: mode bits used to set permissions on this file.
-                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                  If not specified, the volume defaultMode will be used.
-                                                  This might be in conflict with other options that affect the file
-                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: |-
-                                                  path is the relative path of the file to map the key to.
-                                                  May not be an absolute path.
-                                                  May not contain the path element '..'.
-                                                  May not start with the string '..'.
                                                 type: string
                                             required:
                                               - key
@@ -3731,69 +1811,42 @@ spec:
                                           x-kubernetes-list-type: atomic
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                           type: string
                                         optional:
-                                          description: optional specify whether the ConfigMap or its keys must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     downwardAPI:
-                                      description: downwardAPI information about the downwardAPI data to project
                                       properties:
                                         items:
-                                          description: Items is a list of DownwardAPIVolume file
                                           items:
-                                            description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                             properties:
                                               fieldRef:
-                                                description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
                                                 properties:
                                                   apiVersion:
-                                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
-                                                    description: Path of the field to select in the specified API version.
                                                     type: string
                                                 required:
                                                   - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               mode:
-                                                description: |-
-                                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                  If not specified, the volume defaultMode will be used.
-                                                  This might be in conflict with other options that affect the file
-                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                 type: string
                                               resourceFieldRef:
-                                                description: |-
-                                                  Selects a resource of the container: only resources limits and requests
-                                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                 properties:
                                                   containerName:
-                                                    description: 'Container name: required for volumes, optional for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                       - type: integer
                                                       - type: string
-                                                    description: Specifies the output format of the exposed resources, defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
-                                                    description: 'Required: resource to select'
                                                     type: string
                                                 required:
                                                   - resource
@@ -3806,161 +1859,39 @@ spec:
                                           x-kubernetes-list-type: atomic
                                       type: object
                                     podCertificate:
-                                      description: |-
-                                        Projects an auto-rotating credential bundle (private key and certificate
-                                        chain) that the pod can use either as a TLS client or server.
-
-                                        Kubelet generates a private key and uses it to send a
-                                        PodCertificateRequest to the named signer.  Once the signer approves the
-                                        request and issues a certificate chain, Kubelet writes the key and
-                                        certificate chain to the pod filesystem.  The pod does not start until
-                                        certificates have been issued for each podCertificate projected volume
-                                        source in its spec.
-
-                                        Kubelet will begin trying to rotate the certificate at the time indicated
-                                        by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                        timestamp.
-
-                                        Kubelet can write a single file, indicated by the credentialBundlePath
-                                        field, or separate files, indicated by the keyPath and
-                                        certificateChainPath fields.
-
-                                        The credential bundle is a single file in PEM format.  The first PEM
-                                        entry is the private key (in PKCS#8 format), and the remaining PEM
-                                        entries are the certificate chain issued by the signer (typically,
-                                        signers will return their certificate chain in leaf-to-root order).
-
-                                        Prefer using the credential bundle format, since your application code
-                                        can read it atomically.  If you use keyPath and certificateChainPath,
-                                        your application must make two separate file reads. If these coincide
-                                        with a certificate rotation, it is possible that the private key and leaf
-                                        certificate you read may not correspond to each other.  Your application
-                                        will need to check for this condition, and re-read until they are
-                                        consistent.
-
-                                        The named signer controls chooses the format of the certificate it
-                                        issues; consult the signer implementation's documentation to learn how to
-                                        use the certificates it issues.
                                       properties:
                                         certificateChainPath:
-                                          description: |-
-                                            Write the certificate chain at this path in the projected volume.
-
-                                            Most applications should use credentialBundlePath.  When using keyPath
-                                            and certificateChainPath, your application needs to check that the key
-                                            and leaf certificate are consistent, because it is possible to read the
-                                            files mid-rotation.
                                           type: string
                                         credentialBundlePath:
-                                          description: |-
-                                            Write the credential bundle at this path in the projected volume.
-
-                                            The credential bundle is a single file that contains multiple PEM blocks.
-                                            The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                            key.
-
-                                            The remaining blocks are CERTIFICATE blocks, containing the issued
-                                            certificate chain from the signer (leaf and any intermediates).
-
-                                            Using credentialBundlePath lets your Pod's application code make a single
-                                            atomic read that retrieves a consistent key and certificate chain.  If you
-                                            project them to separate files, your application code will need to
-                                            additionally check that the leaf certificate was issued to the key.
                                           type: string
                                         keyPath:
-                                          description: |-
-                                            Write the key at this path in the projected volume.
-
-                                            Most applications should use credentialBundlePath.  When using keyPath
-                                            and certificateChainPath, your application needs to check that the key
-                                            and leaf certificate are consistent, because it is possible to read the
-                                            files mid-rotation.
                                           type: string
                                         keyType:
-                                          description: |-
-                                            The type of keypair Kubelet will generate for the pod.
-
-                                            Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                            "ECDSAP521", and "ED25519".
                                           type: string
                                         maxExpirationSeconds:
-                                          description: |-
-                                            maxExpirationSeconds is the maximum lifetime permitted for the
-                                            certificate.
-
-                                            Kubelet copies this value verbatim into the PodCertificateRequests it
-                                            generates for this projection.
-
-                                            If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                            will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                            value is 7862400 (91 days).
-
-                                            The signer implementation is then free to issue a certificate with any
-                                            lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                            seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                            `kubernetes.io` signers will never issue certificates with a lifetime
-                                            longer than 24 hours.
                                           format: int32
                                           type: integer
                                         signerName:
-                                          description: Kubelet's generated CSRs will be addressed to this signer.
                                           type: string
                                         userAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            userAnnotations allow pod authors to pass additional information to
-                                            the signer implementation.  Kubernetes does not restrict or validate this
-                                            metadata in any way.
-
-                                            These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
-                                            the PodCertificateRequest objects that Kubelet creates.
-
-                                            Entries are subject to the same validation as object metadata annotations,
-                                            with the addition that all keys must be domain-prefixed. No restrictions
-                                            are placed on values, except an overall size limitation on the entire field.
-
-                                            Signers should document the keys and values they support. Signers should
-                                            deny requests that contain keys they do not recognize.
                                           type: object
                                       required:
                                         - keyType
                                         - signerName
                                       type: object
                                     secret:
-                                      description: secret information about the secret data to project
                                       properties:
                                         items:
-                                          description: |-
-                                            items if unspecified, each key-value pair in the Data field of the referenced
-                                            Secret will be projected into the volume as a file whose name is the
-                                            key and content is the value. If specified, the listed keys will be
-                                            projected into the specified paths, and unlisted keys will not be
-                                            present. If a key is specified which is not present in the Secret,
-                                            the volume setup will error unless it is marked optional. Paths must be
-                                            relative and may not contain the '..' path or start with '..'.
                                           items:
-                                            description: Maps a string key to a path within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: |-
-                                                  mode is Optional: mode bits used to set permissions on this file.
-                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                  If not specified, the volume defaultMode will be used.
-                                                  This might be in conflict with other options that affect the file
-                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: |-
-                                                  path is the relative path of the file to map the key to.
-                                                  May not be an absolute path.
-                                                  May not contain the path element '..'.
-                                                  May not start with the string '..'.
                                                 type: string
                                             required:
                                               - key
@@ -3970,42 +1901,19 @@ spec:
                                           x-kubernetes-list-type: atomic
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                           type: string
                                         optional:
-                                          description: optional field specify whether the Secret or its key must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     serviceAccountToken:
-                                      description: serviceAccountToken is information about the serviceAccountToken data to project
                                       properties:
                                         audience:
-                                          description: |-
-                                            audience is the intended audience of the token. A recipient of a token
-                                            must identify itself with an identifier specified in the audience of the
-                                            token, and otherwise should reject the token. The audience defaults to the
-                                            identifier of the apiserver.
                                           type: string
                                         expirationSeconds:
-                                          description: |-
-                                            expirationSeconds is the requested duration of validity of the service
-                                            account token. As the token approaches expiration, the kubelet volume
-                                            plugin will proactively rotate the service account token. The kubelet will
-                                            start trying to rotate the token if the token is older than 80 percent of
-                                            its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                            and must be at least 10 minutes.
                                           format: int64
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the path relative to the mount point of the file to project the
-                                            token into.
                                           type: string
                                       required:
                                         - path
@@ -4015,176 +1923,84 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                           quobyte:
-                            description: |-
-                              quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
-                              Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                             properties:
                               group:
-                                description: |-
-                                  group to map volume access to
-                                  Default is no group
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                  Defaults to false.
                                 type: boolean
                               registry:
-                                description: |-
-                                  registry represents a single or multiple Quobyte Registry services
-                                  specified as a string as host:port pair (multiple entries are separated with commas)
-                                  which acts as the central registry for volumes
                                 type: string
                               tenant:
-                                description: |-
-                                  tenant owning the given Quobyte volume in the Backend
-                                  Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                 type: string
                               user:
-                                description: |-
-                                  user to map volume access to
-                                  Defaults to serivceaccount user
                                 type: string
                               volume:
-                                description: volume is a string that references an already created Quobyte volume by name.
                                 type: string
                             required:
                               - registry
                               - volume
                             type: object
                           rbd:
-                            description: |-
-                              rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                              Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type of the volume that you want to mount.
-                                  Tip: Ensure that the filesystem type is supported by the host operating system.
-                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                 type: string
                               image:
-                                description: |-
-                                  image is the rados image name.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                               keyring:
                                 default: /etc/ceph/keyring
-                                description: |-
-                                  keyring is the path to key ring for RBDUser.
-                                  Default is /etc/ceph/keyring.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                               monitors:
-                                description: |-
-                                  monitors is a collection of Ceph monitors.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
                                 default: rbd
-                                description: |-
-                                  pool is the rados pool name.
-                                  Default is rbd.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly here will force the ReadOnly setting in VolumeMounts.
-                                  Defaults to false.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: boolean
                               secretRef:
-                                description: |-
-                                  secretRef is name of the authentication secret for RBDUser. If provided
-                                  overrides keyring.
-                                  Default is nil.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
                                 default: admin
-                                description: |-
-                                  user is the rados user name.
-                                  Default is admin.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                             required:
                               - image
                               - monitors
                             type: object
                           scaleIO:
-                            description: |-
-                              scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
-                              Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                             properties:
                               fsType:
                                 default: xfs
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs".
-                                  Default is "xfs".
                                 type: string
                               gateway:
-                                description: gateway is the host address of the ScaleIO API Gateway.
                                 type: string
                               protectionDomain:
-                                description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly Defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretRef:
-                                description: |-
-                                  secretRef references to the secret for ScaleIO user and other
-                                  sensitive information. If this is not provided, Login operation will fail.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               sslEnabled:
-                                description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                 type: boolean
                               storageMode:
                                 default: ThinProvisioned
-                                description: |-
-                                  storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                  Default is ThinProvisioned.
                                 type: string
                               storagePool:
-                                description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                 type: string
                               system:
-                                description: system is the name of the storage system as configured in ScaleIO.
                                 type: string
                               volumeName:
-                                description: |-
-                                  volumeName is the name of a volume already created in the ScaleIO system
-                                  that is associated with this volume source.
                                 type: string
                             required:
                               - gateway
@@ -4192,52 +2008,19 @@ spec:
                               - system
                             type: object
                           secret:
-                            description: |-
-                              secret represents a secret that should populate this volume.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                             properties:
                               defaultMode:
-                                description: |-
-                                  defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values
-                                  for mode bits. Defaults to 0644.
-                                  Directories within the path are not affected by this setting.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               items:
-                                description: |-
-                                  items If unspecified, each key-value pair in the Data field of the referenced
-                                  Secret will be projected into the volume as a file whose name is the
-                                  key and content is the value. If specified, the listed keys will be
-                                  projected into the specified paths, and unlisted keys will not be
-                                  present. If a key is specified which is not present in the Secret,
-                                  the volume setup will error unless it is marked optional. Paths must be
-                                  relative and may not contain the '..' path or start with '..'.
                                 items:
-                                  description: Maps a string key to a path within a volume.
                                   properties:
                                     key:
-                                      description: key is the key to project.
                                       type: string
                                     mode:
-                                      description: |-
-                                        mode is Optional: mode bits used to set permissions on this file.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        If not specified, the volume defaultMode will be used.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     path:
-                                      description: |-
-                                        path is the relative path of the file to map the key to.
-                                        May not be an absolute path.
-                                        May not contain the path element '..'.
-                                        May not start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -4246,81 +2029,37 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               optional:
-                                description: optional field specify whether the Secret or its keys must be defined
                                 type: boolean
                               secretName:
-                                description: |-
-                                  secretName is the name of the secret in the pod's namespace to use.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                 type: string
                             type: object
                           storageos:
-                            description: |-
-                              storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
-                              Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretRef:
-                                description: |-
-                                  secretRef specifies the secret to use for obtaining the StorageOS API
-                                  credentials.  If not specified, default values will be attempted.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               volumeName:
-                                description: |-
-                                  volumeName is the human-readable name of the StorageOS volume.  Volume
-                                  names are only unique within a namespace.
                                 type: string
                               volumeNamespace:
-                                description: |-
-                                  volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                  namespace is specified then the Pod's namespace will be used.  This allows the
-                                  Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                  Set VolumeName to any name to override the default behaviour.
-                                  Set to "default" if you are not using namespaces within StorageOS.
-                                  Namespaces that do not pre-exist within StorageOS will be created.
                                 type: string
                             type: object
                           vsphereVolume:
-                            description: |-
-                              vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
-                              Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
-                              are redirected to the csi.vsphere.vmware.com CSI driver.
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               storagePolicyID:
-                                description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                 type: string
                               storagePolicyName:
-                                description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                 type: string
                               volumePath:
-                                description: volumePath is the path that identifies vSphere volume vmdk
                                 type: string
                             required:
                               - volumePath
@@ -4334,106 +2073,53 @@ spec:
                       x-kubernetes-list-type: map
                   type: object
                 registrarImage:
-                  description: |-
-                    RegistrarImage is the image configuration for the CSI node driver registrar sidecar.
-                    Default image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1
                   properties:
                     jmxEnabled:
-                      description: |-
-                        Define whether the Agent image should support JMX.
-                        To be used if the `Name` field does not correspond to a full image string.
                       type: boolean
                     name:
-                      description: |-
-                        Defines the Agent image name for the pod. You can provide this as:
-                        * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
-                        for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
-                        * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
-                        and `[key].image.jmxEnabled` are ignored.
-                        * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
-                          like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
                       type: string
                     pullPolicy:
-                      description: |-
-                        The Kubernetes pull policy:
-                        Use `Always`, `Never`, or `IfNotPresent`.
                       type: string
                     pullSecrets:
-                      description: |-
-                        It is possible to specify Docker registry credentials.
-                        See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
                       items:
-                        description: |-
-                          LocalObjectReference contains enough information to let you locate the
-                          referenced object inside the same namespace.
                         properties:
                           name:
                             default: ""
-                            description: |-
-                              Name of the referent.
-                              This field is effectively required, but due to backwards compatibility is
-                              allowed to be empty. Instances of this type with an empty value here are
-                              almost certainly wrong.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
                       type: array
                     tag:
-                      description: |-
-                        Define the image tag to use.
-                        To be used if the `Name` field does not correspond to a full image string.
                       type: string
                   type: object
               type: object
             status:
-              description: DatadogCSIDriverStatus defines the observed state of DatadogCSIDriver
               properties:
                 conditions:
-                  description: Conditions represents the latest available observations of the DatadogCSIDriver's current state.
                   items:
-                    description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
                       lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                         format: date-time
                         type: string
                       message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
                       reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
                         maxLength: 1024
                         minLength: 1
                         pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                         type: string
                       status:
-                        description: status of the condition, one of True, False, Unknown.
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                         type: string
                       type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -4449,45 +2135,33 @@ spec:
                     - type
                   x-kubernetes-list-type: map
                 csiDriverName:
-                  description: CSIDriverName is the name of the managed CSIDriver Kubernetes object.
                   type: string
                 daemonSet:
-                  description: DaemonSet tracks the status of the CSI driver DaemonSet.
                   properties:
                     available:
-                      description: Number of available pods in the DaemonSet.
                       format: int32
                       type: integer
                     current:
-                      description: Number of current pods in the DaemonSet.
                       format: int32
                       type: integer
                     currentHash:
-                      description: CurrentHash is the stored hash of the DaemonSet.
                       type: string
                     daemonsetName:
-                      description: DaemonsetName corresponds to the name of the created DaemonSet.
                       type: string
                     desired:
-                      description: Number of desired pods in the DaemonSet.
                       format: int32
                       type: integer
                     lastUpdate:
-                      description: LastUpdate is the last time the status was updated.
                       format: date-time
                       type: string
                     ready:
-                      description: Number of ready pods in the DaemonSet.
                       format: int32
                       type: integer
                     state:
-                      description: State corresponds to the DaemonSet state.
                       type: string
                     status:
-                      description: Status corresponds to the DaemonSet computed status.
                       type: string
                     upToDate:
-                      description: Number of up to date pods in the DaemonSet.
                       format: int32
                       type: integer
                   required:
@@ -4498,7 +2172,6 @@ spec:
                     - upToDate
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed for this resource.
                   format: int64
                   type: integer
               type: object

--- a/charts/datadog-crds/update-crds.sh
+++ b/charts/datadog-crds/update-crds.sh
@@ -25,9 +25,9 @@ download_crd() {
     echo "Download CRD \"$inFile\" version \"$version\" from repo \"$repo\" tag \"$tag\""
     curl --silent --show-error --fail --location --output "$path" "https://raw.githubusercontent.com/$repo/$tag/config/crd/bases/$version/$inFile"
 
-    if [ "$name" = "datadogagents" ] || [ "$name" = "datadogagentinternals" ] || [ "$name" = "datadogagentprofiles" ]; then
+    if [ "$name" = "datadogagents" ] || [ "$name" = "datadogagentinternals" ] || [ "$name" = "datadogagentprofiles" ] || [ "$name" = "datadogcsidrivers" ]; then
         yq -i eval 'del(.. | select(has("defaultOverride")).defaultOverride.properties)' "$path"
-        yq -i eval 'del(.. | select(has("description") and (path | .[-1] != "openAPIV3Schema")) | .description)' "$path"
+        yq -i eval 'del(.. | select(has("description") and (.description | kind == "scalar") and (path | .[-1] != "openAPIV3Schema")) | .description)' "$path"
     fi
 
     ifCondition="{{- if .Values.crds.$installOption }}"

--- a/crds/datadoghq.com_datadogcsidrivers.yaml
+++ b/crds/datadoghq.com_datadogcsidrivers.yaml
@@ -29,137 +29,56 @@ spec:
           description: DatadogCSIDriver is the Schema for the datadogcsidrivers API
           properties:
             apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              description: DatadogCSIDriverSpec defines the desired state of DatadogCSIDriver
               properties:
                 apmSocketPath:
-                  description: |-
-                    APMSocketPath is the host path to the APM socket.
-                    Default: /var/run/datadog/apm.socket
                   type: string
                 csiDriverImage:
-                  description: |-
-                    CSIDriverImage is the image configuration for the main CSI node driver container.
-                    Default image: gcr.io/datadoghq/csi-driver:1.2.1
                   properties:
                     jmxEnabled:
-                      description: |-
-                        Define whether the Agent image should support JMX.
-                        To be used if the `Name` field does not correspond to a full image string.
                       type: boolean
                     name:
-                      description: |-
-                        Defines the Agent image name for the pod. You can provide this as:
-                        * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
-                        for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
-                        * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
-                        and `[key].image.jmxEnabled` are ignored.
-                        * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
-                          like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
                       type: string
                     pullPolicy:
-                      description: |-
-                        The Kubernetes pull policy:
-                        Use `Always`, `Never`, or `IfNotPresent`.
                       type: string
                     pullSecrets:
-                      description: |-
-                        It is possible to specify Docker registry credentials.
-                        See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
                       items:
-                        description: |-
-                          LocalObjectReference contains enough information to let you locate the
-                          referenced object inside the same namespace.
                         properties:
                           name:
                             default: ""
-                            description: |-
-                              Name of the referent.
-                              This field is effectively required, but due to backwards compatibility is
-                              allowed to be empty. Instances of this type with an empty value here are
-                              almost certainly wrong.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
                       type: array
                     tag:
-                      description: |-
-                        Define the image tag to use.
-                        To be used if the `Name` field does not correspond to a full image string.
                       type: string
                   type: object
                 dsdSocketPath:
-                  description: |-
-                    DSDSocketPath is the host path to the DogStatsD socket.
-                    Default: /var/run/datadog/dsd.socket
                   type: string
                 override:
-                  description: Override allows customization of the CSI driver DaemonSet pod template.
                   properties:
                     affinity:
-                      description: Affinity specifies the pod's scheduling constraints.
                       properties:
                         nodeAffinity:
-                          description: Describes node affinity scheduling rules for the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                The scheduler will prefer to schedule pods to nodes that satisfy
-                                the affinity expressions specified by this field, but it may choose
-                                a node that violates one or more of the expressions. The node that is
-                                most preferred is the one with the greatest sum of weights, i.e.
-                                for each node that meets all of the scheduling requirements (resource
-                                request, requiredDuringScheduling affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field and adding
-                                "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                node(s) with the highest sum are the most preferred.
                               items:
-                                description: |-
-                                  An empty preferred scheduling term matches all objects with implicit weight 0
-                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -171,27 +90,13 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -205,7 +110,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   weight:
-                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -215,43 +119,18 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                If the affinity requirements specified by this field are not met at
-                                scheduling time, the pod will not be scheduled onto the node.
-                                If the affinity requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from its node.
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The terms are ORed.
                                   items:
-                                    description: |-
-                                      A null or empty node selector term matches no objects. The requirements of
-                                      them are ANDed.
-                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements by node's labels.
                                         items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -263,27 +142,13 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       matchFields:
-                                        description: A list of node selector requirements by node's fields.
                                         items:
-                                          description: |-
-                                            A node selector requirement is a selector that contains values, a key, and an operator
-                                            that relates the key and values.
                                           properties:
                                             key:
-                                              description: The label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                Represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: |-
-                                                An array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will be interpreted as an integer.
-                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -304,51 +169,22 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                The scheduler will prefer to schedule pods to nodes that satisfy
-                                the affinity expressions specified by this field, but it may choose
-                                a node that violates one or more of the expressions. The node that is
-                                most preferred is the one with the greatest sum of weights, i.e.
-                                for each node that meets all of the scheduling requirements (resource
-                                request, requiredDuringScheduling affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field and adding
-                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                node(s) with the highest sum are the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: |-
-                                          A label query over a set of resources, in this case pods.
-                                          If it's null, this PodAffinityTerm matches with no Pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -362,70 +198,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: |-
-                                          MatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: |-
-                                          MismatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: |-
-                                          A label query over the set of namespaces that the term applies to.
-                                          The term is applied to the union of the namespaces selected by this field
-                                          and the ones listed in the namespaces field.
-                                          null selector and null or empty namespaces list means "this pod's namespace".
-                                          An empty selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -439,38 +234,20 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: |-
-                                          namespaces specifies a static list of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces listed in this field
-                                          and the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       topologyKey:
-                                        description: |-
-                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches that of any node on which any of the
-                                          selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: |-
-                                      weight associated with matching the corresponding podAffinityTerm,
-                                      in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -480,49 +257,18 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                If the affinity requirements specified by this field are not met at
-                                scheduling time, the pod will not be scheduled onto the node.
-                                If the affinity requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod label update), the
-                                system may or may not try to eventually evict the pod from its node.
-                                When there are multiple elements, the lists of nodes corresponding to each
-                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: |-
-                                  Defines a set of pods (namely those matching the labelSelector
-                                  relative to the given namespace(s)) that this pod should be
-                                  co-located (affinity) or not co-located (anti-affinity) with,
-                                  where co-located is defined as running on a node whose value of
-                                  the label with key <topologyKey> matches that of any node on which
-                                  a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      A label query over a set of resources, in this case pods.
-                                      If it's null, this PodAffinityTerm matches with no Pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -536,70 +282,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: |-
-                                      MismatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: |-
-                                      A label query over the set of namespaces that the term applies to.
-                                      The term is applied to the union of the namespaces selected by this field
-                                      and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list means "this pod's namespace".
-                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -613,30 +318,15 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: |-
-                                      namespaces specifies a static list of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces listed in this field
-                                      and the ones selected by namespaceSelector.
-                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   topologyKey:
-                                    description: |-
-                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey matches that of any node on which any of the
-                                      selected pods is running.
-                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -645,51 +335,22 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                The scheduler will prefer to schedule pods to nodes that satisfy
-                                the anti-affinity expressions specified by this field, but it may choose
-                                a node that violates one or more of the expressions. The node that is
-                                most preferred is the one with the greatest sum of weights, i.e.
-                                for each node that meets all of the scheduling requirements (resource
-                                request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field and subtracting
-                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                node(s) with the highest sum are the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: |-
-                                          A label query over a set of resources, in this case pods.
-                                          If it's null, this PodAffinityTerm matches with no Pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -703,70 +364,29 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       matchLabelKeys:
-                                        description: |-
-                                          MatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       mismatchLabelKeys:
-                                        description: |-
-                                          MismatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       namespaceSelector:
-                                        description: |-
-                                          A label query over the set of namespaces that the term applies to.
-                                          The term is applied to the union of the namespaces selected by this field
-                                          and the ones listed in the namespaces field.
-                                          null selector and null or empty namespaces list means "this pod's namespace".
-                                          An empty selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -780,38 +400,20 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: |-
-                                          namespaces specifies a static list of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces listed in this field
-                                          and the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       topologyKey:
-                                        description: |-
-                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches that of any node on which any of the
-                                          selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: |-
-                                      weight associated with matching the corresponding podAffinityTerm,
-                                      in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -821,49 +423,18 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: |-
-                                If the anti-affinity requirements specified by this field are not met at
-                                scheduling time, the pod will not be scheduled onto the node.
-                                If the anti-affinity requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod label update), the
-                                system may or may not try to eventually evict the pod from its node.
-                                When there are multiple elements, the lists of nodes corresponding to each
-                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: |-
-                                  Defines a set of pods (namely those matching the labelSelector
-                                  relative to the given namespace(s)) that this pod should be
-                                  co-located (affinity) or not co-located (anti-affinity) with,
-                                  where co-located is defined as running on a node whose value of
-                                  the label with key <topologyKey> matches that of any node on which
-                                  a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      A label query over a set of resources, in this case pods.
-                                      If it's null, this PodAffinityTerm matches with no Pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -877,70 +448,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: |-
-                                      MismatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: |-
-                                      A label query over the set of namespaces that the term applies to.
-                                      The term is applied to the union of the namespaces selected by this field
-                                      and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list means "this pod's namespace".
-                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -954,30 +484,15 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: |-
-                                      namespaces specifies a static list of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces listed in this field
-                                      and the ones selected by namespaceSelector.
-                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   topologyKey:
-                                    description: |-
-                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey matches that of any node on which any of the
-                                      selected pods is running.
-                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -989,120 +504,64 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: Annotations provides annotations that are added to the CSI driver DaemonSet pods.
                       type: object
                     containers:
                       additionalProperties:
-                        description: DatadogAgentGenericContainer is the generic structure describing any container's common configuration.
                         properties:
                           appArmorProfileName:
-                            description: AppArmorProfileName specifies an apparmor profile.
                             type: string
                           args:
-                            description: Args allows the specification of extra args to the `Command` parameter
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           command:
-                            description: Command allows the specification of a custom entrypoint for container
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           env:
-                            description: |-
-                              Specify additional environment variables in the container.
-                              See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables
                             items:
-                              description: EnvVar represents an environment variable present in a Container.
                               properties:
                                 name:
-                                  description: |-
-                                    Name of the environment variable.
-                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fileKeyRef:
-                                      description: |-
-                                        FileKeyRef selects a key of the env file.
-                                        Requires the EnvFiles feature gate to be enabled.
                                       properties:
                                         key:
-                                          description: |-
-                                            The key within the env file. An invalid key will prevent the pod from starting.
-                                            The keys defined within a source may consist of any printable ASCII characters except '='.
-                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
                                           type: string
                                         optional:
                                           default: false
-                                          description: |-
-                                            Specify whether the file or its key must be defined. If the file or key
-                                            does not exist, then the env var is not published.
-                                            If optional is set to true and the specified key does not exist,
-                                            the environment variable will not be set in the Pod's containers.
-
-                                            If optional is set to false and the specified key does not exist,
-                                            an error will be returned during Pod creation.
                                           type: boolean
                                         path:
-                                          description: |-
-                                            The path within the volume from which to select the file.
-                                            Must be relative and may not contain the '..' path or start with '..'.
                                           type: string
                                         volumeName:
-                                          description: The name of the volume mount containing the env file.
                                           type: string
                                       required:
                                         - key
@@ -1111,44 +570,29 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -1163,73 +607,42 @@ spec:
                               - name
                             x-kubernetes-list-type: map
                           healthPort:
-                            description: |-
-                              HealthPort of the container for the internal liveness probe.
-                              Must be the same as the Liveness/Readiness probes.
                             format: int32
                             type: integer
                           livenessProbe:
-                            description: Configure the Liveness Probe of the container
                             properties:
                               exec:
-                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
-                                    description: |-
-                                      Command is the command line to execute inside the container, the working directory for the
-                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                      a shell, you need to explicitly call out to that shell.
-                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
                               failureThreshold:
-                                description: |-
-                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
-                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                     format: int32
                                     type: integer
                                   service:
                                     default: ""
-                                    description: |-
-                                      Service is the name of the service to place in the gRPC HealthCheckRequest
-                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-                                      If this is not specified, the default behavior is defined by gRPC.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
-                                    description: |-
-                                      Host name to connect to, defaults to the pod IP. You probably want to set
-                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: |-
-                                            The header field name.
-                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1238,128 +651,64 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Name or number of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: |-
-                                      Scheme to use for connecting to the host.
-                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: |-
-                                  Number of seconds after the container has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: |-
-                                  How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: |-
-                                  Minimum consecutive successes for the probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies a connection to a TCP port.
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Number or name of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: |-
-                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                  The grace period is the duration in seconds after the processes running in the pod are sent
-                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                  Set this value longer than the expected cleanup time for your process.
-                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                  value overrides the value provided by the pod spec.
-                                  Value must be non-negative integer. The value zero indicates stop immediately via
-                                  the kill signal (no opportunity to shut down).
-                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: |-
-                                  Number of seconds after which the probe times out.
-                                  Defaults to 1 second. Minimum value is 1.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                             type: object
                           logLevel:
-                            description: |-
-                              LogLevel sets logging verbosity (overrides global setting).
-                              Valid log levels are: trace, debug, info, warn, error, critical, and off.
-                              Default: 'info'
                             type: string
                           name:
-                            description: Name of the container that is overridden
                             type: string
                           ports:
-                            description: |-
-                              Specify additional ports to be exposed by the container. Not specifying a port here
-                              DOES NOT prevent that port from being exposed.
-                              See https://pkg.go.dev/k8s.io/api/core/v1#Container documentation for more details.
                             items:
-                              description: ContainerPort represents a network port in a single container.
                               properties:
                                 containerPort:
-                                  description: |-
-                                    Number of port to expose on the pod's IP address.
-                                    This must be a valid port number, 0 < x < 65536.
                                   format: int32
                                   type: integer
                                 hostIP:
-                                  description: What host IP to bind the external port to.
                                   type: string
                                 hostPort:
-                                  description: |-
-                                    Number of port to expose on the host.
-                                    If specified, this must be a valid port number, 0 < x < 65536.
-                                    If HostNetwork is specified, this must match ContainerPort.
-                                    Most containers do not need this.
                                   format: int32
                                   type: integer
                                 name:
-                                  description: |-
-                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                                    named port in a pod must have a unique name. Name for the port that can be
-                                    referred to by services.
                                   type: string
                                 protocol:
                                   default: TCP
-                                  description: |-
-                                    Protocol for port. Must be UDP, TCP, or SCTP.
-                                    Defaults to "TCP".
                                   type: string
                               required:
                                 - containerPort
@@ -1367,67 +716,39 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           readinessProbe:
-                            description: Configure the Readiness Probe of the container
                             properties:
                               exec:
-                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
-                                    description: |-
-                                      Command is the command line to execute inside the container, the working directory for the
-                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                      a shell, you need to explicitly call out to that shell.
-                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
                               failureThreshold:
-                                description: |-
-                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
-                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                     format: int32
                                     type: integer
                                   service:
                                     default: ""
-                                    description: |-
-                                      Service is the name of the service to place in the gRPC HealthCheckRequest
-                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-                                      If this is not specified, the default behavior is defined by gRPC.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
-                                    description: |-
-                                      Host name to connect to, defaults to the pod IP. You probably want to set
-                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: |-
-                                            The header field name.
-                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1436,112 +757,53 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Name or number of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: |-
-                                      Scheme to use for connecting to the host.
-                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: |-
-                                  Number of seconds after the container has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: |-
-                                  How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: |-
-                                  Minimum consecutive successes for the probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies a connection to a TCP port.
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Number or name of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: |-
-                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                  The grace period is the duration in seconds after the processes running in the pod are sent
-                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                  Set this value longer than the expected cleanup time for your process.
-                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                  value overrides the value provided by the pod spec.
-                                  Value must be non-negative integer. The value zero indicates stop immediately via
-                                  the kill signal (no opportunity to shut down).
-                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: |-
-                                  Number of seconds after which the probe times out.
-                                  Defaults to 1 second. Minimum value is 1.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: |-
-                              Specify the Request and Limits of the pods
-                              To get guaranteed QoS class, specify requests and limits equal.
-                              See also: http://kubernetes.io/docs/user-guide/compute-resources/
                             properties:
                               claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-                                  This field depends on the
-                                  DynamicResourceAllocation feature gate.
-
-                                  This field is immutable. It can only be set for containers.
                                 items:
-                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
                                       type: string
                                     request:
-                                      description: |-
-                                        Request is the name chosen for a request in the referenced claim.
-                                        If empty, everything from the claim is made available, otherwise
-                                        only the result of this request.
                                       type: string
                                   required:
                                     - name
@@ -1557,9 +819,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1568,54 +827,25 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           seccompConfig:
-                            description: |-
-                              Seccomp configurations to override Operator actions. For all other Seccomp Profile manipulation,
-                              use SecurityContext.
                             properties:
                               customProfile:
-                                description: |-
-                                  CustomProfile specifies a ConfigMap containing a custom Seccomp Profile.
-                                  ConfigMap data must either have the key `system-probe-seccomp.json` or CustomProfile.Items
-                                  must include a corev1.KeytoPath that maps the key to the path `system-probe-seccomp.json`.
                                 properties:
                                   configData:
-                                    description: ConfigData corresponds to the configuration file content.
                                     type: string
                                   configMap:
-                                    description: ConfigMap references an existing ConfigMap with the configuration file content.
                                     properties:
                                       items:
-                                        description: Items maps a ConfigMap data `key` to a file `path` mount.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: |-
-                                                mode is Optional: mode bits used to set permissions on this file.
-                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                If not specified, the volume defaultMode will be used.
-                                                This might be in conflict with other options that affect the file
-                                                mode, like fsGroup, and the result can be other mode bits set.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: |-
-                                                path is the relative path of the file to map the key to.
-                                                May not be an absolute path.
-                                                May not contain the path element '..'.
-                                                May not start with the string '..'.
                                               type: string
                                           required:
                                             - key
@@ -1626,261 +856,118 @@ spec:
                                           - key
                                         x-kubernetes-list-type: map
                                       name:
-                                        description: Name is the name of the ConfigMap.
                                         type: string
                                     type: object
                                 type: object
                               customRootPath:
-                                description: CustomRootPath specifies a custom Seccomp Profile root location.
                                 type: string
                             type: object
                           securityContext:
-                            description: Container-level SecurityContext.
                             properties:
                               allowPrivilegeEscalation:
-                                description: |-
-                                  AllowPrivilegeEscalation controls whether a process can gain more
-                                  privileges than its parent process. This bool directly controls if
-                                  the no_new_privs flag will be set on the container process.
-                                  AllowPrivilegeEscalation is true always when the container is:
-                                  1) run as Privileged
-                                  2) has CAP_SYS_ADMIN
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: boolean
                               appArmorProfile:
-                                description: |-
-                                  appArmorProfile is the AppArmor options to use by this container. If set, this profile
-                                  overrides the pod's appArmorProfile.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   localhostProfile:
-                                    description: |-
-                                      localhostProfile indicates a profile loaded on the node that should be used.
-                                      The profile must be preconfigured on the node to work.
-                                      Must match the loaded name of the profile.
-                                      Must be set if and only if type is "Localhost".
                                     type: string
                                   type:
-                                    description: |-
-                                      type indicates which kind of AppArmor profile will be applied.
-                                      Valid options are:
-                                        Localhost - a profile pre-loaded on the node.
-                                        RuntimeDefault - the container runtime's default profile.
-                                        Unconfined - no AppArmor enforcement.
                                     type: string
                                 required:
                                   - type
                                 type: object
                               capabilities:
-                                description: |-
-                                  The capabilities to add/drop when running containers.
-                                  Defaults to the default set of capabilities granted by the container runtime.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   add:
-                                    description: Added capabilities
                                     items:
-                                      description: Capability represent POSIX capabilities type
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   drop:
-                                    description: Removed capabilities
                                     items:
-                                      description: Capability represent POSIX capabilities type
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
                               privileged:
-                                description: |-
-                                  Run container in privileged mode.
-                                  Processes in privileged containers are essentially equivalent to root on the host.
-                                  Defaults to false.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: boolean
                               procMount:
-                                description: |-
-                                  procMount denotes the type of proc mount to use for the containers.
-                                  The default value is Default which uses the container runtime defaults for
-                                  readonly paths and masked paths.
-                                  This requires the ProcMountType feature flag to be enabled.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: string
                               readOnlyRootFilesystem:
-                                description: |-
-                                  Whether this container has a read-only root filesystem.
-                                  Default is false.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: boolean
                               runAsGroup:
-                                description: |-
-                                  The GID to run the entrypoint of the container process.
-                                  Uses runtime default if unset.
-                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               runAsNonRoot:
-                                description: |-
-                                  Indicates that the container must run as a non-root user.
-                                  If true, the Kubelet will validate the image at runtime to ensure that it
-                                  does not run as UID 0 (root) and fail to start the container if it does.
-                                  If unset or false, no such validation will be performed.
-                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: boolean
                               runAsUser:
-                                description: |-
-                                  The UID to run the entrypoint of the container process.
-                                  Defaults to user specified in image metadata if unspecified.
-                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               seLinuxOptions:
-                                description: |-
-                                  The SELinux context to be applied to the container.
-                                  If unspecified, the container runtime will allocate a random SELinux context for each
-                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   level:
-                                    description: Level is SELinux level label that applies to the container.
                                     type: string
                                   role:
-                                    description: Role is a SELinux role label that applies to the container.
                                     type: string
                                   type:
-                                    description: Type is a SELinux type label that applies to the container.
                                     type: string
                                   user:
-                                    description: User is a SELinux user label that applies to the container.
                                     type: string
                                 type: object
                               seccompProfile:
-                                description: |-
-                                  The seccomp options to use by this container. If seccomp options are
-                                  provided at both the pod & container level, the container options
-                                  override the pod options.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   localhostProfile:
-                                    description: |-
-                                      localhostProfile indicates a profile defined in a file on the node should be used.
-                                      The profile must be preconfigured on the node to work.
-                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                      Must be set if type is "Localhost". Must NOT be set for any other type.
                                     type: string
                                   type:
-                                    description: |-
-                                      type indicates which kind of seccomp profile will be applied.
-                                      Valid options are:
-
-                                      Localhost - a profile defined in a file on the node should be used.
-                                      RuntimeDefault - the container runtime default profile should be used.
-                                      Unconfined - no profile should be applied.
                                     type: string
                                 required:
                                   - type
                                 type: object
                               windowsOptions:
-                                description: |-
-                                  The Windows specific settings applied to all containers.
-                                  If unspecified, the options from the PodSecurityContext will be used.
-                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name is linux.
                                 properties:
                                   gmsaCredentialSpec:
-                                    description: |-
-                                      GMSACredentialSpec is where the GMSA admission webhook
-                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                      GMSA credential spec named by the GMSACredentialSpecName field.
                                     type: string
                                   gmsaCredentialSpecName:
-                                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                     type: string
                                   hostProcess:
-                                    description: |-
-                                      HostProcess determines if a container should be run as a 'Host Process' container.
-                                      All of a Pod's containers must have the same effective HostProcess value
-                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
                                     type: boolean
                                   runAsUserName:
-                                    description: |-
-                                      The UserName in Windows to run the entrypoint of the container process.
-                                      Defaults to the user specified in image metadata if unspecified.
-                                      May also be set in PodSecurityContext. If set in both SecurityContext and
-                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: string
                                 type: object
                             type: object
                           startupProbe:
-                            description: Configure the Startup Probe of the container
                             properties:
                               exec:
-                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
-                                    description: |-
-                                      Command is the command line to execute inside the container, the working directory for the
-                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                      a shell, you need to explicitly call out to that shell.
-                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
                               failureThreshold:
-                                description: |-
-                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
-                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                                     format: int32
                                     type: integer
                                   service:
                                     default: ""
-                                    description: |-
-                                      Service is the name of the service to place in the gRPC HealthCheckRequest
-                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-                                      If this is not specified, the default behavior is defined by gRPC.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
-                                    description: |-
-                                      Host name to connect to, defaults to the pod IP. You probably want to set
-                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: |-
-                                            The header field name.
-                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1889,140 +976,61 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Name or number of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: |-
-                                      Scheme to use for connecting to the host.
-                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: |-
-                                  Number of seconds after the container has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: |-
-                                  How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: |-
-                                  Minimum consecutive successes for the probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies a connection to a TCP port.
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: |-
-                                      Number or name of the port to access on the container.
-                                      Number must be in the range 1 to 65535.
-                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: |-
-                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                  The grace period is the duration in seconds after the processes running in the pod are sent
-                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                  Set this value longer than the expected cleanup time for your process.
-                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                  value overrides the value provided by the pod spec.
-                                  Value must be non-negative integer. The value zero indicates stop immediately via
-                                  the kill signal (no opportunity to shut down).
-                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: |-
-                                  Number of seconds after which the probe times out.
-                                  Defaults to 1 second. Minimum value is 1.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
-                            description: Specify additional volume mounts in the container.
                             items:
-                              description: VolumeMount describes a mounting of a Volume within a container.
                               properties:
                                 mountPath:
-                                  description: |-
-                                    Path within the container at which the volume should be mounted.  Must
-                                    not contain ':'.
                                   type: string
                                 mountPropagation:
-                                  description: |-
-                                    mountPropagation determines how mounts are propagated from the host
-                                    to container and the other way around.
-                                    When not set, MountPropagationNone is used.
-                                    This field is beta in 1.10.
-                                    When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
-                                    (which defaults to None).
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    Mounted read-only if true, read-write otherwise (false or unspecified).
-                                    Defaults to false.
                                   type: boolean
                                 recursiveReadOnly:
-                                  description: |-
-                                    RecursiveReadOnly specifies whether read-only mounts should be handled
-                                    recursively.
-
-                                    If ReadOnly is false, this field has no meaning and must be unspecified.
-
-                                    If ReadOnly is true, and this field is set to Disabled, the mount is not made
-                                    recursively read-only.  If this field is set to IfPossible, the mount is made
-                                    recursively read-only, if it is supported by the container runtime.  If this
-                                    field is set to Enabled, the mount is made recursively read-only if it is
-                                    supported by the container runtime, otherwise the pod will not be started and
-                                    an error will be generated to indicate the reason.
-
-                                    If this field is set to IfPossible or Enabled, MountPropagation must be set to
-                                    None (or be unspecified, which defaults to None).
-
-                                    If this field is not specified, it is treated as an equivalent of Disabled.
                                   type: string
                                 subPath:
-                                  description: |-
-                                    Path within the volume from which the container's volume should be mounted.
-                                    Defaults to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: |-
-                                    Expanded path within the volume from which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                    Defaults to "" (volume's root).
-                                    SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -2034,101 +1042,49 @@ spec:
                               - mountPath
                             x-kubernetes-list-type: map
                         type: object
-                      description: |-
-                        Containers allows overriding container-level configuration for the CSI driver containers.
-                        Valid keys are: "csi-node-driver" and "csi-node-driver-registrar".
                       type: object
                     env:
-                      description: Env specifies additional environment variables for all containers.
                       items:
-                        description: EnvVar represents an environment variable present in a Container.
                         properties:
                           name:
-                            description: |-
-                              Name of the environment variable.
-                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
-                            description: |-
-                              Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in the container and
-                              any service environment variables. If a variable cannot be resolved,
-                              the reference in the input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                              Escaped references will never be expanded, regardless of whether the variable
-                              exists or not.
-                              Defaults to "".
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value. Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
-                                    description: The key to select.
                                     type: string
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
-                                description: |-
-                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fileKeyRef:
-                                description: |-
-                                  FileKeyRef selects a key of the env file.
-                                  Requires the EnvFiles feature gate to be enabled.
                                 properties:
                                   key:
-                                    description: |-
-                                      The key within the env file. An invalid key will prevent the pod from starting.
-                                      The keys defined within a source may consist of any printable ASCII characters except '='.
-                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
                                     type: string
                                   optional:
                                     default: false
-                                    description: |-
-                                      Specify whether the file or its key must be defined. If the file or key
-                                      does not exist, then the env var is not published.
-                                      If optional is set to true and the specified key does not exist,
-                                      the environment variable will not be set in the Pod's containers.
-
-                                      If optional is set to false and the specified key does not exist,
-                                      an error will be returned during Pod creation.
                                     type: boolean
                                   path:
-                                    description: |-
-                                      The path within the volume from which to select the file.
-                                      Must be relative and may not contain the '..' path or start with '..'.
                                     type: string
                                   volumeName:
-                                    description: The name of the volume mount containing the env file.
                                     type: string
                                 required:
                                   - key
@@ -2137,44 +1093,29 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes, optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Specifies the output format of the exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -2191,206 +1132,73 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: AdditionalLabels provides labels that are added to the CSI driver DaemonSet pods.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: |-
-                        NodeSelector is a map of key-value pairs. For the CSI driver pod to run on a
-                        specific node, the node must have these key-value pairs as labels.
                       type: object
                     priorityClassName:
-                      description: PriorityClassName indicates the pod's priority.
                       type: string
                     securityContext:
-                      description: SecurityContext holds pod-level security attributes.
                       properties:
                         appArmorProfile:
-                          description: |-
-                            appArmorProfile is the AppArmor options to use by the containers in this pod.
-                            Note that this field cannot be set when spec.os.name is windows.
                           properties:
                             localhostProfile:
-                              description: |-
-                                localhostProfile indicates a profile loaded on the node that should be used.
-                                The profile must be preconfigured on the node to work.
-                                Must match the loaded name of the profile.
-                                Must be set if and only if type is "Localhost".
                               type: string
                             type:
-                              description: |-
-                                type indicates which kind of AppArmor profile will be applied.
-                                Valid options are:
-                                  Localhost - a profile pre-loaded on the node.
-                                  RuntimeDefault - the container runtime's default profile.
-                                  Unconfined - no AppArmor enforcement.
                               type: string
                           required:
                             - type
                           type: object
                         fsGroup:
-                          description: |-
-                            A special supplemental group that applies to all containers in a pod.
-                            Some volume types allow the Kubelet to change the ownership of that volume
-                            to be owned by the pod:
-
-                            1. The owning GID will be the FSGroup
-                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
-                            3. The permission bits are OR'd with rw-rw----
-
-                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
-                            Note that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
-                          description: |-
-                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
-                            before being exposed inside Pod. This field will only apply to
-                            volume types which support fsGroup based ownership(and permissions).
-                            It will have no effect on ephemeral volume types such as: secret, configmaps
-                            and emptydir.
-                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
-                            Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         runAsGroup:
-                          description: |-
-                            The GID to run the entrypoint of the container process.
-                            Uses runtime default if unset.
-                            May also be set in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence
-                            for that container.
-                            Note that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: |-
-                            Indicates that the container must run as a non-root user.
-                            If true, the Kubelet will validate the image at runtime to ensure that it
-                            does not run as UID 0 (root) and fail to start the container if it does.
-                            If unset or false, no such validation will be performed.
-                            May also be set in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: |-
-                            The UID to run the entrypoint of the container process.
-                            Defaults to user specified in image metadata if unspecified.
-                            May also be set in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence
-                            for that container.
-                            Note that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         seLinuxChangePolicy:
-                          description: |-
-                            seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
-                            It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
-                            Valid values are "MountOption" and "Recursive".
-
-                            "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
-                            This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
-
-                            "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
-                            This requires all Pods that share the same volume to use the same SELinux label.
-                            It is not possible to share the same volume among privileged and unprivileged Pods.
-                            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
-                            whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
-                            CSIDriver instance. Other volumes are always re-labelled recursively.
-                            "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
-
-                            If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                            If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                            and "Recursive" for all other volumes.
-
-                            This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
-
-                            All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
-                            Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         seLinuxOptions:
-                          description: |-
-                            The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random SELinux context for each
-                            container.  May also be set in SecurityContext.  If set in
-                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                            Note that this field cannot be set when spec.os.name is windows.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies to the container.
                               type: string
                           type: object
                         seccompProfile:
-                          description: |-
-                            The seccomp options to use by the containers in this pod.
-                            Note that this field cannot be set when spec.os.name is windows.
                           properties:
                             localhostProfile:
-                              description: |-
-                                localhostProfile indicates a profile defined in a file on the node should be used.
-                                The profile must be preconfigured on the node to work.
-                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                Must be set if type is "Localhost". Must NOT be set for any other type.
                               type: string
                             type:
-                              description: |-
-                                type indicates which kind of seccomp profile will be applied.
-                                Valid options are:
-
-                                Localhost - a profile defined in a file on the node should be used.
-                                RuntimeDefault - the container runtime default profile should be used.
-                                Unconfined - no profile should be applied.
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
-                          description: |-
-                            A list of groups applied to the first process run in each container, in
-                            addition to the container's primary GID and fsGroup (if specified).  If
-                            the SupplementalGroupsPolicy feature is enabled, the
-                            supplementalGroupsPolicy field determines whether these are in addition
-                            to or instead of any group memberships defined in the container image.
-                            If unspecified, no additional groups are added, though group memberships
-                            defined in the container image may still be used, depending on the
-                            supplementalGroupsPolicy field.
-                            Note that this field cannot be set when spec.os.name is windows.
                           items:
                             format: int64
                             type: integer
                           type: array
                           x-kubernetes-list-type: atomic
                         supplementalGroupsPolicy:
-                          description: |-
-                            Defines how supplemental groups of the first container processes are calculated.
-                            Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
-                            (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
-                            and the container runtime must implement support for this feature.
-                            Note that this field cannot be set when spec.os.name is windows.
                           type: string
                         sysctls:
-                          description: |-
-                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
-                            sysctls (by the container runtime) might fail to launch.
-                            Note that this field cannot be set when spec.os.name is windows.
                           items:
-                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
-                                description: Name of a property to set
                                 type: string
                               value:
-                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -2399,348 +1207,160 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         windowsOptions:
-                          description: |-
-                            The Windows specific settings applied to all containers.
-                            If unspecified, the options within a container's SecurityContext will be used.
-                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                            Note that this field cannot be set when spec.os.name is linux.
                           properties:
                             gmsaCredentialSpec:
-                              description: |-
-                                GMSACredentialSpec is where the GMSA admission webhook
-                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                GMSA credential spec named by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                               type: string
                             hostProcess:
-                              description: |-
-                                HostProcess determines if a container should be run as a 'Host Process' container.
-                                All of a Pod's containers must have the same effective HostProcess value
-                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                In addition, if HostProcess is true then HostNetwork must also be set to true.
                               type: boolean
                             runAsUserName:
-                              description: |-
-                                The UserName in Windows to run the entrypoint of the container process.
-                                Defaults to the user specified in image metadata if unspecified.
-                                May also be set in PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
-                      description: ServiceAccountName sets the ServiceAccount used by the CSI driver DaemonSet.
                       type: string
                     tolerations:
-                      description: Tolerations configure the CSI driver DaemonSet pod tolerations.
                       items:
-                        description: |-
-                          The pod this Toleration is attached to tolerates any taint that matches
-                          the triple <key,value,effect> using the matching operator <operator>.
                         properties:
                           effect:
-                            description: |-
-                              Effect indicates the taint effect to match. Empty means match all taint effects.
-                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
-                            description: |-
-                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                             type: string
                           operator:
-                            description: |-
-                              Operator represents a key's relationship to the value.
-                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                              Exists is equivalent to wildcard for value, so that a pod can
-                              tolerate all taints of a particular category.
-                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                             type: string
                           tolerationSeconds:
-                            description: |-
-                              TolerationSeconds represents the period of time the toleration (which must be
-                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                              it is not set, which means tolerate the taint forever (do not evict). Zero and
-                              negative values will be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
-                            description: |-
-                              Value is the taint value the toleration matches to.
-                              If the operator is Exists, the value should be empty, otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                       x-kubernetes-list-type: atomic
                     updateStrategy:
-                      description: UpdateStrategy is the DaemonSet update strategy configuration.
                       properties:
                         rollingUpdate:
-                          description: Configure the rolling update strategy of the Deployment or DaemonSet.
                           properties:
                             maxSurge:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: |-
-                                MaxSurge behaves differently based on the Kubernetes resource. Refer to the
-                                Kubernetes API documentation for additional details.
                               x-kubernetes-int-or-string: true
                             maxUnavailable:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: |-
-                                The maximum number of pods that can be unavailable during the update.
-                                Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                                Refer to the Kubernetes API documentation for additional details..
                               x-kubernetes-int-or-string: true
                           type: object
                         type:
-                          description: |-
-                            Type can be "RollingUpdate" or "OnDelete" for DaemonSets and "RollingUpdate"
-                            or "Recreate" for Deployments
                           type: string
                       type: object
                     volumes:
-                      description: Volumes specifies additional volumes to add to the CSI driver DaemonSet pods.
                       items:
-                        description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                         properties:
                           awsElasticBlockStore:
-                            description: |-
-                              awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                              kubelet's host machine and then exposed to the pod.
-                              Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
-                              awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type of the volume that you want to mount.
-                                  Tip: Ensure that the filesystem type is supported by the host operating system.
-                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 type: string
                               partition:
-                                description: |-
-                                  partition is the partition in the volume that you want to mount.
-                                  If omitted, the default is to mount by volume name.
-                                  Examples: For volume /dev/sda1, you specify the partition as "1".
-                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                 format: int32
                                 type: integer
                               readOnly:
-                                description: |-
-                                  readOnly value true will force the readOnly setting in VolumeMounts.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 type: boolean
                               volumeID:
-                                description: |-
-                                  volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 type: string
                             required:
                               - volumeID
                             type: object
                           azureDisk:
-                            description: |-
-                              azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
-                              Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
-                              are redirected to the disk.csi.azure.com CSI driver.
                             properties:
                               cachingMode:
-                                description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                 type: string
                               diskName:
-                                description: diskName is the Name of the data disk in the blob storage
                                 type: string
                               diskURI:
-                                description: diskURI is the URI of data disk in the blob storage
                                 type: string
                               fsType:
                                 default: ext4
-                                description: |-
-                                  fsType is Filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               kind:
-                                description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                 type: string
                               readOnly:
                                 default: false
-                                description: |-
-                                  readOnly Defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                             required:
                               - diskName
                               - diskURI
                             type: object
                           azureFile:
-                            description: |-
-                              azureFile represents an Azure File Service mount on the host and bind mount to the pod.
-                              Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
-                              are redirected to the file.csi.azure.com CSI driver.
                             properties:
                               readOnly:
-                                description: |-
-                                  readOnly defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretName:
-                                description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                 type: string
                               shareName:
-                                description: shareName is the azure share Name
                                 type: string
                             required:
                               - secretName
                               - shareName
                             type: object
                           cephfs:
-                            description: |-
-                              cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
-                              Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                             properties:
                               monitors:
-                                description: |-
-                                  monitors is Required: Monitors is a collection of Ceph monitors
-                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               path:
-                                description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
-                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                 type: boolean
                               secretFile:
-                                description: |-
-                                  secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                 type: string
                               secretRef:
-                                description: |-
-                                  secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
-                                description: |-
-                                  user is optional: User is the rados user name, default is admin
-                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                 type: string
                             required:
                               - monitors
                             type: object
                           cinder:
-                            description: |-
-                              cinder represents a cinder volume attached and mounted on kubelets host machine.
-                              Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
-                              are redirected to the cinder.csi.openstack.org CSI driver.
-                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
-                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                 type: boolean
                               secretRef:
-                                description: |-
-                                  secretRef is optional: points to a secret object containing parameters used to connect
-                                  to OpenStack.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               volumeID:
-                                description: |-
-                                  volumeID used to identify the volume in cinder.
-                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                 type: string
                             required:
                               - volumeID
                             type: object
                           configMap:
-                            description: configMap represents a configMap that should populate this volume
                             properties:
                               defaultMode:
-                                description: |-
-                                  defaultMode is optional: mode bits used to set permissions on created files by default.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  Defaults to 0644.
-                                  Directories within the path are not affected by this setting.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               items:
-                                description: |-
-                                  items if unspecified, each key-value pair in the Data field of the referenced
-                                  ConfigMap will be projected into the volume as a file whose name is the
-                                  key and content is the value. If specified, the listed keys will be
-                                  projected into the specified paths, and unlisted keys will not be
-                                  present. If a key is specified which is not present in the ConfigMap,
-                                  the volume setup will error unless it is marked optional. Paths must be
-                                  relative and may not contain the '..' path or start with '..'.
                                 items:
-                                  description: Maps a string key to a path within a volume.
                                   properties:
                                     key:
-                                      description: key is the key to project.
                                       type: string
                                     mode:
-                                      description: |-
-                                        mode is Optional: mode bits used to set permissions on this file.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        If not specified, the volume defaultMode will be used.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     path:
-                                      description: |-
-                                        path is the relative path of the file to map the key to.
-                                        May not be an absolute path.
-                                        May not contain the path element '..'.
-                                        May not start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -2750,129 +1370,67 @@ spec:
                                 x-kubernetes-list-type: atomic
                               name:
                                 default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               optional:
-                                description: optional specify whether the ConfigMap or its keys must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           csi:
-                            description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                             properties:
                               driver:
-                                description: |-
-                                  driver is the name of the CSI driver that handles this volume.
-                                  Consult with your admin for the correct name as registered in the cluster.
                                 type: string
                               fsType:
-                                description: |-
-                                  fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                  If not provided, the empty value is passed to the associated CSI driver
-                                  which will determine the default filesystem to apply.
                                 type: string
                               nodePublishSecretRef:
-                                description: |-
-                                  nodePublishSecretRef is a reference to the secret object containing
-                                  sensitive information to pass to the CSI driver to complete the CSI
-                                  NodePublishVolume and NodeUnpublishVolume calls.
-                                  This field is optional, and  may be empty if no secret is required. If the
-                                  secret object contains more than one secret, all secret references are passed.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               readOnly:
-                                description: |-
-                                  readOnly specifies a read-only configuration for the volume.
-                                  Defaults to false (read/write).
                                 type: boolean
                               volumeAttributes:
                                 additionalProperties:
                                   type: string
-                                description: |-
-                                  volumeAttributes stores driver-specific properties that are passed to the CSI
-                                  driver. Consult your driver's documentation for supported values.
                                 type: object
                             required:
                               - driver
                             type: object
                           downwardAPI:
-                            description: downwardAPI represents downward API about the pod that should populate this volume
                             properties:
                               defaultMode:
-                                description: |-
-                                  Optional: mode bits to use on created files by default. Must be a
-                                  Optional: mode bits used to set permissions on created files by default.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  Defaults to 0644.
-                                  Directories within the path are not affected by this setting.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               items:
-                                description: Items is a list of downward API volume file
                                 items:
-                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                   properties:
                                     fieldRef:
-                                      description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     mode:
-                                      description: |-
-                                        Optional: mode bits used to set permissions on this file, must be an octal value
-                                        between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        If not specified, the volume defaultMode will be used.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     path:
-                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                       type: string
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
@@ -2885,125 +1443,36 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                           emptyDir:
-                            description: |-
-                              emptyDir represents a temporary directory that shares a pod's lifetime.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                             properties:
                               medium:
-                                description: |-
-                                  medium represents what type of storage medium should back this directory.
-                                  The default is "" which means to use the node's default medium.
-                                  Must be an empty string (default) or Memory.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                 type: string
                               sizeLimit:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: |-
-                                  sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                  The size limit is also applicable for memory medium.
-                                  The maximum usage on memory medium EmptyDir would be the minimum value between
-                                  the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                  The default is nil which means that the limit is undefined.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
                             type: object
                           ephemeral:
-                            description: |-
-                              ephemeral represents a volume that is handled by a cluster storage driver.
-                              The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                              and deleted when the pod is removed.
-
-                              Use this if:
-                              a) the volume is only needed while the pod runs,
-                              b) features of normal volumes like restoring from snapshot or capacity
-                                 tracking are needed,
-                              c) the storage driver is specified through a storage class, and
-                              d) the storage driver supports dynamic volume provisioning through
-                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                 information on the connection between this volume type
-                                 and PersistentVolumeClaim).
-
-                              Use PersistentVolumeClaim or one of the vendor-specific
-                              APIs for volumes that persist for longer than the lifecycle
-                              of an individual pod.
-
-                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                              be used that way - see the documentation of the driver for
-                              more information.
-
-                              A pod can use both types of ephemeral volumes and
-                              persistent volumes at the same time.
                             properties:
                               volumeClaimTemplate:
-                                description: |-
-                                  Will be used to create a stand-alone PVC to provision the volume.
-                                  The pod in which this EphemeralVolumeSource is embedded will be the
-                                  owner of the PVC, i.e. the PVC will be deleted together with the
-                                  pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                  `<volume name>` is the name from the `PodSpec.Volumes` array
-                                  entry. Pod validation will reject the pod if the concatenated name
-                                  is not valid for a PVC (for example, too long).
-
-                                  An existing PVC with that name that is not owned by the pod
-                                  will *not* be used for the pod to avoid using an unrelated
-                                  volume by mistake. Starting the pod is then blocked until
-                                  the unrelated PVC is removed. If such a pre-created PVC is
-                                  meant to be used by the pod, the PVC has to updated with an
-                                  owner reference to the pod once the pod exists. Normally
-                                  this should not be necessary, but it may be useful when
-                                  manually reconstructing a broken cluster.
-
-                                  This field is read-only and no changes will be made by Kubernetes
-                                  to the PVC after it has been created.
-
-                                  Required, must not be nil.
                                 properties:
                                   metadata:
-                                    description: |-
-                                      May contain labels and annotations that will be copied into the PVC
-                                      when creating it. No other fields are allowed and will be rejected during
-                                      validation.
                                     type: object
                                   spec:
-                                    description: |-
-                                      The specification for the PersistentVolumeClaim. The entire content is
-                                      copied unchanged into the PVC that gets created from this
-                                      template. The same fields as in a PersistentVolumeClaim
-                                      are also valid here.
                                     properties:
                                       accessModes:
-                                        description: |-
-                                          accessModes contains the desired access modes the volume should have.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                         items:
                                           type: string
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       dataSource:
-                                        description: |-
-                                          dataSource field can be used to specify either:
-                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                          * An existing PVC (PersistentVolumeClaim)
-                                          If the provisioner or an external controller can support the specified data source,
-                                          it will create a new volume based on the contents of the specified data source.
-                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                         properties:
                                           apiGroup:
-                                            description: |-
-                                              APIGroup is the group for the resource being referenced.
-                                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                                              For any other third-party types, APIGroup is required.
                                             type: string
                                           kind:
-                                            description: Kind is the type of resource being referenced
                                             type: string
                                           name:
-                                            description: Name is the name of resource being referenced
                                             type: string
                                         required:
                                           - kind
@@ -3011,60 +1480,20 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       dataSourceRef:
-                                        description: |-
-                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                          volume is desired. This may be any object from a non-empty API group (non
-                                          core object) or a PersistentVolumeClaim object.
-                                          When this field is specified, volume binding will only succeed if the type of
-                                          the specified object matches some installed volume populator or dynamic
-                                          provisioner.
-                                          This field will replace the functionality of the dataSource field and as such
-                                          if both fields are non-empty, they must have the same value. For backwards
-                                          compatibility, when namespace isn't specified in dataSourceRef,
-                                          both fields (dataSource and dataSourceRef) will be set to the same
-                                          value automatically if one of them is empty and the other is non-empty.
-                                          When namespace is specified in dataSourceRef,
-                                          dataSource isn't set to the same value and must be empty.
-                                          There are three important differences between dataSource and dataSourceRef:
-                                          * While dataSource only allows two specific types of objects, dataSourceRef
-                                            allows any non-core object, as well as PersistentVolumeClaim objects.
-                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                            preserves all values, and generates an error if a disallowed value is
-                                            specified.
-                                          * While dataSource only allows local objects, dataSourceRef allows objects
-                                            in any namespaces.
-                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                         properties:
                                           apiGroup:
-                                            description: |-
-                                              APIGroup is the group for the resource being referenced.
-                                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                                              For any other third-party types, APIGroup is required.
                                             type: string
                                           kind:
-                                            description: Kind is the type of resource being referenced
                                             type: string
                                           name:
-                                            description: Name is the name of resource being referenced
                                             type: string
                                           namespace:
-                                            description: |-
-                                              Namespace is the namespace of resource being referenced
-                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                             type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
-                                        description: |-
-                                          resources represents the minimum resources the volume should have.
-                                          Users are allowed to specify resource requirements
-                                          that are lower than previous value but must still be higher than capacity recorded in the
-                                          status field of the claim.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -3073,9 +1502,6 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Limits describes the maximum amount of compute resources allowed.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -3084,37 +1510,18 @@ spec:
                                                 - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Requests describes the minimum amount of compute resources required.
-                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                         type: object
                                       selector:
-                                        description: selector is a label query over volumes to consider for binding.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -3128,38 +1535,16 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       storageClassName:
-                                        description: |-
-                                          storageClassName is the name of the StorageClass required by the claim.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                         type: string
                                       volumeAttributesClassName:
-                                        description: |-
-                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                          If specified, the CSI driver will create or update the volume with the attributes defined
-                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                          it can be changed after the claim is created. An empty string or nil value indicates that no
-                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                          this field can be reset to its previous value (including nil) to cancel the modification.
-                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                          exists.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
                                         type: string
                                       volumeMode:
-                                        description: |-
-                                          volumeMode defines what type of volume is required by the claim.
-                                          Value of Filesystem is implied when not included in claim spec.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                         type: string
                                     type: object
                                 required:
@@ -3167,79 +1552,41 @@ spec:
                                 type: object
                             type: object
                           fc:
-                            description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               lun:
-                                description: 'lun is Optional: FC target lun number'
                                 format: int32
                                 type: integer
                               readOnly:
-                                description: |-
-                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               targetWWNs:
-                                description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               wwids:
-                                description: |-
-                                  wwids Optional: FC volume world wide identifiers (wwids)
-                                  Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                             type: object
                           flexVolume:
-                            description: |-
-                              flexVolume represents a generic volume resource that is
-                              provisioned/attached using an exec based plugin.
-                              Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                             properties:
                               driver:
-                                description: driver is the name of the driver to use for this volume.
                                 type: string
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                 type: string
                               options:
                                 additionalProperties:
                                   type: string
-                                description: 'options is Optional: this field holds extra command options if any.'
                                 type: object
                               readOnly:
-                                description: |-
-                                  readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretRef:
-                                description: |-
-                                  secretRef is Optional: secretRef is reference to the secret object containing
-                                  sensitive information to pass to the plugin scripts. This may be
-                                  empty if no secret object is specified. If the secret object
-                                  contains more than one secret, all secrets are passed to the plugin
-                                  scripts.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -3247,230 +1594,98 @@ spec:
                               - driver
                             type: object
                           flocker:
-                            description: |-
-                              flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
-                              Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                             properties:
                               datasetName:
-                                description: |-
-                                  datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                  should be considered as deprecated
                                 type: string
                               datasetUUID:
-                                description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                 type: string
                             type: object
                           gcePersistentDisk:
-                            description: |-
-                              gcePersistentDisk represents a GCE Disk resource that is attached to a
-                              kubelet's host machine and then exposed to the pod.
-                              Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
-                              gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is filesystem type of the volume that you want to mount.
-                                  Tip: Ensure that the filesystem type is supported by the host operating system.
-                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 type: string
                               partition:
-                                description: |-
-                                  partition is the partition in the volume that you want to mount.
-                                  If omitted, the default is to mount by volume name.
-                                  Examples: For volume /dev/sda1, you specify the partition as "1".
-                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 format: int32
                                 type: integer
                               pdName:
-                                description: |-
-                                  pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly here will force the ReadOnly setting in VolumeMounts.
-                                  Defaults to false.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 type: boolean
                             required:
                               - pdName
                             type: object
                           gitRepo:
-                            description: |-
-                              gitRepo represents a git repository at a particular revision.
-                              Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
-                              EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                              into the Pod's container.
                             properties:
                               directory:
-                                description: |-
-                                  directory is the target directory name.
-                                  Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                  git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                  the subdirectory with the given name.
                                 type: string
                               repository:
-                                description: repository is the URL
                                 type: string
                               revision:
-                                description: revision is the commit hash for the specified revision.
                                 type: string
                             required:
                               - repository
                             type: object
                           glusterfs:
-                            description: |-
-                              glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                              Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                             properties:
                               endpoints:
-                                description: endpoints is the endpoint name that details Glusterfs topology.
                                 type: string
                               path:
-                                description: |-
-                                  path is the Glusterfs volume path.
-                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                  Defaults to false.
-                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                 type: boolean
                             required:
                               - endpoints
                               - path
                             type: object
                           hostPath:
-                            description: |-
-                              hostPath represents a pre-existing file or directory on the host
-                              machine that is directly exposed to the container. This is generally
-                              used for system agents or other privileged things that are allowed
-                              to see the host machine. Most containers will NOT need this.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                             properties:
                               path:
-                                description: |-
-                                  path of the directory on the host.
-                                  If the path is a symlink, it will follow the link to the real path.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                 type: string
                               type:
-                                description: |-
-                                  type for HostPath Volume
-                                  Defaults to ""
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                 type: string
                             required:
                               - path
                             type: object
                           image:
-                            description: |-
-                              image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
-                              The volume is resolved at pod startup depending on which PullPolicy value is provided:
-
-                              - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-                              - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-                              - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
-
-                              The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
-                              A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
-                              The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
-                              The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                              The volume will be mounted read-only (ro) and non-executable files (noexec).
-                              Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
-                              The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                             properties:
                               pullPolicy:
-                                description: |-
-                                  Policy for pulling OCI objects. Possible values are:
-                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
-                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
                                 type: string
                               reference:
-                                description: |-
-                                  Required: Image or artifact reference to be used.
-                                  Behaves in the same way as pod.spec.containers[*].image.
-                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
-                                  More info: https://kubernetes.io/docs/concepts/containers/images
-                                  This field is optional to allow higher level config management to default or override
-                                  container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                             type: object
                           iscsi:
-                            description: |-
-                              iscsi represents an ISCSI Disk resource that is attached to a
-                              kubelet's host machine and then exposed to the pod.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                             properties:
                               chapAuthDiscovery:
-                                description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                 type: boolean
                               chapAuthSession:
-                                description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                 type: boolean
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type of the volume that you want to mount.
-                                  Tip: Ensure that the filesystem type is supported by the host operating system.
-                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                 type: string
                               initiatorName:
-                                description: |-
-                                  initiatorName is the custom iSCSI Initiator Name.
-                                  If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                  <target portal>:<volume name> will be created for the connection.
                                 type: string
                               iqn:
-                                description: iqn is the target iSCSI Qualified Name.
                                 type: string
                               iscsiInterface:
                                 default: default
-                                description: |-
-                                  iscsiInterface is the interface Name that uses an iSCSI transport.
-                                  Defaults to 'default' (tcp).
                                 type: string
                               lun:
-                                description: lun represents iSCSI Target Lun number.
                                 format: int32
                                 type: integer
                               portals:
-                                description: |-
-                                  portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                  is other than default (typically TCP ports 860 and 3260).
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               readOnly:
-                                description: |-
-                                  readOnly here will force the ReadOnly setting in VolumeMounts.
-                                  Defaults to false.
                                 type: boolean
                               secretRef:
-                                description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               targetPortal:
-                                description: |-
-                                  targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                  is other than default (typically TCP ports 860 and 3260).
                                 type: string
                             required:
                               - iqn
@@ -3478,162 +1693,68 @@ spec:
                               - targetPortal
                             type: object
                           name:
-                            description: |-
-                              name of the volume.
-                              Must be a DNS_LABEL and unique within the pod.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                           nfs:
-                            description: |-
-                              nfs represents an NFS mount on the host that shares a pod's lifetime
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                             properties:
                               path:
-                                description: |-
-                                  path that is exported by the NFS server.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly here will force the NFS export to be mounted with read-only permissions.
-                                  Defaults to false.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                 type: boolean
                               server:
-                                description: |-
-                                  server is the hostname or IP address of the NFS server.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                 type: string
                             required:
                               - path
                               - server
                             type: object
                           persistentVolumeClaim:
-                            description: |-
-                              persistentVolumeClaimVolumeSource represents a reference to a
-                              PersistentVolumeClaim in the same namespace.
-                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                             properties:
                               claimName:
-                                description: |-
-                                  claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly Will force the ReadOnly setting in VolumeMounts.
-                                  Default false.
                                 type: boolean
                             required:
                               - claimName
                             type: object
                           photonPersistentDisk:
-                            description: |-
-                              photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
-                              Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               pdID:
-                                description: pdID is the ID that identifies Photon Controller persistent disk
                                 type: string
                             required:
                               - pdID
                             type: object
                           portworxVolume:
-                            description: |-
-                              portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
-                              Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                              are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                              is on.
                             properties:
                               fsType:
-                                description: |-
-                                  fSType represents the filesystem type to mount
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               volumeID:
-                                description: volumeID uniquely identifies a Portworx volume
                                 type: string
                             required:
                               - volumeID
                             type: object
                           projected:
-                            description: projected items for all in one resources secrets, configmaps, and downward API
                             properties:
                               defaultMode:
-                                description: |-
-                                  defaultMode are the mode bits used to set permissions on created files by default.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  Directories within the path are not affected by this setting.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               sources:
-                                description: |-
-                                  sources is the list of volume projections. Each entry in this list
-                                  handles one source.
                                 items:
-                                  description: |-
-                                    Projection that may be projected along with other supported volume types.
-                                    Exactly one of these fields must be set.
                                   properties:
                                     clusterTrustBundle:
-                                      description: |-
-                                        ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                        of ClusterTrustBundle objects in an auto-updating file.
-
-                                        Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-                                        ClusterTrustBundle objects can either be selected by name, or by the
-                                        combination of signer name and a label selector.
-
-                                        Kubelet performs aggressive normalization of the PEM contents written
-                                        into the pod filesystem.  Esoteric PEM features such as inter-block
-                                        comments and block headers are stripped.  Certificates are deduplicated.
-                                        The ordering of certificates within the file is arbitrary, and Kubelet
-                                        may change the order over time.
                                       properties:
                                         labelSelector:
-                                          description: |-
-                                            Select all ClusterTrustBundles that match this label selector.  Only has
-                                            effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                            interpreted as "match nothing".  If set but empty, interpreted as "match
-                                            everything".
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3647,72 +1768,31 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         name:
-                                          description: |-
-                                            Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                            with signerName and labelSelector.
                                           type: string
                                         optional:
-                                          description: |-
-                                            If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                            aren't available.  If using name, then the named ClusterTrustBundle is
-                                            allowed not to exist.  If using signerName, then the combination of
-                                            signerName and labelSelector is allowed to match zero
-                                            ClusterTrustBundles.
                                           type: boolean
                                         path:
-                                          description: Relative path from the volume root to write the bundle.
                                           type: string
                                         signerName:
-                                          description: |-
-                                            Select all ClusterTrustBundles that match this signer name.
-                                            Mutually-exclusive with name.  The contents of all selected
-                                            ClusterTrustBundles will be unified and deduplicated.
                                           type: string
                                       required:
                                         - path
                                       type: object
                                     configMap:
-                                      description: configMap information about the configMap data to project
                                       properties:
                                         items:
-                                          description: |-
-                                            items if unspecified, each key-value pair in the Data field of the referenced
-                                            ConfigMap will be projected into the volume as a file whose name is the
-                                            key and content is the value. If specified, the listed keys will be
-                                            projected into the specified paths, and unlisted keys will not be
-                                            present. If a key is specified which is not present in the ConfigMap,
-                                            the volume setup will error unless it is marked optional. Paths must be
-                                            relative and may not contain the '..' path or start with '..'.
                                           items:
-                                            description: Maps a string key to a path within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: |-
-                                                  mode is Optional: mode bits used to set permissions on this file.
-                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                  If not specified, the volume defaultMode will be used.
-                                                  This might be in conflict with other options that affect the file
-                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: |-
-                                                  path is the relative path of the file to map the key to.
-                                                  May not be an absolute path.
-                                                  May not contain the path element '..'.
-                                                  May not start with the string '..'.
                                                 type: string
                                             required:
                                               - key
@@ -3722,69 +1802,42 @@ spec:
                                           x-kubernetes-list-type: atomic
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                           type: string
                                         optional:
-                                          description: optional specify whether the ConfigMap or its keys must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     downwardAPI:
-                                      description: downwardAPI information about the downwardAPI data to project
                                       properties:
                                         items:
-                                          description: Items is a list of DownwardAPIVolume file
                                           items:
-                                            description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                             properties:
                                               fieldRef:
-                                                description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
                                                 properties:
                                                   apiVersion:
-                                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                     type: string
                                                   fieldPath:
-                                                    description: Path of the field to select in the specified API version.
                                                     type: string
                                                 required:
                                                   - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               mode:
-                                                description: |-
-                                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                  If not specified, the volume defaultMode will be used.
-                                                  This might be in conflict with other options that affect the file
-                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                 type: string
                                               resourceFieldRef:
-                                                description: |-
-                                                  Selects a resource of the container: only resources limits and requests
-                                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                 properties:
                                                   containerName:
-                                                    description: 'Container name: required for volumes, optional for env vars'
                                                     type: string
                                                   divisor:
                                                     anyOf:
                                                       - type: integer
                                                       - type: string
-                                                    description: Specifies the output format of the exposed resources, defaults to "1"
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
-                                                    description: 'Required: resource to select'
                                                     type: string
                                                 required:
                                                   - resource
@@ -3797,161 +1850,39 @@ spec:
                                           x-kubernetes-list-type: atomic
                                       type: object
                                     podCertificate:
-                                      description: |-
-                                        Projects an auto-rotating credential bundle (private key and certificate
-                                        chain) that the pod can use either as a TLS client or server.
-
-                                        Kubelet generates a private key and uses it to send a
-                                        PodCertificateRequest to the named signer.  Once the signer approves the
-                                        request and issues a certificate chain, Kubelet writes the key and
-                                        certificate chain to the pod filesystem.  The pod does not start until
-                                        certificates have been issued for each podCertificate projected volume
-                                        source in its spec.
-
-                                        Kubelet will begin trying to rotate the certificate at the time indicated
-                                        by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                        timestamp.
-
-                                        Kubelet can write a single file, indicated by the credentialBundlePath
-                                        field, or separate files, indicated by the keyPath and
-                                        certificateChainPath fields.
-
-                                        The credential bundle is a single file in PEM format.  The first PEM
-                                        entry is the private key (in PKCS#8 format), and the remaining PEM
-                                        entries are the certificate chain issued by the signer (typically,
-                                        signers will return their certificate chain in leaf-to-root order).
-
-                                        Prefer using the credential bundle format, since your application code
-                                        can read it atomically.  If you use keyPath and certificateChainPath,
-                                        your application must make two separate file reads. If these coincide
-                                        with a certificate rotation, it is possible that the private key and leaf
-                                        certificate you read may not correspond to each other.  Your application
-                                        will need to check for this condition, and re-read until they are
-                                        consistent.
-
-                                        The named signer controls chooses the format of the certificate it
-                                        issues; consult the signer implementation's documentation to learn how to
-                                        use the certificates it issues.
                                       properties:
                                         certificateChainPath:
-                                          description: |-
-                                            Write the certificate chain at this path in the projected volume.
-
-                                            Most applications should use credentialBundlePath.  When using keyPath
-                                            and certificateChainPath, your application needs to check that the key
-                                            and leaf certificate are consistent, because it is possible to read the
-                                            files mid-rotation.
                                           type: string
                                         credentialBundlePath:
-                                          description: |-
-                                            Write the credential bundle at this path in the projected volume.
-
-                                            The credential bundle is a single file that contains multiple PEM blocks.
-                                            The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                            key.
-
-                                            The remaining blocks are CERTIFICATE blocks, containing the issued
-                                            certificate chain from the signer (leaf and any intermediates).
-
-                                            Using credentialBundlePath lets your Pod's application code make a single
-                                            atomic read that retrieves a consistent key and certificate chain.  If you
-                                            project them to separate files, your application code will need to
-                                            additionally check that the leaf certificate was issued to the key.
                                           type: string
                                         keyPath:
-                                          description: |-
-                                            Write the key at this path in the projected volume.
-
-                                            Most applications should use credentialBundlePath.  When using keyPath
-                                            and certificateChainPath, your application needs to check that the key
-                                            and leaf certificate are consistent, because it is possible to read the
-                                            files mid-rotation.
                                           type: string
                                         keyType:
-                                          description: |-
-                                            The type of keypair Kubelet will generate for the pod.
-
-                                            Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                            "ECDSAP521", and "ED25519".
                                           type: string
                                         maxExpirationSeconds:
-                                          description: |-
-                                            maxExpirationSeconds is the maximum lifetime permitted for the
-                                            certificate.
-
-                                            Kubelet copies this value verbatim into the PodCertificateRequests it
-                                            generates for this projection.
-
-                                            If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                            will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                            value is 7862400 (91 days).
-
-                                            The signer implementation is then free to issue a certificate with any
-                                            lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                            seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                            `kubernetes.io` signers will never issue certificates with a lifetime
-                                            longer than 24 hours.
                                           format: int32
                                           type: integer
                                         signerName:
-                                          description: Kubelet's generated CSRs will be addressed to this signer.
                                           type: string
                                         userAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            userAnnotations allow pod authors to pass additional information to
-                                            the signer implementation.  Kubernetes does not restrict or validate this
-                                            metadata in any way.
-
-                                            These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
-                                            the PodCertificateRequest objects that Kubelet creates.
-
-                                            Entries are subject to the same validation as object metadata annotations,
-                                            with the addition that all keys must be domain-prefixed. No restrictions
-                                            are placed on values, except an overall size limitation on the entire field.
-
-                                            Signers should document the keys and values they support. Signers should
-                                            deny requests that contain keys they do not recognize.
                                           type: object
                                       required:
                                         - keyType
                                         - signerName
                                       type: object
                                     secret:
-                                      description: secret information about the secret data to project
                                       properties:
                                         items:
-                                          description: |-
-                                            items if unspecified, each key-value pair in the Data field of the referenced
-                                            Secret will be projected into the volume as a file whose name is the
-                                            key and content is the value. If specified, the listed keys will be
-                                            projected into the specified paths, and unlisted keys will not be
-                                            present. If a key is specified which is not present in the Secret,
-                                            the volume setup will error unless it is marked optional. Paths must be
-                                            relative and may not contain the '..' path or start with '..'.
                                           items:
-                                            description: Maps a string key to a path within a volume.
                                             properties:
                                               key:
-                                                description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: |-
-                                                  mode is Optional: mode bits used to set permissions on this file.
-                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                  If not specified, the volume defaultMode will be used.
-                                                  This might be in conflict with other options that affect the file
-                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: |-
-                                                  path is the relative path of the file to map the key to.
-                                                  May not be an absolute path.
-                                                  May not contain the path element '..'.
-                                                  May not start with the string '..'.
                                                 type: string
                                             required:
                                               - key
@@ -3961,42 +1892,19 @@ spec:
                                           x-kubernetes-list-type: atomic
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                           type: string
                                         optional:
-                                          description: optional field specify whether the Secret or its key must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     serviceAccountToken:
-                                      description: serviceAccountToken is information about the serviceAccountToken data to project
                                       properties:
                                         audience:
-                                          description: |-
-                                            audience is the intended audience of the token. A recipient of a token
-                                            must identify itself with an identifier specified in the audience of the
-                                            token, and otherwise should reject the token. The audience defaults to the
-                                            identifier of the apiserver.
                                           type: string
                                         expirationSeconds:
-                                          description: |-
-                                            expirationSeconds is the requested duration of validity of the service
-                                            account token. As the token approaches expiration, the kubelet volume
-                                            plugin will proactively rotate the service account token. The kubelet will
-                                            start trying to rotate the token if the token is older than 80 percent of
-                                            its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                            and must be at least 10 minutes.
                                           format: int64
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the path relative to the mount point of the file to project the
-                                            token into.
                                           type: string
                                       required:
                                         - path
@@ -4006,176 +1914,84 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                           quobyte:
-                            description: |-
-                              quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
-                              Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                             properties:
                               group:
-                                description: |-
-                                  group to map volume access to
-                                  Default is no group
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                  Defaults to false.
                                 type: boolean
                               registry:
-                                description: |-
-                                  registry represents a single or multiple Quobyte Registry services
-                                  specified as a string as host:port pair (multiple entries are separated with commas)
-                                  which acts as the central registry for volumes
                                 type: string
                               tenant:
-                                description: |-
-                                  tenant owning the given Quobyte volume in the Backend
-                                  Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                 type: string
                               user:
-                                description: |-
-                                  user to map volume access to
-                                  Defaults to serivceaccount user
                                 type: string
                               volume:
-                                description: volume is a string that references an already created Quobyte volume by name.
                                 type: string
                             required:
                               - registry
                               - volume
                             type: object
                           rbd:
-                            description: |-
-                              rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                              Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type of the volume that you want to mount.
-                                  Tip: Ensure that the filesystem type is supported by the host operating system.
-                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                 type: string
                               image:
-                                description: |-
-                                  image is the rados image name.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                               keyring:
                                 default: /etc/ceph/keyring
-                                description: |-
-                                  keyring is the path to key ring for RBDUser.
-                                  Default is /etc/ceph/keyring.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                               monitors:
-                                description: |-
-                                  monitors is a collection of Ceph monitors.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
                                 default: rbd
-                                description: |-
-                                  pool is the rados pool name.
-                                  Default is rbd.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly here will force the ReadOnly setting in VolumeMounts.
-                                  Defaults to false.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: boolean
                               secretRef:
-                                description: |-
-                                  secretRef is name of the authentication secret for RBDUser. If provided
-                                  overrides keyring.
-                                  Default is nil.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
                                 default: admin
-                                description: |-
-                                  user is the rados user name.
-                                  Default is admin.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                 type: string
                             required:
                               - image
                               - monitors
                             type: object
                           scaleIO:
-                            description: |-
-                              scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
-                              Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                             properties:
                               fsType:
                                 default: xfs
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs".
-                                  Default is "xfs".
                                 type: string
                               gateway:
-                                description: gateway is the host address of the ScaleIO API Gateway.
                                 type: string
                               protectionDomain:
-                                description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly Defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretRef:
-                                description: |-
-                                  secretRef references to the secret for ScaleIO user and other
-                                  sensitive information. If this is not provided, Login operation will fail.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               sslEnabled:
-                                description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                 type: boolean
                               storageMode:
                                 default: ThinProvisioned
-                                description: |-
-                                  storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                  Default is ThinProvisioned.
                                 type: string
                               storagePool:
-                                description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                 type: string
                               system:
-                                description: system is the name of the storage system as configured in ScaleIO.
                                 type: string
                               volumeName:
-                                description: |-
-                                  volumeName is the name of a volume already created in the ScaleIO system
-                                  that is associated with this volume source.
                                 type: string
                             required:
                               - gateway
@@ -4183,52 +1999,19 @@ spec:
                               - system
                             type: object
                           secret:
-                            description: |-
-                              secret represents a secret that should populate this volume.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                             properties:
                               defaultMode:
-                                description: |-
-                                  defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values
-                                  for mode bits. Defaults to 0644.
-                                  Directories within the path are not affected by this setting.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               items:
-                                description: |-
-                                  items If unspecified, each key-value pair in the Data field of the referenced
-                                  Secret will be projected into the volume as a file whose name is the
-                                  key and content is the value. If specified, the listed keys will be
-                                  projected into the specified paths, and unlisted keys will not be
-                                  present. If a key is specified which is not present in the Secret,
-                                  the volume setup will error unless it is marked optional. Paths must be
-                                  relative and may not contain the '..' path or start with '..'.
                                 items:
-                                  description: Maps a string key to a path within a volume.
                                   properties:
                                     key:
-                                      description: key is the key to project.
                                       type: string
                                     mode:
-                                      description: |-
-                                        mode is Optional: mode bits used to set permissions on this file.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        If not specified, the volume defaultMode will be used.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     path:
-                                      description: |-
-                                        path is the relative path of the file to map the key to.
-                                        May not be an absolute path.
-                                        May not contain the path element '..'.
-                                        May not start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -4237,81 +2020,37 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               optional:
-                                description: optional field specify whether the Secret or its keys must be defined
                                 type: boolean
                               secretName:
-                                description: |-
-                                  secretName is the name of the secret in the pod's namespace to use.
-                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                 type: string
                             type: object
                           storageos:
-                            description: |-
-                              storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
-                              Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is the filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               readOnly:
-                                description: |-
-                                  readOnly defaults to false (read/write). ReadOnly here will force
-                                  the ReadOnly setting in VolumeMounts.
                                 type: boolean
                               secretRef:
-                                description: |-
-                                  secretRef specifies the secret to use for obtaining the StorageOS API
-                                  credentials.  If not specified, default values will be attempted.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               volumeName:
-                                description: |-
-                                  volumeName is the human-readable name of the StorageOS volume.  Volume
-                                  names are only unique within a namespace.
                                 type: string
                               volumeNamespace:
-                                description: |-
-                                  volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                  namespace is specified then the Pod's namespace will be used.  This allows the
-                                  Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                  Set VolumeName to any name to override the default behaviour.
-                                  Set to "default" if you are not using namespaces within StorageOS.
-                                  Namespaces that do not pre-exist within StorageOS will be created.
                                 type: string
                             type: object
                           vsphereVolume:
-                            description: |-
-                              vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
-                              Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
-                              are redirected to the csi.vsphere.vmware.com CSI driver.
                             properties:
                               fsType:
-                                description: |-
-                                  fsType is filesystem type to mount.
-                                  Must be a filesystem type supported by the host operating system.
-                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                 type: string
                               storagePolicyID:
-                                description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                 type: string
                               storagePolicyName:
-                                description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                 type: string
                               volumePath:
-                                description: volumePath is the path that identifies vSphere volume vmdk
                                 type: string
                             required:
                               - volumePath
@@ -4325,106 +2064,53 @@ spec:
                       x-kubernetes-list-type: map
                   type: object
                 registrarImage:
-                  description: |-
-                    RegistrarImage is the image configuration for the CSI node driver registrar sidecar.
-                    Default image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1
                   properties:
                     jmxEnabled:
-                      description: |-
-                        Define whether the Agent image should support JMX.
-                        To be used if the `Name` field does not correspond to a full image string.
                       type: boolean
                     name:
-                      description: |-
-                        Defines the Agent image name for the pod. You can provide this as:
-                        * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
-                        for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
-                        * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
-                        and `[key].image.jmxEnabled` are ignored.
-                        * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
-                          like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
                       type: string
                     pullPolicy:
-                      description: |-
-                        The Kubernetes pull policy:
-                        Use `Always`, `Never`, or `IfNotPresent`.
                       type: string
                     pullSecrets:
-                      description: |-
-                        It is possible to specify Docker registry credentials.
-                        See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
                       items:
-                        description: |-
-                          LocalObjectReference contains enough information to let you locate the
-                          referenced object inside the same namespace.
                         properties:
                           name:
                             default: ""
-                            description: |-
-                              Name of the referent.
-                              This field is effectively required, but due to backwards compatibility is
-                              allowed to be empty. Instances of this type with an empty value here are
-                              almost certainly wrong.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
                       type: array
                     tag:
-                      description: |-
-                        Define the image tag to use.
-                        To be used if the `Name` field does not correspond to a full image string.
                       type: string
                   type: object
               type: object
             status:
-              description: DatadogCSIDriverStatus defines the observed state of DatadogCSIDriver
               properties:
                 conditions:
-                  description: Conditions represents the latest available observations of the DatadogCSIDriver's current state.
                   items:
-                    description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
                       lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                         format: date-time
                         type: string
                       message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
                         maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
                         format: int64
                         minimum: 0
                         type: integer
                       reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
                         maxLength: 1024
                         minLength: 1
                         pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                         type: string
                       status:
-                        description: status of the condition, one of True, False, Unknown.
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                         type: string
                       type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -4440,45 +2126,33 @@ spec:
                     - type
                   x-kubernetes-list-type: map
                 csiDriverName:
-                  description: CSIDriverName is the name of the managed CSIDriver Kubernetes object.
                   type: string
                 daemonSet:
-                  description: DaemonSet tracks the status of the CSI driver DaemonSet.
                   properties:
                     available:
-                      description: Number of available pods in the DaemonSet.
                       format: int32
                       type: integer
                     current:
-                      description: Number of current pods in the DaemonSet.
                       format: int32
                       type: integer
                     currentHash:
-                      description: CurrentHash is the stored hash of the DaemonSet.
                       type: string
                     daemonsetName:
-                      description: DaemonsetName corresponds to the name of the created DaemonSet.
                       type: string
                     desired:
-                      description: Number of desired pods in the DaemonSet.
                       format: int32
                       type: integer
                     lastUpdate:
-                      description: LastUpdate is the last time the status was updated.
                       format: date-time
                       type: string
                     ready:
-                      description: Number of ready pods in the DaemonSet.
                       format: int32
                       type: integer
                     state:
-                      description: State corresponds to the DaemonSet state.
                       type: string
                     status:
-                      description: Status corresponds to the DaemonSet computed status.
                       type: string
                     upToDate:
-                      description: Number of up to date pods in the DaemonSet.
                       format: int32
                       type: integer
                   required:
@@ -4489,7 +2163,6 @@ spec:
                     - upToDate
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed for this resource.
                   format: int64
                   type: integer
               type: object


### PR DESCRIPTION
#### What this PR does / why we need it:
* 62a7be791345d0f5d1298685d7273724948a8ae2 Updates the CRD script:
    * Include csidrivers
    * Guard stripping on scalar field to avoid dropping an entry that is not a description
* Uses the updated script to perform the cleaning

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits