### PR TITLE
tooling: OperatorRelease Worker Permissions

### DIFF
--- a/.github/chainguard/self.operatorrelease-prod.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-prod.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://vault.us1.ddbuild.io/v1/identity/oidc
+
+# ddtool auth whois --datacenter us1.ddbuild.io rapid-agent-delivery-operatorrelease --format json | jq -r .id
+subject: "f012f0b0-d135-9dd7-7f53-44a4d5cb50ca"
+
+claim_pattern:
+  name: "rapid-agent-delivery-operatorrelease"
+
+permissions:
+  contents: read
+  pull_requests: write

--- a/.github/chainguard/self.operatorrelease-staging.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-staging.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://vault.us1.staging.dog/v1/identity/oidc
+
+# ddtool auth whois --datacenter us1.staging.dog rapid-agent-delivery-operatorrelease --format json | jq -r .id
+subject: "1fed960d-1fe4-47de-ebb5-0992bfc0364e"
+
+claim_pattern:
+  name: "rapid-agent-delivery-operatorrelease"
+
+permissions:
+  contents: read
+  pull_requests: write


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds permissions for Operator Release worker to create Pull Requests for release. (same as https://github.com/DataDog/datadog-operator/pull/2943)
