### PR TITLE
Add helm parameters for DD_DASHBOARD_WATCH_NAMESPACE and DD_GENERIC_RESOURCE_WATCH_NAMESPACE

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.23.0-dev.3
+
+* Support Helm parameters for `DD_DASHBOARD_WATCH_NAMESPACE`and `DD_GENERIC_RESOURCE_WATCH_NAMESPACE`
+
 ## 2.23.0-dev.2
 
 * Install the DatadogPodAutoscalerClusterProfiles CRD by default. 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.23.0
+## 2.23.0-dev.3
 
 * Support Helm parameters for `DD_DASHBOARD_WATCH_NAMESPACE`and `DD_GENERIC_RESOURCE_WATCH_NAMESPACE`
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.23.0-dev.3
+## 2.23.0
 
 * Support Helm parameters for `DD_DASHBOARD_WATCH_NAMESPACE`and `DD_GENERIC_RESOURCE_WATCH_NAMESPACE`
 

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.23.0-dev.3
+version: 2.23.0
 appVersion: 1.27.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.23.0
+version: 2.23.0-dev.3
 appVersion: 1.27.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.23.0-dev.2
+version: 2.23.0-dev.3
 appVersion: 1.27.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.23.0](https://img.shields.io/badge/Version-2.23.0-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
+![Version: 2.23.0-dev.3](https://img.shields.io/badge/Version-2.23.0--dev.3-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.23.0-dev.3](https://img.shields.io/badge/Version-2.23.0--dev.3-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
+![Version: 2.23.0](https://img.shields.io/badge/Version-2.23.0-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.23.0-dev.2](https://img.shields.io/badge/Version-2.23.0--dev.2-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
+![Version: 2.23.0-dev.3](https://img.shields.io/badge/Version-2.23.0--dev.3-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
 
 ## Values
 
@@ -75,6 +75,8 @@
 | watchNamespaces | list | `[]` | Restricts the Operator to watch its managed resources on specific namespaces unless CRD-specific watchNamespaces properties are set |
 | watchNamespacesAgent | list | `[]` | Restricts the Operator to watch DatadogAgent resources on specific namespaces. Requires v1.8.0+ |
 | watchNamespacesAgentProfile | list | `[]` | Restricts the Operator to watch DatadogAgentProfile resources on specific namespaces. Requires v1.8.0+ |
+| watchNamespacesDashboard | list | `[]` | Restricts the Operator to watch DatadogDashboard resources on specific namespaces. Requires v1.13.0+ |
+| watchNamespacesGenericResource | list | `[]` | Restricts the Operator to watch DatadogGenericResource resources on specific namespaces. Requires v1.13.0+ |
 | watchNamespacesMonitor | list | `[]` | Restricts the Operator to watch DatadogMonitor resources on specific namespaces. Requires v1.8.0+ |
 | watchNamespacesSLO | list | `[]` | Restricts the Operator to watch DatadogSLO resources on specific namespaces. Requires v1.8.0+ |
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -81,15 +81,14 @@ spec:
             - name: DD_AGENT_PROFILE_WATCH_NAMESPACE
               value: {{ .Values.watchNamespacesAgentProfile | join "," }}
             {{- end }}
-            {{- if .Values. }}
+            {{- if .Values.watchNamespacesDashboard }}
             - name: DD_DASHBOARD_WATCH_NAMESPACE
-              value: {{ .Values. | join "," }}
+              value: {{ .Values.watchNamespacesDashboard | join "," }}
             {{- end }}
-            {{- if .Values. }}
+            {{- if .Values.watchNamespacesGenericResource }}
             - name: DD_GENERIC_RESOURCE_WATCH_NAMESPACE
-              value: {{ .Values. | join "," }}
+              value: {{ .Values.watchNamespacesGenericResource | join "," }}
             {{- end }}
-            {{- if .Values. }}
             - name: DD_HOSTNAME
               valueFrom:
                 fieldRef:

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -81,6 +81,15 @@ spec:
             - name: DD_AGENT_PROFILE_WATCH_NAMESPACE
               value: {{ .Values.watchNamespacesAgentProfile | join "," }}
             {{- end }}
+            {{- if .Values. }}
+            - name: DD_DASHBOARD_WATCH_NAMESPACE
+              value: {{ .Values. | join "," }}
+            {{- end }}
+            {{- if .Values. }}
+            - name: DD_GENERIC_RESOURCE_WATCH_NAMESPACE
+              value: {{ .Values. | join "," }}
+            {{- end }}
+            {{- if .Values. }}
             - name: DD_HOSTNAME
               valueFrom:
                 fieldRef:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -258,6 +258,30 @@ watchNamespacesAgentProfile: []
 # watchNamespacesAgentProfile:
 # - ""
 
+# watchNamespacesDashboard -- Restricts the Operator to watch DatadogDashboard resources on specific namespaces.
+# Requires v1.13.0+
+watchNamespacesDashboard: []
+# example: watch only two namespaces:
+# watchNamespacesDashboard:
+# - "default"
+# - "datadog"
+
+# to watch all namespaces
+# watchNamespacesDashboard:
+# - ""
+
+# watchNamespacesGenericResource -- Restricts the Operator to watch DatadogGenericResource resources on specific namespaces.
+# Requires v1.13.0+
+watchNamespacesGenericResource: []
+# example: watch only two namespaces:
+# watchNamespacesGenericResource:
+# - "default"
+# - "datadog"
+
+# to watch all namespaces
+# watchNamespacesGenericResource:
+# - ""
+
 # containerSecurityContext -- A security context defines privileges and access control settings for a container.
 containerSecurityContext: {}
 

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.23.0-dev.2
+    helm.sh/chart: datadog-operator-2.23.0-dev.3
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.27.0-rc.1"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds Helm parameters for the env vars `DD_DASHBOARD_WATCH_NAMESPACE` and `DD_GENERIC_RESOURCE_WATCH_NAMESPACE`. These env vars were implemented back in Operator 1.13.0 so I think its fair to add Helm options for these: https://github.com/DataDog/datadog-operator/pull/1649

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits