### PR TITLE
[CONS-8251]  Delete unused resources when node agent or cluster agent is disabled

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.201.8
+
+* [CONS-8251] Service is not needed when node agent is disabled ([#2589](https://github.com/DataDog/helm-charts/pull/2589)).
+
 ## 3.201.7
 
 * [CONS-8251] Service is not needed when node agent is disabled ([#2575](https://github.com/DataDog/helm-charts/pull/2575)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.201.7
+version: 3.201.8
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.201.7](https://img.shields.io/badge/Version-3.201.7-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.201.8](https://img.shields.io/badge/Version-3.201.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -1045,7 +1045,7 @@ Return Kubelet volumeMount
 Return true if the Cluster Agent needs a confd configmap
 */}}
 {{- define "need-cluster-agent-confd" -}}
-{{- if (or (.Values.clusterAgent.confd) (.Values.datadog.kubeStateMetricsCore.enabled) (.Values.clusterAgent.advancedConfd) (.Values.datadog.helmCheck.enabled) (.Values.datadog.collectEvents) (.Values.clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus)) -}}
+{{- if and .Values.clusterAgent.enabled (or (.Values.clusterAgent.confd) (.Values.datadog.kubeStateMetricsCore.enabled) (.Values.clusterAgent.advancedConfd) (.Values.datadog.helmCheck.enabled) (.Values.datadog.collectEvents) (.Values.clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus)) -}}
 true
 {{- else -}}
 false
@@ -1687,6 +1687,27 @@ true
 {{- end }}
 {{- end }}
 
+{{/*
+Return true if install info configmap is needed.
+*/}}
+{{- define "need-install-info" -}}
+{{- if or .Values.clusterAgent.enabled .Values.agents.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if kpi telemetry configmap is needed.
+*/}}
+{{- define "need-kpi-telemetry-conf" -}}
+{{- if or .Values.clusterAgent.enabled .Values.agents.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
 
 {{/*
 This helper computes the Deployment name for the operator when installed as a subchart of the datadog chart.

--- a/charts/datadog/templates/install_info-configmap.yaml
+++ b/charts/datadog/templates/install_info-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "need-install-info" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
       tool: helm
       tool_version: {{ .Release.Service }}
       installer_version: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end -}}

--- a/charts/datadog/templates/kpi-telemetry-configmap.yaml
+++ b/charts/datadog/templates/kpi-telemetry-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "need-kpi-telemetry-conf" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
   install_id: {{ uuidv4 | quote }}
   install_time: {{ now | unixEpoch | quote }}
   {{- end }}
+{{- end -}}

--- a/charts/datadog/templates/kube-state-metrics-core-rbac.yaml
+++ b/charts/datadog/templates/kube-state-metrics-core-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.datadog.kubeStateMetricsCore.enabled .Values.datadog.kubeStateMetricsCore.rbac.create }}
+{{- if and .Values.clusterAgent.enabled .Values.datadog.kubeStateMetricsCore.enabled .Values.datadog.kubeStateMetricsCore.rbac.create }}
 {{- $imageTag := ternary (.Values.clusterChecksRunner.image.tag | toString) (.Values.agents.image.tag | toString) .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners }}
 {{- $doNotCheckTag := ternary .Values.clusterChecksRunner.image.doNotCheckTag .Values.agents.image.doNotCheckTag .Values.datadog.kubeStateMetricsCore.useClusterCheckRunners }}
 {{- if .Values.datadog.kubeStateMetricsCore.namespaces }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Raised in CONS-8251
Some resources are not in use when node agent or cluster agent is disabled.

- Install info (ConfigMap)
- kpi telemetry config 
- ksm rbac
