### PR TITLE
[CONTP-1629] Fix false positive outcome in csi e2e test and bump CSI driver version.

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.11.0
+## 0.10.1
 
 * Fix false positive outcome in csi e2e test ([#2579](https://github.com/DataDog/helm-charts/pull/2579)).
 * Bump CSI driver version to include bug fix ([#77](https://github.com/DataDog/datadog-csi-driver/pull/77)).

--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.10.1
+## 0.11.0
 
 * Fix false positive outcome in csi e2e test ([#2579](https://github.com/DataDog/helm-charts/pull/2579)).
 * Bump CSI driver version to include bug fix ([#77](https://github.com/DataDog/datadog-csi-driver/pull/77)).

--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.0
+
+* Fix false positive outcome in csi e2e test ([#2579](https://github.com/DataDog/helm-charts/pull/2579)).
+
 ## 0.10.0
 
 * Add `priorityClassName` support for CSI driver daemonset pods (default: `""`).

--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 0.11.0
+## 0.10.1
 
 * Fix false positive outcome in csi e2e test ([#2579](https://github.com/DataDog/helm-charts/pull/2579)).
+* Bump CSI driver version to include bug fix ([#77](https://github.com/DataDog/datadog-csi-driver/pull/77)).
 
 ## 0.10.0
 

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.11.0
+version: 0.10.1
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.10.1
+version: 0.11.0
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.10.0
+version: 0.11.0
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 
@@ -21,7 +21,7 @@ Datadog CSI Driver helm chart
 | image.pullPolicy | string | `"IfNotPresent"` | CSI driver image pullPolicy |
 | image.pullSecrets | list | `[]` | CSI driver repository pullSecret (for example: specify Docker registry credentials) |
 | image.repository | string | `"gcr.io/datadoghq/csi-driver"` | Override default registry + image.name for CSI driver |
-| image.tag | string | `"1.2.1"` | CSI driver image tag to use |
+| image.tag | string | `"1.2.2"` | CSI driver image tag to use |
 | nameOverride | string | `""` | Allows overriding the name of the chart. If set, this value replaces the default chart name. |
 | nodeAffinity | object | `{}` | Configure the nodeAffinity for the csi driver daemonset pods. |
 | nodeSelector | object | `{}` | Configure the nodeSelector for the csi driver daemonset pods. |

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 

--- a/charts/datadog-csi-driver/values.yaml
+++ b/charts/datadog-csi-driver/values.yaml
@@ -13,7 +13,7 @@ fullnameOverride: ""
 ## Define the Datadog CSI Driver image to work with
 image:
   # image.tag -- CSI driver image tag to use
-  tag: 1.2.1
+  tag: 1.2.2
 
   # image.repository -- Override default registry + image.name for CSI driver
   repository: gcr.io/datadoghq/csi-driver

--- a/test/datadog-csi-driver/baseline/CSI_Driver_annotation_and_securitycontext.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_annotation_and_securitycontext.yaml
@@ -42,7 +42,7 @@ spec:
         runAsUser: 0
       containers:
         - name: csi-node-driver
-          image: "gcr.io/datadoghq/csi-driver:1.2.1"
+          image: "gcr.io/datadoghq/csi-driver:1.2.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/test/datadog-csi-driver/baseline/CSI_Driver_default.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_default.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: csi-node-driver
-          image: "gcr.io/datadoghq/csi-driver:1.2.1"
+          image: "gcr.io/datadoghq/csi-driver:1.2.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/test/datadog-csi-driver/baseline/CSI_Driver_nodeselector_and_nodeaffinity.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_nodeselector_and_nodeaffinity.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: csi-node-driver
-          image: "gcr.io/datadoghq/csi-driver:1.2.1"
+          image: "gcr.io/datadoghq/csi-driver:1.2.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/test/e2e/datadog/e2e_gke_autopilot_csi_test.go
+++ b/test/e2e/datadog/e2e_gke_autopilot_csi_test.go
@@ -39,44 +39,56 @@ func TestGKEAutopilotCSISuite(t *testing.T) {
 }
 
 func (v *gkeAutopilotCSISuite) TestGKEAutopilotCSI() {
-
 	v.T().Log("Running GKE Autopilot CSI driver test")
 
-	chartPath, err := filepath.Abs("../../../charts/datadog-csi-driver")
-	if err != nil {
-		v.T().Fatalf("Failed to get chart path: %v", err)
-	}
-	v.T().Logf("Using CSI chart from: %s", chartPath)
+	kubeconfigPath := v.writeKubeconfig()
+	defer os.Remove(kubeconfigPath)
 
-	// Write kubeconfig to temp file
+	v.logClusterInfo()
+
+	chartPath, err := filepath.Abs("../../../charts/datadog-csi-driver")
+	require.NoError(v.T(), err, "Failed to get chart path")
+
+	v.helmInstall(chartPath, kubeconfigPath)
+	v.waitForPodsReady()
+}
+
+// writeKubeconfig writes the cluster kubeconfig to a temp file and returns the path.
+func (v *gkeAutopilotCSISuite) writeKubeconfig() string {
 	kubeconfigFile, err := os.CreateTemp("", "gke-kubeconfig-")
-	if err != nil {
-		v.T().Fatalf("Failed to create kubeconfig temp file: %v", err)
-	}
-	defer os.Remove(kubeconfigFile.Name())
+	require.NoError(v.T(), err, "Failed to create kubeconfig temp file")
 
 	kubeconfig := v.Env().KubernetesCluster.KubeConfig
-	if err := os.WriteFile(kubeconfigFile.Name(), []byte(kubeconfig), 0600); err != nil {
-		v.T().Fatalf("Failed to write kubeconfig: %v", err)
-	}
-	if err := kubeconfigFile.Close(); err != nil {
-		v.T().Fatalf("Failed to close kubeconfig file: %v", err)
-	}
+	require.NoError(v.T(), os.WriteFile(kubeconfigFile.Name(), []byte(kubeconfig), 0600), "Failed to write kubeconfig")
+	require.NoError(v.T(), kubeconfigFile.Close(), "Failed to close kubeconfig file")
 
-	// Installing the csi driver via helm
-	v.T().Log("Installing CSI driver")
-	helmCmd := exec.Command("helm", "install", "datadog-csi-driver", chartPath,
-		"--kubeconfig", kubeconfigFile.Name(),
-		"--namespace", "datadog-agent", "--create-namespace")
+	return kubeconfigFile.Name()
+}
 
-	output, err := helmCmd.CombinedOutput()
-	v.T().Logf("Helm output: %s", string(output))
+// logClusterInfo logs the Kubernetes server version for diagnosing which
+// Autopilot detection path the helm chart takes.
+func (v *gkeAutopilotCSISuite) logClusterInfo() {
+	serverVersion, err := v.Env().KubernetesCluster.Client().Discovery().ServerVersion()
 	if err != nil {
-		v.T().Fatalf("Helm install failed: %v", err)
+		v.T().Logf("Failed to get server version: %v", err)
+		return
 	}
-	v.T().Log("CSI driver installed")
+	v.T().Logf("Kubernetes server version: %s (Major=%s Minor=%s)", serverVersion.GitVersion, serverVersion.Major, serverVersion.Minor)
+}
 
-	// Check if CSI driver pods exist
+// helmInstall installs the CSI driver chart via helm.
+func (v *gkeAutopilotCSISuite) helmInstall(chartPath, kubeconfigPath string) {
+	helmCmd := exec.Command("helm", "install", "datadog-csi-driver", chartPath,
+		"--kubeconfig", kubeconfigPath,
+		"--namespace", "datadog-agent", "--create-namespace")
+	output, err := helmCmd.CombinedOutput()
+	v.T().Logf("Helm install output: %s", string(output))
+	require.NoError(v.T(), err, "Helm install failed")
+}
+
+// waitForPodsReady polls for CSI driver pods and asserts that every container
+// in every pod is ready with zero restarts.
+func (v *gkeAutopilotCSISuite) waitForPodsReady() {
 	assert.EventuallyWithTf(v.T(), func(c *assert.CollectT) {
 		listOptions := metav1.ListOptions{LabelSelector: "app=datadog-csi-driver-node-server"}
 		res, err := v.Env().KubernetesCluster.Client().CoreV1().Pods("datadog-agent").List(context.TODO(), listOptions)
@@ -84,15 +96,72 @@ func (v *gkeAutopilotCSISuite) TestGKEAutopilotCSI() {
 
 		assert.True(c, len(res.Items) > 0, "No CSI driver pods found")
 
-		runningPods := 0
+		allReady := true
 		for _, pod := range res.Items {
-			if pod.Status.Phase == corev1.PodPhase("Running") {
-				runningPods++
+			assert.NotEmpty(c, pod.Status.ContainerStatuses, "pod %s has no container statuses yet", pod.Name)
+			for _, cs := range pod.Status.ContainerStatuses {
+				if !cs.Ready || cs.RestartCount > 0 {
+					allReady = false
+					v.T().Logf("Pod %s container %s: ready=%v restarts=%d", pod.Name, cs.Name, cs.Ready, cs.RestartCount)
+					v.logContainerState(cs)
+				}
+				assert.True(c, cs.Ready, "container %s in pod %s is not ready", cs.Name, pod.Name)
+				assert.Zero(c, cs.RestartCount, "container %s in pod %s has restarted %d times", cs.Name, pod.Name, cs.RestartCount)
 			}
 		}
 
-		assert.Equal(c, len(res.Items), runningPods, "All CSI driver pods are not running")
-
+		if !allReady {
+			v.logFailureDiagnostics(res.Items)
+		}
 	}, 5*time.Minute, 30*time.Second, "CSI Driver readiness timed out")
+}
 
+// logContainerState logs the waiting/terminated state of an unhealthy container.
+func (v *gkeAutopilotCSISuite) logContainerState(cs corev1.ContainerStatus) {
+	if cs.State.Waiting != nil {
+		v.T().Logf("  state: waiting reason=%s message=%s", cs.State.Waiting.Reason, cs.State.Waiting.Message)
+	}
+	if cs.State.Terminated != nil {
+		v.T().Logf("  state: terminated reason=%s exitCode=%d", cs.State.Terminated.Reason, cs.State.Terminated.ExitCode)
+	}
+	if cs.LastTerminationState.Terminated != nil {
+		v.T().Logf("  lastTermination: reason=%s exitCode=%d", cs.LastTerminationState.Terminated.Reason, cs.LastTerminationState.Terminated.ExitCode)
+	}
+}
+
+// logFailureDiagnostics collects container logs and namespace events when pods
+// are unhealthy, to help diagnose the root cause.
+func (v *gkeAutopilotCSISuite) logFailureDiagnostics(pods []corev1.Pod) {
+	tailLines := int64(30)
+	for _, pod := range pods {
+		for _, container := range pod.Spec.Containers {
+			for _, previous := range []bool{false, true} {
+				label := "current"
+				if previous {
+					label = "previous"
+				}
+				logs, err := v.Env().KubernetesCluster.Client().CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+					Container: container.Name,
+					TailLines: &tailLines,
+					Previous:  previous,
+				}).Do(context.TODO()).Raw()
+				if err != nil {
+					continue
+				}
+				if len(logs) > 0 {
+					v.T().Logf("%s logs %s/%s:\n%s", label, pod.Name, container.Name, string(logs))
+				}
+			}
+		}
+	}
+
+	events, err := v.Env().KubernetesCluster.Client().CoreV1().Events("datadog-agent").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+	for _, event := range events.Items {
+		if event.Type != "Normal" {
+			v.T().Logf("Event %s %s/%s: %s - %s", event.Type, event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Reason, event.Message)
+		}
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

The CSI e2e tests were possibly passing when they should fail (false positive).

The issue was caused by the fact that we report success in case the csi pod has `pod.Phase="Running"`, without making sure we assert all pod containers are in good shape (no errors/restarts).

This PR fixes this issue and adds more logging to the e2e test to help with future investigations.

If also bumps the CSI driver version to one that passes the e2e tests for gke autopilot.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits