### PR TITLE
[autoscaling] add spot scheduling

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.208.0
+
+* Add cluster autoscaling RBAC permissions.
+
 ## 3.207.0
 
 * Add cluster agent RBAC permissions required for cluster-profile-aware workload autoscaling: `datadogpodautoscalerclusterprofiles` CRD access for reading and writing cluster-wide scaling profiles; `statefulsets` and `argoproj.io/rollouts` get/list/watch/patch to read workload metadata and trigger rollouts; `namespaces` get/list/watch to resolve namespace-scoped profiles.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.207.0
+version: 3.208.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.207.0](https://img.shields.io/badge/Version-3.207.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.208.0](https://img.shields.io/badge/Version-3.208.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -788,7 +788,7 @@ helm install <RELEASE_NAME> \
 | datadog.asm.iast.enabled | bool | `false` | Enable Application Security Management Interactive Application Security Testing by injecting `DD_IAST_ENABLED=true` environment variable to all pods in the cluster |
 | datadog.asm.sca.enabled | bool | `false` | Enable Application Security Management Software Composition Analysis by injecting `DD_APPSEC_SCA_ENABLED=true` environment variable to all pods in the cluster |
 | datadog.asm.threats.enabled | bool | `false` | Enable Application Security Management Threats App & API Protection by injecting `DD_APPSEC_ENABLED=true` environment variable to all pods in the cluster |
-| datadog.autoscaling.workload.enabled | string | `nil` | Enable Workload Autoscaling. |
+| datadog.autoscaling.workload.enabled | bool | `nil` | Enable Workload Autoscaling. |
 | datadog.celWorkloadExclude | string | `nil` | Exclude workloads using a CEL-based definition in the Agent. (Requires Agent 7.73.0+) ref: https://docs.datadoghq.com/containers/guide/container-discovery-management/ |
 | datadog.checksCardinality | string | `nil` | Sets the tag cardinality for the checks run by the Agent. |
 | datadog.checksd | object | `{}` | Provide additional custom checks as python code |

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -485,6 +485,10 @@ spec:
           - name: DD_AUTOSCALING_CLUSTER_ENABLED
             value: {{ (((.Values.datadog.autoscaling).cluster).enabled) | quote }}
           {{- end }}
+          {{- if ((((.Values.datadog.autoscaling).cluster).spot).enabled) }}
+          - name: DD_AUTOSCALING_CLUSTER_SPOT_ENABLED
+            value: {{ ((((.Values.datadog.autoscaling).cluster).spot).enabled) | quote }}
+          {{- end }}
           - name: DD_INSTRUMENTATION_INSTALL_TIME
             valueFrom:
               configMapKeyRef:

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -621,7 +621,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end -}}
 
-{{- if or (((.Values.datadog.autoscaling).workload).enabled) (((.Values.datadog.autoscaling).cluster).enabled) }}
+{{- if or (((.Values.datadog.autoscaling).workload).enabled) (((.Values.datadog.autoscaling).cluster).enabled) ((((.Values.datadog.autoscaling).cluster).spot).enabled) }}
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
@@ -671,24 +671,6 @@ rules:
   - pods/resize
   verbs:
   - patch
-# In-place resize: evicting pods that cannot resize in-place
-- apiGroups:
-  - ""
-  resources:
-  - pods/eviction
-  verbs:
-  - create
-# Patching workloads to trigger rollout; list/watch for cluster profiles
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
 - apiGroups:
   - argoproj.io
   resources:
@@ -707,6 +689,26 @@ rules:
   - get
   - list
   - watch
+{{- end}}
+{{- if or (((.Values.datadog.autoscaling).workload).enabled) ((((.Values.datadog.autoscaling).cluster).spot).enabled) }}
+# Read and patch workloads for autoscaling and spot on-demand fallback
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+# Evict pods during in-place resize or spot-to-on-demand fallback
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 {{- end}}
 {{- if (((.Values.datadog.autoscaling).cluster).enabled) }}
 - apiGroups:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1444,7 +1444,7 @@ datadog:
   # Configuration related to Workload Autoscaling
   autoscaling:
     workload:
-      # datadog.autoscaling.workload.enabled -- Enable Workload Autoscaling.
+      # datadog.autoscaling.workload.enabled -- (bool) Enable Workload Autoscaling.
       enabled:
 
 ## This is the Datadog Cluster Agent implementation that handles cluster-wide


### PR DESCRIPTION
What does this PR do?
---------------------
Adds `datadog.autoscaling.cluster.spot.enabled` to enable RBAC permissions
for the spot instance scheduler in the Cluster Agent:
- Deployments and StatefulSets (get, list, watch, patch) — to write the
  spot-disabled-until annotation during on-demand fallback.
- pods/eviction (create) — to evict pending spot pods and trigger
  on-demand fallback rescheduling.

Motivation
----------
The spot scheduler MVP was added in https://github.com/DataDog/datadog-agent/pull/47429 
The equivalent operator change is https://github.com/DataDog/datadog-operator/pull/2957

Minimum Agent Versions
----------------------
* Cluster Agent: v7.79.0

Updates https://datadoghq.atlassian.net/browse/CASCL-1315

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits