### PR TITLE
[datadog] Test Automation Final Release

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 3.200.0
+
+* Bump Datadog Operator chart dependency to 2.21.0.
+* Bump Datadog CRD chart dependency to 2.18.0.
+* Bump Operator image tag to 1.25.0.
+
 ## 3.199.2
 
 * DDOT FIPS with an incompatible version: fail instead of falling back to non-FIPS ([#2527](https://github.com/DataDog/helm-charts/pull/2527)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.199.2
+version: 3.200.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.199.2](https://img.shields.io/badge/Version-3.199.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.200.0](https://img.shields.io/badge/Version-3.200.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -31,9 +31,9 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://helm.datadoghq.com | datadog-crds | 2.13.1 |
+| https://helm.datadoghq.com | datadog-crds | 2.18.0 |
 | https://helm.datadoghq.com | datadog-csi-driver | 0.10.0 |
-| https://helm.datadoghq.com | operator(datadog-operator) | 2.19.1 |
+| https://helm.datadoghq.com | operator(datadog-operator) | 2.21.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 
 ## Quick start
@@ -1070,7 +1070,7 @@ helm install <RELEASE_NAME> \
 | operator.datadogGenericResource.enabled | bool | `false` | Enables the Datadog Generic Resource controller |
 | operator.datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | operator.datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
-| operator.image.tag | string | `"1.24.0"` | Define the Datadog Operator version to use |
+| operator.image.tag | string | `"1.25.0"` | Define the Datadog Operator version to use |
 | otelAgentGateway.additionalLabels | object | `{}` | Adds labels to the Agent Gateway Deployment and pods |
 | otelAgentGateway.affinity | object | `{}` | Allow the Gateway Deployment to schedule using affinity rules |
 | otelAgentGateway.autoscaling.annotations | object | `{}` | annotations for OTel Agent Gateway HPA |

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.13.1
+  version: 2.18.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
@@ -10,6 +10,6 @@ dependencies:
   version: 0.10.0
 - name: datadog-operator
   repository: https://helm.datadoghq.com
-  version: 2.19.1
-digest: sha256:c22bcb476a7d8088131e31dc9f3ee9971992c8eeb97aaa5f86ddae8c431f2931
-generated: "2026-03-31T15:30:57.526366+02:00"
+  version: 2.21.0
+digest: sha256:8d8ee282488bc33089f0190c8b084ebcf29c8c255455d2e071a19b336279128b
+generated: "2026-04-20T15:04:55.684623-04:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: datadog-crds
-    version: 2.13.1
+    version: 2.18.0
     repository: https://helm.datadoghq.com
     condition: datadog.autoscaling.workload.enabled,clusterAgent.metricsProvider.useDatadogMetrics
     tags:
@@ -14,7 +14,7 @@ dependencies:
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator
-    version: 2.19.1
+    version: 2.21.0
     repository: https://helm.datadoghq.com
     condition: datadog.operator.enabled
     alias: operator

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -3002,7 +3002,7 @@ clusterChecksRunner:
 operator:
   image:
     # operator.image.tag -- Define the Datadog Operator version to use
-    tag: 1.24.0
+    tag: 1.25.0
 
   datadogAgent:
     # operator.datadogAgent.enabled -- Enables Datadog Agent controller

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1857,7 +1858,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1920,7 +1921,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1857,7 +1858,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1920,7 +1921,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -458,6 +458,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1781,7 +1782,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1844,7 +1845,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1752,7 +1753,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1815,7 +1816,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -161,7 +161,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -454,6 +454,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1307,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1370,7 +1371,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -161,7 +161,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -454,6 +454,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1307,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1370,7 +1371,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -161,7 +161,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -454,6 +454,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1307,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1370,7 +1371,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -161,7 +161,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -454,6 +454,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1307,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1370,7 +1371,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -201,7 +201,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -494,6 +494,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1823,7 +1824,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1886,7 +1887,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1746,7 +1747,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1809,7 +1810,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1746,7 +1747,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1809,7 +1810,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1579,7 +1580,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1642,7 +1643,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1596,7 +1597,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1659,7 +1660,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -163,7 +163,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -456,6 +456,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1652,7 +1653,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1715,7 +1716,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1622,7 +1623,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1685,7 +1686,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -399,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -692,6 +692,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -2137,7 +2138,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2200,7 +2201,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -399,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -692,6 +692,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -2201,7 +2202,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2264,7 +2265,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -399,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -692,6 +692,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -2079,7 +2080,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2142,7 +2143,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -163,7 +163,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -456,6 +456,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1780,7 +1781,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1843,7 +1844,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -163,7 +163,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -456,6 +456,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1652,7 +1653,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1715,7 +1716,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -163,7 +163,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -456,6 +456,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1676,7 +1677,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1739,7 +1740,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -405,7 +405,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -698,6 +698,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -2198,7 +2199,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2261,7 +2262,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -192,7 +192,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -485,6 +485,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1811,7 +1812,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1874,7 +1875,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -399,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -692,6 +692,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -2264,7 +2265,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2327,7 +2328,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -219,7 +219,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -512,6 +512,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1940,7 +1941,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2003,7 +2004,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1859,7 +1860,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1922,7 +1923,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -219,7 +219,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -512,6 +512,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1934,7 +1935,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1997,7 +1998,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -191,7 +191,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -484,6 +484,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1518,7 +1519,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1581,7 +1582,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -191,7 +191,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -484,6 +484,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1518,7 +1519,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1581,7 +1582,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -515,6 +515,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1575,7 +1576,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1638,7 +1639,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -515,6 +515,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1575,7 +1576,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1638,7 +1639,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -171,7 +171,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -464,6 +464,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1903,7 +1904,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1966,7 +1967,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -219,7 +219,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -512,6 +512,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1936,7 +1937,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1999,7 +2000,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -219,7 +219,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -512,6 +512,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1930,7 +1931,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1993,7 +1994,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1746,7 +1747,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1809,7 +1810,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -442,6 +442,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1753,7 +1754,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1816,7 +1817,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -441,6 +441,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1822,7 +1823,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1885,7 +1886,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -163,7 +163,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -456,6 +456,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -1797,7 +1798,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1860,7 +1861,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -400,7 +400,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -693,6 +693,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -2444,7 +2445,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2507,7 +2508,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -399,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -692,6 +692,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -2285,7 +2286,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2348,7 +2349,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -399,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -692,6 +692,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -2335,7 +2336,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2398,7 +2399,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -400,7 +400,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -693,6 +693,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -2257,7 +2258,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2320,7 +2321,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -400,7 +400,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -693,6 +693,7 @@ rules:
     resources:
       - endpointslices
     verbs:
+      - get
       - list
       - watch
   - apiGroups:
@@ -2165,7 +2166,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.24.0
+    app.kubernetes.io/version: 1.25.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2228,7 +2229,9 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_EU
               value: "true"
-          image: registry.datadoghq.com/operator:1.24.0
+            - name: DD_REGISTRY_OVERRIDE_DEFAULT
+              value: "true"
+          image: registry.datadoghq.com/operator:1.25.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## Test PR Automation

Automate final datadog chart Operator dependency update: https://github.com/DataDog/helm-charts/pull/2538

No differences. Simplest to automate as it's just bumping the image tag, bumping the helm deps, and running other scripts.