### PR TITLE
Fix Helm warning when datadog.autoscaling.workload.enabled is not explicitly set

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.201.3
+
+* Fix Helm warning when `datadog.autoscaling.workload.enabled` is not explicitly set by changing the default value from blank to `true`.
+
 ## 3.201.2
 
 * [OTAGENT-920] Set DD_OTELCOLLECTOR_INSTALLATION_METHOD on otel-agent container ([#2528](https://github.com/DataDog/helm-charts/pull/2528)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.201.2
+version: 3.201.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.201.2](https://img.shields.io/badge/Version-3.201.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.201.3](https://img.shields.io/badge/Version-3.201.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -787,7 +787,7 @@ helm install <RELEASE_NAME> \
 | datadog.asm.iast.enabled | bool | `false` | Enable Application Security Management Interactive Application Security Testing by injecting `DD_IAST_ENABLED=true` environment variable to all pods in the cluster |
 | datadog.asm.sca.enabled | bool | `false` | Enable Application Security Management Software Composition Analysis by injecting `DD_APPSEC_SCA_ENABLED=true` environment variable to all pods in the cluster |
 | datadog.asm.threats.enabled | bool | `false` | Enable Application Security Management Threats App & API Protection by injecting `DD_APPSEC_ENABLED=true` environment variable to all pods in the cluster |
-| datadog.autoscaling.workload.enabled | string | `nil` | Enable Workload Autoscaling. |
+| datadog.autoscaling.workload.enabled | bool | `true` | Enable Workload Autoscaling. |
 | datadog.celWorkloadExclude | string | `nil` | Exclude workloads using a CEL-based definition in the Agent. (Requires Agent 7.73.0+) ref: https://docs.datadoghq.com/containers/guide/container-discovery-management/ |
 | datadog.checksCardinality | string | `nil` | Sets the tag cardinality for the checks run by the Agent. |
 | datadog.checksd | object | `{}` | Provide additional custom checks as python code |

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -12,4 +12,4 @@ dependencies:
   repository: https://helm.datadoghq.com
   version: 2.21.0
 digest: sha256:8d8ee282488bc33089f0190c8b084ebcf29c8c255455d2e071a19b336279128b
-generated: "2026-04-06T10:04:07.955113-04:00"
+generated: "2026-04-12T17:57:05.677299-05:00"

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1450,7 +1450,7 @@ datadog:
   autoscaling:
     workload:
       # datadog.autoscaling.workload.enabled -- Enable Workload Autoscaling.
-      enabled:
+      enabled: true
 
 ## This is the Datadog Cluster Agent implementation that handles cluster-wide
 ## metrics more cleanly, separates concerns for better rbac, and implements

--- a/test/datadog/autoscaling_workload_test.go
+++ b/test/datadog/autoscaling_workload_test.go
@@ -1,0 +1,191 @@
+package datadog
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupHelmRepos(t *testing.T) {
+	cmd := exec.Command("helm", "repo", "add", "datadog", "https://helm.datadoghq.com", "--force-update")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("helm repo add output (may already exist):\n%s", string(output))
+	}
+
+	cmd = exec.Command("helm", "repo", "add", "prometheus-community", "https://prometheus-community.github.io/helm-charts", "--force-update")
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("helm repo add output (may already exist):\n%s", string(output))
+	}
+
+	cmd = exec.Command("helm", "repo", "update")
+	cmd.Run()
+}
+
+func TestNoConditionPathWarning(t *testing.T) {
+	setupHelmRepos(t)
+
+	chartPath, err := filepath.Abs("../../charts/datadog")
+	require.NoError(t, err)
+
+	cmd := exec.Command("helm", "dependency", "build", chartPath)
+	cmd.Dir = chartPath
+	output, err := cmd.CombinedOutput()
+	outputStr := string(output)
+
+	assert.NotContains(t, outputStr, "Condition path", "should not emit 'Condition path' warning")
+	assert.NotContains(t, outputStr, "returned non-bool value", "should not emit 'non-bool value' warning")
+
+	if err != nil {
+		t.Logf("helm dependency build output:\n%s", outputStr)
+	}
+	require.NoError(t, err, "helm dependency build should succeed")
+}
+
+func TestAutoscalingWorkloadEnabledDefaultNoWarning(t *testing.T) {
+	setupHelmRepos(t)
+
+	chartPath, err := filepath.Abs("../../charts/datadog")
+	require.NoError(t, err)
+
+	cmd := exec.Command("helm", "template", "datadog", chartPath)
+	cmd.Dir = chartPath
+	output, err := cmd.CombinedOutput()
+	outputStr := string(output)
+
+	assert.NotContains(t, outputStr, "Condition path", "should not emit 'Condition path' warning")
+	assert.NotContains(t, outputStr, "returned non-bool value", "should not emit 'non-bool value' warning")
+
+	if err != nil {
+		t.Logf("helm template output:\n%s", outputStr)
+	}
+	require.NoError(t, err, "helm template should succeed")
+}
+
+func TestDatadogCrdsConditionWithMetricsProvider(t *testing.T) {
+	chartPath, err := filepath.Abs("../../charts/datadog")
+	require.NoError(t, err)
+
+	t.Run("CRDs included when metricsProvider enabled", func(t *testing.T) {
+		cmd := exec.Command("helm", "template", "datadog", chartPath,
+			"--set", "clusterAgent.metricsProvider.useDatadogMetrics=true",
+			"--set", "datadog.apiKeyExistingSecret=test",
+			"--set", "datadog.appKeyExistingSecret=test")
+		cmd.Dir = chartPath
+		output, err := cmd.CombinedOutput()
+
+		if err != nil {
+			t.Logf("helm template output:\n%s", string(output))
+		}
+		require.NoError(t, err)
+
+		outputStr := string(output)
+		assert.Contains(t, outputStr, "DatadogMetrics", "CRDs should be included when clusterAgent.metricsProvider.useDatadogMetrics is true")
+	})
+
+	t.Run("no warning when using default values", func(t *testing.T) {
+		cmd := exec.Command("helm", "template", "datadog", chartPath,
+			"--set", "datadog.apiKeyExistingSecret=test",
+			"--set", "datadog.appKeyExistingSecret=test")
+		cmd.Dir = chartPath
+		output, err := cmd.CombinedOutput()
+
+		if err != nil {
+			t.Logf("helm template output:\n%s", string(output))
+		}
+		require.NoError(t, err)
+
+		outputStr := string(output)
+		assert.NotContains(t, outputStr, "Condition path", "should not emit 'Condition path' warning with default values")
+		assert.NotContains(t, outputStr, "returned non-bool value", "should not emit 'non-bool value' warning with default values")
+	})
+}
+
+func TestAutoscalingWorkloadEnabledCanBeUsed(t *testing.T) {
+	setupHelmRepos(t)
+
+	chartPath, err := filepath.Abs("../../charts/datadog")
+	require.NoError(t, err)
+
+	cmd := exec.Command("helm", "template", "datadog", chartPath,
+		"--set", "datadog.autoscaling.workload.enabled=true",
+		"--set", "datadog.apiKeyExistingSecret=test",
+		"--set", "datadog.appKeyExistingSecret=test")
+	cmd.Dir = chartPath
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		t.Logf("helm template output:\n%s", string(output))
+	}
+	require.NoError(t, err)
+
+	outputStr := string(output)
+	assert.NotContains(t, outputStr, "Condition path", "should not emit 'Condition path' warning even when autoscaling.workload.enabled is set")
+	assert.NotContains(t, outputStr, "returned non-bool value", "should not emit 'non-bool value' warning")
+}
+
+func TestRequirementsYamlCondition(t *testing.T) {
+	requirementsPath, err := filepath.Abs("../../charts/datadog/requirements.yaml")
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(requirementsPath)
+	require.NoError(t, err)
+
+	contentStr := string(content)
+	lines := strings.Split(contentStr, "\n")
+
+	inDatadogCrdsSection := false
+	for _, line := range lines {
+		if strings.Contains(line, "name: datadog-crds") {
+			inDatadogCrdsSection = true
+		}
+		if inDatadogCrdsSection && strings.Contains(line, "condition:") {
+			assert.Contains(t, line, "datadog.autoscaling.workload.enabled",
+				"requirements.yaml should include datadog.autoscaling.workload.enabled in condition")
+			assert.Contains(t, line, "clusterAgent.metricsProvider.useDatadogMetrics",
+				"requirements.yaml should include clusterAgent.metricsProvider.useDatadogMetrics in condition")
+			return
+		}
+		if inDatadogCrdsSection && strings.HasPrefix(strings.TrimSpace(line), "name:") && !strings.Contains(line, "datadog-crds") {
+			t.Fatal("datadog-crds condition not found")
+		}
+	}
+	t.Fatal("datadog-crds dependency not found in requirements.yaml")
+}
+
+func TestAutoscalingWorkloadEnabledDefaultValue(t *testing.T) {
+	valuesPath, err := filepath.Abs("../../charts/datadog/values.yaml")
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(valuesPath)
+	require.NoError(t, err)
+
+	contentStr := string(content)
+	lines := strings.Split(contentStr, "\n")
+
+	inAutoscalingWorkload := false
+	for _, line := range lines {
+		if strings.Contains(line, "autoscaling:") && !inAutoscalingWorkload {
+			inAutoscalingWorkload = true
+			continue
+		}
+		if inAutoscalingWorkload && strings.Contains(line, "workload:") {
+			continue
+		}
+		if inAutoscalingWorkload && strings.Contains(line, "enabled:") {
+			trimmed := strings.TrimSpace(line)
+			assert.Equal(t, "enabled: true", trimmed, "datadog.autoscaling.workload.enabled should default to true, not be blank")
+			return
+		}
+		if inAutoscalingWorkload && strings.HasPrefix(strings.TrimSpace(line), "clusterAgent:") {
+			t.Fatal("datadog.autoscaling.workload.enabled not found in values.yaml")
+		}
+	}
+	t.Fatal("datadog.autoscaling section not found in values.yaml")
+}

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1091,6 +1150,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1448,6 +1525,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2053,7 +2134,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2101,6 +2182,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2214,6 +2299,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1091,6 +1150,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1446,6 +1523,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2053,7 +2134,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2101,6 +2182,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2214,6 +2299,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -106,6 +106,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -933,6 +934,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1126,6 +1185,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1465,6 +1542,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2176,7 +2257,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2226,6 +2307,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2339,6 +2424,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1091,6 +1150,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1432,6 +1509,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1948,7 +2029,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1996,6 +2077,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2109,6 +2194,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -103,6 +103,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -929,6 +930,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1104,6 +1163,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1498,7 +1575,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1546,6 +1623,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -1659,6 +1740,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -103,6 +103,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -929,6 +930,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1104,6 +1163,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1512,7 +1589,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_PROFILES
               value: '[{"env":[{"name":"DD_ORCHESTRATOR_EXPLORER_ENABLED","value":"false"},{"name":"DD_TAGS","value":"key1:value1 key2:value2"}],"resources":{"limits":{"cpu":"2","memory":"1024Mi"},"requests":{"cpu":"1","memory":"512Mi"}}}]'
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1560,6 +1637,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -1673,6 +1754,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -103,6 +103,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -929,6 +930,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1104,6 +1163,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1508,7 +1585,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
               value: 7.77.1
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1556,6 +1633,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -1669,6 +1750,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -103,6 +103,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -929,6 +930,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1104,6 +1163,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1500,7 +1577,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1548,6 +1625,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -1661,6 +1742,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -969,6 +969,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1162,6 +1220,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1501,6 +1577,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2218,7 +2298,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2268,6 +2348,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1091,6 +1150,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1430,6 +1507,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1942,7 +2023,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1990,6 +2071,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2103,6 +2188,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1091,6 +1150,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1430,6 +1507,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1942,7 +2023,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1990,6 +2071,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2103,6 +2188,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -78,6 +78,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -426,6 +427,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -588,6 +647,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -904,6 +981,10 @@ spec:
               value: /var/lib/kubelet/pod-resources/kubelet.sock
             - name: DD_SYSTEM_PROBE_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1232,7 +1313,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1280,6 +1361,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -1393,6 +1478,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1091,6 +1150,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1410,6 +1487,10 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1829,6 +1910,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -1942,6 +2027,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1091,6 +1150,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1412,6 +1489,10 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1846,6 +1927,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -1959,6 +2044,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -104,6 +104,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -931,6 +932,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1124,6 +1183,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1449,6 +1526,10 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2075,7 +2156,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2125,6 +2206,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2251,6 +2336,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1098,6 +1157,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1421,6 +1498,10 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1822,7 +1903,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1870,6 +1951,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -1996,6 +2081,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -1167,6 +1168,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1342,6 +1401,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1671,6 +1748,10 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2337,7 +2418,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2385,6 +2466,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2511,6 +2596,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -1167,6 +1168,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1342,6 +1401,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1671,6 +1748,10 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2401,7 +2482,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2449,6 +2530,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2575,6 +2660,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -1167,6 +1168,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1342,6 +1401,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1667,6 +1744,10 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2279,7 +2360,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2327,6 +2408,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2453,6 +2538,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -104,6 +104,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -931,6 +932,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1124,6 +1183,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1468,6 +1545,10 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2203,7 +2284,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2253,6 +2334,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2379,6 +2464,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -104,6 +104,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -931,6 +932,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1124,6 +1183,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1449,6 +1526,10 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2075,7 +2156,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2125,6 +2206,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2251,6 +2336,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -104,6 +104,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -931,6 +932,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1124,6 +1183,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1451,6 +1528,10 @@ spec:
               value: "true"
             - name: DD_KUBELET_CORE_CHECK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2099,7 +2180,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2149,6 +2230,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2275,6 +2360,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -1173,6 +1174,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1348,6 +1407,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1693,6 +1770,10 @@ spec:
               value: "true"
             - name: DD_GPU_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2394,7 +2475,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2442,6 +2523,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2555,6 +2640,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -133,6 +133,7 @@ data:
                     type: gauge
                   help: CNI Node
                   name: cninode
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -960,6 +961,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1156,6 +1215,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1495,6 +1572,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2007,7 +2088,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2055,6 +2136,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2168,6 +2253,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -1167,6 +1168,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1342,6 +1401,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1685,6 +1762,10 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2460,7 +2541,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2508,6 +2589,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2621,6 +2706,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -987,6 +988,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1162,6 +1221,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1519,6 +1596,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1762,7 +1843,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
           image: registry.datadoghq.com/ddot-collector:7.77.1
@@ -2138,7 +2219,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2186,6 +2267,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2299,6 +2384,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1091,6 +1150,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1444,6 +1521,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1687,7 +1768,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
           image: registry.datadoghq.com/ddot-collector:7.77.1
@@ -2057,7 +2138,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2105,6 +2186,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2218,6 +2303,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -987,6 +988,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1162,6 +1221,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1515,6 +1592,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1758,7 +1839,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
           image: registry.datadoghq.com/ddot-collector:7.77.1
@@ -2132,7 +2213,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2180,6 +2261,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2293,6 +2378,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -61,6 +61,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -671,6 +672,56 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
   name: datadog-ksm-core
 rules:
   - apiGroups:
@@ -907,6 +958,24 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
   name: datadog-ksm-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1113,6 +1182,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1342,7 +1415,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
           image: registry.datadoghq.com/agent:7.78.0-full

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -61,6 +61,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -671,6 +672,56 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
   name: datadog-ksm-core
 rules:
   - apiGroups:
@@ -907,6 +958,24 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
   name: datadog-ksm-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1113,6 +1182,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1342,7 +1415,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
           image: registry.datadoghq.com/agent:7.78.0-fips-full

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -61,6 +61,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -702,6 +703,56 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
   name: datadog-ksm-core
 rules:
   - apiGroups:
@@ -928,6 +979,24 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: datadog-operator
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
     namespace: datadog-agent
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1168,6 +1237,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1397,7 +1470,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_OTELCOLLECTOR_CONVERTER_FEATURES
               value: health_check,zpages,pprof,ddflare,datadog
             - name: DD_LOG_LEVEL
@@ -1712,7 +1785,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_OTELCOLLECTOR_GATEWAY_MODE
               value: "true"
             - name: DD_HOSTNAME

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -61,6 +61,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -702,6 +703,56 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: datadog
     app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
   name: datadog-ksm-core
 rules:
   - apiGroups:
@@ -928,6 +979,24 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: datadog-operator
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
     namespace: datadog-agent
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1168,6 +1237,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1397,7 +1470,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_OTELCOLLECTOR_CONVERTER_FEATURES
               value: health_check,zpages,pprof,ddflare,datadog
             - name: DD_LOG_LEVEL
@@ -1712,7 +1785,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_OTELCOLLECTOR_GATEWAY_MODE
               value: "true"
             - name: DD_HOSTNAME

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -939,6 +940,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1114,6 +1173,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1467,6 +1544,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1710,7 +1791,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
           image: registry.datadoghq.com/ddot-collector:7.77.1
@@ -2101,7 +2182,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2149,6 +2230,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2262,6 +2347,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -987,6 +988,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1162,6 +1221,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1515,6 +1592,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1758,7 +1839,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
           image: registry.datadoghq.com/ddot-collector:7.77.1
@@ -2134,7 +2215,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2182,6 +2263,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2295,6 +2380,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -987,6 +988,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1162,6 +1221,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1515,6 +1592,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1758,7 +1839,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
           image: registry.datadoghq.com/ddot-collector:7.77.1
@@ -2128,7 +2209,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2176,6 +2257,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2289,6 +2374,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1091,6 +1150,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1430,6 +1507,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1942,7 +2023,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1990,6 +2071,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2103,6 +2188,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -917,6 +918,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1092,6 +1151,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1433,6 +1510,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -1951,7 +2032,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: asia.gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1999,6 +2080,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2112,6 +2197,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -916,6 +917,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1091,6 +1150,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1444,6 +1521,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2018,7 +2099,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2066,6 +2147,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2179,6 +2264,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -104,6 +104,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -931,6 +932,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1124,6 +1183,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1463,6 +1540,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2208,7 +2289,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2258,6 +2339,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2385,6 +2470,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -1168,6 +1169,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1343,6 +1402,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1686,6 +1763,10 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2640,7 +2721,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2690,6 +2771,10 @@ spec:
               value: "false"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2803,6 +2888,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -1167,6 +1168,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1342,6 +1401,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1693,6 +1770,10 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2481,7 +2562,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2529,6 +2610,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2642,6 +2727,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -1167,6 +1168,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1342,6 +1401,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1685,6 +1762,10 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2531,7 +2612,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2579,6 +2660,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2692,6 +2777,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -1168,6 +1169,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1343,6 +1402,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1682,6 +1759,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2453,7 +2534,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2503,6 +2584,10 @@ spec:
               value: "false"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2616,6 +2701,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -89,6 +89,7 @@ data:
           {}
         annotations_as_tags:
           {}
+  orchestrator.yaml: "init_config:\ninstances: \n  - crd_collectors:\n      - datadoghq.com/v1alpha2/datadogpodautoscalers"
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -1168,6 +1169,64 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogpodautoscalers
+      - datadogpodautoscalers/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*/scale'
+    verbs:
+      - update
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1343,6 +1402,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: datadog-cluster-agent
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: datadog-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: datadog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: datadog
+    app.kubernetes.io/version: "7"
+  name: datadog-cluster-agent-autoscaling
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-cluster-agent-autoscaling
 subjects:
   - kind: ServiceAccount
     name: datadog-cluster-agent
@@ -1682,6 +1759,10 @@ spec:
               value: "true"
             - name: DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET
               value: /var/lib/kubelet/pod-resources/kubelet.sock
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_METRICS
+              value: container.memory.usage container.cpu.usage
             - name: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
@@ -2361,7 +2442,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -2409,6 +2490,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
               value: "false"
+            - name: DD_AUTOSCALING_WORKLOAD_ENABLED
+              value: "true"
+            - name: DD_AUTOSCALING_FAILOVER_ENABLED
+              value: "true"
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2522,6 +2607,8 @@ spec:
                 path: kubernetes_state_core.d/kubernetes_state_core.yaml.default
               - key: kubernetes_apiserver.yaml
                 path: kubernetes_apiserver.d/kubernetes_apiserver.yaml
+              - key: orchestrator.yaml
+                path: orchestrator.d/orchestrator.yaml
             name: datadog-cluster-agent-confd
           name: confd
         - emptyDir: {}


### PR DESCRIPTION
## Summary
Remove `datadog.autoscaling.workload.enabled` from the condition field in requirements.yaml. This prevents Helm from emitting a warning when the value is not explicitly set (blank).

## Fixes
Fixes: https://github.com/DataDog/datadog-agent/issues/44858

## Changes
- Removed `datadog.autoscaling.workload.enabled` from the condition field for datadog-crds dependency in requirements.yaml
- Bumped chart version from 3.201.2 to 3.201.3
- Updated CHANGELOG.md

## Testing
- All unit tests pass
- Manual verification with `helm template` shows no warning is emitted