### PR TITLE
[CASCL-1397] datadog: allow cluster-agent to read `dd-cluster-info`

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.198.1
+
+* Grant the Cluster Agent `get`/`list`/`watch` on the `dd-cluster-info` ConfigMap (cluster-wide, gated by `datadog.orchestratorExplorer.enabled`). Required by the orchestrator check to surface the cluster-info snapshot written by `kubectl datadog autoscaling cluster install` to the Datadog back-end.
+
 ## 3.198.0
 
 * Update datadog-csi-driver chart dependency version to support configuring `priorityClass` on csi driver node server pods.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.198.0
+version: 3.198.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.198.0](https://img.shields.io/badge/Version-3.198.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.198.1](https://img.shields.io/badge/Version-3.198.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -391,6 +391,16 @@ rules:
   - list
   - watch
   - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - dd-cluster-info
+  verbs:
+  - get
+  - list
+  - watch
 {{- include "orchestratorExplorer-config-crs" . }}
 {{- end }}
 {{- if .Values.datadog.appsec.injector.enabled }}

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -932,6 +932,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -928,6 +928,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -928,6 +928,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -928,6 +928,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -928,6 +928,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -968,6 +968,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -426,6 +426,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -930,6 +930,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1166,6 +1166,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1166,6 +1166,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1166,6 +1166,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -930,6 +930,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -930,6 +930,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -930,6 +930,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -1172,6 +1172,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -959,6 +959,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1166,6 +1166,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -986,6 +986,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -986,6 +986,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -986,6 +986,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -986,6 +986,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -938,6 +938,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -986,6 +986,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -986,6 +986,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -916,6 +916,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -915,6 +915,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -930,6 +930,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1167,6 +1167,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -1166,6 +1166,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1166,6 +1166,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -1167,6 +1167,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -1167,6 +1167,16 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - dd-cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
#### What this PR does / why we need it:

Grants the Cluster Agent `get`/`list`/`watch` on the `dd-cluster-info` ConfigMap (gated by `datadog.orchestratorExplorer.enabled`), so it can read the cluster-info snapshot written by `kubectl datadog autoscaling cluster install` (see [DataDog/datadog-operator#2945](https://github.com/DataDog/datadog-operator/pull/2945), [#2980](https://github.com/DataDog/datadog-operator/pull/2980)).

This RBAC rule unblocks the orchestrator-check enhancement tracked in [DataDog/datadog-agent#51107](https://github.com/DataDog/datadog-agent/pull/51107), which surfaces per-node management info (Fargate / Karpenter / EKS managed node group / ASG / standalone), the autoscaling solutions detected on the cluster, and the EKS cluster ARN to the Datadog back-end through the synthetic Cluster payload.

Kubernetes ignores `resourceNames` for `list`/`watch` verbs, so the rule effectively grants those verbs cluster-wide on `configmaps`; the agent narrows the result client-side via the `app.kubernetes.io/managed-by=kubectl-datadog` label and a `metadata.name` field selector.

The agent degrades gracefully if this rule is absent (logs `Forbidden` at debug level, leaves the new fields unset). So the two PRs can merge in either order.

Jira: [CASCL-1397](https://datadoghq.atlassian.net/browse/CASCL-1397).

#### Which issue this PR fixes

n/a

#### Special notes for your reviewer:

- The Chart version is bumped from `3.198.0` to `3.198.1`. The `datadog/patch-version` label is applied.
- `make update-test-baselines` was run; 42 baseline manifests now include the new ClusterRole rule.
- `helm-docs` was not run locally (would require installing helm-docs); the only README change here is the version badge bump, which I updated manually.

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub
- [x] Chart Version semver bump label has been added (`datadog/patch-version`)
- [x] For `datadog` chart changes, test baselines have been updated (`make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team (pending review)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md` (no new variables — RBAC-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)