### PR TITLE
[CONTP-1642] support configuring labels for csi driver pods

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0
+
+* Add `labels` value to configure labels on CSI driver daemonset pods.
+
 ## 0.11.0
 
 * Registry allow list is now configured via `global.apmRegistryAllowList` in the parent `datadog` chart. When set, the CSI driver enforces the list via `DD_REGISTRY_ALLOW_LIST` and the admission controller enforces it via `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY_ALLOW_LIST`. Both layers must be satisfied for injection to proceed.

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.11.0
+version: 0.12.0
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 
@@ -24,6 +24,7 @@ Datadog CSI Driver helm chart
 | image.pullSecrets | list | `[]` | CSI driver repository pullSecret (for example: specify Docker registry credentials) |
 | image.repository | string | `"gcr.io/datadoghq/csi-driver"` | Override default registry + image.name for CSI driver |
 | image.tag | string | `"1.2.2"` | CSI driver image tag to use |
+| labels | object | `{}` | Configure the labels for the csi driver daemonset pods. |
 | nameOverride | string | `""` | Allows overriding the name of the chart. If set, this value replaces the default chart name. |
 | nodeAffinity | object | `{}` | Configure the nodeAffinity for the csi driver daemonset pods. |
 | nodeSelector | object | `{}` | Configure the nodeSelector for the csi driver daemonset pods. |

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         app: {{ include "datadog-csi-driver.daemonsetName" . }}
         admission.datadoghq.com/enabled: "false"
+      {{- with .Values.labels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/datadog-csi-driver/values.yaml
+++ b/charts/datadog-csi-driver/values.yaml
@@ -97,6 +97,9 @@ securityContext: {}
 # annotations -- Configure the annotations for the csi driver daemonset pods.
 annotations: {}
 
+# labels -- Configure the labels for the csi driver daemonset pods.
+labels: {}
+
 # global -- Global values shared across charts when this chart is used as a sub-chart.
 # When installed standalone, these values have no effect.
 global:

--- a/test/datadog-csi-driver/baseline/CSI_Driver_annotation_and_securitycontext.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_annotation_and_securitycontext.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app: datadog-csi-driver-node-server
         admission.datadoghq.com/enabled: "false"
+        cost-center: engineering
+        team: observability
       annotations:
         ad.datadoghq.com/csi-node-driver.checks: |
           {

--- a/test/datadog-csi-driver/manifests/added_annotation_and_securitycontext.yaml
+++ b/test/datadog-csi-driver/manifests/added_annotation_and_securitycontext.yaml
@@ -1,3 +1,7 @@
+labels:
+  team: observability
+  cost-center: engineering
+
 annotations:
   ad.datadoghq.com/csi-node-driver.checks: |
     {


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for configuring labels on csi driver pods.

We already support configuring annotations.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - Links to [external contribution](https://github.com/DataDog/helm-charts/pull/2193)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits