### PR TITLE
[datadog-operator] Remove Metadata Handling Notice

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.22.0-dev.3
+
+* [No-op] Remove metadata change notice for 1.21.0+.
+
 ## 2.22.0-dev.2
 
 * [No-op] Lint operator ClusterRole template

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.22.0-dev.2
+version: 2.22.0-dev.3
 appVersion: 1.26.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.22.0-dev.2](https://img.shields.io/badge/Version-2.22.0--dev.2-informational?style=flat-square) ![AppVersion: 1.26.0-rc.1](https://img.shields.io/badge/AppVersion-1.26.0--rc.1-informational?style=flat-square)
+![Version: 2.22.0-dev.3](https://img.shields.io/badge/Version-2.22.0--dev.3-informational?style=flat-square) ![AppVersion: 1.26.0-rc.1](https://img.shields.io/badge/AppVersion-1.26.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/NOTES.txt
+++ b/charts/datadog-operator/templates/NOTES.txt
@@ -42,16 +42,6 @@ Setting a value will not change the default defined in the Operator.
     {{- end }}
 {{- end }}
 
-{{- if (semverCompare ">=1.18.0-rc.1" $version) }}
-##############################################################################
-####               WARNING: Upcoming metadata change in Operator 1.21.    ####
-##############################################################################
-
-We are changing Datadog Agent daemonset and pod metadata handling in upcoming releases.
-Please check Operator README for more details https://github.com/DataDog/datadog-operator/blob/main/README.md
-
-{{- end }}
-
 {{- if .Values.clusterRole.kubeletFineGrainedAuthorization }}
 ##############################################################################
 ####               WARNING: Fine-grained authorization flag enabled.      ####

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.22.0-dev.2
+    helm.sh/chart: datadog-operator-2.22.0-dev.3
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.26.0-rc.1"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove old notice: https://datadoghq.atlassian.net/browse/CONTP-1539?atlOrigin=eyJpIjoiYzkyMWZkNTQ4MjQ3NGEwNGI4MzJkYzA1OGQ0NDJhZDgiLCJwIjoiaiJ9

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits