### PR TITLE
feat(datadog-csi-driver): annotate CSIDriver with apm-enabled

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.0
+
+* Set the `csi.datadoghq.com/apm-enabled` annotation on the `k8s.csi.datadoghq.com` `CSIDriver` resource based on `apm.enabled`. The cluster-agent admission controller reads this annotation (via the `workloadmeta-kubeapiserver` CSIDriver collector) to decide whether SSI library injection can use CSI mode for this driver.
+
 ## 0.13.0
 
 * Add `driver.resources` value to configure resource requests and limits for the CSI driver container.

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.13.0
+version: 0.14.0
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 

--- a/charts/datadog-csi-driver/templates/csidriver.yaml
+++ b/charts/datadog-csi-driver/templates/csidriver.yaml
@@ -2,6 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: k8s.csi.datadoghq.com
+  annotations:
+    csi.datadoghq.com/apm-enabled: {{ .Values.apm.enabled | quote }}
 spec:
   volumeLifecycleModes:
     - Persistent


### PR DESCRIPTION
#### What this PR does / why we need it:

Expose the operator's APM/SSI intent on the `k8s.csi.datadoghq.com` `CSIDriver` resource via a new annotation `csi.datadoghq.com/apm-enabled`, driven by the existing `apm.enabled` value.

The cluster-agent's admission controller now reads this annotation through the `workloadmeta-kubeapiserver` CSIDriver collector to decide whether SSI library injection can use CSI mode for our driver. Without the annotation, the cluster-agent silently falls back to the init-container injection mode.

Paired with the cluster-agent RBAC change that grants `get`/`list`/`watch` on `csidrivers.storage.k8s.io` (see [companion PR on the `datadog` chart](https://github.com/DataDog/helm-charts/pull/2684)).

Cluster-agent associated PR: https://github.com/DataDog/datadog-agent/pull/50353

#### Which issue this PR fixes
  - fixes #

#### Special notes for your reviewer:

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`) — `datadog-csi-driver/minor-version`
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`) — N/A, no chart-side render diff
- [ ] For `datadog` chart changes, received ✅ from a member of your team — N/A, csi-driver chart only

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`) — N/A, no new value introduced
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md` — N/A, no new value introduced

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits