### PR TITLE
feat(datadog): allow overriding agent container command

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.226.0
+
+* Add `agents.containers.agent.command` value to override the default `agent run` entrypoint of the agent container. When unset, the agent container continues to run `agent run` as before. Setting this value on GKE Autopilot or GDC is rejected at template render time to avoid breaking the Datadog WorkloadAllowlist constraint.
+
 ## 3.225.1
 
 * Update `fips.image.tag` to `1.1.27` fixing CVEs and updating packages.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.225.1
+version: 3.226.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.225.1](https://img.shields.io/badge/Version-3.225.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.226.0](https://img.shields.io/badge/Version-3.226.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -470,6 +470,7 @@ helm install <RELEASE_NAME> \
 |-----|------|---------|-------------|
 | agents.additionalLabels | object | `{}` | Adds labels to the Agent daemonset and pods |
 | agents.affinity | object | `{}` | Allow the DaemonSet to schedule using affinity rules |
+| agents.containers.agent.command | list | `[]` | Override the default `agent run` entrypoint for the agent container. Useful for wrapping the agent in a shell entrypoint (e.g. to set environment variables based on node-level information before `exec`-ing the agent). When unset, the container runs `agent run`. Not supported on GKE Autopilot or GDC: the Datadog WorkloadAllowlist requires the agent container command to be exactly `["agent", "run"]` on those providers, so setting this value with `providers.gke.autopilot=true` or `providers.gke.gdc=true` fails at template render time. |
 | agents.containers.agent.env | list | `[]` | Additional environment variables for the agent container |
 | agents.containers.agent.envDict | object | `{}` | Set environment variables specific to agent container defined in a dict |
 | agents.containers.agent.envFrom | list | `[]` | Set environment variables specific to agent container from configMaps and/or secrets |

--- a/charts/datadog/ci/agent-with-command-override-values.yaml
+++ b/charts/datadog/ci/agent-with-command-override-values.yaml
@@ -1,0 +1,10 @@
+datadog:
+  apiKey: "00000000000000000000000000000000"
+agents:
+  enabled: true
+  containers:
+    agent:
+      command:
+        - /bin/sh
+        - -c
+        - "exec agent run"

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -6,7 +6,15 @@
   lifecycle:
 {{ toYaml .Values.agents.lifecycle | indent 4 }}
   {{- end }}
+  {{- if and .Values.agents.containers.agent.command (or .Values.providers.gke.autopilot .Values.providers.gke.gdc) }}
+  {{- fail "agents.containers.agent.command override is not supported on GKE Autopilot or GDC. The Datadog WorkloadAllowlist requires the agent container command to be exactly [\"agent\", \"run\"]." }}
+  {{- end }}
+  {{- if .Values.agents.containers.agent.command }}
+  command:
+{{ toYaml .Values.agents.containers.agent.command | indent 4 }}
+  {{- else }}
   command: ["agent", "run"]
+  {{- end }}
 {{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.agent.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version "sysAdmin" (and (eq (include "should-enable-sbom-container-image-collection" .) "true") (and .Values.datadog.sbom.containerImage.uncompressedLayersSupport (not .Values.datadog.sbom.containerImage.overlayFSDirectScan))) "apparmor" (and .Values.agents.podSecurity.apparmor.enabled (eq (include "should-enable-sbom-container-image-collection" .) "true") .Values.datadog.sbom.containerImage.uncompressedLayersSupport "unconfined") "mknod" .Values.datadog.gpuMonitoring.enabled) | indent 2 }}
   resources:
 {{- if and (empty .Values.agents.containers.agent.resources) .Values.providers.gke.autopilot -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2322,6 +2322,14 @@ agents:
       # agents.containers.agent.ports -- Allows to specify extra ports (hostPorts for instance) for this container
       ports: []
 
+      # agents.containers.agent.command -- Override the default `agent run` entrypoint for the agent container.
+      # Useful for wrapping the agent in a shell entrypoint (e.g. to set environment variables based on
+      # node-level information before `exec`-ing the agent). When unset, the container runs `agent run`.
+      # Not supported on GKE Autopilot or GDC: the Datadog WorkloadAllowlist requires the agent container
+      # command to be exactly `["agent", "run"]` on those providers, so setting this value with
+      # `providers.gke.autopilot=true` or `providers.gke.gdc=true` fails at template render time.
+      command: []
+
     privateActionRunner:
       # agents.containers.privateActionRunner.env -- Additional environment variables for the private-action-runner container
       env: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a new `agents.containers.agent.command` value to override the default `["agent", "run"]` command of the agent container. When unset (the default), the agent container runs `agent run` exactly as today — fully backwards-compatible.

There are cases where the agent needs to be wrapped in a shell entrypoint: for example, to compute and export environment variables from node-level information before `exec`-ing into `agent run`. Today this requires forking the chart; this PR makes it a values-driven knob.

Setting this value together with `providers.gke.autopilot=true` or `providers.gke.gdc=true` is rejected at template render time, because the Datadog WorkloadAllowlist pins the agent container's command to `["agent", "run"]` on those providers (per `charts/datadog/docs/internal/gke-constraints-review-guide.md` section 1).

#### Special notes for your reviewer:

- Added a CI fixture `charts/datadog/ci/agent-with-command-override-values.yaml` exercising the new value. Chart version bumped to 3.217.3.
- `chatgpt-codex-connector` flagged the GKE Autopilot/GDC WorkloadAllowlist constraint on first pass; addressed in-template with a `{{- fail ... }}` guard in `_container-agent.yaml`, documented in `values.yaml`, and noted in the CHANGELOG.
- First-time contributor here — would appreciate a maintainer kicking off the workflow runs when convenient. Happy to address any further feedback.

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits