### PR TITLE
TON-347: Replace imgix image URLs with DRUIDS equivalent

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.3
+
+* TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).
+
 ## 0.3.2
 
 * Update Docker image to `v0.1.25`

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.3.2
 # This is the version of the "application". Right now, we follow the image version.
 appVersion: v0.1.25
 home: https://www.datadoghq.com/
-icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
+icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 maintainers:
   - name: Datadog
     email: support@datadoghq.com

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.3.2
+version: 0.3.3
 # This is the version of the "application". Right now, we follow the image version.
 appVersion: v0.1.25
 home: https://www.datadoghq.com/

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.25](https://img.shields.io/badge/AppVersion-v0.1.25-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.25](https://img.shields.io/badge/AppVersion-v0.1.25-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.20.0-dev.5
+
+* TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).
+
 ## 2.20.0-dev.4
 
 * Update CRDs from Datadog Operator v1.26.0-rc.3 release candidate tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - alerting
 - metric
 home: https://www.datadoghq.com
-icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
+icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 sources:
 - https://app.datadoghq.com/account/settings#agent/kubernetes
 - https://github.com/DataDog/datadog-operator

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.20.0-dev.4
+version: 2.20.0-dev.5
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.20.0-dev.4](https://img.shields.io/badge/Version-2.20.0--dev.4-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.20.0-dev.5](https://img.shields.io/badge/Version-2.20.0--dev.5-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.22.0-dev.6
+
+* TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).
+
 ## 2.22.0-dev.5
 
 * Update Datadog Operator chart for 1.26.0-rc.3.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - alerting
 - metric
 home: https://www.datadoghq.com
-icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
+icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 sources:
 - https://app.datadoghq.com/account/settings#agent/kubernetes
 - https://github.com/DataDog/datadog-agent

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.22.0-dev.5
+version: 2.22.0-dev.6
 appVersion: 1.26.0-rc.3
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.22.0-dev.5](https://img.shields.io/badge/Version-2.22.0--dev.5-informational?style=flat-square) ![AppVersion: 1.26.0-rc.3](https://img.shields.io/badge/AppVersion-1.26.0--rc.3-informational?style=flat-square)
+![Version: 2.22.0-dev.6](https://img.shields.io/badge/Version-2.22.0--dev.6-informational?style=flat-square) ![AppVersion: 1.26.0-rc.3](https://img.shields.io/badge/AppVersion-1.26.0--rc.3-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.202.4
+
+* TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).
+
 ## 3.202.3
 
 * [CSPM] add new configuration to run CSPM within system-probe

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.202.3
+version: 3.202.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - alerting
   - metric
 home: https://www.datadoghq.com
-icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
+icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 sources:
   - https://app.datadoghq.com/account/settings#agent/kubernetes
   - https://github.com/DataDog/datadog-agent

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.202.3](https://img.shields.io/badge/Version-3.202.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.202.4](https://img.shields.io/badge/Version-3.202.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/extended-daemon-set/CHANGELOG.md
+++ b/charts/extended-daemon-set/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.3
+
+* TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).
+
 ## 0.3.2
 
 * Add RBAC for the leader election lease.

--- a/charts/extended-daemon-set/Chart.yaml
+++ b/charts/extended-daemon-set/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.8.0
 description: Extended Daemonset Controller
 name: extendeddaemonset
-version: v0.3.2
+version: v0.3.3
 keywords:
   - monitoring
   - alerting

--- a/charts/extended-daemon-set/Chart.yaml
+++ b/charts/extended-daemon-set/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - alerting
   - metric
 home: https://www.datadoghq.com
-icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
+icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 sources:
   - https://github.com/DataDog/extendeddaemonset
 maintainers:

--- a/charts/extended-daemon-set/README.md
+++ b/charts/extended-daemon-set/README.md
@@ -1,6 +1,6 @@
 # Extended DaemonSet
 
-![Version: v0.3.2](https://img.shields.io/badge/Version-v0.3.2-informational?style=flat-square) ![AppVersion: v0.8.0](https://img.shields.io/badge/AppVersion-v0.8.0-informational?style=flat-square)
+![Version: v0.3.3](https://img.shields.io/badge/Version-v0.3.3-informational?style=flat-square) ![AppVersion: v0.8.0](https://img.shields.io/badge/AppVersion-v0.8.0-informational?style=flat-square)
 
 This chart installs the Extended DaemonSet (EDS). It aims to provide a new implementation of the Kubernetes DaemonSet resource with key features:
 - Canary Deployment: Deploy a new DaemonSet version with only a few nodes.

--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.15.3
+
+* TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).
+
 ## 2.15.2
 
 - Switch default `livenessProbe`/`readinessProbe` from `httpGet` to `tcpSocket` on port 8686. Upstream Vector replaced the HTTP/GraphQL observability API with a gRPC server ([vectordotdev/vector#24364](https://github.com/vectordotdev/vector/pull/24364)), so the previous `httpGet :8686/health` probes were incompatible with the worker as of OPW 2.15.0+ and caused pods to enter a probe-failure restart loop. The default `tcpSocket :8686` handler is injected by the chart template only when the user has not provided their own probe handler (`httpGet`/`tcpSocket`/`exec`/`grpc`) — existing user overrides are preserved as-is and not coalesced with the default. The legacy broken `httpGet :8686/health` is also stripped if it appears in the rendered values (e.g., carried over by `helm upgrade --reuse-values` from chart 2.15.0/2.15.1).

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - metrics
   - traces
 home: https://www.datadoghq.com
-icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
+icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 maintainers:
   - name: Datadog
     email: support@datadoghq.com

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: 2.15.2
+version: 2.15.3
 description: Observability Pipelines Worker
 type: application
 keywords:

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.15.2](https://img.shields.io/badge/Version-2.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.1](https://img.shields.io/badge/AppVersion-2.15.1-informational?style=flat-square)
+![Version: 2.15.3](https://img.shields.io/badge/Version-2.15.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.1](https://img.shields.io/badge/AppVersion-2.15.1-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 

--- a/charts/private-action-runner/CHANGELOG.md
+++ b/charts/private-action-runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 1.28.1
+
+* TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).
+
 ## 1.28.0
 
 * Bump private actions runner version to v1.21.0!

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
     - app builder
     - workflow automation
 home: https://www.datadoghq.com
-icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
+icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 sources:
     - https://docs.datadoghq.com/service_management/workflows/private_actions
     - https://app.datadoghq.com/app-builder/private-action-runners

--- a/charts/private-action-runner/Chart.yaml
+++ b/charts/private-action-runner/Chart.yaml
@@ -3,7 +3,7 @@ name: private-action-runner
 description: Datadog Private Action Runner
 
 type: application
-version: 1.28.0
+version: 1.28.1
 appVersion: "v1.21.0"
 keywords:
     - app builder

--- a/charts/private-action-runner/README.md
+++ b/charts/private-action-runner/README.md
@@ -1,6 +1,6 @@
 # Datadog Private Action Runner
 
-![Version: 1.28.0](https://img.shields.io/badge/Version-1.28.0-informational?style=flat-square) ![AppVersion: v1.21.0](https://img.shields.io/badge/AppVersion-v1.21.0-informational?style=flat-square)
+![Version: 1.28.1](https://img.shields.io/badge/Version-1.28.1-informational?style=flat-square) ![AppVersion: v1.21.0](https://img.shields.io/badge/AppVersion-v1.21.0-informational?style=flat-square)
 
 ## Overview
 

--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.17.23
+
+* TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).
+
 ## 0.17.22
 
 * Update private location image version to `1.66.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - monitoring
 - synthetics
 home: https://www.datadoghq.com
-icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
+icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 sources:
 - https://docs.datadoghq.com/synthetics/private_locations
 - https://app.datadoghq.com/synthetics/settings/private-locations

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.17.22
+version: 0.17.23
 appVersion: 1.66.0
 description: Datadog Synthetics Private Location
 keywords:

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.17.22](https://img.shields.io/badge/Version-0.17.22-informational?style=flat-square) ![AppVersion: 1.66.0](https://img.shields.io/badge/AppVersion-1.66.0-informational?style=flat-square)
+![Version: 0.17.23](https://img.shields.io/badge/Version-0.17.23-informational?style=flat-square) ![AppVersion: 1.66.0](https://img.shields.io/badge/AppVersion-1.66.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations/?tab=helmchart).
 

--- a/test/private-action-runner/__snapshot__/config-overrides.yaml
+++ b/test/private-action-runner/__snapshot__/config-overrides.yaml
@@ -6,7 +6,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.21.0"
@@ -87,7 +87,7 @@ metadata:
   name: custom-full-name
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: override-test
     app.kubernetes.io/version: "v1.21.0"
@@ -102,7 +102,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: override-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
+++ b/test/private-action-runner/__snapshot__/custom-pod-scheduling.yaml
@@ -6,7 +6,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.21.0"
@@ -85,7 +85,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.21.0"
@@ -100,7 +100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/custom-resources.yaml
+++ b/test/private-action-runner/__snapshot__/custom-resources.yaml
@@ -6,7 +6,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.21.0"
@@ -85,7 +85,7 @@ metadata:
   name: resources-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: resources-test
     app.kubernetes.io/version: "v1.21.0"
@@ -100,7 +100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: resources-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/custom-service-account.yaml
+++ b/test/private-action-runner/__snapshot__/custom-service-account.yaml
@@ -6,7 +6,7 @@ metadata:
   name: my-custom-runner-sa
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: custom-sa-test
     app.kubernetes.io/version: "v1.21.0"
@@ -88,7 +88,7 @@ metadata:
   name: custom-sa-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: custom-sa-test
     app.kubernetes.io/version: "v1.21.0"
@@ -103,7 +103,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: custom-sa-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/default.yaml
+++ b/test/private-action-runner/__snapshot__/default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.21.0"
@@ -85,7 +85,7 @@ metadata:
   name: default-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: default-test
     app.kubernetes.io/version: "v1.21.0"
@@ -100,7 +100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: default-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/deployment-metadata-annotations.yaml
+++ b/test/private-action-runner/__snapshot__/deployment-metadata-annotations.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deployment-metadata-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: deployment-metadata-test
     app.kubernetes.io/version: "v1.21.0"
@@ -88,7 +88,7 @@ metadata:
     deployment.kubernetes.io/revision: "1"
     example.com/owner: platform-team
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: deployment-metadata-test
     app.kubernetes.io/version: "v1.21.0"
@@ -103,7 +103,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: deployment-metadata-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/deployment-metadata-labels.yaml
+++ b/test/private-action-runner/__snapshot__/deployment-metadata-labels.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deployment-metadata-labels-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: deployment-metadata-labels-test
     app.kubernetes.io/version: "v1.21.0"
@@ -85,7 +85,7 @@ metadata:
   name: deployment-metadata-labels-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: deployment-metadata-labels-test
     app.kubernetes.io/version: "v1.21.0"
@@ -102,7 +102,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: deployment-metadata-labels-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/deployment-runner-annotations.yaml
+++ b/test/private-action-runner/__snapshot__/deployment-runner-annotations.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deployment-runner-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: deployment-runner-test
     app.kubernetes.io/version: "v1.21.0"
@@ -87,7 +87,7 @@ metadata:
   annotations:
     example.com/owner: platform-team
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: deployment-runner-test
     app.kubernetes.io/version: "v1.21.0"
@@ -102,7 +102,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: deployment-runner-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/deprecated-modes.yaml
+++ b/test/private-action-runner/__snapshot__/deprecated-modes.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deprecated-modes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: deprecated-modes-test
     app.kubernetes.io/version: "v1.21.0"
@@ -85,7 +85,7 @@ metadata:
   name: deprecated-modes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: deprecated-modes-test
     app.kubernetes.io/version: "v1.21.0"
@@ -100,7 +100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: deprecated-modes-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
+++ b/test/private-action-runner/__snapshot__/enable-kubernetes-actions.yaml
@@ -6,7 +6,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.21.0"
@@ -138,7 +138,7 @@ metadata:
   name: kubernetes-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: kubernetes-test
     app.kubernetes.io/version: "v1.21.0"
@@ -153,7 +153,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: kubernetes-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/example.yaml
+++ b/test/private-action-runner/__snapshot__/example.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.21.0"
@@ -201,7 +201,7 @@ metadata:
   name: example-test-private-action-runner-scripts
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.21.0"
@@ -265,7 +265,7 @@ metadata:
   name: example-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: example-test
     app.kubernetes.io/version: "v1.21.0"
@@ -280,7 +280,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: example-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/existing-service-account.yaml
+++ b/test/private-action-runner/__snapshot__/existing-service-account.yaml
@@ -72,7 +72,7 @@ metadata:
   name: existing-sa-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: existing-sa-test
     app.kubernetes.io/version: "v1.21.0"
@@ -87,7 +87,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: existing-sa-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/external-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/external-secrets.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.21.0"
@@ -83,7 +83,7 @@ metadata:
   name: secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: secrets-test
     app.kubernetes.io/version: "v1.21.0"
@@ -98,7 +98,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: secrets-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/image-pull-secrets-with-custom-sa.yaml
+++ b/test/private-action-runner/__snapshot__/image-pull-secrets-with-custom-sa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: custom-sa
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: combined-test
     app.kubernetes.io/version: "v1.21.0"
@@ -87,7 +87,7 @@ metadata:
   name: combined-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: combined-test
     app.kubernetes.io/version: "v1.21.0"
@@ -102,7 +102,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: combined-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/image-pull-secrets.yaml
+++ b/test/private-action-runner/__snapshot__/image-pull-secrets.yaml
@@ -6,7 +6,7 @@ metadata:
   name: image-pull-secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: image-pull-secrets-test
     app.kubernetes.io/version: "v1.21.0"
@@ -85,7 +85,7 @@ metadata:
   name: image-pull-secrets-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: image-pull-secrets-test
     app.kubernetes.io/version: "v1.21.0"
@@ -100,7 +100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: image-pull-secrets-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/pod-annotations.yaml
+++ b/test/private-action-runner/__snapshot__/pod-annotations.yaml
@@ -6,7 +6,7 @@ metadata:
   name: runner-pod-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: runner-pod-test
     app.kubernetes.io/version: "v1.21.0"
@@ -85,7 +85,7 @@ metadata:
   name: runner-pod-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: runner-pod-test
     app.kubernetes.io/version: "v1.21.0"
@@ -100,7 +100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: runner-pod-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/scc-enabled.yaml
+++ b/test/private-action-runner/__snapshot__/scc-enabled.yaml
@@ -6,7 +6,7 @@ metadata:
   name: scc-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scc-test
     app.kubernetes.io/version: "v1.21.0"
@@ -85,7 +85,7 @@ metadata:
   name: scc-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scc-test
     app.kubernetes.io/version: "v1.21.0"
@@ -100,7 +100,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: scc-test
         app.kubernetes.io/version: "v1.21.0"
@@ -140,7 +140,7 @@ apiVersion: security.openshift.io/v1
 metadata:
   name: scc-test-private-action-runner
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scc-test
     app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/scripts-configuration.yaml
+++ b/test/private-action-runner/__snapshot__/scripts-configuration.yaml
@@ -6,7 +6,7 @@ metadata:
   name: scripts-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
     app.kubernetes.io/version: "v1.21.0"
@@ -43,7 +43,7 @@ metadata:
   name: scripts-test-private-action-runner-scripts
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
     app.kubernetes.io/version: "v1.21.0"
@@ -107,7 +107,7 @@ metadata:
   name: scripts-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
     app.kubernetes.io/version: "v1.21.0"
@@ -122,7 +122,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: scripts-test
         app.kubernetes.io/version: "v1.21.0"

--- a/test/private-action-runner/__snapshot__/service-annotations.yaml
+++ b/test/private-action-runner/__snapshot__/service-annotations.yaml
@@ -6,7 +6,7 @@ metadata:
   name: scripts-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
     app.kubernetes.io/version: "v1.21.0"
@@ -88,7 +88,7 @@ metadata:
   name: scripts-test-private-action-runner
   namespace: datadog-agent
   labels:
-    helm.sh/chart: private-action-runner-1.28.0
+    helm.sh/chart: private-action-runner-1.28.1
     app.kubernetes.io/name: private-action-runner
     app.kubernetes.io/instance: scripts-test
     app.kubernetes.io/version: "v1.21.0"
@@ -103,7 +103,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: private-action-runner-1.28.0
+        helm.sh/chart: private-action-runner-1.28.1
         app.kubernetes.io/name: private-action-runner
         app.kubernetes.io/instance: scripts-test
         app.kubernetes.io/version: "v1.21.0"


### PR DESCRIPTION
#### What this PR does / why we need it:

The #websites team is migrating image hosting off Imgix. This updates the `icon:` field in our chart manifests from `datadog-live.imgix.net` to the DRUIDS SVG equivalent (`https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg`).

Hits 8 charts: `datadog`, `datadog-crds`, `datadog-operator`, `private-action-runner`, `synthetics-private-location`, `extended-daemon-set`, `observability-pipelines-worker`, `cloudprem`.



#### Special notes for your reviewer:

Icon URL only — does not affect rendered manifests, values, or templates.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [X] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] `CHANGELOG.md` has been updated 

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits