### PR TITLE
Add Claude OTEL resource attributes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "repo.owner=DataDog,repo.name=helm-charts"
+  },
+  "extraKnownMarketplaces": {
+    "datadog-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "DataDog/claude-marketplace"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "marketplace-auto-update@datadog-claude-plugins": true,
+    "dd@datadog-claude-plugins": true
+  }
+}


### PR DESCRIPTION
## Problem

Claude sessions in this repository do not declare repo-level OpenTelemetry resource attributes, so telemetry cannot reliably attribute activity to `DataDog/helm-charts`.

## Changes

- Add `.claude/settings.json` with `OTEL_RESOURCE_ATTRIBUTES=repo.owner=DataDog,repo.name=helm-charts`.
- Register the Datadog Claude plugin marketplace and enable the Datadog plugin plus marketplace auto-update.

## Validation

- Verified the settings payload is valid JSON.
- No runtime tests were run; this is a Claude settings-only change.