### PR TITLE
[CONTP-1511] Support backend refresh intervals in operator install

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.22.0
+
+* [CONTP-1511] Support backend refresh intervals in operator install ([#2617](https://github.com/DataDog/helm-charts/pull/2617)).
+
 ## 2.22.0-dev.6
 
 * TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.22.0
+## 2.22.0-dev.7
 
 * [CONTP-1511] Support backend refresh intervals in operator install ([#2617](https://github.com/DataDog/helm-charts/pull/2617)).
 

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.22.0-dev.6
+version: 2.22.0
 appVersion: 1.26.0-rc.3
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.22.0
+version: 2.22.0-dev.7
 appVersion: 1.26.0-rc.3
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.22.0-dev.6](https://img.shields.io/badge/Version-2.22.0--dev.6-informational?style=flat-square) ![AppVersion: 1.26.0-rc.3](https://img.shields.io/badge/AppVersion-1.26.0--rc.3-informational?style=flat-square)
+![Version: 2.22.0](https://img.shields.io/badge/Version-2.22.0-informational?style=flat-square) ![AppVersion: 1.26.0-rc.3](https://img.shields.io/badge/AppVersion-1.26.0--rc.3-informational?style=flat-square)
 
 ## Values
 
@@ -61,6 +61,7 @@
 | resources | object | `{}` | Set resources requests/limits for Datadog Operator PODs |
 | secretBackend.arguments | string | `""` | Specifies the space-separated arguments passed to the command that implements the secret backend api |
 | secretBackend.command | string | `""` | Specifies the path to the command that implements the secret backend api |
+| secretBackend.refreshInterval | string | `nil` | Specifies the secret backend refresh interval in seconds. |
 | serviceAccount.annotations | object | `{}` | Allows setting additional annotations for service account |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Specifies whether the service account token should be automatically mounted |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.22.0](https://img.shields.io/badge/Version-2.22.0-informational?style=flat-square) ![AppVersion: 1.26.0-rc.3](https://img.shields.io/badge/AppVersion-1.26.0--rc.3-informational?style=flat-square)
+![Version: 2.22.0-dev.7](https://img.shields.io/badge/Version-2.22.0--dev.7-informational?style=flat-square) ![AppVersion: 1.26.0-rc.3](https://img.shields.io/badge/AppVersion-1.26.0--rc.3-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -150,9 +150,9 @@ spec:
           {{- if .Values.secretBackend.arguments }}
             - "-secretBackendArgs={{ .Values.secretBackend.arguments }}"
           {{- end }}
-          {{- if .Values.secretBackend.refreshInterval | quote }}
+          {{- if .Values.secretBackend.refreshInterval }}
             - "-secretRefreshInterval={{ .Values.secretBackend.refreshInterval }}"
-          {{ end }}
+          {{- end }}
           {{- if and .Values.maximumGoroutines (semverCompare ">=1.0.0-rc.13" $version) }}
             - "-maximumGoroutines={{ .Values.maximumGoroutines }}"
           {{- end }}

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -150,6 +150,9 @@ spec:
           {{- if .Values.secretBackend.arguments }}
             - "-secretBackendArgs={{ .Values.secretBackend.arguments }}"
           {{- end }}
+          {{- if .Values.secretBackend.refreshInterval | quote }}
+            - "-secretRefreshInterval={{ .Values.secretBackend.refreshInterval }}"
+          {{ end }}
           {{- if and .Values.maximumGoroutines (semverCompare ">=1.0.0-rc.13" $version) }}
             - "-maximumGoroutines={{ .Values.maximumGoroutines }}"
           {{- end }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -81,6 +81,8 @@ secretBackend:
   command: ""
   # secretBackend.arguments -- Specifies the space-separated arguments passed to the command that implements the secret backend api
   arguments: ""
+  # secretBackend.refreshInterval -- Specifies the secret backend refresh interval in seconds.
+  refreshInterval: # 0s
 datadogAgent:
   # datadogAgent.enabled -- Enables Datadog Agent controller
   enabled: true

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -82,7 +82,7 @@ secretBackend:
   # secretBackend.arguments -- Specifies the space-separated arguments passed to the command that implements the secret backend api
   arguments: ""
   # secretBackend.refreshInterval -- Specifies the secret backend refresh interval in seconds.
-  refreshInterval: # 0s
+  refreshInterval:  # 0s
 datadogAgent:
   # datadogAgent.enabled -- Enables Datadog Agent controller
   enabled: true

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.22.0-dev.5
+    helm.sh/chart: datadog-operator-2.22.0
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.26.0-rc.3"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:

Surfaces secret refresh interval configuration for the datadog operator (`secretBackend.refreshInterval`).

1. Create api/app key secret
```
k create secret generic datadog-secret \                                                                                      
--from-literal api-key="$DD_API_KEY" \
--from-literal app-key="$DD_APP_KEY" \
-n datadog
```
2. Helm install operator (install datadog-crds) if needed.
```yaml
apiKey: "ENC[api-key]"
appKey: "ENC[app-key]"
image:
  repository: test/operator
  tag: "1"
datadogMonitor:
  enabled: true
secretBackend:
  refreshInterval: 30s
  command: "/readsecret.sh"
  arguments: "/etc/secrets"
volumes:
  - name: secrets
    secret:
      secretName: datadog-secret
      items:
        - key: api-key
          path: api-key
        - key: app-key
          path: app-key
volumeMounts:
  - name: secrets
    mountPath: /etc/secrets
    readOnly: true
```

```bash
helm upgrade --install datadog-operator charts/datadog-operator -n datadog --values workloads/operator_values.yaml    
```

3. Install Datadog monitor to validate reconciliation works
```
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMonitor
metadata:
  name: refresh-secrets-test-monitor
  namespace: datadog
spec:
  name: "[refresh-secrets] Test CPU Monitor"
  type: metric alert
  query: "avg(last_5m):avg:system.cpu.user{*} > 90"
  message: "Test monitor for secret refresh validation. Ignore this alert."
  tags:
    - "test:refresh-secrets"
  options:
    thresholds:
      critical: "90"
      warning: "80"
    notifyNoData: false
```

4. Rotate the api/app key secret (change `DD_API_KEY` and `DD_APP_KEY` env vars)
```
kubectl patch secret datadog-secret -n datadog -p "{\"stringData\":{\"api-key\":\"$DD_API_KEY\",\"app-key\":\"$DD_APP_KEY\"}}"
```

5. Check operator logs for updated creds log.
```
{"level":"INFO","ts":"2026-04-28T18:33:57.340Z","logger":"setup","msg":"Credentials have changed, updating creds"}
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits