### PR TITLE
Update CSI driver allowlist to enable SSI on GKE autopilot

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.15.0
 
-* Enable SSI (Single Step Instrumentation) on GKE Autopilot by always rendering the `storage-dir` volume/mount and the `DD_APM_ENABLED` env var, and by adding a new `datadog-datadog-csi-driver-daemonset-exemption-v1.1.0` allowlist entry.
+* Enable Single Step Instrumentation (SSI) on GKE Autopilot >= 1.32.1-gke.1729000 by rendering `storage-dir` and `DD_APM_ENABLED`.
 
 ## 0.14.0
 

--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.15.0
 
-* Enable Single Step Instrumentation (SSI) on GKE Autopilot >= 1.32.1-gke.1729000 by rendering `storage-dir` and `DD_APM_ENABLED`.
+* Enable Single Step Instrumentation (SSI) on GKE Autopilot >= 1.32.1-gke.1729000 by rendering `storage-dir` and `DD_APM_ENABLED`. The DaemonSet now matches the new `datadog-datadog-csi-driver-daemonset-exemption-v1.1.0` WorkloadAllowlist (which exempts the new `storage-dir` hostPath and the `DD_APM_ENABLED` env var), replacing `v1.0.1` in the `AllowlistSynchronizer`.
 
 ## 0.14.0
 

--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.0
+
+* Enable SSI (Single Step Instrumentation) on GKE Autopilot by always rendering the `storage-dir` volume/mount and the `DD_APM_ENABLED` env var, and by adding a new `datadog-datadog-csi-driver-daemonset-exemption-v1.1.0` allowlist entry.
+
 ## 0.14.0
 
 * Set the `csi.datadoghq.com/apm-enabled` annotation on the `k8s.csi.datadoghq.com` `CSIDriver` resource based on `apm.enabled`. The cluster-agent admission controller reads this annotation (via the `workloadmeta-kubeapiserver` CSIDriver collector) to decide whether SSI library injection can use CSI mode for this driver.

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.14.0
+version: 0.15.0
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 

--- a/charts/datadog-csi-driver/templates/_helpers.tpl
+++ b/charts/datadog-csi-driver/templates/_helpers.tpl
@@ -80,16 +80,3 @@ true
 false
 {{- end -}}
 {{- end -}}
-
-{{/*
-Check if target cluster is GKE Autopilot (any version).
-Older GKE Autopilot versions have allowlistedv2workloads.auto.gke.io CRD.
-Newer versions (>= 1.32.1-gke.1729000) have WorkloadAllowlist and AllowlistSynchronizer CRDs.
-*/}}
-{{- define "csi.gke-autopilot" -}}
-{{- if or (.Capabilities.APIVersions.Has "allowlistedv2workloads.auto.gke.io/v1/AllowlistedV2Workload") (eq (include "csi.gke-autopilot-workloadallowlists-enabled" .) "true") -}}
-true
-{{- else -}}
-false
-{{- end -}}
-{{- end -}}

--- a/charts/datadog-csi-driver/templates/_helpers.tpl
+++ b/charts/datadog-csi-driver/templates/_helpers.tpl
@@ -80,3 +80,15 @@ true
 false
 {{- end -}}
 {{- end -}}
+
+{{/*
+Check if target cluster is legacy GKE Autopilot (GKE Autopilot but no
+WorkloadAllowlist support, i.e. GKE < 1.32.1-gke.1729000).
+*/}}
+{{- define "csi.gke-autopilot-legacy" -}}
+{{- if and (.Capabilities.APIVersions.Has "allowlistedv2workloads.auto.gke.io/v1/AllowlistedV2Workload") (ne (include "csi.gke-autopilot-workloadallowlists-enabled" .) "true") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -62,9 +62,15 @@ spec:
             # it is created by the node server and needs to be writeable.
             - name: plugin-dir
               mountPath: /csi
+            {{- if ne (include "csi.gke-autopilot-legacy" .) "true" }}
             # storage-dir stores the data and database for the CSI driver.
+            # Skipped on legacy GKE Autopilot (< 1.32.1-gke.1729000, AllowlistedV2Workload
+            # mode): no updated AllowlistedV2Workload exemption is published for the
+            # CSI driver in that mode, so rendering this hostPath would cause Warden
+            # to reject the DaemonSet.
             - name: storage-dir
               mountPath: /var/lib/datadog-csi-driver
+            {{- end }}
             - name: apm-socket
               mountPath: {{ (dir .Values.sockets.apmHostSocketPath) }}
               readOnly: true
@@ -83,11 +89,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if ne (include "csi.gke-autopilot-legacy" .) "true" }}
+            # DD_APM_ENABLED controls SSI on the CSI driver. Skipped on legacy GKE
+            # Autopilot (< 1.32.1-gke.1729000, AllowlistedV2Workload mode) because
+            # no updated exemption is published for it in that mode.
             - name: DD_APM_ENABLED
               value: {{ .Values.apm.enabled | quote }}
             {{- if .Values.global.apmRegistryAllowList }}
             - name: DD_REGISTRY_ALLOW_LIST
               value: {{ join "," .Values.global.apmRegistryAllowList | quote }}
+            {{- end }}
             {{- end }}
         - name: csi-node-driver-registrar
           image: "{{ .Values.registrar.image.repository }}:{{ .Values.registrar.image.tag }}"
@@ -132,10 +143,12 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/datadog.csi/driver
             type: DirectoryOrCreate
+        {{- if ne (include "csi.gke-autopilot-legacy" .) "true" }}
         - name: storage-dir
           hostPath:
             path: /var/lib/kubelet/plugins/datadog.csi/storage
             type: DirectoryOrCreate
+        {{- end }}
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- if (eq (include "csi.gke-autopilot-workloadallowlists-enabled" .) "true") }}
   labels:
-    cloud.google.com/matching-allowlist: "datadog-datadog-csi-driver-daemonset-exemption-v1.0.1"
+    cloud.google.com/matching-allowlist: "datadog-datadog-csi-driver-daemonset-exemption-v1.1.0"
   {{- end }}
 spec:
   {{- with .Values.updateStrategy }}
@@ -62,11 +62,9 @@ spec:
             # it is created by the node server and needs to be writeable.
             - name: plugin-dir
               mountPath: /csi
-            {{- if ne (include "csi.gke-autopilot" .) "true" }}
             # storage-dir stores the data and database for the CSI driver.
             - name: storage-dir
               mountPath: /var/lib/datadog-csi-driver
-            {{- end }}
             - name: apm-socket
               mountPath: {{ (dir .Values.sockets.apmHostSocketPath) }}
               readOnly: true
@@ -85,13 +83,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            {{- if ne (include "csi.gke-autopilot" .) "true" }}
             - name: DD_APM_ENABLED
               value: {{ .Values.apm.enabled | quote }}
             {{- if .Values.global.apmRegistryAllowList }}
             - name: DD_REGISTRY_ALLOW_LIST
               value: {{ join "," .Values.global.apmRegistryAllowList | quote }}
-            {{- end }}
             {{- end }}
         - name: csi-node-driver-registrar
           image: "{{ .Values.registrar.image.repository }}:{{ .Values.registrar.image.tag }}"
@@ -136,12 +132,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/datadog.csi/driver
             type: DirectoryOrCreate
-        {{- if ne (include "csi.gke-autopilot" .) "true" }}
         - name: storage-dir
           hostPath:
             path: /var/lib/kubelet/plugins/datadog.csi/storage
             type: DirectoryOrCreate
-        {{- end }}
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry

--- a/charts/datadog-csi-driver/templates/gke_autopilot_allowlist_synchronizer.yaml
+++ b/charts/datadog-csi-driver/templates/gke_autopilot_allowlist_synchronizer.yaml
@@ -8,6 +8,5 @@ metadata:
     "helm.sh/hook-weight": "-1"
 spec:
   allowlistPaths:
-  - Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.0.1.yaml
   - Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.0.yaml
 {{- end }}

--- a/charts/datadog-csi-driver/templates/gke_autopilot_allowlist_synchronizer.yaml
+++ b/charts/datadog-csi-driver/templates/gke_autopilot_allowlist_synchronizer.yaml
@@ -9,4 +9,5 @@ metadata:
 spec:
   allowlistPaths:
   - Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.0.1.yaml
+  - Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.0.yaml
 {{- end }}

--- a/charts/datadog-csi-driver/values.yaml
+++ b/charts/datadog-csi-driver/values.yaml
@@ -72,6 +72,7 @@ sockets:
   dsdHostSocketPath: /var/run/datadog/dsd.socket
 
 ## APM/Single Step Instrumentation (SSI) configuration for the CSI driver.
+## Note: SSI is not supported on legacy GKE Autopilot clusters (< 1.32.1-gke.1729000)
 apm:
   # apm.enabled -- Enable APM/SSI support for the CSI driver.
   enabled: true

--- a/charts/datadog-csi-driver/values.yaml
+++ b/charts/datadog-csi-driver/values.yaml
@@ -72,8 +72,6 @@ sockets:
   dsdHostSocketPath: /var/run/datadog/dsd.socket
 
 ## APM/Single Step Instrumentation (SSI) configuration for the CSI driver.
-## Note: SSI is not yet supported on GKE Autopilot. SSI-related configurations
-## are not rendered when running on GKE Autopilot clusters.
 apm:
   # apm.enabled -- Enable APM/SSI support for the CSI driver.
   enabled: true

--- a/test/datadog-csi-driver/baseline/CSI_Driver_gke_autopilot_workloadallowlist.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_gke_autopilot_workloadallowlist.yaml
@@ -1,0 +1,111 @@
+---
+# Source: datadog-csi-driver/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: datadog-csi-driver-node-server
+  namespace: datadog-agent
+  labels:
+    cloud.google.com/matching-allowlist: "datadog-datadog-csi-driver-daemonset-exemption-v1.1.0"
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: datadog-csi-driver-node-server
+  template:
+    metadata:
+      labels:
+        app: datadog-csi-driver-node-server
+        admission.datadoghq.com/enabled: "false"
+    spec:
+      containers:
+        - name: csi-node-driver
+          image: "gcr.io/datadoghq/csi-driver:1.2.2"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 5000
+              protocol: TCP
+          args:
+            - --apm-host-socket-path=/var/run/datadog/apm.socket
+            - --dsd-host-socket-path=/var/run/datadog/dsd.socket
+          volumeMounts:
+            # plugin-dir stores the socket on which CSI node server service is exposed.
+            # it is created by the node server and needs to be writeable.
+            - name: plugin-dir
+              mountPath: /csi
+            # storage-dir stores the data and database for the CSI driver.
+            # Skipped on legacy GKE Autopilot (< 1.32.1-gke.1729000): the v1.0.1
+            # AllowlistedV2Workload allowlist does not exempt this hostPath, so
+            # rendering it would cause Warden to reject the DaemonSet.
+            - name: storage-dir
+              mountPath: /var/lib/datadog-csi-driver
+            - name: apm-socket
+              mountPath: /var/run/datadog
+              readOnly: true
+            # write mode is required to perform a volume mount
+            # csi driver has to create a subdirectory under /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~csi/datadog/mount.
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # DD_APM_ENABLED controls SSI on the CSI driver. Skipped on legacy GKE
+            # Autopilot (< 1.32.1-gke.1729000) because the v1.0.1 allowlist does
+            # not exempt this env var.
+            - name: DD_APM_ENABLED
+              value: "true"
+        - name: csi-node-driver-registrar
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/datadog.csi/driver/csi.sock
+          volumeMounts:
+            # plugin-dir stores the socket created by the CSI driver node server.
+            # it is needed by the registrar to fetch the driver name from the driver contain (via the CSI GetPluginInfo() call).
+            - name: plugin-dir
+              mountPath: /csi # Match this to ADDRESS
+              readOnly: true
+            # registration-dir is used to store the registration information and register the driver with kubelet.
+            # it needs to be writeable
+            - name: registration-dir
+              mountPath: /registration # This is where the registrar writes the registration information
+      volumes:
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/datadog.csi/driver
+            type: DirectoryOrCreate
+        - name: storage-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/datadog.csi/storage
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
+          name: apm-socket
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
+          name: dsd-socket

--- a/test/datadog-csi-driver/baseline/CSI_Driver_legacy_gke_autopilot.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_legacy_gke_autopilot.yaml
@@ -1,0 +1,94 @@
+---
+# Source: datadog-csi-driver/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: datadog-csi-driver-node-server
+  namespace: datadog-agent
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: datadog-csi-driver-node-server
+  template:
+    metadata:
+      labels:
+        app: datadog-csi-driver-node-server
+        admission.datadoghq.com/enabled: "false"
+    spec:
+      containers:
+        - name: csi-node-driver
+          image: "gcr.io/datadoghq/csi-driver:1.2.2"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 5000
+              protocol: TCP
+          args:
+            - --apm-host-socket-path=/var/run/datadog/apm.socket
+            - --dsd-host-socket-path=/var/run/datadog/dsd.socket
+          volumeMounts:
+            # plugin-dir stores the socket on which CSI node server service is exposed.
+            # it is created by the node server and needs to be writeable.
+            - name: plugin-dir
+              mountPath: /csi
+            - name: apm-socket
+              mountPath: /var/run/datadog
+              readOnly: true
+            # write mode is required to perform a volume mount
+            # csi driver has to create a subdirectory under /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~csi/datadog/mount.
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+        - name: csi-node-driver-registrar
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/datadog.csi/driver/csi.sock
+          volumeMounts:
+            # plugin-dir stores the socket created by the CSI driver node server.
+            # it is needed by the registrar to fetch the driver name from the driver contain (via the CSI GetPluginInfo() call).
+            - name: plugin-dir
+              mountPath: /csi # Match this to ADDRESS
+              readOnly: true
+            # registration-dir is used to store the registration information and register the driver with kubelet.
+            # it needs to be writeable
+            - name: registration-dir
+              mountPath: /registration # This is where the registrar writes the registration information
+      volumes:
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/datadog.csi/driver
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
+          name: apm-socket
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
+          name: dsd-socket

--- a/test/datadog-csi-driver/baseline_test.go
+++ b/test/datadog-csi-driver/baseline_test.go
@@ -75,6 +75,52 @@ func Test_baseline_manifests(t *testing.T) {
 			baselineManifestPath: "./baseline/CSI_Driver_nodeselector_and_nodeaffinity.yaml",
 			assertions:           verifyCSIDriverDaemonSet,
 		},
+		{
+			// Legacy GKE Autopilot (< 1.32.1-gke.1729000) exposes the
+			// AllowlistedV2Workload CRD but not the newer WorkloadAllowlist /
+			// AllowlistSynchronizer CRDs. The Datadog CSI driver allowlist published
+			// for this mode (v1.0.1) does not exempt the `storage-dir` hostPath nor
+			// the `DD_APM_ENABLED` env var, so the chart must omit them. This
+			// baseline pins that behavior to avoid regressing legacy Autopilot
+			// installability.
+			name: "CSI Driver on legacy GKE Autopilot (AllowlistedV2Workload)",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-csi-driver",
+				ChartPath:   "../../charts/datadog-csi-driver",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog-csi-driver/values.yaml"},
+				Overrides:   map[string]string{},
+				ExtraArgs: []string{
+					"--api-versions=allowlistedv2workloads.auto.gke.io/v1/AllowlistedV2Workload",
+					"--kube-version=1.31.0-gke.0",
+				},
+			},
+			baselineManifestPath: "./baseline/CSI_Driver_legacy_gke_autopilot.yaml",
+			assertions:           verifyCSIDriverDaemonSet,
+		},
+		{
+			// New GKE Autopilot (>= 1.32.1-gke.1729000) exposes the
+			// WorkloadAllowlist / AllowlistSynchronizer CRDs. The chart installs
+			// the v1.1.0 allowlist (via gke_autopilot_allowlist_synchronizer.yaml)
+			// which exempts the `storage-dir` hostPath and the `DD_APM_ENABLED`
+			// env var, so SSI is enabled. The DaemonSet must carry the matching
+			// `cloud.google.com/matching-allowlist` label pointing at v1.1.0.
+			name: "CSI Driver on GKE Autopilot (WorkloadAllowlist)",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-csi-driver",
+				ChartPath:   "../../charts/datadog-csi-driver",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog-csi-driver/values.yaml"},
+				Overrides:   map[string]string{},
+				ExtraArgs: []string{
+					"--api-versions=auto.gke.io/v1/AllowlistSynchronizer",
+					"--api-versions=auto.gke.io/v1/WorkloadAllowlist",
+					"--kube-version=1.32.1-gke.1729000",
+				},
+			},
+			baselineManifestPath: "./baseline/CSI_Driver_gke_autopilot_workloadallowlist.yaml",
+			assertions:           verifyCSIDriverDaemonSet,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/go.mod
+++ b/test/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/testutil v0.72.2
-	github.com/DataDog/datadog-agent/test/e2e-framework v0.81.0-devel.0.20260603184509-8777b3e98e25
+	github.com/DataDog/datadog-agent/test/e2e-framework v0.81.0-devel.0.20260604145753-f3062050f517
 	github.com/DataDog/datadog-agent/test/fakeintake v0.72.2
 	github.com/Masterminds/semver v1.5.0
 	github.com/google/go-cmp v0.7.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -42,8 +42,8 @@ github.com/DataDog/datadog-agent/pkg/util/testutil v0.72.2 h1:05R9eLwsAqHoxxIBZh
 github.com/DataDog/datadog-agent/pkg/util/testutil v0.72.2/go.mod h1:+2wH1RZ6UWGNaYw5BLofYnbrGhcHv8OeCIjEnTopfss=
 github.com/DataDog/datadog-agent/pkg/version v0.76.0-rc.4 h1:PF7WZ0izV1CasPia3D7Nqbl12YTMMxNz+XdRM2M8/Pk=
 github.com/DataDog/datadog-agent/pkg/version v0.76.0-rc.4/go.mod h1:4I4x0IqhIr0fXr90G8Qauz9iID0xhonjUB2lAZH9qyI=
-github.com/DataDog/datadog-agent/test/e2e-framework v0.81.0-devel.0.20260603184509-8777b3e98e25 h1:n6QZcpfYjFKZmw+Ii9O0MnS+R38jnjFw2LpEhvUqaZk=
-github.com/DataDog/datadog-agent/test/e2e-framework v0.81.0-devel.0.20260603184509-8777b3e98e25/go.mod h1:JnpM2cRERcDjXo2HNzu363yEFtZQu7hVQcRbehfboOA=
+github.com/DataDog/datadog-agent/test/e2e-framework v0.81.0-devel.0.20260604145753-f3062050f517 h1:MinijtRLCmnekNslVK0aCkIp6QKZ0Q1SoL1pQRtL3/g=
+github.com/DataDog/datadog-agent/test/e2e-framework v0.81.0-devel.0.20260604145753-f3062050f517/go.mod h1:JnpM2cRERcDjXo2HNzu363yEFtZQu7hVQcRbehfboOA=
 github.com/DataDog/datadog-agent/test/fakeintake v0.72.2 h1:nnIdPVOgjzmccYuy34ftPV1qBcMf2kkP1LMswMaiFE0=
 github.com/DataDog/datadog-agent/test/fakeintake v0.72.2/go.mod h1:XNZc/fQ/lYjAGRzPKauZcJkAAdlUgGG5uwMtF8ZfeSA=
 github.com/DataDog/datadog-api-client-go/v2 v2.60.0 h1:YzEB2H42symyDlHzNo0wcjW1mfXSW1E1UCbThHx4xrc=


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the CSI driver allowlist to enable SSI on GKE autopilot.

Since version 1.2.0, the CSI driver needs a storage mount and a new env var allowed: `DD_APM_ENABLED`

Related PR: https://github.com/DataDog/datadog-gke-workload-allowlist/pull/16

Manual testing:
- Install the new WorkloadAllowlist from https://github.com/DataDog/datadog-gke-workload-allowlist/pull/16
```
kubectl apply -f datadog-gke-workload-allowlist/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.0.yaml
```
- Install the CSI driver using the Helm Chart from this PR
```
helm install datadog-csi-driver helm-charts/charts/datadog-csi-driver
```
- Check the pod `datadog-csi-driver-node-server` has `storage-dir` in the volumes list

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits