### PR TITLE
[autoscaling] expand workload autoscaling RBAC for cluster profiles

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.207.0
+
+* Add cluster agent RBAC permissions required for cluster-profile-aware workload autoscaling: `datadogpodautoscalerclusterprofiles` CRD access for reading and writing cluster-wide scaling profiles; `statefulsets` and `argoproj.io/rollouts` get/list/watch/patch to read workload metadata and trigger rollouts; `namespaces` get/list/watch to resolve namespace-scoped profiles.
+
 ## 3.206.0
 
 * Bump Datadog Operator chart dependency to 2.22.0.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.206.0
+version: 3.207.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.206.0](https://img.shields.io/badge/Version-3.206.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.207.0](https://img.shields.io/badge/Version-3.207.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -645,6 +645,8 @@ rules:
   resources:
   - "datadogpodautoscalers"
   - "datadogpodautoscalers/status"
+  - "datadogpodautoscalerclusterprofiles"
+  - "datadogpodautoscalerclusterprofiles/status"
   verbs:
   - "*"
 # Scale subresource for all resources
@@ -653,8 +655,8 @@ rules:
   resources:
   - "*/scale"
   verbs:
-  - 'update'
-  - 'get'
+  - get
+  - update
 # Patching POD to add annotations. TODO: Remove when we have a better way to generate single event
 - apiGroups:
   - ""
@@ -676,19 +678,35 @@ rules:
   - pods/eviction
   verbs:
   - create
-# Triggering rollout on Deployments
+# Patching workloads to trigger rollout; list/watch for cluster profiles
 - apiGroups:
   - apps
   resources:
   - deployments
+  - statefulsets
   verbs:
+  - get
+  - list
+  - watch
   - patch
 - apiGroups:
   - argoproj.io
   resources:
   - rollouts
   verbs:
+  - get
+  - list
+  - watch
   - patch
+# List/watch namespaces for cluster profiles
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 {{- end}}
 {{- if (((.Values.datadog.autoscaling).cluster).enabled) }}
 - apiGroups:
@@ -696,16 +714,22 @@ rules:
   resources:
   - '*'
   verbs:
-  - create
-  - delete
   - get
   - list
   - watch
+  - create
   - patch
   - update
+  - delete
+- apiGroups:
+  - karpenter.k8s.aws
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
 - apiGroups:
   - eks.amazonaws.com
-  - karpenter.k8s.aws
   resources:
   - '*'
   verbs:


### PR DESCRIPTION
What does this PR do?
---------------------
Adds RBAC permissions to the cluster agent required for cluster-profile-aware
workload autoscaling:

- `datadogpodautoscalerclusterprofiles` and `datadogpodautoscalerclusterprofiles/status`:
  read and write cluster-wide scaling profiles (own CRD)
- `apps/statefulsets` get/list/watch/patch: read workload metadata for profile
  matching and patch to trigger rollouts
- `argoproj.io/rollouts` get/list/watch/patch: same as above for Argo Rollouts
  (previously patch-only, missing read verbs)
- `""` namespaces get/list/watch: resolve namespace-scoped cluster profiles
- reorder some rules to match datadog-operator RBAC

Motivation
----------
The cluster agent requires these permissions to support the
DatadogPodAutoscalerClusterProfile CRD, which groups workloads into shared
scaling behavior profiles scoped by namespace.

Reference: https://github.com/DataDog/datadog-operator/pull/2794

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits