### PR TITLE
[datadog] Mount datadog-yaml ConfigMap on private-action-runner sidecar

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.201.9
+
+* Mount the `datadog-yaml` ConfigMap on the private-action-runner sidecar when `agents.useConfigMap: true`, so `agents.customAgentConfig` reaches the PAR process (which reads the same `datadog.yaml` as the main agent via its `-c` flag).
+
 ## 3.201.8
 
 * Fix deployment issues when using an agent image tag that contains the string `latest` when `doNotCheckTag` is not set due to the semverCompare for `controllerrevisions` in `kube-state-metrics-core-rbac.yaml`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.201.8
+version: 3.201.9
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.201.8](https://img.shields.io/badge/Version-3.201.8-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.201.9](https://img.shields.io/badge/Version-3.201.9-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/ci/private-action-runner-customagentconfig-values.yaml
+++ b/charts/datadog/ci/private-action-runner-customagentconfig-values.yaml
@@ -1,0 +1,21 @@
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  appKey: "0000000000000000000000000000000000000000"
+  kubelet:
+    tlsVerify: false
+
+  privateActionRunner:
+    enabled: true
+    selfEnroll: false
+    urn: "urn:dd:apps:on-prem-runner:us1:123456:test-runner"
+    privateKey: "dGVzdA=="
+
+agents:
+  useConfigMap: true
+  customAgentConfig:
+    private_action_runner:
+      restricted_shell:
+        allowed_commands:
+          - "rshell:cat"
+        allowed_paths:
+          - "/host/var/log"

--- a/charts/datadog/templates/_container-private-action-runner.yaml
+++ b/charts/datadog/templates/_container-private-action-runner.yaml
@@ -51,6 +51,12 @@
     - name: config
       mountPath: {{ template "datadog.confPath" . }}
       readOnly: false
+    {{- if and .Values.agents.useConfigMap (eq .Values.targetSystem "linux") }}
+    - name: datadog-yaml
+      mountPath: {{ template "datadog.confPath" . }}/datadog.yaml
+      subPath: datadog.yaml
+      readOnly: true
+    {{- end }}
     - name: logdatadog
       mountPath: {{ template "datadog.logDirectoryPath" . }}
       readOnly: false


### PR DESCRIPTION
### What does this PR do?

When `agents.useConfigMap: true`, mount the generated `datadog-yaml` ConfigMap on the `private-action-runner` sidecar container (at `{datadog.confPath}/datadog.yaml` via `subPath: datadog.yaml`), mirroring the existing mount on the main agent container.

### Motivation

The PAR sidecar is launched with `-c {{ template \"datadog.confPath\" . }}` and reads `datadog.yaml` from that path. Today, when an operator uses `agents.customAgentConfig` to put configuration into `datadog.yaml` (e.g. `private_action_runner.restricted_shell.*` allow-lists), the chart only overlays that ConfigMap onto the main agent container (`_container-agent.yaml`). The PAR sidecar (`_container-private-action-runner.yaml`) mounts only the shared `config` emptyDir, so PAR reads the image's baked-in default `datadog.yaml` — the operator-supplied keys silently never reach it.

This was discovered while writing E2E tests for the rshell operator-side allow-list intersection behavior in the agent repo: every test that set `private_action_runner.restricted_shell.allowed_commands` (or `allowed_paths`) in `customAgentConfig` observed operator-as-unset behavior because PAR never saw the YAML.

### Describe how you validated your changes

- Rendered the template with `agents.useConfigMap: true` + a minimal `customAgentConfig` containing `private_action_runner.restricted_shell.allowed_commands`; verified the `datadog-yaml` subPath mount is added to the PAR container's `volumeMounts` alongside the main agent container's existing mount.
- Added `ci/private-action-runner-customagentconfig-values.yaml` exercising this exact scenario.
- No change when `useConfigMap` is unset (guarded on `.Values.agents.useConfigMap`).

### Scope

- One-line mount addition scoped to `_container-private-action-runner.yaml`, gated on the same `useConfigMap` + `targetSystem=linux` conditions as the main agent's mount.
- Chart version bumped to `3.201.9`; `CHANGELOG.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)