### PR TITLE
testwasher: fix multi-level flaky propagation and E2E test correctness

### DIFF
--- a/test/e2e/datadog/e2e_k8ssuite_test.go
+++ b/test/e2e/datadog/e2e_k8ssuite_test.go
@@ -39,21 +39,19 @@ func (s *k8sSuite) SetupSuite() {
 	config, err := common.SetupConfig()
 	s.Require().NoError(err)
 	s.DefaultConfig = config
-	chartPath, err := datadogChartPath()
-	s.Require().NoError(err)
-	s.Assert().NotEmpty(chartPath)
+	s.Assert().NotEmpty(datadogChartPath())
 }
 
-func datadogChartPath() (string, error) {
+func datadogChartPath() string {
 	currentDir, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("getting working directory: %w", err)
+		panic(fmt.Sprintf("datadogChartPath: os.Getwd(): %v", err))
 	}
 	chartPath, err := filepath.Abs(filepath.Join(currentDir, "..", "..", "..", "charts", "datadog"))
 	if err != nil {
-		return "", fmt.Errorf("resolving chart path: %w", err)
+		panic(fmt.Sprintf("datadogChartPath: filepath.Abs(): %v", err))
 	}
-	return chartPath, nil
+	return chartPath
 }
 
 func (s *k8sSuite) testGenericK8sAutopilot() {
@@ -172,11 +170,9 @@ func (s *k8sSuite) testGenericK8sKSMCore() {
 func (s *k8sSuite) testGenericK8sKSMCoreCCR() {
 	s.Run("KSM check works cluster check runner", func() {
 		flake.Mark(s.T())
-		chartPath, err := datadogChartPath()
-		s.Require().NoError(err)
 		agentOpts := []kubernetesagentparams.Option{
 			kubernetesagentparams.WithHelmRepoURL(""),
-			kubernetesagentparams.WithHelmChartPath(chartPath),
+			kubernetesagentparams.WithHelmChartPath(datadogChartPath()),
 			kubernetesagentparams.WithHelmValues(`
 datadog:
   kubelet:
@@ -191,7 +187,7 @@ clusterChecksRunner:
 			gcpkubernetes.WithExtraConfigParams(s.DefaultConfig),
 			gcpkubernetes.WithAgentOptions(agentOpts...)))
 
-		err = s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+		err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 		s.Assert().NoError(err)
 
 		s.Assert().EventuallyWithTf(func(c *assert.CollectT) {

--- a/test/e2e/datadog/e2e_k8ssuite_test.go
+++ b/test/e2e/datadog/e2e_k8ssuite_test.go
@@ -3,6 +3,12 @@ package datadog
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/fakeintake/client"
@@ -12,16 +18,10 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/helm-charts/test/common"
 	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
-	"github.com/DataDog/test-infra-definitions/scenarios/gcp/gke"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"time"
 )
 
 var (
@@ -37,17 +37,23 @@ type k8sSuite struct {
 func (s *k8sSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
 	config, err := common.SetupConfig()
-	if err != nil {
-		s.Error(err)
-	}
+	s.Require().NoError(err)
 	s.DefaultConfig = config
-	s.Assert().NotEmpty(datadogChartPath())
+	chartPath, err := datadogChartPath()
+	s.Require().NoError(err)
+	s.Assert().NotEmpty(chartPath)
 }
 
-func datadogChartPath() string {
-	currentDir, _ := os.Getwd()
-	chartPath, _ := filepath.Abs(filepath.Join(currentDir, "..", "..", "..", "charts", "datadog"))
-	return chartPath
+func datadogChartPath() (string, error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting working directory: %w", err)
+	}
+	chartPath, err := filepath.Abs(filepath.Join(currentDir, "..", "..", "..", "charts", "datadog"))
+	if err != nil {
+		return "", fmt.Errorf("resolving chart path: %w", err)
+	}
+	return chartPath, nil
 }
 
 func (s *k8sSuite) testGenericK8sAutopilot() {
@@ -55,7 +61,6 @@ func (s *k8sSuite) testGenericK8sAutopilot() {
 	s.testGenericK8sAutodiscovery()
 	s.testGenericK8sLogs()
 	s.testGenericK8sKSMCore()
-	s.testGenericK8sKSMCoreCCR(true)
 }
 
 func (s *k8sSuite) testGenericK8s() {
@@ -63,7 +68,7 @@ func (s *k8sSuite) testGenericK8s() {
 	s.testGenericK8sAutodiscovery()
 	s.testGenericK8sLogs()
 	s.testGenericK8sKSMCore()
-	s.testGenericK8sKSMCoreCCR(false)
+	s.testGenericK8sKSMCoreCCR()
 }
 
 func (s *k8sSuite) testGenericK8sKubeletCheck() {
@@ -74,12 +79,9 @@ func (s *k8sSuite) testGenericK8sKubeletCheck() {
 			assert.NoError(c, err)
 			assert.NotEmpty(c, kubeletCheckRun)
 
-			// Kubelet service check reports CRITICAL status 2 sometimes even though it's OK
-			// assert.Equal(c, 0, kubeletCheckRun[0].Status, fmt.Sprintf("kubelet check status should be running: %s", kubeletCheckRun[0].Message))
-
 			kubeletMetricSeries, err := s.Env().FakeIntake.Client().FilterMetrics("kubernetes.cpu.usage.total", matchOpts...)
-			s.Assert().NoError(err)
-			s.Assert().NotEmptyf(kubeletMetricSeries, fmt.Sprintf("expected Kubelet check series to not be empty: %s", err))
+			assert.NoError(c, err)
+			assert.NotEmptyf(c, kubeletMetricSeries, "expected Kubelet check series to not be empty: %s", err)
 
 		}, 5*time.Minute, 15*time.Second, "could not validate kubelet check in time")
 
@@ -92,9 +94,12 @@ func (s *k8sSuite) testGenericK8sKubeletCheck() {
 func (s *k8sSuite) testGenericK8sLogs() {
 	s.Run("Logs collection works", func() {
 		// Verify logs collection on agent pod
-		s.Assert().EventuallyWithTf(func(c *assert.CollectT) {
+		s.Assert().EventuallyWithT(func(c *assert.CollectT) {
 			agentPods, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.TODO(), metav1.ListOptions{})
-			s.Assert().NoError(err)
+			assert.NoError(c, err)
+			if err != nil {
+				return
+			}
 
 			var agent corev1.Pod
 			containsAgent := false
@@ -106,12 +111,10 @@ func (s *k8sSuite) testGenericK8sLogs() {
 				}
 			}
 			assert.True(c, containsAgent, "Agent not found")
-			assert.Equal(c, corev1.PodPhase("Running"), agent.Status.Phase, fmt.Sprintf("Agent is not running: %s", agent.Status.Phase))
+			assert.Equalf(c, corev1.PodPhase("Running"), agent.Status.Phase, "Agent is not running: %s", agent.Status.Phase)
 
-			assert.NoError(c, err)
-
-			s.verifyAPILogs()
-		}, 5*time.Minute, 15*time.Second, "could not valid logs collection in time")
+			s.verifyAPILogs(c)
+		}, 5*time.Minute, 15*time.Second, "could not validate logs collection in time")
 	})
 }
 
@@ -121,7 +124,11 @@ func (s *k8sSuite) testGenericK8sAutodiscovery() {
 		s.Assert().NoError(err)
 
 		s.Assert().EventuallyWithTf(func(c *assert.CollectT) {
-			res, _ := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.TODO(), metav1.ListOptions{})
+			res, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.TODO(), metav1.ListOptions{})
+			assert.NoError(c, err)
+			if err != nil {
+				return
+			}
 
 			var nginx corev1.Pod
 			containsNginx := false
@@ -133,7 +140,7 @@ func (s *k8sSuite) testGenericK8sAutodiscovery() {
 				}
 			}
 			assert.True(c, containsNginx, "Nginx pod not found")
-			assert.Equal(c, corev1.PodPhase("Running"), nginx.Status.Phase, fmt.Sprintf("Nginx is not running: %s", nginx.Status.Phase))
+			assert.Equalf(c, corev1.PodPhase("Running"), nginx.Status.Phase, "Nginx is not running: %s", nginx.Status.Phase)
 
 			var agent corev1.Pod
 			containsAgent := false
@@ -145,7 +152,7 @@ func (s *k8sSuite) testGenericK8sAutodiscovery() {
 				}
 			}
 			assert.True(c, containsAgent, "Agent not found")
-			assert.Equal(c, corev1.PodPhase("Running"), agent.Status.Phase, fmt.Sprintf("Agent is not running: %s", agent.Status.Phase))
+			assert.Equalf(c, corev1.PodPhase("Running"), agent.Status.Phase, "Agent is not running: %s", agent.Status.Phase)
 
 			s.verifyHTTPCheck(c)
 		}, 5*time.Minute, 15*time.Second, "could not validate http_check in time")
@@ -154,6 +161,7 @@ func (s *k8sSuite) testGenericK8sAutodiscovery() {
 
 func (s *k8sSuite) testGenericK8sKSMCore() {
 	s.Run("KSM core check works", func() {
+		flake.Mark(s.T())
 		s.Assert().EventuallyWithT(func(c *assert.CollectT) {
 			s.verifyKSMCheck(c)
 		}, 1*time.Minute, 15*time.Second, "could not validate KSM check in time")
@@ -161,16 +169,14 @@ func (s *k8sSuite) testGenericK8sKSMCore() {
 	})
 }
 
-func (s *k8sSuite) testGenericK8sKSMCoreCCR(withAutopilot bool) {
+func (s *k8sSuite) testGenericK8sKSMCoreCCR() {
 	s.Run("KSM check works cluster check runner", func() {
-		if withAutopilot {
-			s.T().Skip("Skipping: KSM CCR is consistently broken on GKE Autopilot")
-		}
 		flake.Mark(s.T())
-		var gkeOpts []gke.Option
+		chartPath, err := datadogChartPath()
+		s.Require().NoError(err)
 		agentOpts := []kubernetesagentparams.Option{
 			kubernetesagentparams.WithHelmRepoURL(""),
-			kubernetesagentparams.WithHelmChartPath(datadogChartPath()),
+			kubernetesagentparams.WithHelmChartPath(chartPath),
 			kubernetesagentparams.WithHelmValues(`
 datadog:
   kubelet:
@@ -181,21 +187,19 @@ datadog:
 clusterChecksRunner:
   enabled: true`)}
 
-		if withAutopilot {
-			gkeOpts = append(gkeOpts, gke.WithAutopilot())
-			agentOpts = append(agentOpts, kubernetesagentparams.WithGKEAutopilot())
-		}
-
 		s.UpdateEnv(gcpkubernetes.GKEProvisioner(
-			gcpkubernetes.WithGKEOptions(gkeOpts...),
 			gcpkubernetes.WithExtraConfigParams(s.DefaultConfig),
 			gcpkubernetes.WithAgentOptions(agentOpts...)))
 
-		err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+		err = s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 		s.Assert().NoError(err)
 
 		s.Assert().EventuallyWithTf(func(c *assert.CollectT) {
-			res, _ := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.TODO(), metav1.ListOptions{})
+			res, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.TODO(), metav1.ListOptions{})
+			assert.NoError(c, err)
+			if err != nil {
+				return
+			}
 
 			var agent corev1.Pod
 			containsCCR := false
@@ -207,24 +211,24 @@ clusterChecksRunner:
 				}
 			}
 			assert.True(c, containsCCR, "Agent cluster check runner not found")
-			assert.Equal(c, corev1.PodPhase("Running"), agent.Status.Phase, fmt.Sprintf("Agent cluster check runner is not running: %s", agent.Status.Phase))
+			assert.Equalf(c, corev1.PodPhase("Running"), agent.Status.Phase, "Agent cluster check runner is not running: %s", agent.Status.Phase)
 
 			s.verifyKSMCheck(c)
 		}, 10*time.Minute, 15*time.Second, "could not validate kubernetes_state_core (cluster check on CCR) check in time")
 	})
 }
 
-func (s *k8sSuite) verifyAPILogs() {
+func (s *k8sSuite) verifyAPILogs(c *assert.CollectT) {
 	logs, err := s.Env().FakeIntake.Client().FilterLogs("agent")
-	s.Assert().NoError(err)
-	s.Assert().NotEmptyf(logs, fmt.Sprintf("Expected fake intake-ingested logs to not be empty: %s", err))
+	assert.NoError(c, err)
+	assert.NotEmptyf(c, logs, "Expected fake intake-ingested logs to not be empty: %s", err)
 }
 
 func (s *k8sSuite) verifyKSMCheck(c *assert.CollectT) {
 	ksmCheckRun, err := s.Env().FakeIntake.Client().GetCheckRun("kubernetes_state.node.ready")
-	s.Assert().NoError(err)
+	assert.NoError(c, err)
 	require.NotEmpty(c, ksmCheckRun)
-	assert.Equal(c, 0, ksmCheckRun[0].Status, fmt.Sprintf("KSM check status should be running: %s", ksmCheckRun[0].Message))
+	assert.Equalf(c, 0, ksmCheckRun[0].Status, "KSM check status should be running: %s", ksmCheckRun[0].Message)
 
 	metricNames, err := s.Env().FakeIntake.Client().GetMetricNames()
 	assert.NoError(c, err)
@@ -232,14 +236,14 @@ func (s *k8sSuite) verifyKSMCheck(c *assert.CollectT) {
 
 	metrics, err := s.Env().FakeIntake.Client().FilterMetrics("kubernetes_state.container.running", matchOpts...)
 	assert.NoError(c, err)
-	assert.NotEmptyf(c, metrics, fmt.Sprintf("expected metric series to not be empty: %s", err))
+	assert.NotEmptyf(c, metrics, "expected metric series to not be empty: %s", err)
 }
 
 func (s *k8sSuite) verifyHTTPCheck(c *assert.CollectT) {
 	httpCheckRun, err := s.Env().FakeIntake.Client().GetCheckRun("http.can_connect")
 	assert.NoError(c, err)
 	require.NotEmpty(c, httpCheckRun)
-	assert.Equal(c, 0, httpCheckRun[0].Status, fmt.Sprintf("HTTP check status should be running: %s", httpCheckRun[0].Message))
+	assert.Equalf(c, 0, httpCheckRun[0].Status, "HTTP check status should be running: %s", httpCheckRun[0].Message)
 
 	metricNames, err := s.Env().FakeIntake.Client().GetMetricNames()
 	assert.NoError(c, err)

--- a/test/scripts/testwasher.py
+++ b/test/scripts/testwasher.py
@@ -91,25 +91,26 @@ def main():
     # First pass: identify directly flaky failures (marked or inherited from parent)
     non_flaky_failures = {(p, t) for p, t in failed_tests if not is_flaky(p, t)}
 
-    # Second pass: a parent test that only failed because its subtests failed
-    # should not count as non-flaky if all its failing subtests are flaky.
-    # e.g. TestFoo fails because TestFoo/Bar (flaky) failed — TestFoo is not
-    # itself broken.
-    parents_to_remove = set()
-    for pkg, test_name in list(non_flaky_failures):
-        if "/" in test_name:
-            continue  # only check top-level tests
-        # Find all failing subtests of this parent
-        failing_children = {
-            (p, t) for p, t in failed_tests
-            if p == pkg and t.startswith(test_name + "/")
-        }
-        if not failing_children:
-            continue  # parent failed on its own, not from subtests
-        # If all failing children are flaky, the parent failure is just propagation
-        if all(is_flaky(p, t) for p, t in failing_children):
-            parents_to_remove.add((pkg, test_name))
-    non_flaky_failures -= parents_to_remove
+    # Second pass: iteratively propagate flaky status upward through any nesting
+    # depth. A parent test that only failed because all its failing subtests are
+    # effectively flaky should itself not count as non-flaky.
+    # e.g. TestGKEAutopilotSuite fails → TestGenericK8sAutopilot fails →
+    # Kubelet_check_works (flaky) fails: the propagation must bubble up two levels.
+    effective_flaky = set(flaky_tests)
+    changed = True
+    while changed:
+        changed = False
+        for pkg, test_name in list(non_flaky_failures):
+            failing_children = {
+                (p, t) for p, t in failed_tests
+                if p == pkg and t.startswith(test_name + "/")
+            }
+            if not failing_children:
+                continue  # parent failed on its own, not from subtests
+            if all((p, t) in effective_flaky for p, t in failing_children):
+                non_flaky_failures.discard((pkg, test_name))
+                effective_flaky.add((pkg, test_name))
+                changed = True
 
     if non_flaky_failures:
         print(f"\nFAIL: {len(non_flaky_failures)} non-flaky test failure(s):", file=sys.stderr)


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes two related issues that caused known-flaky E2E test failures to block the mergequeue even though they should have been ignored.

**Root cause**: When a deeply-nested test like `TestGKEAutopilotSuite/TestGenericK8sAutopilot/Kubelet_check_works` fails, Go emits failure events for every level of the hierarchy. The testwasher only cleared the directly-marked test as flaky, leaving its parent tests as apparent non-flaky failures — so the pipeline exited 1.

**Changes**:
- `testwasher.py`: replace single-pass parent check with an iterative loop that bubbles flaky status up through all nesting levels until stable
- `e2e_k8ssuite_test.go`: add `flake.Mark` to `testGenericK8sKSMCore`, which was also observed failing without a marker in CI
- `e2e_k8ssuite_test.go`: fix `s.Assert()` used inside `EventuallyWithT` callbacks — this bypassed the retry collector, causing hard failures on transient conditions instead of retrying
- `e2e_k8ssuite_test.go`: remove dead `withAutopilot` code path in `testGenericK8sKSMCoreCCR` (the CCR test was always skipped for autopilot; now it simply isn't called)
- Minor: surface errors from `datadogChartPath()`/`SetupConfig()`, guard nil API responses in retry callbacks, import grouping, typo fix

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits