### PR TITLE
Explicit datadog-operator deployment health port

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.23.0-dev.1
 
 * Update Datadog Operator chart for 1.27.0-rc.1.
+* Explicitly document health endpoint as a named container port.
 
 ## 2.22.2
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.23.0-dev.2
+## 2.23.0
 
 * Update Datadog Operator chart for 1.27.0-rc.1.
 * Explicitly document health endpoint as a named container port.

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.23.0-dev.1
+## 2.23.0-dev.2
 
 * Update Datadog Operator chart for 1.27.0-rc.1.
 * Explicitly document health endpoint as a named container port.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.23.0-dev.1
+version: 2.23.0-dev.2
 appVersion: 1.27.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.23.0-dev.2
+version: 2.23.0
 appVersion: 1.27.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.23.0](https://img.shields.io/badge/Version-2.23.0-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
+![Version: 2.23.0-dev.2](https://img.shields.io/badge/Version-2.23.0--dev.2-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.23.0-dev.1](https://img.shields.io/badge/Version-2.23.0--dev.1-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
+![Version: 2.23.0-dev.2](https://img.shields.io/badge/Version-2.23.0--dev.2-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.23.0-dev.2](https://img.shields.io/badge/Version-2.23.0--dev.2-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
+![Version: 2.23.0](https://img.shields.io/badge/Version-2.23.0-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -191,10 +191,13 @@ spec:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}
               protocol: TCP
+            - name: health
+              containerPort: 8081
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz/
-              port: 8081
+              port: health
             {{- if .Values.livenessProbe }}
             {{- toYaml .Values.livenessProbe | nindent 12 }}
             {{- end }}

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -81,10 +81,13 @@ spec:
             - name: metrics
               containerPort: 8383
               protocol: TCP
+            - name: health
+              containerPort: 8081
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz/
-              port: 8081
+              port: health
             initialDelaySeconds: 15
             periodSeconds: 10
           resources:

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/DataDog/helm-charts/test/common"
 )
@@ -209,6 +210,18 @@ func verifyDeployment(t *testing.T, manifest string) {
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
 	assert.Equal(t, "registry.datadoghq.com/operator:1.27.0-rc.1", operatorContainer.Image)
+	assert.ElementsMatch(t, []v1.ContainerPort{
+		{
+			Name:          "metrics",
+			ContainerPort: 8383,
+			Protocol:      v1.ProtocolTCP,
+		},
+		{
+			Name:          "health",
+			ContainerPort: 8081,
+			Protocol:      v1.ProtocolTCP,
+		},
+	}, operatorContainer.Ports)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }
@@ -223,6 +236,7 @@ func verifyLivenessProbe(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "/healthz/", operatorContainer.LivenessProbe.HTTPGet.Path)
+	assert.Equal(t, intstr.FromString("health"), operatorContainer.LivenessProbe.HTTPGet.Port)
 }
 
 func verifyLivenessProbeOverride(t *testing.T, manifest string) {
@@ -231,6 +245,7 @@ func verifyLivenessProbeOverride(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "/healthz/", operatorContainer.LivenessProbe.HTTPGet.Path)
+	assert.Equal(t, intstr.FromString("health"), operatorContainer.LivenessProbe.HTTPGet.Port)
 	assert.Equal(t, int32(20), operatorContainer.LivenessProbe.PeriodSeconds)
 	assert.Equal(t, int32(20), operatorContainer.LivenessProbe.TimeoutSeconds)
 	assert.Equal(t, int32(3), operatorContainer.LivenessProbe.FailureThreshold)


### PR DESCRIPTION
#### Summary

This pull requests explicitly documents that the container exposes a health-specific port, that is then used in the liveness probe.

This is purely a documentation change, mostly to make linters happy when applying the helm chart on a cluster.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits