### PR TITLE
Update codeowners, remove stale container-ecosystems handle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,16 @@
 # Code owners for charts
 
-*  @DataDog/container-helm-chart-maintainers
+* @DataDog/telemetry-onboarding @DataDog/container-helm-chart-maintainers
 
 # Documentation
 *.md             @DataDog/container-helm-chart-maintainers
 
 # Charts
 charts/cloudprem                                       @DataDog/logs-cloudprem
-charts/datadog-crds                                    @DataDog/container-ecosystems @DataDog/container-platform
+charts/datadog-crds                                    @DataDog/container-platform
 charts/datadog-csi-driver                              @Datadog/container-platform @DataDog/container-helm-chart-maintainers
-charts/datadog-operator                                @DataDog/container-ecosystems @DataDog/container-platform
-charts/extended-daemon-set                             @DataDog/container-ecosystems @DataDog/container-platform
+charts/datadog-operator                                @DataDog/container-platform
+charts/extended-daemon-set                             @DataDog/container-platform
 charts/datadog                                         @DataDog/telemetry-onboarding @DataDog/container-helm-chart-maintainers 
 charts/datadog/templates/_container-process-agent.yaml @DataDog/container-experiences @DataDog/container-helm-chart-maintainers
 charts/datadog/templates/_container-system-probe.yaml  @DataDog/ebpf-platform @DataDog/container-helm-chart-maintainers
@@ -26,5 +26,5 @@ charts/observability-pipelines-worker                  @DataDog/observability-pi
 charts/private-action-runner                           @DataDog/action-platform
 
 # Tests
-test/datadog-operator                                  @DataDog/container-ecosystems @DataDog/container-platform
+test/datadog-operator                                  @DataDog/container-platform
 test/private-action-runner                             @DataDog/action-platform


### PR DESCRIPTION
#### What this PR does / why we need it:

Update codeowners:
- Add team @DataDog/telemetry-onboarding to `*`
- Remove stale @DataDog/container-ecosystems handle

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits