### PR TITLE
[datadog-operator] Test Automation: Operator RC1

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.22.0-dev.1
+
+* Update Datadog Operator chart for 1.26.0-rc.1.
+
 ## 2.21.1
 
 * Bump `datadog-crds` chart to 2.18.1, no-op change.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.18.1
-digest: sha256:74678cb7de4754c022a1eb1bc60fb4f7ed96fa4742b55bb420c61bd85490c019
-generated: "2026-04-08T15:31:36.632134-04:00"
+  version: 2.20.0-dev.2
+digest: sha256:151ad6fffe935f6be21a2ecd60a86c5b3a5e18531c09c9c0e6a4040ae814d730
+generated: "2026-04-20T14:09:00.749556-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.21.1
-appVersion: 1.25.0
+version: 2.22.0-dev.1
+appVersion: 1.26.0-rc.1
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: 2.18.1
+  version: 2.20.0-dev.2
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.21.1](https://img.shields.io/badge/Version-2.21.1-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
+![Version: 2.22.0-dev.1](https://img.shields.io/badge/Version-2.22.0--dev.1-informational?style=flat-square) ![AppVersion: 1.26.0-rc.1](https://img.shields.io/badge/AppVersion-1.26.0--rc.1-informational?style=flat-square)
 
 ## Values
 
@@ -39,7 +39,7 @@
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"registry.datadoghq.com/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.25.0"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.26.0-rc.1"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |

--- a/charts/datadog-operator/templates/_helpers.tpl
+++ b/charts/datadog-operator/templates/_helpers.tpl
@@ -186,6 +186,6 @@ Check operator image tag version.
 {{- $parts := split "@" $tag -}}
 {{- index $parts "_0"}}
 {{- else -}}
-{{ "1.25.0" }}
+{{ "1.26.0-rc.1" }}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -68,6 +68,18 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/resize
+  verbs:
+  - patch
+- apiGroups:
   - '*'
   resources:
   - '*/scale'
@@ -100,7 +112,11 @@ rules:
   resources:
   - controllerrevisions
   verbs:
+  - create
+  - delete
+  - get
   - list
+  - patch
   - watch
 - apiGroups:
   - apps
@@ -120,10 +136,18 @@ rules:
   - apps
   resources:
   - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - statefulsets
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - argoproj.io
@@ -138,9 +162,10 @@ rules:
   resources:
   - rollouts
   verbs:
+  - get
   - list
-  - watch
   - patch
+  - watch
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -271,6 +296,8 @@ rules:
 - apiGroups:
   - datadoghq.com
   resources:
+  - datadogpodautoscalerclusterprofiles
+  - datadogpodautoscalerclusterprofiles/status
   - datadogpodautoscalers
   - datadogpodautoscalers/status
   verbs:
@@ -286,7 +313,6 @@ rules:
   - watch
 - apiGroups:
   - datadoghq.com
-  - eks.amazonaws.com
   - karpenter.azure.com
   resources:
   - '*'
@@ -312,33 +338,33 @@ rules:
   - list
   - watch
 - apiGroups:
-    - gateway.envoyproxy.io
+  - gateway.envoyproxy.io
   resources:
-    - envoyextensionpolicies
+  - envoyextensionpolicies
   verbs:
-    - create
-    - delete
-    - get
+  - create
+  - delete
+  - get
 - apiGroups:
-    - gateway.networking.k8s.io
+  - gateway.networking.k8s.io
   resources:
-    - gatewayclasses
-    - gateways
-    - httproutes
+  - gatewayclasses
+  - gateways
+  - httproutes
   verbs:
-    - get
-    - list
-    - patch
-    - watch
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups:
-    - gateway.networking.k8s.io
+  - gateway.networking.k8s.io
   resources:
-    - referencegrants
+  - referencegrants
   verbs:
-    - create
-    - delete
-    - get
-    - patch
+  - create
+  - delete
+  - get
+  - patch
 - apiGroups:
   - karpenter.sh
   resources:
@@ -366,13 +392,13 @@ rules:
   verbs:
   - get
 - apiGroups:
-    - networking.istio.io
+  - networking.istio.io
   resources:
-    - envoyfilters
+  - envoyfilters
   verbs:
-    - create
-    - delete
-    - get
+  - create
+  - delete
+  - get
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -469,13 +495,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:  # EKS kube_scheduler and kube_controller_manager control plane metrics
-  - "metrics.eks.amazonaws.com"
-  resources:
-  - kcm/metrics
-  - ksh/metrics
-  verbs:
-  - get
 {{- if .Values.datadogAgentInternal.enabled }}
 - apiGroups:
   - datadoghq.com

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: registry.datadoghq.com/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.25.0
+  tag: 1.26.0-rc.1
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
   # image.doNotCheckTag -- Permit skipping operator image tag compatibility with the chart.

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.17.3
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-2.18.0'
+    helm.sh/chart: 'datadogCRDs-2.20.0-dev.2'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -35,6 +35,10 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: age
           type: date
+        - jsonPath: .status.experiment.phase
+          name: experiment-phase
+          priority: 1
+          type: string
       name: v2alpha1
       schema:
         openAPIV3Schema:
@@ -58,6 +62,13 @@ spec:
                           properties:
                             clusterAgentCommunicationEnabled:
                               type: boolean
+                            clusterAgentTlsVerification:
+                              properties:
+                                copyCaConfigMap:
+                                  type: boolean
+                                enabled:
+                                  type: boolean
+                              type: object
                             enabled:
                               type: boolean
                             image:
@@ -362,6 +373,17 @@ spec:
                           properties:
                             enabled:
                               type: boolean
+                          type: object
+                        probe:
+                          properties:
+                            enabled:
+                              type: boolean
+                            gracePeriod:
+                              format: int32
+                              type: integer
+                            interval:
+                              format: int32
+                              type: integer
                           type: object
                         registry:
                           type: string
@@ -1843,6 +1865,8 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     useFIPSAgent:
+                      type: boolean
+                    useVSock:
                       type: boolean
                   type: object
                 override:
@@ -4306,6 +4330,23 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                experiment:
+                  properties:
+                    generation:
+                      format: int64
+                      type: integer
+                    id:
+                      type: string
+                    phase:
+                      enum:
+                        - running
+                        - stopped
+                        - rollback
+                        - timeout
+                        - promoted
+                        - aborted
+                      type: string
+                  type: object
                 otelAgentGateway:
                   properties:
                     availableReplicas:
@@ -4349,6 +4390,13 @@ spec:
                               properties:
                                 clusterAgentCommunicationEnabled:
                                   type: boolean
+                                clusterAgentTlsVerification:
+                                  properties:
+                                    copyCaConfigMap:
+                                      type: boolean
+                                    enabled:
+                                      type: boolean
+                                  type: object
                                 enabled:
                                   type: boolean
                                 image:
@@ -4653,6 +4701,17 @@ spec:
                               properties:
                                 enabled:
                                   type: boolean
+                              type: object
+                            probe:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                gracePeriod:
+                                  format: int32
+                                  type: integer
+                                interval:
+                                  format: int32
+                                  type: integer
                               type: object
                             registry:
                               type: string

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.21.0
+    helm.sh/chart: datadog-operator-2.22.0-dev.1
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.25.0"
+    app.kubernetes.io/version: "1.26.0-rc.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator
       containers:
         - name: datadog-operator
-          image: "registry.datadoghq.com/operator:1.25.0"
+          image: "registry.datadoghq.com/operator:1.26.0-rc.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -208,7 +208,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "registry.datadoghq.com/operator:1.25.0", operatorContainer.Image)
+	assert.Equal(t, "registry.datadoghq.com/operator:1.26.0-rc.1", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
## Test PR

Testing script for automatically creating Operator Release helm-chart PRs.

Properly updates the chart version, deps versions, and operator version thoughout. Updates the clusterrole. (Note: already included the exception for csidriver in the script which is why the perms are not added here... those will be manual)

Reference: https://github.com/DataDog/helm-charts/pull/2562