### PR TITLE
Update CloudPrem Helm chart to 0.4.0

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0
+
+* Update Docker image to `v0.1.26`.
+* Add intake service: new `intake` deployment, service, configmap, HPA, PDB, and ingress (disabled by default; enable with `intake.enabled=true`) for accepting Datadog Agent and OTLP traffic ([#74](https://github.com/DataDog/pomsky-helm-charts/pull/74)).
+* Add top-level `signals` config (`logs`, `metrics`, `traces`) to gate intake ingress paths and the indexes the cloudprem binary creates on startup. Defaults: logs enabled, metrics and traces disabled.
+
 ## 0.3.3
 
 * TON-347: Replace imgix image URLs with DRUIDS equivalent ([#2608](https://github.com/DataDog/helm-charts/pull/2608)).

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.3.3
+version: 0.4.0
 # This is the version of the "application". Right now, we follow the image version.
-appVersion: v0.1.25
+appVersion: v0.1.26
 home: https://www.datadoghq.com/
 icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 maintainers:

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.25](https://img.shields.io/badge/AppVersion-v0.1.25-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.26](https://img.shields.io/badge/AppVersion-v0.1.26-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/templates/_helpers.tpl
+++ b/charts/cloudprem/templates/_helpers.tpl
@@ -101,6 +101,38 @@ app.kubernetes.io/component: indexer
 {{- end }}
 
 {{/*
+Intake Selector labels
+*/}}
+{{- define "quickwit.intake.selectorLabels" -}}
+{{ include "quickwit.selectorLabels" . }}
+app.kubernetes.io/component: intake
+{{- end }}
+
+{{/*
+Intake container ports
+*/}}
+{{- define "quickwit.intake.ports" -}}
+- name: dd-agent
+  containerPort: 8181
+  protocol: TCP
+- name: http-ingest
+  containerPort: 8282
+  protocol: TCP
+- name: otlp-grpc
+  containerPort: 8383
+  protocol: TCP
+- name: otlp-http
+  containerPort: 8384
+  protocol: TCP
+- name: connections
+  containerPort: 8585
+  protocol: TCP
+- name: api
+  containerPort: 8686
+  protocol: TCP
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "quickwit.serviceAccountName" -}}

--- a/charts/cloudprem/templates/configmap.yaml
+++ b/charts/cloudprem/templates/configmap.yaml
@@ -19,6 +19,9 @@
 {{- end }}
 
 {{- $cloudpremConfig := set ($config.cloudprem | default dict) "mtls_header" $mtlsHeader }}
+{{- $_ := set $cloudpremConfig "create_dd_logs_index" .Values.signals.logs.enabled }}
+{{- $_ := set $cloudpremConfig "create_dd_metrics_index" .Values.signals.metrics.enabled }}
+{{- $_ := set $cloudpremConfig "create_dd_traces_index" .Values.signals.traces.enabled }}
 {{- $config = merge $config (dict "cloudprem" $cloudpremConfig) }}
 
 apiVersion: v1

--- a/charts/cloudprem/templates/ingress/intake.yaml
+++ b/charts/cloudprem/templates/ingress/intake.yaml
@@ -1,0 +1,137 @@
+{{- $fullname := include "quickwit.fullname" . }}
+{{- $labels := include "quickwit.labels" . }}
+{{- $ingress := .Values.intake.ingress }}
+{{- $ingressClassName := $ingress.ingressClassName }}
+{{- $signals := .Values.signals }}
+
+{{- if and .Values.intake.enabled $ingress.enabled -}}
+{{- if not (or $signals.logs.enabled $signals.metrics.enabled $signals.traces.enabled) -}}
+{{- fail "intake ingress is enabled but no signals are enabled — set at least one of signals.{logs,metrics,traces}.enabled" -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullname }}-intake
+  labels: {{- $labels | nindent 4 }}
+  annotations:
+    {{- if eq $ingressClassName "alb" }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+    alb.ingress.kubernetes.io/scheme: {{ $ingress.albScheme | default "internal" }}
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/healthcheck-port: "8686"
+    {{- end }}
+  {{- with $ingress.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ $ingressClassName }}
+  {{- with $ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - http:
+        paths:
+          # OTLP HTTP endpoints (listed first to win path precedence)
+          {{- if $signals.logs.enabled }}
+          - path: /v1/logs
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: otlp-http
+          {{- end }}
+          {{- if $signals.metrics.enabled }}
+          - path: /v1/metrics
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: otlp-http
+          {{- end }}
+          {{- if $signals.traces.enabled }}
+          - path: /v1/traces
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: otlp-http
+          {{- end }}
+          # Datadog agent endpoints
+          {{- if $signals.metrics.enabled }}
+          - path: /api/v1/series
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: dd-agent
+          - path: /api/v2/series
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: dd-agent
+          - path: /api/beta/sketches
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: dd-agent
+          {{- end }}
+          {{- if $signals.logs.enabled }}
+          - path: /api/v2/logs
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: dd-agent
+          - path: /v1/input
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: dd-agent
+          {{- end }}
+          {{- if $signals.traces.enabled }}
+          - path: /v0.4/traces
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: dd-agent
+          - path: /v0.5/traces
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: dd-agent
+          - path: /v0.6/traces
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: dd-agent
+          - path: /v0.7/traces
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}-intake
+                port:
+                  name: dd-agent
+          {{- end }}
+      {{- with $ingress.host }}
+      host: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/cloudprem/templates/intake-configmap.yaml
+++ b/charts/cloudprem/templates/intake-configmap.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.intake.enabled }}
+{{- $indexer := printf "http://%s-indexer.%s.svc.%s:7280" (include "quickwit.fullname" .) .Release.Namespace .Values.clusterDomain }}
+{{- $signalConfig := dict }}
+{{- if .Values.signals.logs.enabled }}
+  {{- $_ := set $signalConfig "logs_endpoint" (printf "%s/api/datadog/v1/byoc/logs" $indexer) }}
+{{- end }}
+{{- if .Values.signals.metrics.enabled }}
+  {{- $_ := set $signalConfig "metrics_endpoint" (printf "%s/api/datadog/v1/byoc/metrics" $indexer) }}
+{{- end }}
+{{- if .Values.signals.traces.enabled }}
+  {{- $_ := set $signalConfig "traces_endpoint" (printf "%s/api/datadog/v1/byoc/traces" $indexer) }}
+{{- end }}
+{{- $config := merge (.Values.intake.config | default dict) $signalConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "quickwit.fullname" . }}-intake
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml $config | nindent 4 }}
+{{- end }}

--- a/charts/cloudprem/templates/intake-deployment.yaml
+++ b/charts/cloudprem/templates/intake-deployment.yaml
@@ -1,0 +1,130 @@
+{{- if .Values.intake.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "quickwit.fullname" . }}-intake
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+    {{- if .Values.azure.clientId }}
+    azure.workload.identity/use: "true"
+    {{- end }}
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.intake.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if and (hasKey .Values.intake "replicaCount") (not .Values.intake.autoscaling.enabled) }}
+  replicas: {{ .Values.intake.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "quickwit.intake.selectorLabels" . | nindent 6 }}
+  {{- with .Values.intake.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/intake-configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.intake.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "quickwit.additionalLabels" . | nindent 8 }}
+        {{- include "quickwit.intake.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "quickwit.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.intake.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{ end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["pomsky-intake"]
+          {{- if $.Values.intake.args }}
+          args: {{- toYaml $.Values.intake.args | nindent 10 }}
+          {{- else }}
+          args: ["--config", "/quickwit/config.yaml"]
+          {{- end }}
+          env:
+            {{- include "quickwit.environment" . | nindent 12 }}
+            {{- with (include "quickwit.extraEnv" .Values.intake.extraEnv) }}
+            {{- . | nindent 12 }}
+            {{- end }}
+          {{- if or (.Values.environmentFrom) (.Values.intake.extraEnvFrom) }}
+          envFrom:
+          {{- with .Values.environmentFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.intake.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          ports:
+            {{- include "quickwit.intake.ports" . | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.intake.startupProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.intake.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.intake.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /quickwit/
+            - name: data
+              mountPath: /quickwit/qwdata
+            {{- with .Values.intake.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.intake.resources | nindent 12 }}
+          {{- with .Values.intake.lifecycleHooks }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.intake.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "quickwit.fullname" . }}-intake
+        - name: data
+          emptyDir: {}
+        {{- with .Values.intake.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.intake.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with merge (dict) .Values.intake.affinity .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- $tolerations := concat .Values.tolerations .Values.intake.tolerations | compact | uniq }}
+      tolerations:
+        {{- toYaml $tolerations | nindent 8 }}
+      {{- with .Values.intake.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.intake.runtimeClassName }}
+      runtimeClassName: {{ .Values.intake.runtimeClassName | quote }}
+      {{- end }}
+{{- end }}

--- a/charts/cloudprem/templates/intake-hpa.yaml
+++ b/charts/cloudprem/templates/intake-hpa.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.intake.enabled .Values.intake.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "quickwit.fullname" . }}-intake
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: intake-hpa
+  {{- with .Values.intake.autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "quickwit.fullname" . }}-intake
+  minReplicas: {{ .Values.intake.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.intake.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.intake.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.intake.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.intake.autoscaling.targetCPUUtilizationPercentage }}
+  {{- with .Values.intake.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cloudprem/templates/intake-pdb.yaml
+++ b/charts/cloudprem/templates/intake-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.intake.enabled .Values.intake.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "quickwit.fullname" . }}-intake
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "quickwit.intake.selectorLabels" . | nindent 6 }}
+  {{- toYaml .Values.intake.podDisruptionBudget | nindent 2 }}
+{{- end -}}

--- a/charts/cloudprem/templates/intake-service.yaml
+++ b/charts/cloudprem/templates/intake-service.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.intake.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "quickwit.fullname" . }}-intake
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.intake.serviceAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.intake.serviceType | default .Values.service.type }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ .Values.service.ipFamilies | toYaml | nindent 2 }}
+  {{- end }}
+  ports:
+    - port: 8181
+      targetPort: dd-agent
+      protocol: TCP
+      name: dd-agent
+    - port: 8282
+      targetPort: http-ingest
+      protocol: TCP
+      name: http-ingest
+    - port: 8383
+      targetPort: otlp-grpc
+      protocol: TCP
+      name: otlp-grpc
+    - port: 8384
+      targetPort: otlp-http
+      protocol: TCP
+      name: otlp-http
+    - port: 8585
+      targetPort: connections
+      protocol: TCP
+      name: connections
+    - port: 8686
+      targetPort: api
+      protocol: TCP
+      name: api
+  selector:
+    {{- include "quickwit.intake.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/cloudprem/values.yaml
+++ b/charts/cloudprem/values.yaml
@@ -21,6 +21,17 @@ datadog:
   ## If set, this parameter takes precedence over `datadog.apiKey`.
   apiKeyExistingSecret:
 
+# Which observability signals this deployment accepts. Gates the intake ingress
+# path groups; the binary uses the same flags to create default indexes on startup.
+# At least one signal must be enabled when `intake.ingress.enabled` is true.
+signals:
+  logs:
+    enabled: true
+  metrics:
+    enabled: false
+  traces:
+    enabled: false
+
 # CloudPrem configuration
 cloudprem:
   # # Index configuration
@@ -695,6 +706,128 @@ janitor:
   topologySpreadConstraints: []
 
   runtimeClassName: ""
+
+intake:
+  # Enable the intake Deployment, Service, ConfigMap (+ HPA / Ingress if enabled below).
+  enabled: false
+
+  replicaCount: 1
+
+  # Vector pipeline config mounted at /quickwit/config.yaml.
+  # If empty, the binary falls back to its built-in defaults.
+  config: {}
+
+  # Extra env for intake.
+  # Legacy map format (e.g. extraEnv: { KEY: VALUE }) is also supported for backward compatibility.
+  extraEnv: []
+    # - name: KEY
+    #   value: VALUE
+  extraEnvFrom: []
+    # - secretRef:
+    #     name: quickwit-intake
+
+  # extraVolumes -- Additional volumes to use with Pods.
+  extraVolumes: []
+
+  # extraVolumeMounts -- Additional volumes to mount into intake containers.
+  extraVolumeMounts: []
+
+  # No CPU limit on purpose — lets the pod use any spare CPU on the node when available.
+  resources:
+    requests:
+      cpu: 2
+      memory: 1Gi
+    limits:
+      memory: 1Gi
+
+  startupProbe:
+    httpGet:
+      path: /health
+      port: api
+    failureThreshold: 12
+    periodSeconds: 5
+
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: api
+    failureThreshold: 5
+    periodSeconds: 10
+    timeoutSeconds: 15
+
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: api
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 15
+
+  # Override args. When unset, defaults to `["--config", "/quickwit/config.yaml"]`.
+  # The container command is always `pomsky-intake` (set explicitly in the Deployment).
+  args: []
+
+  # initContainers -- Init containers to be added to the pods.
+  initContainers: []
+
+  annotations: {}
+
+  podAnnotations: {}
+
+  serviceAnnotations: {}
+
+  # serviceType: ClusterIP
+
+  updateStrategy: {}
+
+  lifecycleHooks: {}
+
+  terminationGracePeriodSeconds: 60
+
+  # intake.nodeSelector -- Configure
+  # [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
+  nodeSelector: {}
+
+  # intake.tolerations -- Configure
+  # [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+  tolerations: []
+
+  # intake.affinity -- Configure
+  # [affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
+  affinity: {}
+
+  # intake.topologySpreadConstraints -- Configure
+  # [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).
+  topologySpreadConstraints: []
+
+  runtimeClassName: ""
+
+  # Set to `{}` (or a map with minAvailable / maxUnavailable) to create a PodDisruptionBudget.
+  podDisruptionBudget: {}
+    # minAvailable: 1
+
+  # Autoscaling — patterned after the OP worker chart (CPU + memory utilization).
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 80
+    # Set to a number to enable memory-based scaling too.
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
+    annotations: {}
+
+  # AWS ALB ingress for DD agent + OTLP HTTP endpoints.
+  # gRPC is intentionally out of scope — it requires a separate ingress
+  # with `alb.ingress.kubernetes.io/backend-protocol-version: GRPC`.
+  ingress:
+    enabled: false
+    ingressClassName: alb
+    # ALB scheme: `internal` (default) or `internet-facing`.
+    albScheme: internal
+    # host: intake.example.com
+    tls: []
+    extraAnnotations: {}
 
 # Deploy jobs to bootstrap creation of indexes and sources for quickwit clusters
 bootstrap:


### PR DESCRIPTION
Updates CloudPrem chart to version 0.4.0.

## Summary

- Bump chart version `0.3.3` → `0.4.0` and Docker image `v0.1.25` → `v0.1.26`.
- Add intake service (Deployment, Service, ConfigMap, HPA, PDB, Ingress); disabled by default, enable with `intake.enabled=true`.
- Add top-level `signals` config (`logs`/`metrics`/`traces`) that gates intake ingress paths and the indexes the cloudprem binary creates on startup. Defaults: logs enabled, metrics/traces disabled.

Mirrors DataDog/pomsky-helm-charts#79.