### PR TITLE
TON-XXXX: Update Datadog Helm Chart Code Owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@ charts/datadog-crds                                    @DataDog/container-ecosys
 charts/datadog-csi-driver                              @Datadog/container-platform @DataDog/container-helm-chart-maintainers
 charts/datadog-operator                                @DataDog/container-ecosystems @DataDog/container-platform
 charts/extended-daemon-set                             @DataDog/container-ecosystems @DataDog/container-platform
-charts/datadog                                         @DataDog/telemetry-onboarding
+charts/datadog                                         @DataDog/telemetry-onboarding @DataDog/container-helm-chart-maintainers 
 charts/datadog/templates/_container-process-agent.yaml @DataDog/container-experiences @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/_container-system-probe.yaml  @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/_container-trace-agent.yaml   @DataDog/agent-apm @DataDog/container-helm-chart-maintainers


### PR DESCRIPTION
#### What this PR does / why we need it:

Small follow-up from this change https://github.com/DataDog/helm-charts/pull/2616, seems like a force push removed the commit suggestion to add container platform as code owners for the datadog helm chart