### PR TITLE
feat(datadog): add AppSec ingress-nginx injection support

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 3.217.0
 
 * Add cluster-agent helm support for AppSec ingress-nginx injection: new ClusterRole rules (`networking.k8s.io/ingressclasses`, cluster-wide `configmaps`) gated by `datadog.appsec.injector.enabled`, new `datadog.appsec.injector.nginx.moduleMountPath` value, and `ingress-nginx` added to the supported `datadog.appsec.injector.proxies` list.
+
+## 3.216.0
+
 * Expose `datadog.autoscaling.workload.inPlaceVerticalScaling.enabled` to enable in-place vertical scaling for Workload Autoscaling.
 
 ## 3.215.3

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.216.0
+
+* Add cluster-agent helm support for AppSec ingress-nginx injection: new ClusterRole rules (`networking.k8s.io/ingressclasses`, cluster-wide `configmaps`) gated by `datadog.appsec.injector.enabled`, new `datadog.appsec.injector.nginx.moduleMountPath` value, and `ingress-nginx` added to the supported `datadog.appsec.injector.proxies` list.
+
+
 ## 3.215.1
 
 * Add `datadog.kubeStateMetricsCore.useApiServerCache` to enable the use of the API server cache in the Kube Metrics Core check.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.216.0
+## 3.217.0
 
 * Add cluster-agent helm support for AppSec ingress-nginx injection: new ClusterRole rules (`networking.k8s.io/ingressclasses`, cluster-wide `configmaps`) gated by `datadog.appsec.injector.enabled`, new `datadog.appsec.injector.nginx.moduleMountPath` value, and `ingress-nginx` added to the supported `datadog.appsec.injector.proxies` list.
 * Expose `datadog.autoscaling.workload.inPlaceVerticalScaling.enabled` to enable in-place vertical scaling for Workload Autoscaling.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,9 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.215.1
+version: 3.216.0
+version: 3.216.0
+>>>>>>> 89c0ae29 (feat(datadog): add AppSec ingress-nginx injection support)
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.216.0
+version: 3.217.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -769,14 +769,16 @@ helm install <RELEASE_NAME> \
 | datadog.apm.useSocketVolume | bool | `false` | Enable APM over Unix Domain Socket DEPRECATED. Use datadog.apm.socketEnabled instead |
 | datadog.appKey | string | `nil` | Datadog APP key required to use metricsProvider |
 | datadog.appKeyExistingSecret | string | `nil` | Use existing Secret which stores APP key instead of creating a new one. The value should be set with the `app-key` key inside the secret. |
-| datadog.appsec.injector.autoDetect | bool | `true` | Automatically detect and inject supported proxies in the cluster (Envoy Gateway, Istio Gateway API, native Istio Gateway) |
+| datadog.appsec.injector.autoDetect | bool | `true` | Automatically detect and inject supported proxies in the cluster (Envoy Gateway, Istio Gateway API, native Istio Gateway, ingress-nginx) |
 | datadog.appsec.injector.enabled | bool | `false` | Enable App & API Protection on your cluster ingress usage across all your cluster at once |
 | datadog.appsec.injector.mode | string | `""` | Deployment mode for the AppSec processor. Valid values: "sidecar", "external". Leave empty to use the agent default (sidecar). Upgrading users who rely on the external-processor flow (processor.address / processor.service.*) should set this to "external" explicitly. |
+| datadog.appsec.injector.nginx.initImage | string | `"datadog/ingress-nginx-injection"` | Container image for the init container that ships the nginx-datadog module .so into ingress-nginx controller pods |
+| datadog.appsec.injector.nginx.moduleMountPath | string | `"/modules_mount"` | Path inside the ingress-nginx controller pod where the nginx-datadog module .so is mounted from the shared emptyDir |
 | datadog.appsec.injector.processor.address | string | `""` | Address of the AppSec processor service Defaults to `{service.name}.{service.namespace}.svc` |
 | datadog.appsec.injector.processor.port | int | `443` | Port of the AppSec processor service (defaults to 443) |
 | datadog.appsec.injector.processor.service.name | string | `""` | Name of the AppSec processor service |
 | datadog.appsec.injector.processor.service.namespace | string | `""` | Namespace where the AppSec processor service is deployed |
-| datadog.appsec.injector.proxies | list | `[]` | Manually specify which proxy types to inject. Valid values: "envoy-gateway", "istio", "istio-gateway" When autoDetect is true, detected proxies are added to this list When autoDetect is false, only proxies in this list are enabled |
+| datadog.appsec.injector.proxies | list | `[]` | Manually specify which proxy types to inject. Valid values: "envoy-gateway", "istio", "istio-gateway", "ingress-nginx" When autoDetect is true, detected proxies are added to this list When autoDetect is false, only proxies in this list are enabled |
 | datadog.appsec.injector.sidecar.bodyParsingSizeLimit | int | `0` | Request body parsing size limit in bytes for the AppSec sidecar processor. Set to 0 to leave it unset (default agent behavior). Set to a negative value (e.g. -1) to disable body parsing entirely. |
 | datadog.appsec.injector.sidecar.healthPort | int | `8081` | Health check port for the AppSec sidecar processor |
 | datadog.appsec.injector.sidecar.image | string | `"ghcr.io/datadog/dd-trace-go/service-extensions-callout"` | Container image for the AppSec sidecar processor |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.216.0](https://img.shields.io/badge/Version-3.216.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.217.0](https://img.shields.io/badge/Version-3.217.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.215.1](https://img.shields.io/badge/Version-3.215.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.216.0](https://img.shields.io/badge/Version-3.216.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -772,7 +772,6 @@ helm install <RELEASE_NAME> \
 | datadog.appsec.injector.autoDetect | bool | `true` | Automatically detect and inject supported proxies in the cluster (Envoy Gateway, Istio Gateway API, native Istio Gateway, ingress-nginx) |
 | datadog.appsec.injector.enabled | bool | `false` | Enable App & API Protection on your cluster ingress usage across all your cluster at once |
 | datadog.appsec.injector.mode | string | `""` | Deployment mode for the AppSec processor. Valid values: "sidecar", "external". Leave empty to use the agent default (sidecar). Upgrading users who rely on the external-processor flow (processor.address / processor.service.*) should set this to "external" explicitly. |
-| datadog.appsec.injector.nginx.initImage | string | `"datadog/ingress-nginx-injection"` | Container image for the init container that ships the nginx-datadog module .so into ingress-nginx controller pods |
 | datadog.appsec.injector.nginx.moduleMountPath | string | `"/modules_mount"` | Path inside the ingress-nginx controller pod where the nginx-datadog module .so is mounted from the shared emptyDir |
 | datadog.appsec.injector.processor.address | string | `""` | Address of the AppSec processor service Defaults to `{service.name}.{service.namespace}.svc` |
 | datadog.appsec.injector.processor.port | int | `443` | Port of the AppSec processor service (defaults to 443) |

--- a/charts/datadog/files/mapping_datadog_helm_to_datadogagent_crd.yaml
+++ b/charts/datadog/files/mapping_datadog_helm_to_datadogagent_crd.yaml
@@ -374,7 +374,6 @@ datadog.appKeyExistingSecret:
 datadog.appsec.injector.autoDetect: ""
 datadog.appsec.injector.enabled: ""
 datadog.appsec.injector.mode: ""
-datadog.appsec.injector.nginx.initImage: ""
 datadog.appsec.injector.nginx.moduleMountPath: ""
 datadog.appsec.injector.processor.address: ""
 datadog.appsec.injector.processor.port: ""

--- a/charts/datadog/files/mapping_datadog_helm_to_datadogagent_crd.yaml
+++ b/charts/datadog/files/mapping_datadog_helm_to_datadogagent_crd.yaml
@@ -374,6 +374,8 @@ datadog.appKeyExistingSecret:
 datadog.appsec.injector.autoDetect: ""
 datadog.appsec.injector.enabled: ""
 datadog.appsec.injector.mode: ""
+datadog.appsec.injector.nginx.initImage: ""
+datadog.appsec.injector.nginx.moduleMountPath: ""
 datadog.appsec.injector.processor.address: ""
 datadog.appsec.injector.processor.port: ""
 datadog.appsec.injector.processor.service.name: ""

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -540,6 +540,10 @@ spec:
             value: {{ .Values.datadog.appsec.injector.sidecar.resources.requests.cpu | quote }}
           - name: DD_ADMISSION_CONTROLLER_APPSEC_SIDECAR_RESOURCES_REQUESTS_MEMORY
             value: {{ .Values.datadog.appsec.injector.sidecar.resources.requests.memory | quote }}
+          - name: DD_ADMISSION_CONTROLLER_APPSEC_NGINX_INIT_IMAGE
+            value: {{ .Values.datadog.appsec.injector.nginx.initImage | quote }}
+          - name: DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH
+            value: {{ .Values.datadog.appsec.injector.nginx.moduleMountPath | quote }}
           {{- if .Values.datadog.appsec.injector.sidecar.resources.limits.cpu }}
           - name: DD_ADMISSION_CONTROLLER_APPSEC_SIDECAR_RESOURCES_LIMITS_CPU
             value: {{ .Values.datadog.appsec.injector.sidecar.resources.limits.cpu | quote }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -540,8 +540,6 @@ spec:
             value: {{ .Values.datadog.appsec.injector.sidecar.resources.requests.cpu | quote }}
           - name: DD_ADMISSION_CONTROLLER_APPSEC_SIDECAR_RESOURCES_REQUESTS_MEMORY
             value: {{ .Values.datadog.appsec.injector.sidecar.resources.requests.memory | quote }}
-          - name: DD_ADMISSION_CONTROLLER_APPSEC_NGINX_INIT_IMAGE
-            value: {{ .Values.datadog.appsec.injector.nginx.initImage | quote }}
           - name: DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH
             value: {{ .Values.datadog.appsec.injector.nginx.moduleMountPath | quote }}
           {{- if .Values.datadog.appsec.injector.sidecar.resources.limits.cpu }}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -438,6 +438,24 @@ rules:
     - get
     - list
     - watch
+# AppSec proxy injection - ingress-nginx
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingressclasses"]
+  verbs: ["get", "list", "watch"]
+
+# AppSec proxy injection - ingress-nginx ConfigMap management
+# SECURITY CONSIDERATION: These permissions are cluster-wide and unscoped.
+# ConfigMap names are derived dynamically from the controller's --configmap arg
+# (e.g. datadog-appsec-<original-name>) and cannot be predicted at RBAC
+# definition time. The watch verb is needed for the ConfigMap reconciler that
+# keeps DD copies in sync with originals. In practice, the code only operates
+# on ConfigMaps with the labels
+#   appsec.datadoghq.com/watched-configmap=true       (reconciler)
+#   app.kubernetes.io/component=datadog-appsec-injector (cleanup)
+# Consider namespace-scoped Roles if the blast radius needs to be reduced.
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]
 {{- end }}
 ---
 apiVersion: {{ template "rbac.apiVersion" . }}

--- a/charts/datadog/values.schema.json
+++ b/charts/datadog/values.schema.json
@@ -378,9 +378,6 @@
                 "nginx": {
                   "type": "object",
                   "properties": {
-                    "initImage": {
-                      "type": "string"
-                    },
                     "moduleMountPath": {
                       "type": "string"
                     }

--- a/charts/datadog/values.schema.json
+++ b/charts/datadog/values.schema.json
@@ -294,7 +294,8 @@
                     "enum": [
                       "envoy-gateway",
                       "istio",
-                      "istio-gateway"
+                      "istio-gateway",
+                      "ingress-nginx"
                     ]
                   }
                 },
@@ -370,6 +371,18 @@
                         }
                       },
                       "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "nginx": {
+                  "type": "object",
+                  "properties": {
+                    "initImage": {
+                      "type": "string"
+                    },
+                    "moduleMountPath": {
+                      "type": "string"
                     }
                   },
                   "additionalProperties": false

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -775,8 +775,6 @@ datadog:
           namespace: ""
 
       nginx:
-        # datadog.appsec.injector.nginx.initImage -- Container image for the init container that ships the nginx-datadog module .so into ingress-nginx controller pods
-        initImage: "datadog/ingress-nginx-injection"
         # datadog.appsec.injector.nginx.moduleMountPath -- Path inside the ingress-nginx controller pod where the nginx-datadog module .so is mounted from the shared emptyDir
         moduleMountPath: "/modules_mount"
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -719,19 +719,20 @@ datadog:
       # datadog.appsec.injector.enabled -- Enable App & API Protection on your cluster ingress usage across all your cluster at once
       enabled: false
 
-      # datadog.appsec.injector.autoDetect -- Automatically detect and inject supported proxies in the cluster (Envoy Gateway, Istio Gateway API, native Istio Gateway)
+      # datadog.appsec.injector.autoDetect -- Automatically detect and inject supported proxies in the cluster (Envoy Gateway, Istio Gateway API, native Istio Gateway, ingress-nginx)
       autoDetect: true
 
       # datadog.appsec.injector.mode -- Deployment mode for the AppSec processor. Valid values: "sidecar", "external". Leave empty to use the agent default (sidecar). Upgrading users who rely on the external-processor flow (processor.address / processor.service.*) should set this to "external" explicitly.
       mode: ""
 
-      # datadog.appsec.injector.proxies -- Manually specify which proxy types to inject. Valid values: "envoy-gateway", "istio", "istio-gateway"
+      # datadog.appsec.injector.proxies -- Manually specify which proxy types to inject. Valid values: "envoy-gateway", "istio", "istio-gateway", "ingress-nginx"
       # When autoDetect is true, detected proxies are added to this list
       # When autoDetect is false, only proxies in this list are enabled
       proxies: []
       # - envoy-gateway: Configures Envoy Gateway resources for AppSec injection
       # - istio: Watches Istio-managed Kubernetes Gateway API GatewayClasses for AppSec injection
       # - istio-gateway: Watches native Istio Gateway resources for AppSec injection
+      # - ingress-nginx: Watches IngressClass resources to discover ingress-nginx controllers and injects the nginx-datadog module via an init container
 
       sidecar:
         # datadog.appsec.injector.sidecar.image -- Container image for the AppSec sidecar processor
@@ -772,6 +773,12 @@ datadog:
           name: ""
           # datadog.appsec.injector.processor.service.namespace -- Namespace where the AppSec processor service is deployed
           namespace: ""
+
+      nginx:
+        # datadog.appsec.injector.nginx.initImage -- Container image for the init container that ships the nginx-datadog module .so into ingress-nginx controller pods
+        initImage: "datadog/ingress-nginx-injection"
+        # datadog.appsec.injector.nginx.moduleMountPath -- Path inside the ingress-nginx controller pod where the nginx-datadog module .so is mounted from the shared emptyDir
+        moduleMountPath: "/modules_mount"
 
   ## OTLP ingest related configuration
   otlp:

--- a/test/datadog/appsec_injector_test.go
+++ b/test/datadog/appsec_injector_test.go
@@ -31,6 +31,9 @@ const (
 	ddAppsecProcessorAddressEnvVar        = "DD_APPSEC_PROXY_PROCESSOR_ADDRESS"
 	ddAppsecProcessorServiceNameEnvVar    = "DD_CLUSTER_AGENT_APPSEC_INJECTOR_PROCESSOR_SERVICE_NAME"
 	ddAppsecProcessorServiceNsEnvVar      = "DD_CLUSTER_AGENT_APPSEC_INJECTOR_PROCESSOR_SERVICE_NAMESPACE"
+	// nginx-specific env vars
+	ddAppsecNginxInitImageEnvVar       = "DD_ADMISSION_CONTROLLER_APPSEC_NGINX_INIT_IMAGE"
+	ddAppsecNginxModuleMountPathEnvVar = "DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH"
 )
 
 func renderAppsecInjectorEnvVars(t *testing.T, overrides map[string]string, overridesJSON map[string]string) []corev1.EnvVar {
@@ -74,6 +77,8 @@ func Test_AppSecInjector_Disabled_DoesNotRenderAppSecEnvVars(t *testing.T) {
 		ddAppsecSidecarLimitCPUEnvVar,
 		ddAppsecSidecarLimitMemoryEnvVar,
 		ddAppsecSidecarBodyParsingLimitEnvVar,
+		ddAppsecNginxInitImageEnvVar,
+		ddAppsecNginxModuleMountPathEnvVar,
 	} {
 		_, found := findEnvVar(containerEnv, envVarName)
 		assert.False(t, found, "did not expect %s when appsec injector is disabled", envVarName)
@@ -88,16 +93,18 @@ func Test_AppSecInjector_Enabled_RendersDefaultOptions(t *testing.T) {
 	}, nil)
 
 	tests := map[string]string{
-		ddAppsecProxyEnabledEnvVar:      "true",
-		ddAppsecProxyAutoDetectEnvVar:   "true",
-		ddAppsecInjectorEnabledEnvVar:   "true",
-		ddAppsecSidecarImageEnvVar:      "ghcr.io/datadog/dd-trace-go/service-extensions-callout",
-		ddAppsecSidecarImageTagEnvVar:   "v2.6.0",
-		ddAppsecSidecarPortEnvVar:       "8080",
-		ddAppsecSidecarHealthPortEnvVar: "8081",
-		ddAppsecSidecarReqCPUEnvVar:     "10m",
-		ddAppsecSidecarReqMemoryEnvVar:  "128Mi",
-		ddAppsecProcessorPortEnvVar:     "443",
+		ddAppsecProxyEnabledEnvVar:         "true",
+		ddAppsecProxyAutoDetectEnvVar:      "true",
+		ddAppsecInjectorEnabledEnvVar:      "true",
+		ddAppsecSidecarImageEnvVar:         "ghcr.io/datadog/dd-trace-go/service-extensions-callout",
+		ddAppsecSidecarImageTagEnvVar:      "v2.6.0",
+		ddAppsecSidecarPortEnvVar:          "8080",
+		ddAppsecSidecarHealthPortEnvVar:    "8081",
+		ddAppsecSidecarReqCPUEnvVar:        "10m",
+		ddAppsecSidecarReqMemoryEnvVar:     "128Mi",
+		ddAppsecProcessorPortEnvVar:        "443",
+		ddAppsecNginxInitImageEnvVar:       "datadog/ingress-nginx-injection",
+		ddAppsecNginxModuleMountPathEnvVar: "/modules_mount",
 	}
 
 	for envVarName, expectedValue := range tests {
@@ -141,15 +148,17 @@ func Test_AppSecInjector_Enabled_RendersCustomOptions(t *testing.T) {
 		"datadog.appsec.injector.processor.port":                    "8443",
 		"datadog.appsec.injector.processor.service.name":            "appsec-processor",
 		"datadog.appsec.injector.processor.service.namespace":       "datadog",
+		"datadog.appsec.injector.nginx.initImage":                   "myco/init:v1",
+		"datadog.appsec.injector.nginx.moduleMountPath":             "/custom/mount",
 	}, map[string]string{
-		"datadog.appsec.injector.proxies": `["envoy-gateway","istio","istio-gateway"]`,
+		"datadog.appsec.injector.proxies": `["envoy-gateway","istio","istio-gateway","ingress-nginx"]`,
 	})
 
 	tests := map[string]string{
 		ddAppsecProxyEnabledEnvVar:            "true",
 		ddAppsecInjectorEnabledEnvVar:         "true",
 		ddAppsecInjectorModeEnvVar:            "external",
-		ddAppsecProxyProxiesEnvVar:            "[\"envoy-gateway\",\"istio\",\"istio-gateway\"]",
+		ddAppsecProxyProxiesEnvVar:            "[\"envoy-gateway\",\"istio\",\"istio-gateway\",\"ingress-nginx\"]",
 		ddAppsecProcessorPortEnvVar:           "8443",
 		ddAppsecProcessorAddressEnvVar:        "processor.example.svc",
 		ddAppsecProcessorServiceNameEnvVar:    "appsec-processor",
@@ -163,6 +172,8 @@ func Test_AppSecInjector_Enabled_RendersCustomOptions(t *testing.T) {
 		ddAppsecSidecarReqMemoryEnvVar:        "256Mi",
 		ddAppsecSidecarLimitCPUEnvVar:         "200m",
 		ddAppsecSidecarLimitMemoryEnvVar:      "512Mi",
+		ddAppsecNginxInitImageEnvVar:          "myco/init:v1",
+		ddAppsecNginxModuleMountPathEnvVar:    "/custom/mount",
 	}
 
 	for envVarName, expectedValue := range tests {
@@ -219,4 +230,98 @@ func Test_AppSecInjector_RBAC_IncludesIstioGatewaysRule(t *testing.T) {
 	}
 	assert.True(t, hasEnvoyFiltersRule, "expected networking.istio.io/envoyfilters rule")
 	assert.True(t, hasGatewaysRule, "expected networking.istio.io/gateways rule")
+}
+
+func Test_AppSecInjector_RBAC_IncludesNginxRules(t *testing.T) {
+	manifest, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/cluster-agent-rbac.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"datadog.apiKeyExistingSecret":    "datadog-secret",
+			"datadog.appKeyExistingSecret":    "datadog-secret",
+			"datadog.appsec.injector.enabled": "true",
+		},
+	})
+	require.NoError(t, err, "failed to render cluster-agent-rbac.yaml")
+
+	var clusterRole rbacv1.ClusterRole
+	for _, doc := range strings.Split(manifest, "---") {
+		if strings.Contains(doc, "kind: ClusterRole") && strings.Contains(doc, "name: datadog-cluster-agent\n") {
+			common.Unmarshal(t, doc, &clusterRole)
+			break
+		}
+	}
+	require.NotEmpty(t, clusterRole.Rules, "cluster-agent ClusterRole should have rules")
+
+	var hasIngressClassesRule, hasConfigMapsRule bool
+	for _, rule := range clusterRole.Rules {
+		for _, apiGroup := range rule.APIGroups {
+			if apiGroup == "networking.k8s.io" {
+				for _, resource := range rule.Resources {
+					if resource == "ingressclasses" {
+						hasIngressClassesRule = true
+						assert.ElementsMatch(t, []string{"get", "list", "watch"}, rule.Verbs,
+							"networking.k8s.io/ingressclasses rule should have get/list/watch verbs")
+					}
+				}
+			}
+			if apiGroup == "" {
+				for _, resource := range rule.Resources {
+					if resource == "configmaps" {
+						// Check for the AppSec-specific configmaps rule (all 6 verbs)
+						if len(rule.Verbs) == 6 {
+							hasConfigMapsRule = true
+							assert.ElementsMatch(t, []string{"get", "list", "watch", "create", "update", "delete"}, rule.Verbs,
+								"empty apiGroup/configmaps appsec rule should have 6 verbs")
+						}
+					}
+				}
+			}
+		}
+	}
+	assert.True(t, hasIngressClassesRule, "expected networking.k8s.io/ingressclasses rule")
+	assert.True(t, hasConfigMapsRule, "expected empty apiGroup/configmaps rule with 6 verbs for AppSec ingress-nginx")
+}
+
+func Test_AppSecInjector_RBAC_Disabled_OmitsNginxRules(t *testing.T) {
+	manifest, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/cluster-agent-rbac.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"datadog.apiKeyExistingSecret": "datadog-secret",
+			"datadog.appKeyExistingSecret": "datadog-secret",
+		},
+	})
+	require.NoError(t, err, "failed to render cluster-agent-rbac.yaml")
+
+	var clusterRole rbacv1.ClusterRole
+	for _, doc := range strings.Split(manifest, "---") {
+		if strings.Contains(doc, "kind: ClusterRole") && strings.Contains(doc, "name: datadog-cluster-agent\n") {
+			common.Unmarshal(t, doc, &clusterRole)
+			break
+		}
+	}
+	require.NotEmpty(t, clusterRole.Rules, "cluster-agent ClusterRole should have rules")
+
+	for _, rule := range clusterRole.Rules {
+		for _, apiGroup := range rule.APIGroups {
+			if apiGroup == "networking.k8s.io" {
+				for _, resource := range rule.Resources {
+					assert.NotEqual(t, "ingressclasses", resource,
+						"should not have networking.k8s.io/ingressclasses rule when AppSec injector is disabled")
+				}
+			}
+			if apiGroup == "" {
+				for _, resource := range rule.Resources {
+					if resource == "configmaps" && len(rule.Verbs) == 6 {
+						assert.Fail(t, "should not have empty apiGroup/configmaps rule with 6 verbs when AppSec injector is disabled")
+					}
+				}
+			}
+		}
+	}
 }

--- a/test/datadog/appsec_injector_test.go
+++ b/test/datadog/appsec_injector_test.go
@@ -32,7 +32,6 @@ const (
 	ddAppsecProcessorServiceNameEnvVar    = "DD_CLUSTER_AGENT_APPSEC_INJECTOR_PROCESSOR_SERVICE_NAME"
 	ddAppsecProcessorServiceNsEnvVar      = "DD_CLUSTER_AGENT_APPSEC_INJECTOR_PROCESSOR_SERVICE_NAMESPACE"
 	// nginx-specific env vars
-	ddAppsecNginxInitImageEnvVar       = "DD_ADMISSION_CONTROLLER_APPSEC_NGINX_INIT_IMAGE"
 	ddAppsecNginxModuleMountPathEnvVar = "DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH"
 )
 
@@ -77,7 +76,6 @@ func Test_AppSecInjector_Disabled_DoesNotRenderAppSecEnvVars(t *testing.T) {
 		ddAppsecSidecarLimitCPUEnvVar,
 		ddAppsecSidecarLimitMemoryEnvVar,
 		ddAppsecSidecarBodyParsingLimitEnvVar,
-		ddAppsecNginxInitImageEnvVar,
 		ddAppsecNginxModuleMountPathEnvVar,
 	} {
 		_, found := findEnvVar(containerEnv, envVarName)
@@ -103,7 +101,6 @@ func Test_AppSecInjector_Enabled_RendersDefaultOptions(t *testing.T) {
 		ddAppsecSidecarReqCPUEnvVar:        "10m",
 		ddAppsecSidecarReqMemoryEnvVar:     "128Mi",
 		ddAppsecProcessorPortEnvVar:        "443",
-		ddAppsecNginxInitImageEnvVar:       "datadog/ingress-nginx-injection",
 		ddAppsecNginxModuleMountPathEnvVar: "/modules_mount",
 	}
 
@@ -148,7 +145,6 @@ func Test_AppSecInjector_Enabled_RendersCustomOptions(t *testing.T) {
 		"datadog.appsec.injector.processor.port":                    "8443",
 		"datadog.appsec.injector.processor.service.name":            "appsec-processor",
 		"datadog.appsec.injector.processor.service.namespace":       "datadog",
-		"datadog.appsec.injector.nginx.initImage":                   "myco/init:v1",
 		"datadog.appsec.injector.nginx.moduleMountPath":             "/custom/mount",
 	}, map[string]string{
 		"datadog.appsec.injector.proxies": `["envoy-gateway","istio","istio-gateway","ingress-nginx"]`,
@@ -172,7 +168,6 @@ func Test_AppSecInjector_Enabled_RendersCustomOptions(t *testing.T) {
 		ddAppsecSidecarReqMemoryEnvVar:        "256Mi",
 		ddAppsecSidecarLimitCPUEnvVar:         "200m",
 		ddAppsecSidecarLimitMemoryEnvVar:      "512Mi",
-		ddAppsecNginxInitImageEnvVar:          "myco/init:v1",
 		ddAppsecNginxModuleMountPathEnvVar:    "/custom/mount",
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Brings the `datadog/cluster-agent` ClusterRole and `values.yaml` in sync with [datadog-agent#49318](https://github.com/DataDog/datadog-agent/pull/49318) (`feat(appsec): add ingress-nginx injection pattern for AppSec`, merged 2026-04-16), which teaches the cluster-agent's AppSec admission webhook to inject the `nginx-datadog` module into ingress-nginx controller pods.

**What changed:**
- **ClusterRole** (`templates/cluster-agent-rbac.yaml`): Two new RBAC rules gated by `datadog.appsec.injector.enabled`:
  - `networking.k8s.io/ingressclasses` — get, list, watch (needed to discover ingress-nginx controllers via IngressClass)
  - `""/configmaps` — get, list, watch, create, update, delete (needed to create/reconcile the DD-owned shadow ConfigMaps that prepend AppSec directives to `main-snippet`/`http-snippet`). A `SECURITY CONSIDERATION` comment explains the cluster-wide scope and the labels the agent self-constrains to.
- **Values** (`values.yaml`): New `datadog.appsec.injector.nginx.moduleMountPath` value (default: `/modules_mount`) alongside an `ingress-nginx` entry in the `proxies` allowlist documentation.
- **Deployment env var** (`templates/cluster-agent-deployment.yaml`): Forwards the new value as `DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH`.
- **Schema** (`values.schema.json`): Minimal additions — `nginx` object + `ingress-nginx` in proxies enum (required because the schema has `additionalProperties: false` at the injector level).
- **Mapping file** (`files/mapping_datadog_helm_to_datadogagent_crd.yaml`): Empty-mapped entry for the new nginx key.
- **Tests** (`test/datadog/appsec_injector_test.go`): Two new test functions (`Test_AppSecInjector_RBAC_IncludesNginxRules`, `Test_AppSecInjector_RBAC_Disabled_OmitsNginxRules`) and updated existing tests to cover the new env var.
- **Docs**: CHANGELOG entry for 3.215.0, README regenerated via `helm-docs`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - Related: https://github.com/DataDog/datadog-agent/pull/49318

#### Special notes for your reviewer:

**Security trade-off (cluster-wide ConfigMap RBAC):** The new `""/configmaps` rule is intentionally cluster-wide. ConfigMap names are derived at runtime from the ingress-nginx controller's `--configmap` arg (e.g. `datadog-appsec-<original-name>`), making namespace scoping infeasible at install time. In practice, the agent self-constrains to ConfigMaps with the labels `appsec.datadoghq.com/watched-configmap=true` (reconciler) and `app.kubernetes.io/component=datadog-appsec-injector` (cleanup). The verbose comment in the template is intentional — the agent code references these exact label keys.

**Follow-up (separate PR, different repo):** Re-syncing `pkg/clusteragent/appsec/testdata/cluster-agent-rbac.yml` in the `datadog-agent` repo is out of scope here and will be done in a follow-up PR once this chart PR merges.

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added — `datadog/minor-version`
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`) — ✅ baselines unchanged (AppSec injector disabled in all existing baselines)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`) — ✅ run and verified idempotent
- [x] `CHANGELOG.md` has been updated — ✅ `## 3.215.0` entry added
- [x] Variables are documented in the `README.md` — ✅ regenerated

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits