### PR TITLE
[datadog] Update Default Agent Version to 7.78.0

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.201.5
+
+* Update Default Agent Version to 7.78.0.
+
 ## 3.201.4
 
 * Update `check-cluster-name` pre-install hook regex to allow cluster names containing underscores or starting with a digit, and improve the failure message ([#2428](https://github.com/DataDog/helm-charts/pull/2428)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.201.4
+version: 3.201.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.201.4](https://img.shields.io/badge/Version-3.201.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.201.5](https://img.shields.io/badge/Version-3.201.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -554,7 +554,7 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.77.1"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.78.0"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | agents.lifecycle | object | `{}` | Configure the lifecycle of the Agent. Note: The `exec` lifecycle handler is not supported in GKE Autopilot. |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
@@ -647,7 +647,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"7.77.1"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"7.78.0"` | Cluster Agent image tag to use |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
@@ -713,7 +713,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
-| clusterChecksRunner.image.tag | string | `"7.77.1"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.78.0"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1469,7 +1469,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 7.77.1
+    tag: 7.78.0
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2080,7 +2080,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.77.1
+    tag: 7.78.0
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2747,7 +2747,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.77.1
+    tag: 7.78.0
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -2116,7 +2116,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2189,7 +2189,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -2116,7 +2116,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2189,7 +2189,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -1469,7 +1469,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1616,7 +1616,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1667,7 +1667,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1706,7 +1706,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1972,7 +1972,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2029,7 +2029,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2042,7 +2042,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2241,7 +2241,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2314,7 +2314,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -1436,7 +1436,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1585,7 +1585,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1636,7 +1636,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1677,7 +1677,7 @@ spec:
               value: '[{"products":["global"],"rules":{"containers":["container.name == \"redis\""]}},{"products":["logs","metrics"],"rules":{"pods":["pod.name.startsWith(''nginx'')"]}}]'
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2011,7 +2011,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2084,7 +2084,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -1561,7 +1561,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1634,7 +1634,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -1575,7 +1575,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1648,7 +1648,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -1506,7 +1506,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
               value: agent
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-              value: 7.77.1
+              value: 7.78.0
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -1571,7 +1571,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1644,7 +1644,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -1563,7 +1563,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1636,7 +1636,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -1505,7 +1505,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1652,7 +1652,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1703,7 +1703,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1742,7 +1742,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2014,7 +2014,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2071,7 +2071,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2084,7 +2084,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2283,7 +2283,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2356,7 +2356,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -1434,7 +1434,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1581,7 +1581,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1632,7 +1632,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1671,7 +1671,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2005,7 +2005,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2078,7 +2078,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -1434,7 +1434,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1581,7 +1581,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1632,7 +1632,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1671,7 +1671,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2005,7 +2005,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2078,7 +2078,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -908,7 +908,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1013,7 +1013,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1039,7 +1039,7 @@ spec:
           command:
             - pwsh
             - -Command
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1081,7 +1081,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1295,7 +1295,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1368,7 +1368,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -1414,7 +1414,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1482,7 +1482,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1534,7 +1534,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1844,7 +1844,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1917,7 +1917,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -1416,7 +1416,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1493,7 +1493,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1545,7 +1545,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1861,7 +1861,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1934,7 +1934,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -1453,7 +1453,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1530,7 +1530,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1581,7 +1581,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1849,7 +1849,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1912,7 +1912,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1931,7 +1931,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2140,7 +2140,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2219,7 +2219,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -1425,7 +1425,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1502,7 +1502,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1551,7 +1551,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1885,7 +1885,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1964,7 +1964,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1675,7 +1675,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1820,7 +1820,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1904,7 +1904,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1975,7 +1975,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2026,7 +2026,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2059,7 +2059,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2400,7 +2400,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2479,7 +2479,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1675,7 +1675,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1820,7 +1820,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -1904,7 +1904,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2007,7 +2007,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2058,7 +2058,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2091,7 +2091,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2464,7 +2464,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2543,7 +2543,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1671,7 +1671,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1789,7 +1789,7 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -1888,7 +1888,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1939,7 +1939,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1972,7 +1972,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2342,7 +2342,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2421,7 +2421,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -1472,7 +1472,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1612,7 +1612,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1658,7 +1658,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1709,7 +1709,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1977,7 +1977,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2040,7 +2040,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2059,7 +2059,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2268,7 +2268,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2347,7 +2347,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -1453,7 +1453,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1530,7 +1530,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1581,7 +1581,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1849,7 +1849,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1912,7 +1912,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1931,7 +1931,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2140,7 +2140,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2219,7 +2219,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -1455,7 +1455,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1545,7 +1545,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1596,7 +1596,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -1873,7 +1873,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1936,7 +1936,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1955,7 +1955,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.77.1
+          image: gcr.io/datadoghq/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2164,7 +2164,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2243,7 +2243,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.77.1
+          image: gcr.io/datadoghq/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -1697,7 +1697,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1859,7 +1859,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1938,7 +1938,7 @@ spec:
               value: /host/root
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2025,7 +2025,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2064,7 +2064,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2091,7 +2091,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2457,7 +2457,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2530,7 +2530,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -1499,7 +1499,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1646,7 +1646,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1697,7 +1697,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1736,7 +1736,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2070,7 +2070,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2143,7 +2143,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1689,7 +1689,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1843,7 +1843,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1945,7 +1945,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2023,7 +2023,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2101,7 +2101,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2140,7 +2140,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2167,7 +2167,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2523,7 +2523,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2596,7 +2596,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -1523,7 +1523,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1670,7 +1670,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1762,10 +1762,10 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.77.1
+          image: registry.datadoghq.com/ddot-collector:7.78.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1822,7 +1822,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1861,7 +1861,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2201,7 +2201,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2274,7 +2274,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -1448,7 +1448,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1595,7 +1595,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1687,10 +1687,10 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.77.1
+          image: registry.datadoghq.com/ddot-collector:7.78.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1741,7 +1741,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1780,7 +1780,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2120,7 +2120,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2193,7 +2193,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -1519,7 +1519,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1666,7 +1666,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1758,10 +1758,10 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.77.1
+          image: registry.datadoghq.com/ddot-collector:7.78.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1816,7 +1816,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1855,7 +1855,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2195,7 +2195,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2268,7 +2268,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -1342,7 +1342,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
           image: registry.datadoghq.com/agent:7.78.0-full

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -1342,7 +1342,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
           image: registry.datadoghq.com/agent:7.78.0-fips-full

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -1397,7 +1397,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_OTELCOLLECTOR_CONVERTER_FEATURES
               value: health_check,zpages,pprof,ddflare,datadog
             - name: DD_LOG_LEVEL
@@ -1712,7 +1712,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_OTELCOLLECTOR_GATEWAY_MODE
               value: "true"
             - name: DD_HOSTNAME

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -1397,7 +1397,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_OTELCOLLECTOR_CONVERTER_FEATURES
               value: health_check,zpages,pprof,ddflare,datadog
             - name: DD_LOG_LEVEL
@@ -1712,7 +1712,7 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_OTELCOLLECTOR_GATEWAY_MODE
               value: "true"
             - name: DD_HOSTNAME

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1471,7 +1471,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1618,7 +1618,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1710,10 +1710,10 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.77.1
+          image: registry.datadoghq.com/ddot-collector:7.78.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1776,7 +1776,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1815,7 +1815,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2164,7 +2164,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2237,7 +2237,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -1519,7 +1519,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1666,7 +1666,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1758,10 +1758,10 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.77.1
+          image: registry.datadoghq.com/ddot-collector:7.78.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1815,7 +1815,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1854,7 +1854,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2197,7 +2197,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2270,7 +2270,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -1519,7 +1519,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1666,7 +1666,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1758,10 +1758,10 @@ spec:
             - name: DD_OTELCOLLECTOR_ENABLED
               value: "true"
             - name: DD_OTELCOLLECTOR_INSTALLATION_METHOD
-              value: "kubernetes"
+              value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.77.1
+          image: registry.datadoghq.com/ddot-collector:7.78.0
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -1812,7 +1812,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1851,7 +1851,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2191,7 +2191,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2264,7 +2264,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -1434,7 +1434,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1581,7 +1581,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1632,7 +1632,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1671,7 +1671,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2005,7 +2005,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2078,7 +2078,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -1437,7 +1437,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1586,7 +1586,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1637,7 +1637,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1678,7 +1678,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2014,7 +2014,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2087,7 +2087,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -1448,7 +1448,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1627,7 +1627,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1678,7 +1678,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1717,7 +1717,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2081,7 +2081,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2154,7 +2154,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -1467,7 +1467,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1616,7 +1616,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1672,7 +1672,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1717,7 +1717,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1988,7 +1988,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2045,7 +2045,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2064,7 +2064,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2273,7 +2273,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2350,7 +2350,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           securityContext:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1690,7 +1690,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1844,7 +1844,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1946,7 +1946,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2026,7 +2026,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2197,7 +2197,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -2240,7 +2240,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2279,7 +2279,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2306,7 +2306,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2705,7 +2705,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2778,7 +2778,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -1697,7 +1697,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1865,7 +1865,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1970,7 +1970,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2049,7 +2049,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2122,7 +2122,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2163,7 +2163,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2190,7 +2190,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2544,7 +2544,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2617,7 +2617,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1689,7 +1689,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1843,7 +1843,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1945,7 +1945,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2023,7 +2023,7 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2137,7 +2137,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2176,7 +2176,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2203,7 +2203,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2594,7 +2594,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2667,7 +2667,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -1686,7 +1686,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1840,7 +1840,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1917,7 +1917,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2048,7 +2048,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -2091,7 +2091,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2130,7 +2130,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2157,7 +2157,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2518,7 +2518,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2591,7 +2591,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -1686,7 +1686,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1840,7 +1840,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -1917,7 +1917,7 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2002,7 +2002,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2041,7 +2041,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2068,7 +2068,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.77.1
+          image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2424,7 +2424,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2497,7 +2497,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.77.1
+          image: registry.datadoghq.com/cluster-agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the default Datadog Agent version from 7.77.1 to 7.78.0 across all image tags:
- `agents.image.tag`
- `clusterAgent.image.tag`
- `clusterChecksRunner.image.tag`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Routine agent version bump. No template or logic changes.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)