### PR TITLE
[CONTP-1640] support configuring resources requests and limits for csi driver pods

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0
+
+* Add `driver.resources` value to configure resource requests and limits for the CSI driver container.
+
 ## 0.12.0
 
 * Add `labels` value to configure labels on CSI driver daemonset pods.

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.12.0
+version: 0.13.0
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 
@@ -16,6 +16,7 @@ Datadog CSI Driver helm chart
 |-----|------|---------|-------------|
 | annotations | object | `{}` | Configure the annotations for the csi driver daemonset pods. |
 | apm.enabled | bool | `true` | Enable APM/SSI support for the CSI driver. |
+| driver.resources | object | `{}` | Resource requests and limits for the CSI driver container. |
 | driver.securityContext | object | `{"privileged":true,"readOnlyRootFilesystem":true}` | CSI driver securityContext |
 | fullnameOverride | string | `""` | Allows overriding the full name of resources created by the chart. If set, this value completely replaces the generated name, ignoring the standard naming convention. |
 | global | object | `{"apmRegistryAllowList":[]}` | Global values shared across charts when this chart is used as a sub-chart. When installed standalone, these values have no effect. |

--- a/charts/datadog-csi-driver/templates/daemonset.yaml
+++ b/charts/datadog-csi-driver/templates/daemonset.yaml
@@ -47,6 +47,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.driver.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 5000
               protocol: TCP

--- a/charts/datadog-csi-driver/values.yaml
+++ b/charts/datadog-csi-driver/values.yaml
@@ -53,6 +53,15 @@ driver:
     readOnlyRootFilesystem: true
     privileged: true
 
+  # driver.resources -- Resource requests and limits for the CSI driver container.
+  resources: {}
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  limits:
+  #    cpu: 200m
+  #    memory: 256Mi
+
 sockets:
   # apmHostSocketPath -- Host path of the apm socket.
   # Should correspond to `datadog.apm.hostSocketPath`

--- a/test/datadog-csi-driver/baseline/CSI_Driver_resources.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_resources.yaml
@@ -1,0 +1,110 @@
+---
+# Source: datadog-csi-driver/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: datadog-csi-driver-node-server
+  namespace: datadog-agent
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: datadog-csi-driver-node-server
+  template:
+    metadata:
+      labels:
+        app: datadog-csi-driver-node-server
+        admission.datadoghq.com/enabled: "false"
+    spec:
+      containers:
+        - name: csi-node-driver
+          image: "gcr.io/datadoghq/csi-driver:1.2.2"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          ports:
+            - containerPort: 5000
+              protocol: TCP
+          args:
+            - --apm-host-socket-path=/var/run/datadog/apm.socket
+            - --dsd-host-socket-path=/var/run/datadog/dsd.socket
+          volumeMounts:
+            # plugin-dir stores the socket on which CSI node server service is exposed.
+            # it is created by the node server and needs to be writeable.
+            - name: plugin-dir
+              mountPath: /csi
+            # storage-dir stores the data and database for the CSI driver.
+            - name: storage-dir
+              mountPath: /var/lib/datadog-csi-driver
+            - name: apm-socket
+              mountPath: /var/run/datadog
+              readOnly: true
+            # write mode is required to perform a volume mount
+            # csi driver has to create a subdirectory under /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~csi/datadog/mount.
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DD_APM_ENABLED
+              value: "true"
+        - name: csi-node-driver-registrar
+          image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/datadog.csi/driver/csi.sock
+          volumeMounts:
+            # plugin-dir stores the socket created by the CSI driver node server.
+            # it is needed by the registrar to fetch the driver name from the driver contain (via the CSI GetPluginInfo() call).
+            - name: plugin-dir
+              mountPath: /csi # Match this to ADDRESS
+              readOnly: true
+            # registration-dir is used to store the registration information and register the driver with kubelet.
+            # it needs to be writeable
+            - name: registration-dir
+              mountPath: /registration # This is where the registrar writes the registration information
+      volumes:
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/datadog.csi/driver
+            type: DirectoryOrCreate
+        - name: storage-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/datadog.csi/storage
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
+          name: apm-socket
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
+          name: dsd-socket

--- a/test/datadog-csi-driver/baseline_test.go
+++ b/test/datadog-csi-driver/baseline_test.go
@@ -46,6 +46,21 @@ func Test_baseline_manifests(t *testing.T) {
 			assertions:           verifyCSIDriverDaemonSet,
 		},
 		{
+			name: "CSI Driver with resources set",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-csi-driver",
+				ChartPath:   "../../charts/datadog-csi-driver",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values: []string{
+					"../../charts/datadog-csi-driver/values.yaml",
+					"./manifests/added_resources.yaml",
+				},
+				Overrides: map[string]string{},
+			},
+			baselineManifestPath: "./baseline/CSI_Driver_resources.yaml",
+			assertions:           verifyCSIDriverDaemonSet,
+		},
+		{
 			name: "CSI Driver with nodeSelector and nodeAffinity set",
 			command: common.HelmCommand{
 				ReleaseName: "datadog-csi-driver",

--- a/test/datadog-csi-driver/manifests/added_resources.yaml
+++ b/test/datadog-csi-driver/manifests/added_resources.yaml
@@ -1,0 +1,8 @@
+driver:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi


### PR DESCRIPTION
#### What this PR does / why we need it:

See title.

#### Which issue this PR fixes
- relates to external contribution: https://github.com/DataDog/helm-charts/pull/2509


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits