### PR TITLE
Propagate `DD_DOGSTATSD_PORT` to the system-probe container

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.213.4
+
+* Propagate `DD_DOGSTATSD_PORT` to the system-probe container so it keeps submitting its metrics over UDP when the DogStatsD port is changed.
+
 ## 3.213.3
 
 * [GKE Autopilot] Add `agent-data-plane` to WorkloadAllowlist by referencing exemption v1.0.4 when `datadog.dataPlane.enabled=true` ([#2605](https://github.com/DataDog/helm-charts/pull/2605)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.213.3
+version: 3.213.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.213.3](https://img.shields.io/badge/Version-3.213.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.213.4](https://img.shields.io/badge/Version-3.213.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -25,6 +25,10 @@
     - name: HOST_ROOT
       value: "/host/root"
     {{- end }}
+    {{- if .Values.datadog.dogstatsd.port }}
+    - name: DD_DOGSTATSD_PORT
+      value: {{ .Values.datadog.dogstatsd.port | quote }}
+    {{- end }}
     {{- if and .Values.datadog.gpuMonitoring.enabled .Values.datadog.gpuMonitoring.privilegedMode }}
      # depending on the NVIDIA container toolkit configuration, we might need to request visible devices via this env var or via the /var/run/nvidia-container-devices/all volume mount
     - name: NVIDIA_VISIBLE_DEVICES

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -1972,6 +1972,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -1943,6 +1943,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -1940,6 +1940,8 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -1969,6 +1969,8 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -1937,6 +1937,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -2008,6 +2008,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -1937,6 +1937,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -1937,6 +1937,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -1812,6 +1812,8 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1927,6 +1927,8 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: gcr.io/datadoghq/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1927,6 +1927,8 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: gcr.io/datadoghq/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1812,6 +1812,8 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: gcr.io/datadoghq/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -1858,6 +1858,8 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: gcr.io/datadoghq/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -1973,6 +1973,8 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: gcr.io/datadoghq/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -1845,6 +1845,8 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: gcr.io/datadoghq/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -1860,6 +1860,8 @@ spec:
               value: gke-autopilot
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: gcr.io/datadoghq/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -1958,6 +1958,8 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
           image: registry.datadoghq.com/agent:7.78.3

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -2002,6 +2002,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -2046,6 +2046,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -2026,6 +2026,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -1951,6 +1951,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -2022,6 +2022,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -1613,6 +1613,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.0-full
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -1613,6 +1613,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.0-fips-full
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -1668,6 +1668,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.0
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -1668,6 +1668,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.0-fips
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1974,6 +1974,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -2022,6 +2022,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -2022,6 +2022,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -1937,6 +1937,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -1944,6 +1944,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -1983,6 +1983,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -1977,6 +1977,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -2049,6 +2049,8 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -2072,6 +2072,8 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -2046,6 +2046,8 @@ spec:
               value: "false"
             - name: DD_LOG_LEVEL
               value: INFO
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -1940,6 +1940,8 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -1940,6 +1940,8 @@ spec:
               value: INFO
             - name: HOST_ROOT
               value: /host/root
+            - name: DD_DOGSTATSD_PORT
+              value: "8125"
           image: registry.datadoghq.com/agent:7.78.3
           imagePullPolicy: IfNotPresent
           name: system-probe


### PR DESCRIPTION
#### What this PR does / why we need it:

The system-probe container submits its own metrics to the local Agent's DogStatsD server over UDP, but currently relies on the default port (8125). If `datadog.dogstatsd.port` is changed, system-probe keeps targeting the default port and metric submission fails.

To address this, this PR sets the `DD_DOGSTATSD_PORT` env var on the system-probe container from the configured `datadog.dogstatsd.port`.

#### Special notes for your reviewer:

Previous attempt: https://github.com/DataDog/helm-charts/pull/2665

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

CWS-6439