### PR TITLE
[datadog-operator] Lint fixes for Datadog Operator Chart

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.22.0-dev.2
 
-* Update Datadog Operator chart for 1.26.0-rc.1.
+* [No-op] Lint operator ClusterRole template
 
 ## 2.22.0-dev.1
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.22.0-dev.2
+
+* Update Datadog Operator chart for 1.26.0-rc.1.
+
 ## 2.22.0-dev.1
 
 * Update Datadog Operator chart for 1.26.0-rc.1.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.22.0-dev.1
+version: 2.22.0-dev.2
 appVersion: 1.26.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.22.0-dev.1](https://img.shields.io/badge/Version-2.22.0--dev.1-informational?style=flat-square) ![AppVersion: 1.26.0-rc.1](https://img.shields.io/badge/AppVersion-1.26.0--rc.1-informational?style=flat-square)
+![Version: 2.22.0-dev.2](https://img.shields.io/badge/Version-2.22.0--dev.2-informational?style=flat-square) ![AppVersion: 1.26.0-rc.1](https://img.shields.io/badge/AppVersion-1.26.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -136,7 +136,6 @@ rules:
   - apps
   resources:
   - replicasets
-  - statefulsets
   verbs:
   - get
   - list
@@ -146,7 +145,10 @@ rules:
   resources:
   - statefulsets
   verbs:
+  - get
+  - list
   - patch
+  - watch
 - apiGroups:
   - argoproj.io
   resources:
@@ -162,8 +164,8 @@ rules:
   verbs:
   - get
   - list
-  - watch
   - patch
+  - watch
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -311,7 +313,6 @@ rules:
   - watch
 - apiGroups:
   - datadoghq.com
-  - eks.amazonaws.com
   - karpenter.azure.com
   resources:
   - '*'
@@ -337,33 +338,33 @@ rules:
   - list
   - watch
 - apiGroups:
-    - gateway.envoyproxy.io
+  - gateway.envoyproxy.io
   resources:
-    - envoyextensionpolicies
+  - envoyextensionpolicies
   verbs:
-    - create
-    - delete
-    - get
+  - create
+  - delete
+  - get
 - apiGroups:
-    - gateway.networking.k8s.io
+  - gateway.networking.k8s.io
   resources:
-    - gatewayclasses
-    - gateways
-    - httproutes
+  - gatewayclasses
+  - gateways
+  - httproutes
   verbs:
-    - get
-    - list
-    - patch
-    - watch
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups:
-    - gateway.networking.k8s.io
+  - gateway.networking.k8s.io
   resources:
-    - referencegrants
+  - referencegrants
   verbs:
-    - create
-    - delete
-    - get
-    - patch
+  - create
+  - delete
+  - get
+  - patch
 - apiGroups:
   - karpenter.sh
   resources:
@@ -391,13 +392,13 @@ rules:
   verbs:
   - get
 - apiGroups:
-    - networking.istio.io
+  - networking.istio.io
   resources:
-    - envoyfilters
+  - envoyfilters
   verbs:
-    - create
-    - delete
-    - get
+  - create
+  - delete
+  - get
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -494,13 +495,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:  # EKS kube_scheduler and kube_controller_manager control plane metrics
-  - "metrics.eks.amazonaws.com"
-  resources:
-  - kcm/metrics
-  - ksh/metrics
-  verbs:
-  - get
 {{- if .Values.datadogAgentInternal.enabled }}
 - apiGroups:
   - datadoghq.com

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.22.0-dev.1
+    helm.sh/chart: datadog-operator-2.22.0-dev.2
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.26.0-rc.1"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates Operator chart `clusterrole.yaml` to more closely align with `role.yaml`, lint fixes, as well as removing duplicated perms.

Source file: https://github.com/DataDog/helm-charts/blob/main/charts/datadog-operator/templates/clusterrole.yaml

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits