### PR TITLE
Bump pulumi gke k8s version for E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ go.work*
 # VSCode Profiles
 .vscode/*
 !.vscode/extensions.json
+
+# Claude
+.claude/*

--- a/test/common/common_e2e.go
+++ b/test/common/common_e2e.go
@@ -16,7 +16,7 @@ var (
 	clusterAgentVersion  = agentVersion
 	defaultImageRegistry = "gcr.io/datadoghq"
 	defaultPulumiConfigs = runner.ConfigMap{
-		"ddinfra:kubernetesVersion": auto.ConfigValue{Value: "1.32"},
+		"ddinfra:kubernetesVersion": auto.ConfigValue{Value: "1.34"},
 	}
 
 	defaultCIPulumiConfigs = runner.ConfigMap{


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the kubernetes version for GKE E2E tests to 1.34. This version aligns with the [default](https://github.com/DataDog/datadog-agent/blob/d092facc8c2242b6a02885ef00bfe1a1db666f71/test/e2e-framework/common/config/environment.go#L236) in the datadog-agent e2e framework. 

Google has dropped support for 1.32: https://docs.cloud.google.com/kubernetes-engine/docs/release-notes#stable-channel

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits