### PR TITLE
[datadog-operator] Enable DatadogCSIDriver by default and install related CRD

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.23.0-dev.4
+
+* [datadog-operator] Enable DatadogCSIDriver by default and install related CRD ([#2670](https://github.com/DataDog/helm-charts/pull/2670)).
+
 ## 2.23.0-dev.3
 
 * Support Helm parameters for `DD_DASHBOARD_WATCH_NAMESPACE`and `DD_GENERIC_RESOURCE_WATCH_NAMESPACE`

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.23.0-dev.3
+version: 2.23.0-dev.4
 appVersion: 1.27.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.23.0-dev.3](https://img.shields.io/badge/Version-2.23.0--dev.3-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
+![Version: 2.23.0-dev.4](https://img.shields.io/badge/Version-2.23.0--dev.4-informational?style=flat-square) ![AppVersion: 1.27.0-rc.1](https://img.shields.io/badge/AppVersion-1.27.0--rc.1-informational?style=flat-square)
 
 ## Values
 
@@ -21,7 +21,7 @@
 | datadogCRDs.crds.datadogAgentInternals | bool | `true` | Set to true to deploy the DatadogAgentInternals CRD |
 | datadogCRDs.crds.datadogAgentProfiles | bool | `false` | Set to true to deploy the DatadogAgentProfile CRD |
 | datadogCRDs.crds.datadogAgents | bool | `true` | Set to true to deploy the DatadogAgents CRD |
-| datadogCRDs.crds.datadogCSIDrivers | bool | `false` | Set to true to deploy the DatadogCSIDriver CRD |
+| datadogCRDs.crds.datadogCSIDrivers | bool | `true` | Set to true to deploy the DatadogCSIDriver CRD |
 | datadogCRDs.crds.datadogDashboards | bool | `false` | Set to true to deploy the DatadogDashboard CRD |
 | datadogCRDs.crds.datadogGenericResources | bool | `false` | Set to true to deploy the DatadogGenericResource CRD |
 | datadogCRDs.crds.datadogMetrics | bool | `true` | Set to true to deploy the DatadogMetrics CRD |
@@ -29,7 +29,7 @@
 | datadogCRDs.crds.datadogPodAutoscalerClusterProfiles | bool | `true` | Set to true to deploy the DatadogPodAutoscalerClusterProfiles CRD |
 | datadogCRDs.crds.datadogPodAutoscalers | bool | `true` | Set to true to deploy the DatadogPodAutoscalers CRD |
 | datadogCRDs.crds.datadogSLOs | bool | `false` | Set to true to deploy the DatadogSLO CRD |
-| datadogCSIDriver.enabled | bool | `false` | Enables the Datadog CSI Driver controller |
+| datadogCSIDriver.enabled | bool | `true` | Enables the Datadog CSI Driver controller |
 | datadogDashboard.enabled | bool | `false` | Enables the Datadog Dashboard controller |
 | datadogGenericResource.enabled | bool | `false` | Enables the Datadog Generic Resource controller |
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -91,7 +91,7 @@ datadogAgentInternal:
   enabled: true
 datadogCSIDriver:
   # datadogCSIDriver.enabled -- Enables the Datadog CSI Driver controller
-  enabled: false
+  enabled: true
 datadogDashboard:
   # datadogDashboard.enabled -- Enables the Datadog Dashboard controller
   enabled: false
@@ -180,7 +180,7 @@ datadogCRDs:
     # datadogCRDs.crds.datadogSLOs -- Set to true to deploy the DatadogSLO CRD
     datadogSLOs: false
     # datadogCRDs.crds.datadogCSIDrivers -- Set to true to deploy the DatadogCSIDriver CRD
-    datadogCSIDrivers: false
+    datadogCSIDrivers: true
     # datadogCRDs.crds.datadogDashboards -- Set to true to deploy the DatadogDashboard CRD
     datadogDashboards: false
     # datadogCRDs.crds.datadogGenericResources -- Set to true to deploy the DatadogGenericResource CRD

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.23.0-dev.3
+    helm.sh/chart: datadog-operator-2.23.0-dev.4
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.27.0-rc.1"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -76,7 +76,7 @@ spec:
             - "-datadogDashboardEnabled=false"
             - "-datadogGenericResourceEnabled=false"
             - "-remoteConfigEnabled=false"
-            - "-datadogCSIDriverEnabled=false"
+            - "-datadogCSIDriverEnabled=true"
           ports:
             - name: metrics
               containerPort: 8383


### PR DESCRIPTION
#### What this PR does / why we need it:

* Installs by default DatadogCSIDriver CRD
* Starts by default the DatadogCSIDriver controller in the operator

#### Motivation

* Ease out onboarding

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits