### PR TITLE
[ACTP] Add k8s remediation RBAC for Private Action Runner

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.202.0
+
+* Add `clusterAgent.privateActionRunner.k8sRemediationEnabled` to create the ClusterRole and ClusterRoleBinding required for k8s remediation actions ([#2592](https://github.com/DataDog/helm-charts/pull/2592)).
+
 ## 3.201.8
 
 * Fix deployment issues when using an agent image tag that contains the string `latest` when `doNotCheckTag` is not set due to the semverCompare for `controllerrevisions` in `kube-state-metrics-core-rbac.yaml`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.201.8
+version: 3.202.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.201.8](https://img.shields.io/badge/Version-3.201.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.202.0](https://img.shields.io/badge/Version-3.202.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -672,6 +672,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.privateActionRunner.enabled | bool | `false` | Enable the Private Action Runner to execute workflow actions |
 | clusterAgent.privateActionRunner.identityFromExistingSecret | string | `nil` | Use existing Secret which stores the Private Action Runner URN and private key # The secret should contain 'urn' and 'private_key' keys # If set, this parameter takes precedence over "urn" and "privateKey" |
 | clusterAgent.privateActionRunner.identitySecretName | string | `"datadog-private-action-runner-identity"` | Name of the Kubernetes secret used to store PAR identity when self-enrollment is enabled # The Cluster Agent will create and manage this secret for storing the enrolled runner's URN and private key # RBAC permissions are granted specifically for this secret name |
+| clusterAgent.privateActionRunner.k8sRemediationEnabled | bool | `false` | Enable k8s remediation RBAC for the Private Action Runner # When enabled, a ClusterRole and ClusterRoleBinding are created granting the Cluster Agent # permissions to read/patch workloads (Deployments, DaemonSets, StatefulSets, ReplicaSets, Pods) # and manage ConfigMaps and Events cluster-wide. |
 | clusterAgent.privateActionRunner.privateKey | string | `nil` | Private key for the Private Action Runner (required if selfEnroll is false) # This key is used to authenticate the runner with Datadog |
 | clusterAgent.privateActionRunner.selfEnroll | bool | `true` | Enable self-enrollment for the Private Action Runner # When enabled, the runner will automatically register itself with Datadog using the provided API/APP keys # and store its identity in a Kubernetes secret. Requires leader election to be enabled. |
 | clusterAgent.privateActionRunner.urn | string | `nil` | URN of the Private Action Runner (required if selfEnroll is false) # Format: urn:datadog:private-action-runner:organization:<org_id>:runner:<runner_id> |

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -538,6 +538,49 @@ subjects:
     name: {{ template "datadog.fullname" . }}-cluster-agent
     namespace: {{ .Release.Namespace }}
 {{- end }}
+{{- if and .Values.clusterAgent.privateActionRunner.enabled .Values.clusterAgent.privateActionRunner.k8sRemediationEnabled }}
+---
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  labels:
+{{ include "datadog.labels" . | indent 4 }}
+  name: {{ template "datadog.fullname" . }}-private-action-runner
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments", "daemonsets", "statefulsets", "replicasets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "events", "configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["patch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create", "update", "patch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+---
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+{{ include "datadog.labels" . | indent 4 }}
+  name: {{ template "datadog.fullname" . }}-private-action-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "datadog.fullname" . }}-private-action-runner
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "datadog.fullname" . }}-cluster-agent
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}
 
 {{- if and (eq (include "should-deploy-cluster-agent" .) "true") .Values.clusterAgent.rbac.create .Values.clusterAgent.metricsProvider.enabled }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1858,6 +1858,12 @@ clusterAgent:
     #   - "com.datadoghq.http.request"
     #   - "com.datadoghq.kubernetes.core.*"
 
+    # clusterAgent.privateActionRunner.k8sRemediationEnabled -- Enable k8s remediation RBAC for the Private Action Runner
+    ## When enabled, a ClusterRole and ClusterRoleBinding are created granting the Cluster Agent
+    ## permissions to read/patch workloads (Deployments, DaemonSets, StatefulSets, ReplicaSets, Pods)
+    ## and manage ConfigMaps and Events cluster-wide.
+    k8sRemediationEnabled: false
+
   # clusterAgent.livenessProbe -- Override default Cluster Agent liveness probe settings
   # @default -- Every 15s / 6 KO / 1 OK
   livenessProbe:

--- a/test/datadog/private_action_runner_test.go
+++ b/test/datadog/private_action_runner_test.go
@@ -642,3 +642,41 @@ func Test_NodeAgent_PrivateActionRunner_NotSupported_OnAutopilot(t *testing.T) {
 	assert.Contains(t, err.Error(), "Private Action Runner is not supported on GKE Autopilot")
 }
 
+func Test_PrivateActionRunner_K8sRemediation_RBAC_Created(t *testing.T) {
+	manifest, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/cluster-agent-rbac.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"clusterAgent.privateActionRunner.enabled":               "true",
+			"clusterAgent.privateActionRunner.k8sRemediationEnabled": "true",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, manifest, "kind: ClusterRole")
+	assert.Contains(t, manifest, "kind: ClusterRoleBinding")
+	assert.Contains(t, manifest, "name: datadog-private-action-runner")
+	assert.Contains(t, manifest, `["deployments", "daemonsets", "statefulsets", "replicasets"]`)
+	assert.Contains(t, manifest, `["get", "list", "watch"]`)
+	assert.Contains(t, manifest, `["patch"]`)
+}
+
+func Test_PrivateActionRunner_K8sRemediation_RBAC_Not_Created_When_Disabled(t *testing.T) {
+	manifest, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/cluster-agent-rbac.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"clusterAgent.privateActionRunner.enabled":               "true",
+			"clusterAgent.privateActionRunner.k8sRemediationEnabled": "false",
+		},
+	})
+	require.NoError(t, err)
+
+	// The PAR k8s remediation ClusterRole uses inline resource format unique to that block
+	assert.NotContains(t, manifest, `["deployments", "daemonsets", "statefulsets", "replicasets"]`)
+}
+


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `clusterAgent.privateActionRunner.k8sRemediationEnabled` to the `datadog` chart. When enabled alongside `clusterAgent.privateActionRunner.enabled`, a `ClusterRole` and `ClusterRoleBinding` are created granting the Cluster Agent permissions to read and patch workloads (Deployments, DaemonSets, StatefulSets, ReplicaSets, Pods) and manage ConfigMaps and Events cluster-wide.

This mirrors the feature already supported in the Datadog Operator via the `cluster-agent.datadoghq.com/private-action-runner-k8s-remediation-enabled` annotation on the DatadogAgent CR.

#### Special notes for your reviewer:

The permissions granted are identical to those in the operator's `getK8sRemediationPolicyRules()` ([rbac.go](https://github.com/DataDog/datadog-operator/blob/main/internal/controller/datadogagent/feature/privateactionrunner/rbac.go)). The flag defaults to `false` so there is no impact on existing deployments.

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits