### PR TITLE
chore(ci): add agent version drift detection

### DIFF
--- a/.github/workflows/check-agent-version-drift.yaml
+++ b/.github/workflows/check-agent-version-drift.yaml
@@ -1,0 +1,56 @@
+name: Check Agent Version Drift
+
+on:
+  pull_request:
+    paths:
+      - "charts/datadog/values.yaml"
+      - "charts/datadog/templates/_helpers.tpl"
+
+# Permission forced by repo-level setting; only elevate on job-level
+permissions:
+  contents: read
+
+jobs:
+  check-agent-version-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Assert get-agent-version latest matches image tags in values.yaml
+        run: |
+          HELPERS="charts/datadog/templates/_helpers.tpl"
+          VALUES="charts/datadog/values.yaml"
+
+          HELPERS_VERSION=$(grep -A1 '\$version "7".*\$version "latest"' "$HELPERS" | grep -oP '[0-9]+\.[0-9]+\.[0-9]+')
+          AGENT_VERSION=$(yq e '.agents.image.tag' "$VALUES")
+          DCA_VERSION=$(yq e '.clusterAgent.image.tag' "$VALUES")
+          CCR_VERSION=$(yq e '.clusterChecksRunner.image.tag' "$VALUES")
+
+          echo "get-agent-version 'latest' fallback:  ${HELPERS_VERSION}"
+          echo "agents.image.tag:                     ${AGENT_VERSION}"
+          echo "clusterAgent.image.tag:               ${DCA_VERSION}"
+          echo "clusterChecksRunner.image.tag:        ${CCR_VERSION}"
+
+          fail=0
+          check() {
+            local field="$1" value="$2"
+            if [[ "${value}" != "${HELPERS_VERSION}" ]]; then
+              echo "ERROR: ${field} (${value}) does not match get-agent-version fallback (${HELPERS_VERSION})"
+              fail=1
+            fi
+          }
+
+          check "agents.image.tag"              "${AGENT_VERSION}"
+          check "clusterAgent.image.tag"        "${DCA_VERSION}"
+          check "clusterChecksRunner.image.tag" "${CCR_VERSION}"
+
+          if [[ "${fail}" -ne 0 ]]; then
+            echo ""
+            echo "Agent image tags in values.yaml and the get-agent-version 'latest' fallback version"
+            echo "in _helpers.tpl must be set to the same version. Update the stale one(s) above and"
+            echo "run \`make update-test-baselines-datadog-agent\`"
+            exit 1
+          fi
+
+          echo "OK: No drift detected"

--- a/.github/workflows/check-agent-version-drift.yaml
+++ b/.github/workflows/check-agent-version-drift.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Assert get-agent-version latest matches image tags in values.yaml
+      - name: Assert get-agent-version matches image tags in values.yaml
         run: |
           HELPERS="charts/datadog/templates/_helpers.tpl"
           VALUES="charts/datadog/values.yaml"

--- a/.github/workflows/no-ci.yaml
+++ b/.github/workflows/no-ci.yaml
@@ -6,6 +6,8 @@ on:
       - "charts/**/requirements.*"
       - "charts/**/values.*"
       - "charts/**/templates/**"
+      - "charts/**/CHANGELOG.md"
+      - "charts/**/README.md"
 jobs:
   pr-validated:
     name: pr-validated

--- a/.github/workflows/no-ci.yaml
+++ b/.github/workflows/no-ci.yaml
@@ -6,8 +6,6 @@ on:
       - "charts/**/requirements.*"
       - "charts/**/values.*"
       - "charts/**/templates/**"
-      - "charts/**/CHANGELOG.md"
-      - "charts/**/README.md"
 jobs:
   pr-validated:
     name: pr-validated


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a CI check that fails if the `get-agent-version` [helper's](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/templates/_helpers.tpl#L3-L16) fallback version in `_helpers.tpl` drifts out of sync with the agent image tags in `values.yaml` (`agents`, `clusterAgent`, `clusterChecksRunner`).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits