### PR TITLE
Add writev, shutdown, and chown to system-probe seccomp profile

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.208.1
+
+* Allow `writev` and `shutdown` syscalls in the system-probe seccomp profile, required by `system-probe-lite` (Rust/hyper-based) which uses vectored writes and graceful connection shutdown.
+
 ## 3.208.0
 
 * Add cluster autoscaling RBAC permissions.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.208.1
 
-* Allow `writev` and `shutdown` syscalls in the system-probe seccomp profile, required by `system-probe-lite` (Rust/hyper-based) which uses vectored writes and graceful connection shutdown.
+* Allow `writev`, `shutdown`, and `chown` syscalls in the system-probe seccomp profile, required by `system-probe-lite`.
 
 ## 3.208.0
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.208.0
+version: 3.208.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.208.0](https://img.shields.io/badge/Version-3.208.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.208.1](https://img.shields.io/badge/Version-3.208.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -173,9 +173,7 @@ data:
             "capset",
             "chdir",
             "chmod",
-            {{- if (and .Values.datadog.gpuMonitoring.enabled .Values.datadog.gpuMonitoring.privilegedMode) }}
             "chown",
-            {{- end }}
             "clock_gettime",
             "clone",
             "clone3",

--- a/charts/datadog/templates/system-probe-configmap.yaml
+++ b/charts/datadog/templates/system-probe-configmap.yaml
@@ -335,6 +335,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -360,7 +361,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -189,6 +189,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -337,6 +337,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -359,7 +360,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -333,6 +333,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -355,7 +356,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -185,6 +185,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -333,6 +333,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -355,7 +356,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -185,6 +185,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -333,6 +333,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -355,7 +356,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -185,6 +185,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -333,6 +333,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -355,7 +356,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -185,6 +185,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -321,6 +321,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -343,7 +344,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -321,6 +321,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -343,7 +344,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -373,6 +373,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -395,7 +396,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -225,6 +225,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -335,6 +335,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -357,7 +358,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -187,6 +187,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -335,6 +335,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -357,7 +358,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -187,6 +187,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -335,6 +335,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -357,7 +358,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -187,6 +187,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -325,6 +325,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -348,7 +349,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -216,6 +216,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -364,6 +364,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -386,7 +387,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -391,6 +391,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -413,7 +414,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -243,6 +243,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -391,6 +391,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -413,7 +414,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -243,6 +243,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -363,6 +363,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -385,7 +386,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -215,6 +215,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -363,6 +363,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -385,7 +386,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -215,6 +215,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -246,6 +246,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -394,6 +394,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -416,7 +417,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -246,6 +246,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -394,6 +394,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -416,7 +417,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -343,6 +343,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -365,7 +366,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -195,6 +195,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -391,6 +391,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -413,7 +414,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -243,6 +243,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -391,6 +391,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -413,7 +414,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -243,6 +243,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -321,6 +321,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -343,7 +344,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -173,6 +173,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -335,6 +335,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -357,7 +358,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -187,6 +187,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -321,6 +321,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -343,7 +344,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -320,6 +320,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -342,7 +343,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -321,6 +321,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -343,7 +344,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -172,6 +172,7 @@ data:
             "capset",
             "chdir",
             "chmod",
+            "chown",
             "clock_gettime",
             "clone",
             "clone3",

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -321,6 +321,7 @@ data:
             "setsockopt",
             "setuid",
             "setuid32",
+            "shutdown",
             "sigaltstack",
             "socket",
             "socketcall",
@@ -343,7 +344,8 @@ data:
             "wait4",
             "waitid",
             "waitpid",
-            "write"
+            "write",
+            "writev"
           ],
           "action": "SCMP_ACT_ALLOW",
           "args": null


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `writev`, `shutdown`, and `chown` to the `system-probe` seccomp profile (default action `SCMP_ACT_ERRNO`). All three are required by `system-probe-lite` (Rust/hyper-based) but were tolerated or never invoked by the Go `system-probe`, so the existing profile rejected them with `EPERM`.

##### `writev` and `shutdown`

Hyper calls `shutdown(SHUT_WR)` at the end of every served HTTP/1 connection (`proto/h1/dispatch.rs` — `Future::poll` passes `should_shutdown=true` and the dispatcher invokes `poll_shutdown` once `is_done()`), and uses `tokio`'s `AsyncWrite::poll_write_vectored`, which translates to `writev(2)`. The Go-based `system-probe` didn't surface either as a problem because `net/http` buffers responses through `bufio.Writer` and writes them via plain `write(2)`, and the HTTP/1 keep-alive happy path used by the agent's checks never triggers a `shutdown(2)` (Go only calls `CloseWrite` in edge cases like 431 oversized headers or partially-consumed request bodies).

Symptom: hyper's first `writev` returns `EPERM`, so the response body never reaches the agent. The agent's `pkg/system-probe/api/client/check.go:ensureStarted()` retries `GET /debug/stats` every 5s and only ever sees `EOF`, blocking the discovery check from starting at all:

```
SYS-PROBE-LITE | ERROR | Error serving connection: error writing a body to connection
                                                  ^-- BodyWrite, EPERM (Operation not permitted)

CORE | WARN | system-probe not started yet: Get "http://sysprobe/debug/stats": EOF
```

##### `chown`

After binding the socket, `system-probe-lite` calls `std::os::unix::fs::chown(socket_path, uid, gid)` to hand it off to `dd-agent`. On x86_64 this dispatches to the `chown(2)` syscall, which the existing profile rejected with `EPERM`:

```
SYS-PROBE-LITE | WARN | could not set socket ownership: Operation not permitted (os error 1)
```

Two reasons this didn't show up before:
- Go's `syscall.Chown` on Linux always dispatches through `fchownat(AT_FDCWD, ...)` (`src/syscall/syscall_linux.go`), and `fchownat` was already in the allowlist — so the Go `system-probe` was unaffected.
- aarch64 has no `chown(2)` syscall in the kernel; glibc's `chown()` wrapper falls through to `fchownat(2)`. Original verification was done on aarch64, where the profile happened to allow what was actually called.

Failure is non-fatal in default helm deployments where every agent container runs as root (`datadog.securityContext.runAsUser: 0`) and can talk to the resulting `root:root` mode 0720 socket. But for setups overriding the agent user to `dd-agent`, the socket would be unreachable.

#### Which issue this PR fixes

N/A.

#### Special notes for your reviewer:

- All three syscalls are basic socket-I/O / file primitives; they're already in the upstream Docker default seccomp profile.
- The previous GPU-monitoring conditional around `chown` is removed — `fchown`/`fchown32`/`fchownat` were already unconditional, so the `chown` gate was inconsistent.
- Verified on a kind cluster (aarch64 originally, x86_64 follow-up) with the agent built locally execing into `system-probe-lite` — no `Error serving connection` logs, no agent-side `EOF` warnings, no chown WARN, socket correctly owned `dd-agent:root`, `check:discovery` running cleanly.

#### Checklist

- [x] All commits are signed and show as "Verified" on GitHub
- [ ] Chart Version semver bump label has been added (`datadog/patch-version`)
- [x] For `datadog` chart changes, update the test baselines (regenerated via `make update-test-baselines-datadog-agent`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team
- [x] `CHANGELOG.md` has been updated