### PR TITLE
ci: prevent install-chart from being silently skipped on lint-chart failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,8 +120,13 @@ jobs:
     name: install-chart
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # NOTE: install-chart depends only on `changed` so that a metadata-only
+    # failure in lint-chart (e.g. version-bump validation) cannot silently skip
+    # the integration test. lint-chart and lint-docs are still gated by
+    # pr-validated below, which fails (rather than being skipped) when any
+    # upstream check is not in `success` state.
     needs:
-      - lint-chart
+      - changed
       - kubeconform-chart
     strategy:
       matrix:
@@ -166,8 +171,38 @@ jobs:
   pr-validated:
     name: pr-validated
     runs-on: ubuntu-latest
+    # `if: always()` ensures this gate runs even when an upstream job fails or
+    # is skipped, so we can convert SKIPPED upstream jobs into a hard FAIL.
+    # GitHub branch protection treats SKIPPED required checks as PASSED, which
+    # has previously allowed regressions to slip through (e.g. when lint-chart
+    # failed and install-chart was skipped via its `needs:` dependency).
+    if: always()
     needs:
+      - lint-chart
+      - lint-docs
+      - kubeconform-chart
       - install-chart
     steps:
       - name: validate
-        run: echo "PR OK"
+        env:
+          LINT_CHART_RESULT: ${{ needs.lint-chart.result }}
+          LINT_DOCS_RESULT: ${{ needs.lint-docs.result }}
+          KUBECONFORM_RESULT: ${{ needs.kubeconform-chart.result }}
+          INSTALL_CHART_RESULT: ${{ needs.install-chart.result }}
+        run: |
+          set -euo pipefail
+          fail=0
+          check() {
+            if [[ "$2" != "success" ]]; then
+              echo "::error::$1 did not succeed (result: $2)"
+              fail=1
+            else
+              echo "$1: success"
+            fi
+          }
+          check lint-chart        "$LINT_CHART_RESULT"
+          check lint-docs         "$LINT_DOCS_RESULT"
+          check kubeconform-chart "$KUBECONFORM_RESULT"
+          check install-chart     "$INSTALL_CHART_RESULT"
+          [[ "$fail" -eq 0 ]] || exit 1
+          echo "PR OK"


### PR DESCRIPTION
#### What this PR does / why we need it

Closes a CI gap that allowed the OPW probe regression to slip through in chart 2.15.1 ([#2570](https://github.com/DataDog/helm-charts/pull/2570)) — full incident analysis in [#2610](https://github.com/DataDog/helm-charts/pull/2610).

**The gap, in one paragraph**: when `lint-chart` failed (e.g. for a version-bump validation problem unrelated to chart correctness), the `install-chart` integration test was silently **skipped** via its `needs: [lint-chart, ...]` dependency. GitHub branch protection treats `SKIPPED` required checks as `PASSED`, so a chart PR could be merged via the merge queue even though the actual `helm install` test never ran. That's how the broken `httpGet :8686/health` probes in chart 2.15.1 went out to customers.

#### Changes

Two minimal edits to `.github/workflows/ci.yaml`:

**1. Drop `lint-chart` from `install-chart.needs`.**

```diff
   install-chart:
     needs:
-      - lint-chart
+      - changed
       - kubeconform-chart
```

A metadata lint failure should not silently disappear the integration test. `install-chart` still requires `kubeconform-chart` (schema sanity check) and `changed` (the chart-list output it consumes).

**2. Make `pr-validated` strict about SKIPPED upstream jobs.**

```yaml
pr-validated:
  if: always()              # run even if upstream failed/skipped
  needs:
    - lint-chart
    - lint-docs
    - kubeconform-chart
    - install-chart
  steps:
    - name: validate
      env:
        LINT_CHART_RESULT: ${{ needs.lint-chart.result }}
        ...
      run: |
        # explicitly check each upstream is `success` — SKIPPED becomes FAIL
```

`if: always()` ensures the gate runs regardless of upstream state. The script asserts each upstream job result is exactly `success` (not `skipped`/`failure`/`cancelled`) and exits non-zero otherwise. This converts an upstream SKIPPED into a hard FAIL on `pr-validated`, which is the required check.

#### Net effect

A chart PR can no longer merge unless `install-chart`, `lint-chart`, `lint-docs`, and `kubeconform-chart` *all* explicitly succeed. The previous escape hatch — \"lint-chart fails → install-chart skips → pr-validated skips → branch protection sees SKIPPED ≡ PASSED\" — is closed.

#### Validation

- YAML parses cleanly (`yaml.safe_load`).
- `actionlint` reports zero new findings on the changed lines (the 4 pre-existing findings in the `changed` job are out of scope).
- The new gate logic is straightforward bash + GitHub Actions `needs.X.result` expressions; can be additionally validated by reviewers running CI on this PR itself.

#### Related

- [#2610](https://github.com/DataDog/helm-charts/pull/2610) — the OPW chart fix this PR is meant to prevent recurrence of.
- [#2570](https://github.com/DataDog/helm-charts/pull/2570) — the original chart 2.15.1 PR that exhibited the failure mode.
- [Run](https://github.com/DataDog/helm-charts/actions/runs/24459496933) — `lint-chart` failure that caused `install-chart` to skip on #2570.

#### Checklist

- [x] All commits are signed and show as \"Verified\" on GitHub
- [N/A] Chart Version semver bump label — no chart changes
- [N/A] `CHANGELOG.md` — no chart changes