### PR TITLE
[cloudprem] Bump chart to v0.3.2 (appVersion v0.1.25)

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2
+
+* Update Docker image to `v0.1.25`
+
 ## 0.3.1
 
 * Remove unnecessary `datadog-values.yaml` file

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.3.1
+version: 0.3.2
 # This is the version of the "application". Right now, we follow the image version.
-appVersion: v0.1.24
+appVersion: v0.1.25
 home: https://www.datadoghq.com/
 icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
 maintainers:

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.24](https://img.shields.io/badge/AppVersion-v0.1.24-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.25](https://img.shields.io/badge/AppVersion-v0.1.25-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 


### PR DESCRIPTION
## Summary

Sync CloudPrem Helm chart from [pomsky-helm-charts#76](https://github.com/DataDog/pomsky-helm-charts/pull/76).

- Chart `version`: 0.3.1 → 0.3.2
- `appVersion`: v0.1.24 → v0.1.25 (tracks pomsky [v0.1.25](https://github.com/DataDog/pomsky/pull/575))

## Test plan

- [ ] `helm template` renders without errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)