### PR TITLE
[datadog] bump `get-agent-version` fallback for `latest`/`7` to 7.78.3

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.209.0
 
-* Bump `get-agent-version` fallback for `agents.image.tag: latest` (and `"7"`) from `7.67.0` to `7.78.0`. This auto-enables service discovery (using `system-probe-lite`) by default for users on these floating tags, matching the discovery defaulting introduced in [#2598](https://github.com/DataDog/helm-charts/pull/2598) for explicit `>= 7.78.0` tags. Previously the fallback resolved below the `>= 7.78.0` threshold, silently keeping discovery off for `latest` users despite the actual `latest` image supporting it.
+* Bump `get-agent-version` fallback for `agents.image.tag: latest` (and `"7"`) from `7.67.0` to `7.78.0`. Floating tags now behave consistently with the chart's default tag in every version-gated feature: service discovery defaulting auto-enables `system-probe-lite`, Agent Data Plane no longer fails its `< 7.74.0` guard, the `-fips-full` and standalone DDOT FIPS image guards no longer fail, and the `DD_USE_DOGSTATSD` toggle for ADP matches the `^7.75.0-0` branch.
 
 ## 3.208.2
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.209.0
+
+* Bump `get-agent-version` fallback for `agents.image.tag: latest` (and `"7"`) from `7.67.0` to `7.78.0`. This auto-enables service discovery (using `system-probe-lite`) by default for users on these floating tags, matching the discovery defaulting introduced in [#2598](https://github.com/DataDog/helm-charts/pull/2598) for explicit `>= 7.78.0` tags. Previously the fallback resolved below the `>= 7.78.0` threshold, silently keeping discovery off for `latest` users despite the actual `latest` image supporting it.
+
 ## 3.208.2
 
 * Remove bogus setsidaccept4 from system-probe seccomp profile ([#2636](https://github.com/DataDog/helm-charts/pull/2636)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.208.2
+version: 3.209.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.208.2](https://img.shields.io/badge/Version-3.208.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.209.0](https://img.shields.io/badge/Version-3.209.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -10,7 +10,7 @@
 {{- $version = "6.55.1" -}}
 {{- end -}}
 {{- if and (eq $length 1) (or (eq $version "7") (eq $version "latest")) -}}
-{{- $version = "7.67.0" -}}
+{{- $version = "7.78.0" -}}
 {{- end -}}
 {{- $version -}}
 {{- end -}}

--- a/test/datadog/service_discovery_test.go
+++ b/test/datadog/service_discovery_test.go
@@ -67,12 +67,15 @@ func Test_serviceDiscoveryResolvedDefaulting(t *testing.T) {
 			expectDiscoveryBlock: false,
 		},
 		{
-			name: "omitted discovery with floating agent 7 disables discovery",
+			name: "omitted discovery with floating agent 7 follows get-agent-version policy",
 			overrides: map[string]string{
 				"agents.image.tag": "7",
 			},
-			expectSystemProbe:    false,
-			expectDiscoveryBlock: false,
+			expectSystemProbe:           shouldAutoEnableDiscoveryFromTag("7"),
+			expectDiscoveryBlock:        shouldAutoEnableDiscoveryFromTag("7"),
+			expectDiscoveryEnabled:      shouldAutoEnableDiscoveryFromTag("7"),
+			expectUseSystemProbeLiteKey: shouldAutoEnableDiscoveryFromTag("7"),
+			expectUseSystemProbeLite:    shouldAutoEnableDiscoveryFromTag("7"),
 		},
 		{
 			name: "explicit false with agent 7.78.0 keeps discovery disabled",
@@ -308,7 +311,7 @@ func shouldAutoEnableDiscoveryFromTag(tag string) bool {
 	case "6":
 		tag = "6.55.1"
 	case "7", "latest":
-		tag = "7.67.0"
+		tag = "7.78.0"
 	}
 
 	normalized := normalizeDiscoveryVersion(tag)


### PR DESCRIPTION
#### What this PR does / why we need it:

The `get-agent-version` helper substitutes a concrete version for the single-component tags `latest` and `7` so that the chart's version-gated logic has something to compare. The current substitute, `7.67.0`, is now stale: the actual `latest` Datadog Agent image is well past that, and so is the default agent tag shipped by the chart itself (`7.78.3`). As a result, users who explicitly set `agents.image.tag: latest` (or `"7"`) get worse behaviour out of the version-gated logic than users on the default tag, even though they are running the same or newer Agent in practice.

This PR bumps the fallback to `7.78.3` (matching the chart's current default tag, set in #2647) so `latest`/`"7"` are treated as a current Agent in every version-gated code path. Concretely this means:

- **Service discovery defaulting (#2598):** discovery is now auto-enabled (with `system-probe-lite`) for `tag: latest`/`"7"`, matching the default tag and other unparseable tags like `master-py3` that already cross the `>= 7.78.0` gate.
- **Agent Data Plane:** the `< 7.74.0` guard in `should-enable-data-plane` no longer fails for `tag: latest`/`"7"`, so users on those tags can enable `datadog.dataPlane.enabled` without hitting the version check.
- **`-fips-full` image guard:** the `< 7.78.0` guard for `agents.image.tagSuffix: -fips-full` no longer fails for `tag: latest`/`"7"`.
- **Standalone DDOT FIPS image guard:** same `< 7.78.0` guard on the standalone `ddot-collector` FIPS image no longer fails for `tag: latest`/`"7"`.
- **`DD_USE_DOGSTATSD` toggle for ADP:** the `^7.75.0-0` compatibility branch now matches for `tag: latest`/`"7"`, so the env var is emitted consistently with newer Agents.

All of these match the behaviour users would get if they pinned to the chart's default tag (`7.78.3`) instead of using the floating tag.

#### Motivation

Keep the floating tags `latest` and `7` in sync with what those tags actually point to (and with the chart's own default), so version-gated features (discovery, ADP, FIPS image variants) work the same on the floating tags as on the default tag.

This is a behaviour change for users on `tag: latest`/`"7"`:
- Without `datadog.discovery.enabled` set, they will now get a system-probe container running `system-probe-lite`.
- Previously-failing version checks for ADP, `-fips-full`, and standalone DDOT FIPS will now pass.

Hence the minor version bump.

#### Release Note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the note is
simply "None", you should write it as ```release-note
None
```
2. If no release note is required, just write "NONE".
-->
```release-note
Bump the `get-agent-version` fallback for `agents.image.tag: latest` (and `"7"`) from `7.67.0` to `7.78.3` (matching the chart's current default tag). Floating tags now behave consistently with the default tag in every version-gated feature: service discovery defaulting auto-enables `system-probe-lite`, Agent Data Plane no longer fails its `< 7.74.0` guard, the `-fips-full` and standalone DDOT FIPS image guards no longer fail, and the `DD_USE_DOGSTATSD` toggle for ADP matches the `^7.75.0-0` branch.
```