### PR TITLE
Don't add ddai arg for operator >=1.27

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.22.2
+
+* Don't add datadogAgentInternalEnabled arg for operator >= 1.27.
+
 ## 2.22.1
 
 * Datadog-operator automountServiceAccountToken deployment file bug fix.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.22.1
+version: 2.22.2
 appVersion: 1.26.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.22.1](https://img.shields.io/badge/Version-2.22.1-informational?style=flat-square) ![AppVersion: 1.26.0](https://img.shields.io/badge/AppVersion-1.26.0-informational?style=flat-square)
+![Version: 2.22.2](https://img.shields.io/badge/Version-2.22.2-informational?style=flat-square) ![AppVersion: 1.26.0](https://img.shields.io/badge/AppVersion-1.26.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -181,7 +181,7 @@ spec:
           {{- if (semverCompare ">=1.7.0-0" $version) }}
             - "-remoteConfigEnabled={{ .Values.remoteConfiguration.enabled }}"
           {{- end }}
-          {{- if (semverCompare ">=1.18.0-0" $version) }}
+          {{- if and (semverCompare ">=1.18.0-0 <1.27.0-0" $version) (or (not .Values.image.doNotCheckTag) (not .Values.datadogAgentInternal.enabled)) }}
             - "-datadogAgentInternalEnabled={{ .Values.datadogAgentInternal.enabled }}"
           {{- end }}
           {{- if (semverCompare ">=1.26.0-0" $version) }}

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.22.1
+    helm.sh/chart: datadog-operator-2.22.2
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.26.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:

  - Operator image >=1.18.0 and <1.27.0, with normal tag checking: adds ddai arg as normal (no change)
  - Operator image <1.18.0: doesn't add ddai arg (no change)
  - Operator image >=1.27.0, with normal semver tag: does not add ddai arg
  - image.doNotCheckTag=true and datadogAgentInternal.enabled=true: does not add ddai arg (used in e2e tests)
  - image.doNotCheckTag=true and datadogAgentInternal.enabled=false: adds ddai=false while `1.18.0 <= $version <1.27.0`. This keeps the old opt-out behavior for custom or nonstandard 1.18-1.26 images.

https://datadoghq.atlassian.net/browse/CONTP-1536

#### Which issue this PR fixes
- needed for https://github.com/DataDog/datadog-operator/pull/2912

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits