### PR TITLE
Route datadog chart code reviews to @DataDog/telemetry-onboarding

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@ charts/datadog-crds                                    @DataDog/container-ecosys
 charts/datadog-csi-driver                              @Datadog/container-platform @DataDog/container-helm-chart-maintainers
 charts/datadog-operator                                @DataDog/container-ecosystems @DataDog/container-platform
 charts/extended-daemon-set                             @DataDog/container-ecosystems @DataDog/container-platform
-charts/datadog                                         @DataDog/container-helm-chart-maintainers
+charts/datadog                                         @DataDog/telemetry-onboarding
 charts/datadog/templates/_container-process-agent.yaml @DataDog/container-experiences @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/_container-system-probe.yaml  @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/_container-trace-agent.yaml   @DataDog/agent-apm @DataDog/container-helm-chart-maintainers


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates `charts/datadog` ownership in `.github/CODEOWNERS` from `@DataDog/container-helm-chart-maintainers` to `@DataDog/telemetry-onboarding`, so review requests for the agent chart land with a team that has an active Slack channel (#telemetry-onboarding).

Context: per [this thread](https://dd.slack.com/archives/C078N61DRK9/p1777384900314599), `container-helm-chart-maintainers` has no Slack channel attached, making it unclear where reviews should be routed. Operator/CRDs continue to route to `@DataDog/container-platform` (unchanged).

#### Special notes for your reviewer:
- Only the `charts/datadog` line was changed.
- The `*` catch-all, `*.md`, and the per-template overrides under `charts/datadog/templates/` (which pair domain teams with `container-helm-chart-maintainers` as a fallback) are intentionally left alone — happy to expand the scope if reviewers prefer.
- Likely needs a follow-up in `DataDog/web-ui` `teams-config.ts` so doggo can route review requests to the right team/channel.

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (`datadog/no-version-bump` — CODEOWNERS only)

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits