### PR TITLE
Update datadog-csi-driver chart dependency version to support configuring labels and resources requests and limits on csi driver node server pods.

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.214.0
+
+* Update datadog-csi-driver chart dependency version to support configuring labels and resources requests and limits on csi driver node server pods.
+
 ## 3.213.4
 
 * Propagate `DD_DOGSTATSD_PORT` to the system-probe container so it keeps submitting its metrics over UDP when the DogStatsD port is changed.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.213.4
+version: 3.214.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.213.4](https://img.shields.io/badge/Version-3.213.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.214.0](https://img.shields.io/badge/Version-3.214.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -32,7 +32,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 | Repository | Name | Version |
 |------------|------|---------|
 | https://helm.datadoghq.com | datadog-crds | 2.20.0 |
-| https://helm.datadoghq.com | datadog-csi-driver | 0.10.1 |
+| https://helm.datadoghq.com | datadog-csi-driver | 0.13.0 |
 | https://helm.datadoghq.com | operator(datadog-operator) | 2.22.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 2.13.2
 - name: datadog-csi-driver
   repository: https://helm.datadoghq.com
-  version: 0.10.1
+  version: 0.13.0
 - name: datadog-operator
   repository: https://helm.datadoghq.com
   version: 2.22.0
-digest: sha256:dab086d458f6f85cace5697ada1f5c56fc31756e26a543abf5a544a34b7cb241
-generated: "2026-05-04T14:59:53.561458+02:00"
+digest: sha256:3f6124df58b9baaa8343612d23085db8ad47acf91c5a107bdea8bbd562941d9b
+generated: "2026-05-21T10:22:20.750091+02:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: datadog.kubeStateMetricsEnabled
   - name: datadog-csi-driver
-    version: 0.10.1
+    version: 0.13.0
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator


### PR DESCRIPTION
#### What this PR does / why we need it:

See title.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits