### PR TITLE
chore(cloudprem): bump to 0.4.1 with multi-cloud docs + kubeVersion enforcement

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.1
+
+* Enforce `Kubernetes 1.25+` via `Chart.yaml` `kubeVersion` so `helm install` rejects older clusters with a clear error instead of failing later at runtime.
+* Rewrite the README Prerequisites section to reflect the chart's actual multi-cloud support (AWS / GCP / Azure / self-managed), supported ingress controllers (ALB + NGINX), and full object-storage list (S3, GCS, Azure Blob, MinIO, Ceph, any S3-compatible).
+* Fix the `image.tag` default documented in the README values table — it follows the chart's `appVersion`, not the literal string `devel`.
+* Add `azure.*` rows to the README values table so the Azure configuration surface is discoverable.
+
 ## 0.4.0
 
 * Update Docker image to `v0.1.26`.

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,9 +2,15 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.4.0
+version: 0.4.1
 # This is the version of the "application". Right now, we follow the image version.
 appVersion: v0.1.26
+# Minimum Kubernetes version supported. The `-0` suffix accepts cloud-vendor
+# pre-release tags like `1.25.0-eks-abc`. Matches the prerequisite stated in the
+# public install docs (https://docs.datadoghq.com/byoc-logs/install/) and in the
+# README; surfacing it here makes `helm install` reject older clusters with a
+# clear error instead of failing later at runtime.
+kubeVersion: ">= 1.25.0-0"
 home: https://www.datadoghq.com/
 icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 maintainers:

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.26](https://img.shields.io/badge/AppVersion-v0.1.26-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.26](https://img.shields.io/badge/AppVersion-v0.1.26-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 
@@ -13,11 +13,18 @@ helm repo update
 
 ## Prerequisites
 
-- AWS account
-- Kubernetes `1.25+` ([EKS](https://aws.amazon.com/eks/) preferred)
-- [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller)
-- PostgreSQL database ([RDS](https://aws.amazon.com/rds/) preferred)
-- S3 bucket
+- A cloud account (AWS, GCP, Azure) or a self-managed Kubernetes cluster.
+- Kubernetes `1.25+` — enforced by the chart's `kubeVersion` constraint. See the
+  per-cloud install guides at <https://docs.datadoghq.com/byoc-logs/install/>.
+- An ingress controller compatible with the chart defaults:
+    - [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller)
+      (default; required on EKS), or
+    - [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/)
+      (used on AKS, supported elsewhere).
+- PostgreSQL database — managed (RDS, Cloud SQL, Azure Database for PostgreSQL
+  Flexible Server) or self-hosted.
+- Object storage — Amazon S3, Google Cloud Storage, Azure Blob Storage, MinIO,
+  Ceph, or any S3-compatible storage.
 
 ## Quick start
 
@@ -199,7 +206,12 @@ This command removes all the Kubernetes resources associated with the chart and 
 |extraConfigMaps | list | [] | Additional ConfigMaps to create with custom data and configuration|
 |image.pullPolicy | string | IfNotPresent | Image pull policy for CloudPrem containers|
 |image.repository | string | public.ecr.aws/datadog/cloudprem | Repository of the CloudPrem image|
-|image.tag | string | devel | Tag of the CloudPrem image to deploy|
+|image.tag | string | chart `appVersion` (currently `v0.1.26`) | Tag of the CloudPrem image to deploy. When unset, helm uses the chart's `appVersion`.|
+|azure.tenantId | string | "" | Azure tenant ID (when deploying on AKS / using Azure Blob Storage)|
+|azure.clientId | string | "" | Azure client ID for the BYOC Logs service principal|
+|azure.clientSecretRef | dict | {} | Reference to a Secret containing the Azure client secret (`name` + `key`)|
+|azure.storageAccount.name | string | "" | Azure storage account name used for indexes|
+|azure.storageAccount.accessKeySecretRef | dict | {} | Reference to a Secret containing the storage-account access key|
 |ingress.internal.enabled | bool | false | Whether to enable the internal ingress|
 |ingress.internal.host | string | null | Hostname for internal ingress access|
 |ingress.internal.name | string | null | Name of the internal ingress resource|

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -11,6 +11,10 @@ helm repo add datadog https://helm.datadoghq.com
 helm repo update
 ```
 
+## Requirements
+
+Kubernetes: `>= 1.25.0-0`
+
 ## Prerequisites
 
 - A cloud account (AWS, GCP, Azure) or a self-managed Kubernetes cluster.

--- a/charts/cloudprem/README.md.gotmpl
+++ b/charts/cloudprem/README.md.gotmpl
@@ -15,11 +15,18 @@ helm repo update
 
 ## Prerequisites
 
-- AWS account
-- Kubernetes `1.25+` ([EKS](https://aws.amazon.com/eks/) preferred)
-- [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller)
-- PostgreSQL database ([RDS](https://aws.amazon.com/rds/) preferred)
-- S3 bucket
+- A cloud account (AWS, GCP, Azure) or a self-managed Kubernetes cluster.
+- Kubernetes `1.25+` — enforced by the chart's `kubeVersion` constraint. See the
+  per-cloud install guides at <https://docs.datadoghq.com/byoc-logs/install/>.
+- An ingress controller compatible with the chart defaults:
+    - [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller)
+      (default; required on EKS), or
+    - [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/)
+      (used on AKS, supported elsewhere).
+- PostgreSQL database — managed (RDS, Cloud SQL, Azure Database for PostgreSQL
+  Flexible Server) or self-hosted.
+- Object storage — Amazon S3, Google Cloud Storage, Azure Blob Storage, MinIO,
+  Ceph, or any S3-compatible storage.
 
 ## Quick start
 
@@ -201,7 +208,12 @@ This command removes all the Kubernetes resources associated with the chart and 
 |extraConfigMaps | list | [] | Additional ConfigMaps to create with custom data and configuration|
 |image.pullPolicy | string | IfNotPresent | Image pull policy for CloudPrem containers|
 |image.repository | string | public.ecr.aws/datadog/cloudprem | Repository of the CloudPrem image|
-|image.tag | string | devel | Tag of the CloudPrem image to deploy|
+|image.tag | string | chart `appVersion` (currently `v0.1.26`) | Tag of the CloudPrem image to deploy. When unset, helm uses the chart's `appVersion`.|
+|azure.tenantId | string | "" | Azure tenant ID (when deploying on AKS / using Azure Blob Storage)|
+|azure.clientId | string | "" | Azure client ID for the BYOC Logs service principal|
+|azure.clientSecretRef | dict | {} | Reference to a Secret containing the Azure client secret (`name` + `key`)|
+|azure.storageAccount.name | string | "" | Azure storage account name used for indexes|
+|azure.storageAccount.accessKeySecretRef | dict | {} | Reference to a Secret containing the storage-account access key|
 |ingress.internal.enabled | bool | false | Whether to enable the internal ingress|
 |ingress.internal.host | string | null | Hostname for internal ingress access|
 |ingress.internal.name | string | null | Name of the internal ingress resource|


### PR DESCRIPTION
## Summary

Doc-audit follow-up surfaced by an audit of the public BYOC Logs docs against the chart and the pomsky storage layer. Bundles four changes to the `cloudprem` chart so the README + Chart.yaml match the chart's actual multi-cloud support and the public docs.

Audit evidence: https://github.com/DataDog/claude-marketplace/pull/2216#issuecomment-4543572562

### Changes

1. **`kubeVersion: ">= 1.25.0-0"`** added to `Chart.yaml`. Today the K8s 1.25+ requirement is documented in two places (README Prereqs and the public install page) but not enforced — `helm install` accepts older clusters and customers hit obscure runtime failures. The `-0` suffix accepts cloud-vendor variants like `1.25.0-eks-abc`.

2. **README Prerequisites section** rewritten from AWS-only to multi-cloud:
   - The chart's `values.yaml` has had a full `azure:` block; the public install docs cover EKS / GKE / AKS / self-managed K8s; `quickwit-storage` registers S3 + Azure + GCS + S3-compat factories.
   - The README listing "AWS account / AWS Load Balancer Controller / S3 bucket" as bullet prereqs was out of sync with all of those.
   - New Prereqs cover supported clouds, both supported ingress controllers (ALB + NGINX), the per-cloud PostgreSQL options, and the full object-store list.

3. **`image.tag` default** in the values table — was documented as `devel`, actually defaults to the chart's `appVersion` when unset (currently `v0.1.26`). Customers reading the README expected one tag and got another.

4. **`azure.*` rows added** to the values table so the Azure configuration surface is discoverable from the README. (No `gcp.*` rows because GCP uses Workload Identity, wired via `serviceAccount.extraAnnotations` — no chart-key gap there.)

Both `README.md` and `README.md.gotmpl` are edited so the change survives whichever path future regeneration takes.

## Test plan

- [ ] `helm lint charts/cloudprem` passes locally.
- [ ] `helm install` against a K8s 1.24 cluster now fails with `chart requires kubeVersion ">= 1.25.0-0"`.
- [ ] `helm install` against a K8s 1.25+ cluster still installs cleanly with no `image.tag` override.
- [ ] Visual review of the regenerated `README.md` (e.g. via artifacthub preview) matches the values-table additions.
- [ ] CHANGELOG entry under `0.4.1` reads cleanly to the chart-team reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)