### PR TITLE
feat: allow overriding instance label

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.229.0
+
+* Add `agents.instanceLabelOverride`, `clusterAgent.instanceLabelOverride`, and `clusterChecksRunner.instanceLabelOverride` to override the `app.kubernetes.io/instance` label on the corresponding workloads. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label.
+
 ## 3.228.0
 
 * Enable Remote Configuration on the Cluster Agent when `datadog.kubernetesActions.enabled` is set. The Kubernetes Actions product receives its configuration over Remote Configuration, so `DD_REMOTE_CONFIGURATION_ENABLED` is now set to `true` on the Cluster Agent whenever Kubernetes Actions is enabled (alongside the existing admission controller remote instrumentation, private action runner, and workload autoscaling triggers).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.228.0
+version: 3.229.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.228.0](https://img.shields.io/badge/Version-3.228.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.229.0](https://img.shields.io/badge/Version-3.229.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -557,6 +557,7 @@ helm install <RELEASE_NAME> \
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
 | agents.image.tag | string | `"7.80.1"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
+| agents.instanceLabelOverride | string | `nil` | Override the `app.kubernetes.io/instance` label on the Agent daemonset and pods. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label. |
 | agents.lifecycle | object | `{}` | Configure the lifecycle of the Agent. Note: The `exec` lifecycle handler is not supported in GKE Autopilot. |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
 | agents.localService.overrideName | string | `""` | Name of the internal traffic service to target the agent running on the local node |
@@ -649,6 +650,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
 | clusterAgent.image.tag | string | `"7.80.1"` | Cluster Agent image tag to use |
+| clusterAgent.instanceLabelOverride | string | `nil` | Override the `app.kubernetes.io/instance` label on the Cluster Agent deployment and pods. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label. |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
@@ -717,6 +719,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
 | clusterChecksRunner.image.tag | string | `"7.80.1"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
+| clusterChecksRunner.instanceLabelOverride | string | `nil` | Override the `app.kubernetes.io/instance` label on the cluster checks runner deployment and pods. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label. |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |
 | clusterChecksRunner.nodeSelector | object | `{}` | Allow the ClusterChecks Deployment to schedule on selected nodes |

--- a/charts/datadog/files/mapping_datadog_helm_to_datadogagent_crd.yaml
+++ b/charts/datadog/files/mapping_datadog_helm_to_datadogagent_crd.yaml
@@ -102,6 +102,7 @@ agents.image.pullSecrets: ""
 agents.image.repository: ""
 agents.image.tag: spec.override.nodeAgent.image.tag
 agents.image.tagSuffix: ""
+agents.instanceLabelOverride: ""
 agents.localService.forceLocalServiceEnabled: ""
 agents.localService.overrideName: ""
 agents.networkPolicy.create: ""
@@ -200,6 +201,7 @@ clusterAgent.image.pullPolicy: spec.override.clusterAgent.image.pullPolicy
 clusterAgent.image.pullSecrets: ""
 clusterAgent.image.repository: ""
 clusterAgent.image.tag: spec.override.clusterAgent.image.tag
+clusterAgent.instanceLabelOverride: ""
 clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus: ""
 clusterAgent.livenessProbe: ""
 clusterAgent.livenessProbe.failureThreshold: ""
@@ -285,6 +287,7 @@ clusterChecksRunner.image.pullSecrets: ""
 clusterChecksRunner.image.repository: ""
 clusterChecksRunner.image.tag: spec.override.clusterChecksRunner.image.tag
 clusterChecksRunner.image.tagSuffix: ""
+clusterChecksRunner.instanceLabelOverride: ""
 clusterChecksRunner.livenessProbe: ""
 clusterChecksRunner.livenessProbe.failureThreshold: ""
 clusterChecksRunner.livenessProbe.initialDelaySeconds: ""

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -1073,7 +1073,7 @@ NetworkPolicies).
 {{- if and (eq $name "cluster-agent") $ctx.Values.clusterAgent.instanceLabelOverride }}{{- $instance = $ctx.Values.clusterAgent.instanceLabelOverride }}{{- end }}
 {{- if and (eq $name "cluster-checks-runner") $ctx.Values.clusterChecksRunner.instanceLabelOverride }}{{- $instance = $ctx.Values.clusterChecksRunner.instanceLabelOverride }}{{- end }}
 app.kubernetes.io/name: "{{ template "datadog.fullname" $ctx }}"
-app.kubernetes.io/instance: {{ $instance }}
+app.kubernetes.io/instance: {{ $instance | quote }}
 app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
 app.kubernetes.io/part-of: {{ include "part-of-label" $ctx }}
 {{- end }}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -1060,13 +1060,20 @@ Build part-of label
 {{- end }}
 
 {{/*
-Common agent, cluster-agent, and cluster-checks-runner workload template labels
+Common agent, cluster-agent, and cluster-checks-runner workload template labels.
+Per-workload `instanceLabelOverride` overrides the `app.kubernetes.io/instance`
+value (restored from pre-3.140.0 for callers that pin on the previous label, e.g.
+NetworkPolicies).
 */}}
 {{- define "datadog.pod-template-labels" }}
 {{- $ctx := index . 0 }}
 {{- $name := index . 1 }}
+{{- $instance := printf "%s-%s" (include "datadog.fullname" $ctx) $name }}
+{{- if and (eq $name "agent") $ctx.Values.agents.instanceLabelOverride }}{{- $instance = $ctx.Values.agents.instanceLabelOverride }}{{- end }}
+{{- if and (eq $name "cluster-agent") $ctx.Values.clusterAgent.instanceLabelOverride }}{{- $instance = $ctx.Values.clusterAgent.instanceLabelOverride }}{{- end }}
+{{- if and (eq $name "cluster-checks-runner") $ctx.Values.clusterChecksRunner.instanceLabelOverride }}{{- $instance = $ctx.Values.clusterChecksRunner.instanceLabelOverride }}{{- end }}
 app.kubernetes.io/name: "{{ template "datadog.fullname" $ctx }}"
-app.kubernetes.io/instance: {{ template "datadog.fullname" $ctx }}-{{ $name }}
+app.kubernetes.io/instance: {{ $instance }}
 app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
 app.kubernetes.io/part-of: {{ include "part-of-label" $ctx }}
 {{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2013,6 +2013,9 @@ clusterAgent:
   additionalLabels: {}
     # key: "value"
 
+  # clusterAgent.instanceLabelOverride -- Override the `app.kubernetes.io/instance` label on the Cluster Agent deployment and pods. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label.
+  instanceLabelOverride:  # "datadog"
+
   # clusterAgent.containerExclude -- Exclude containers from the Cluster Agent
   # Autodiscovery, as a space-separated list. (Requires Agent/Cluster Agent 7.50.0+)
 
@@ -2754,6 +2757,9 @@ agents:
   additionalLabels: {}
     # key: "value"
 
+  # agents.instanceLabelOverride -- Override the `app.kubernetes.io/instance` label on the Agent daemonset and pods. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label.
+  instanceLabelOverride:  # "datadog"
+
   # agents.useConfigMap -- Configures a configmap to provide the agent configuration. Use this in combination with the `agents.customAgentConfig` parameter.
   useConfigMap:  # false
 
@@ -3045,6 +3051,9 @@ clusterChecksRunner:
   # clusterChecksRunner.additionalLabels -- Adds labels to the cluster checks runner deployment and pods
   additionalLabels: {}
     # key: "value"
+
+  # clusterChecksRunner.instanceLabelOverride -- Override the `app.kubernetes.io/instance` label on the cluster checks runner deployment and pods. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label.
+  instanceLabelOverride:  # "datadog"
 
   # clusterChecksRunner.securityContext -- Allows you to overwrite the default PodSecurityContext on the clusterchecks pods.
   securityContext: {}


### PR DESCRIPTION
## Allow overriding `app.kubernetes.io/instance` label per workload

### Summary

PR #2111 (released in 3.140.0) changed the `app.kubernetes.io/instance` label on the Agent, Cluster Agent, and Cluster Checks Runner workloads from `<release-name>` to `<fullname>-<workload>` (e.g. `datadog-agent`, `datadog-cluster-agent`). This is a breaking change for users whose NetworkPolicies — or any other selector — pin on the previous value.

`agents.additionalLabels` doesn't solve the problem: it appends labels, producing duplicate keys when the key already exists in the templated label set.

This PR adds three new values:

- `agents.instanceLabelOverride`
- `clusterAgent.instanceLabelOverride`
- `clusterChecksRunner.instanceLabelOverride`

When set, each overrides the `app.kubernetes.io/instance` label on the corresponding workload (both `metadata.labels` and `spec.template.metadata.labels`). When unset (default), behavior is unchanged from current `main`.

### Usage

Restore the pre-3.140.0 label so existing NetworkPolicies keep matching:

```yaml
agents:
  instanceLabelOverride: datadog
clusterAgent:
  instanceLabelOverride: datadog
clusterChecksRunner:
  instanceLabelOverride: datadog
```

### Why scoped to a single label

PR #2111 only changed `app.kubernetes.io/instance`. The other three `app.kubernetes.io/*` labels emitted by `datadog.pod-template-labels` were unaffected, so a generic `labelOverrides` map would be wider scope than needed. Keeping it to one string value keeps the helper diff minimal and the values surface obvious.

### Safety

`app.kubernetes.io/instance` is not part of any DaemonSet/Deployment `selector.matchLabels` (selectors use `app: <fullname>...`), so overriding the value does not run into immutability issues on upgrade.

### Test plan

- [ ] `helm template` with defaults: output is byte-identical to current `main` for the relevant manifests
- [ ] `helm template … --set agents.instanceLabelOverride=datadog --set clusterAgent.instanceLabelOverride=datadog --set clusterChecksRunner.instanceLabelOverride=datadog`: confirm the `app.kubernetes.io/instance` value flips on the agent DaemonSet, cluster-agent Deployment, and cluster-checks-runner Deployment (both metadata and pod template)
- [ ] Existing CI matrix passes
- [ ] `helm-docs` regenerated (README in sync)

### Related

- Original change: #2111
