### PR TITLE
Use standard Agent image for ADP container

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.202.2
+
+* Use the standard Agent image for the `agent-data-plane` container instead of the dedicated `agent-data-plane` image, matching the Datadog Operator behavior.
+
 ## 3.202.1
 
 * Update datadog-csi-driver chart dependency version to fix a CSI Driver startup failure bug on gke autopilot. [Release v1.2.2](https://github.com/DataDog/datadog-csi-driver/pull/78)

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.202.1
+version: 3.202.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.202.1](https://img.shields.io/badge/Version-3.202.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.202.2](https://img.shields.io/badge/Version-3.202.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -811,11 +811,6 @@ helm install <RELEASE_NAME> \
 | datadog.csi.enabled | bool | `false` | Enable datadog csi driver Requires version 7.67 or later of the cluster agent Note:   - When set to true, the CSI driver subchart will be installed automatically.   - Do not install the CSI driver separately if this is enabled, or you may hit conflicts. |
 | datadog.dataPlane.dogstatsd.enabled | bool | `false` | Whether or not DogStatsD is enabled in the data plane |
 | datadog.dataPlane.enabled | bool | `false` | Whether or not the data plane is enabled  Requires version 7.74 or later of the Datadog Agent.  The data plane feature is currently in preview. Please reach out to your Datadog representative for more information. |
-| datadog.dataPlane.image.digest | string | `""` | Define the data plane image digest to use, takes precedence over tag if specified |
-| datadog.dataPlane.image.name | string | `"agent-data-plane"` | Data plane image name to use (relative to `registry`) |
-| datadog.dataPlane.image.pullPolicy | string | `"IfNotPresent"` | Data plane image pull policy |
-| datadog.dataPlane.image.repository | string | `nil` | Override default registry + image.name for data plane |
-| datadog.dataPlane.image.tag | string | `"0.1.30"` | Define the data plane version to use |
 | datadog.dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | datadog.disableDefaultOsReleasePaths | bool | `false` | Set this to true to disable mounting datadog.osReleasePath in all containers |
 | datadog.disablePasswdMount | bool | `false` | Set this to true to disable mounting /etc/passwd in all containers |

--- a/charts/datadog/templates/_container-agent-data-plane.yaml
+++ b/charts/datadog/templates/_container-agent-data-plane.yaml
@@ -1,7 +1,7 @@
 {{- define "container-agent-data-plane" -}}
 - name: agent-data-plane
-  image: "{{ include "image-path" (dict "root" .Values "image" .Values.datadog.dataPlane.image) }}"
-  imagePullPolicy: {{ .Values.datadog.dataPlane.image.pullPolicy }}
+  image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
+  imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
   command: ["agent-data-plane", "--config", "{{ template "datadog.confPath" . }}/datadog.yaml", "run"]
   resources:
 {{- if and (empty .Values.agents.containers.agentDataPlane.resources) .Values.providers.gke.autopilot -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -184,10 +184,10 @@ This considers both whether or not the Data Plane feature is enabled and whether
 data pipeline enabled
 */}}
 {{- define "should-enable-data-plane" -}}
-{{- if and .Values.datadog.dataPlane.enabled (not .Values.agents.image.doNotCheckTag) (semverCompare "<7.74.0" (include "get-agent-version" .)) -}}
+{{- if and .Values.datadog.dataPlane.enabled  (not .Values.providers.gke.gdc) -}}
+{{- if and (not .Values.agents.image.doNotCheckTag) (semverCompare "<7.74.0" (include "get-agent-version" .)) -}}
 {{- fail "Agent Data Plane requires Datadog Agent 7.74 or newer." -}}
 {{- end -}}
-{{- if and .Values.datadog.dataPlane.enabled  (not .Values.providers.gke.gdc) -}}
 {{- if .Values.datadog.dataPlane.dogstatsd.enabled -}}
 true
 {{- else -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -184,7 +184,7 @@ This considers both whether or not the Data Plane feature is enabled and whether
 data pipeline enabled
 */}}
 {{- define "should-enable-data-plane" -}}
-{{- if and (not .Values.agents.image.doNotCheckTag) (semverCompare "<7.74.0" (include "get-agent-version" .)) -}}
+{{- if and .Values.datadog.dataPlane.enabled (not .Values.agents.image.doNotCheckTag) (semverCompare "<7.74.0" (include "get-agent-version" .)) -}}
 {{- fail "Agent Data Plane requires Datadog Agent 7.74 or newer." -}}
 {{- end -}}
 {{- if and .Values.datadog.dataPlane.enabled  (not .Values.providers.gke.gdc) -}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -184,9 +184,8 @@ This considers both whether or not the Data Plane feature is enabled and whether
 data pipeline enabled
 */}}
 {{- define "should-enable-data-plane" -}}
-{{- $adpVersion := .Values.datadog.dataPlane.image.tag -}}
-{{- if not (semverCompare ">=0.1.29" $adpVersion) -}}
-{{- fail "Agent Data Plane 0.1.29 or newer is required to enable the Data Plane feature." -}}
+{{- if and (not .Values.agents.image.doNotCheckTag) (semverCompare "<7.74.0" (include "get-agent-version" .)) -}}
+{{- fail "Agent Data Plane requires Datadog Agent 7.74 or newer." -}}
 {{- end -}}
 {{- if and .Values.datadog.dataPlane.enabled  (not .Values.providers.gke.gdc) -}}
 {{- if .Values.datadog.dataPlane.dogstatsd.enabled -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1403,22 +1403,6 @@ datadog:
       # datadog.dataPlane.dogstatsd.enabled -- Whether or not DogStatsD is enabled in the data plane
       enabled: false
 
-    image:
-      # datadog.dataPlane.image.name -- Data plane image name to use (relative to `registry`)
-      name: agent-data-plane
-
-      # datadog.dataPlane.image.tag -- Define the data plane version to use
-      tag: 0.1.30
-
-      # datadog.dataPlane.image.digest -- Define the data plane image digest to use, takes precedence over tag if specified
-      digest: ""
-
-      # datadog.dataPlane.image.repository -- Override default registry + image.name for data plane
-      repository:
-
-      # datadog.dataPlane.image.pullPolicy -- Data plane image pull policy
-      pullPolicy: IfNotPresent
-
   ## Datadog Operator
   ## * Enable the Datadog Operator chart dependency.
   ## * Configure the Datadog Operator sub-chart using the values config, `operator`.

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -1683,7 +1683,7 @@ spec:
               value: "true"
             - name: DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR
               value: tcp://127.0.0.1:5102
-          image: registry.datadoghq.com/agent-data-plane:0.1.30
+          image: registry.datadoghq.com/agent:7.74.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 12

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -1683,7 +1683,7 @@ spec:
               value: "true"
             - name: DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR
               value: tcp://127.0.0.1:5102
-          image: registry.datadoghq.com/agent-data-plane:0.1.30
+          image: registry.datadoghq.com/agent:7.75.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 12


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f9692349-1d08-47dc-9b0c-0c0e886d3ec5","source":"chat","resourceId":"7cb85f12-2aa2-4b94-b75e-1e1c8bd7947a","workflowId":"f67bde8b-2fb2-4c91-aa69-36d0702f19b1","codeChangeId":"f67bde8b-2fb2-4c91-aa69-36d0702f19b1","sourceType":"slack"} -->
#### What this PR does / why we need it:

The `agent-data-plane` container was previously using a dedicated `agent-data-plane` image (e.g. `registry.datadoghq.com/agent-data-plane:0.1.30`) instead of the standard Agent image. This change aligns the Helm chart with the Datadog Operator behavior, which already uses the normal Agent image for the ADP container. This simplifies image management — no separate ADP image tag to track — and ensures consistency across deployment methods.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

The `datadog.dataPlane.image` values block (name, tag, digest, repository, pullPolicy) has been removed from `values.yaml`. The ADP container now inherits the image from `agents.image`, just like all other agent sidecar containers. The minimum version check in `should-enable-data-plane` has been updated from checking the ADP image tag (`>=0.1.29`) to checking the Agent image tag (`>=7.74.0`).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7cb85f12-2aa2-4b94-b75e-1e1c8bd7947a)

Comment @datadog to request changes