### PR TITLE
feat(datadog): grant cluster-agent RBAC on csidrivers.storage.k8s.io

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.215.2
+
+* Grant the cluster-agent `get`/`list`/`watch` on `csidrivers.storage.k8s.io` so the admission controller can auto-detect the Datadog CSI driver for SSI library injection. The rule is rendered whenever `clusterAgent.admissionController.enabled` is `true`.
+
 ## 3.215.1
 
 * Add `datadog.kubeStateMetricsCore.useApiServerCache` to enable the use of the API server cache in the Kube Metrics Core check.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.215.1
+version: 3.215.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.215.1](https://img.shields.io/badge/Version-3.215.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.215.2](https://img.shields.io/badge/Version-3.215.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -274,6 +274,9 @@ rules:
 - apiGroups: [""]
   resources: ["replicationcontrollers"]
   verbs: ["get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["csidrivers"]
+  verbs: ["get", "list", "watch"]
 {{- if and .Values.clusterAgent.admissionController.cwsInstrumentation.enabled (eq .Values.clusterAgent.admissionController.cwsInstrumentation.mode "remote_copy") }}
 - apiGroups: [""]
   resources: ["pods/exec"]

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -877,6 +877,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -877,6 +877,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -1147,6 +1147,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -1143,6 +1143,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -1143,6 +1143,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -1143,6 +1143,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -1143,6 +1143,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -1131,6 +1131,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -1131,6 +1131,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - serviceaccounts

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -1183,6 +1183,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -368,6 +368,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
@@ -877,6 +877,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -877,6 +877,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -877,6 +877,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -892,6 +892,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -877,6 +877,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -1145,6 +1145,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -1145,6 +1145,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -1145,6 +1145,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -1145,6 +1145,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -1135,6 +1135,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -1174,6 +1174,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -1201,6 +1201,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -1201,6 +1201,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1153,6 +1153,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -1201,6 +1201,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -1201,6 +1201,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -1131,6 +1131,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -1145,6 +1145,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1131,6 +1131,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1130,6 +1130,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -1131,6 +1131,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -1131,6 +1131,14 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - security.openshift.io
     resourceNames:
       - datadog-cluster-agent


### PR DESCRIPTION
#### What this PR does / why we need it:

Grant the cluster-agent `get`/`list`/`watch` on `csidrivers.storage.k8s.io` so the admission controller can auto-detect the Datadog CSI driver for SSI library injection.

The cluster-agent's admission controller now reads `CSIDriver` resources via the `workloadmeta-kubeapiserver` collector. Without these RBAC verbs the collector cannot start and the admission controller silently falls back to the init-container injection mode — even when the Datadog CSI driver is installed in the cluster.

The new rule is added to the cluster-agent `ClusterRole`, inside the existing `clusterAgent.admissionController.enabled` block (no new Helm value introduced).

Cluster-agent associated PR: https://github.com/DataDog/datadog-agent/pull/50353

#### Which issue this PR fixes
  - fixes #

#### Special notes for your reviewer:

- The agent-side informer activates on three conditions:
  - `admission_controller.enabled` → already mapped to `clusterAgent.admissionController.enabled` in the chart.
  - `admission_controller.auto_instrumentation.enabled` → defaults `true` server-side, not exposed in the chart.
  - `apm_config.instrumentation.csi_driver_detection_enabled` → temporary feature flag, intentionally **not** wired into the chart.
- Gating the RBAC rule on the existing `admissionController.enabled` block therefore covers the only user-facing toggle. The permission is read-only and low-sensitivity (`CSIDriver` is a public cluster-scoped resource), so granting it whenever the admission controller is enabled is the cleanest posture: operators flipping the agent-side feature later never need to re-roll RBAC.
- `csidrivers.storage.k8s.io` is cluster-scoped, hence the `ClusterRole` (not `Role`). It is the same resource registered by the `datadog-csi-driver` subchart — here we only need read access.
- Baseline manifests diff: 46 files, single 8-line addition per file (the new RBAC rule), no unrelated drift.

#### Checklist
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`) — `datadog/minor-version`
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`) — N/A, no new value introduced
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md` — N/A, no new value introduced

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits