### PR TITLE
[datadog/datadog-crds] Update from operator 1.26.0-rc.2

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.20.0-dev.3
+
+* Update CRDs from Datadog Operator v1.26.0-rc.2 release candidate tag.
+
 ## 2.20.0-dev.2
 
 * Drop `description` fields from `datadogcsidrivers` ([#2563](https://github.com/DataDog/helm-charts/pull/2563)).

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.20.0-dev.2
+version: 2.20.0-dev.3
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.20.0-dev.2](https://img.shields.io/badge/Version-2.20.0--dev.2-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.20.0-dev.3](https://img.shields.io/badge/Version-2.20.0--dev.3-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -4335,9 +4335,6 @@ spec:
                   x-kubernetes-list-type: map
                 experiment:
                   properties:
-                    generation:
-                      format: int64
-                      type: integer
                     id:
                       type: string
                     phase:

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -4326,9 +4326,6 @@ spec:
                   x-kubernetes-list-type: map
                 experiment:
                   properties:
-                    generation:
-                      format: int64
-                      type: integer
                     id:
                       type: string
                     phase:


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits