### PR TITLE
[autoscaling] document datadog.autoscaling.cluster.enabled in values.yaml

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.204.0
+
+* Document `datadog.autoscaling.cluster.enabled` in values.yaml (was missing since #2240).
+
 ## 3.203.0
 
 * Add `datadog.sbom.enrichment.usage.enabled` to enable runtime "package in use" SBOM enrichment via system-probe (Agent 7.79.0+).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.203.0
+version: 3.204.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.203.0](https://img.shields.io/badge/Version-3.203.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.204.0](https://img.shields.io/badge/Version-3.204.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -788,7 +788,8 @@ helm install <RELEASE_NAME> \
 | datadog.asm.iast.enabled | bool | `false` | Enable Application Security Management Interactive Application Security Testing by injecting `DD_IAST_ENABLED=true` environment variable to all pods in the cluster |
 | datadog.asm.sca.enabled | bool | `false` | Enable Application Security Management Software Composition Analysis by injecting `DD_APPSEC_SCA_ENABLED=true` environment variable to all pods in the cluster |
 | datadog.asm.threats.enabled | bool | `false` | Enable Application Security Management Threats App & API Protection by injecting `DD_APPSEC_ENABLED=true` environment variable to all pods in the cluster |
-| datadog.autoscaling.workload.enabled | string | `nil` | Enable Workload Autoscaling. |
+| datadog.autoscaling.cluster.enabled | bool | `nil` | Enable Cluster Autoscaling. |
+| datadog.autoscaling.workload.enabled | bool | `nil` | Enable Workload Autoscaling. |
 | datadog.celWorkloadExclude | string | `nil` | Exclude workloads using a CEL-based definition in the Agent. (Requires Agent 7.73.0+) ref: https://docs.datadoghq.com/containers/guide/container-discovery-management/ |
 | datadog.checksCardinality | string | `nil` | Sets the tag cardinality for the checks run by the Agent. |
 | datadog.checksd | object | `{}` | Provide additional custom checks as python code |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1444,7 +1444,10 @@ datadog:
   # Configuration related to Workload Autoscaling
   autoscaling:
     workload:
-      # datadog.autoscaling.workload.enabled -- Enable Workload Autoscaling.
+      # datadog.autoscaling.workload.enabled -- (bool) Enable Workload Autoscaling.
+      enabled:
+    cluster:
+      # datadog.autoscaling.cluster.enabled -- (bool) Enable Cluster Autoscaling.
       enabled:
 
 ## This is the Datadog Cluster Agent implementation that handles cluster-wide


### PR DESCRIPTION
## What does this PR do?

Documents `datadog.autoscaling.cluster.enabled` in `values.yaml`. This value was used in the cluster-agent RBAC template since #2240 but was never added to `values.yaml`, leaving it undocumented.

## Motivation

Fixes the oversight from #2240 so that users can discover and configure cluster autoscaling through standard Helm tooling (e.g. `helm show values`).

## Additional Notes

No functional change — the template already handles the missing key gracefully via optional chaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)