### PR TITLE
[opw] Set default CPU/memory resource requests

### DIFF
--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.15.7
+
+* Set default resource requests for the Worker container (`requests.cpu: 2`, `requests.memory: 4Gi`). No limits are set by default: a CPU limit would cause CFS throttling under bursty pipeline load and break `autoscaling.targetCPUUtilizationPercentage` (HPA), while a memory limit can OOMKill the Worker exactly when it is absorbing downstream backpressure. Recommended limit values are documented as commented examples in `values.yaml`. Installs that previously relied on the empty default (`resources: {}`) will now require nodes with at least 2 CPU and 4Gi memory available; override `resources` in your values to keep the prior behavior. Partial overrides under `resources` (e.g., setting only `resources.limits` or only `resources.requests.memory`) will inherit any unset keys from the new defaults — provide a full `resources` block if you need to opt out of the new requests.
+
 ## 2.15.6
 
 * Adding PROXY and NOPROXY options to Observability Pipelines ([#2578](https://github.com/DataDog/helm-charts/pull/2578)).

--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.15.7
 
-* Set default resource requests for the Worker container (`requests.cpu: 2`, `requests.memory: 4Gi`). No limits are set by default: a CPU limit would cause CFS throttling under bursty pipeline load and break `autoscaling.targetCPUUtilizationPercentage` (HPA), while a memory limit can OOMKill the Worker exactly when it is absorbing downstream backpressure. Recommended limit values are documented as commented examples in `values.yaml`. Installs that previously relied on the empty default (`resources: {}`) will now require nodes with at least 2 CPU and 4Gi memory available; override `resources` in your values to keep the prior behavior. Partial overrides under `resources` (e.g., setting only `resources.limits` or only `resources.requests.memory`) will inherit any unset keys from the new defaults — provide a full `resources` block if you need to opt out of the new requests.
+* Set default resource requests on the Worker container (`requests.cpu: 2`, `requests.memory: 4Gi`); limits remain unset by default (commented example in `values.yaml`). Installs previously on `resources: {}` will now need nodes with 2 CPU / 4Gi available — override `resources` to opt out ([#2664](https://github.com/DataDog/helm-charts/pull/2664)).
 
 ## 2.15.6
 

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: 2.15.6
+version: 2.15.7
 description: Observability Pipelines Worker
 type: application
 keywords:

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.15.6](https://img.shields.io/badge/Version-2.15.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.2](https://img.shields.io/badge/AppVersion-2.15.2-informational?style=flat-square)
+![Version: 2.15.7](https://img.shields.io/badge/Version-2.15.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.15.2](https://img.shields.io/badge/AppVersion-2.15.2-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 
@@ -147,7 +147,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | podSecurityContext | object | `{}` | Allows you to overwrite the default [PodSecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
 | readinessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":15,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":15}` | Specify the readinessProbe [configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes). When no probe handler (`httpGet`, `tcpSocket`, `exec`, `grpc`) is provided, the chart defaults to `tcpSocket` on the Worker API port (8686) — chosen because the Worker API is a gRPC (HTTP/2) server and `tcpSocket` is compatible with every supported Kubernetes version. Setting any handler in your values disables the default, so existing overrides are not coalesced with it. |
 | replicas | int | `1` | Specify the number of replicas to create. |
-| resources | object | `{}` | Specify resource requests and limits. |
+| resources | object | `{"requests":{"cpu":2,"memory":"4Gi"}}` | Specify resource requests and limits. The default requests are conservative recommendations for typical Worker workloads; tune for your pipeline throughput. Limits are intentionally omitted by default — see the commented example below. |
 | securityContext | object | `{}` | Specify securityContext for Containers. |
 | service.annotations | object | `{}` | Specify annotations for the Service. |
 | service.enabled | bool | `true` | If **true**, create a Service resource. |

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -168,14 +168,20 @@ envFrom: []
 # containerPorts -- Manually define ContainerPort array, overriding automated generation of ContainerPorts.
 containerPorts: []
 
-# resources -- Specify resource requests and limits.
-resources: {}
-  # requests:
-  #   cpu: 200m
-  #   memory: 256Mi
+# resources -- Specify resource requests and limits. The default requests are conservative recommendations for typical Worker workloads; tune for your pipeline throughput. Limits are intentionally omitted by default — see the commented example below.
+resources:
+  requests:
+    cpu: 2
+    memory: 4Gi
+  # Limits are commented out by default:
+  #   - cpu: CFS throttling hurts bursty pipeline workloads and breaks
+  #     `autoscaling.targetCPUUtilizationPercentage` (HPA).
+  #   - memory: OPW absorbs downstream backpressure in memory, so a hard cap can
+  #     OOMKill the Worker exactly when buffering is most needed. Set `limits.memory`
+  #     only once you know your real memory ceiling.
   # limits:
-  #   cpu: 200m
-  #   memory: 256Mi
+  #   cpu: 2
+  #   memory: 4Gi
 
 # lifecycle -- Specify lifecycle hooks for Containers.
 lifecycle: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Sets default resource requests on the Observability Pipelines Worker
container so customers deploying the chart with no overrides get sane scheduling and HPA behavior out of the box:

```yaml
resources:
  requests:
    cpu: 2
    memory: 4Gi
```

**Limits are intentionally not set by default:**

- **No CPU limit** — A CPU limit would cause CFS throttling on the
  Worker's bursty pipeline workload. It would also break HPA:
  with `autoscaling.enabled: true`,
  `autoscaling.targetCPUUtilizationPercentage` computes `usage /
  requests.cpu`, but the throttled pod can't generate the utilization
  signal needed to scale up — you get throttling instead of scaling.
- **No memory limit** — OPW absorbs downstream sink backpressure in
  memory. A hard default cap (e.g. 4Gi) would risk OOMKilling existing
  installs that have organically grown above that ceiling on upgrade,
  and would kill the Worker exactly when buffering is most needed
  during downstream incidents. Recommended example values are kept as
  commented examples in `values.yaml`.

**Why this is also an HPA fix:** Today, any user who flipped
`autoscaling.enabled: true` without also setting `resources.requests.cpu`
got a silently broken HPA — the CPU utilization metric is computed as
`usage / requests.cpu`, which can't be evaluated when `requests.cpu` is
absent. The new `requests.cpu: 2` default makes the chart's existing
HPA defaults actually work.

#### Checklist

- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
