### PR TITLE
Datadog-operator automountServiceAccountToken deployment file bug fix.

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.22.0-dev.4
+
+* Datadog-operator automountServiceAccountToken deployment file bug fix.
+
 ## 2.22.0-dev.3
 
 * [No-op] Remove metadata change notice for 1.21.0+.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.22.0-dev.3
+version: 2.22.0-dev.4
 appVersion: 1.26.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.22.0-dev.3](https://img.shields.io/badge/Version-2.22.0--dev.3-informational?style=flat-square) ![AppVersion: 1.26.0-rc.1](https://img.shields.io/badge/AppVersion-1.26.0--rc.1-informational?style=flat-square)
+![Version: 2.22.0-dev.4](https://img.shields.io/badge/Version-2.22.0--dev.4-informational?style=flat-square) ![AppVersion: 1.26.0-rc.1](https://img.shields.io/badge/AppVersion-1.26.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "datadog-operator.serviceAccountName" . }}
+      {{- if eq .Values.serviceAccount.automountServiceAccountToken false }}
+      automountServiceAccountToken: false
+      {{- end }} 
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
#### What this PR does / why we need it:
This fixes an issue in the datadog-operator chart. automountServiceAccountToken = false does not operate as expected without the additional deployment config. 

The datadog-operator will not start unless this configuration is defined in both the serviceAccount and the Deployment file. Tested in several production grade environments.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - n/a

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [X] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [X] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated 
- [X] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits