### PR TITLE
Preserve latest DDOT image tags

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.217.3
+
+* Preserve the floating `latest` tag for the standalone DDOT Collector image when `datadog.otelCollector.useStandaloneImage=true` and the Agent image is configured as `latest`, `latest-jmx`, or `latest` with `agents.image.tagSuffix=jmx`.
+
 ## 3.217.2
 
 * Update `fips.image.tag` to `1.1.26` fixing CVEs and updating packages.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.217.2
+version: 3.217.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.217.2](https://img.shields.io/badge/Version-3.217.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.217.3](https://img.shields.io/badge/Version-3.217.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -607,7 +607,11 @@ Return a remote otel-agent based on `.Values` (passed as .)
       {{- if semverCompare "<7.67.0" (include "get-agent-version" .) -}}
         {{- fail "datadog.otelCollector.useStandaloneImage is only supported for agent versions 7.67.0+. Please bump the agent version to 7.67.0+ or set datadog.otelCollector.useStandaloneImage to false and set agents.image.tagSuffix to `-full`" -}}
       {{- end -}}
-      {{- $ddotImage := dict "name" "ddot-collector" "tag" (include "get-agent-version" .) -}}
+      {{- $ddotTag := include "get-agent-version" . -}}
+      {{- if eq (.Values.agents.image.tag | toString | trimSuffix "-jmx") "latest" -}}
+        {{- $ddotTag = "latest" -}}
+      {{- end -}}
+      {{- $ddotImage := dict "name" "ddot-collector" "tag" $ddotTag -}}
       {{- if and (eq (include "use-fips-images" .Values) "true") (not .Values.agents.image.doNotCheckTag) (semverCompare "<7.78.0" (include "get-agent-version" .)) -}}
         {{- fail "The standalone FIPS ddot-collector image is not available before 7.78.0. Upgrade agents.image.tag to 7.78.0+, set useFIPSAgent to false, or set agents.image.doNotCheckTag to true." -}}
       {{- else -}}

--- a/test/datadog/otel_agent_test.go
+++ b/test/datadog/otel_agent_test.go
@@ -125,6 +125,70 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 		},
 		{
+			name: "useStandaloneImage true with latest agent tag",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "latest",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:latest")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:latest")
+			},
+		},
+		{
+			name: "useStandaloneImage true with latest-jmx agent tag",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "latest-jmx",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:latest-jmx")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:latest")
+			},
+		},
+		{
+			name: "useStandaloneImage true with latest agent tag and jmx tagSuffix",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "latest",
+					"agents.image.tagSuffix":                   "jmx",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:latest-jmx")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:latest")
+			},
+		},
+		{
 			name: "useStandaloneImage true with agent version 7.66.0 should fail",
 			command: common.HelmCommand{
 				ReleaseName: "datadog",


### PR DESCRIPTION
## Problem

When `datadog.otelCollector.useStandaloneImage=true`, the chart derives the standalone DDOT Collector tag from the Agent tag via `get-agent-version`.

That turns floating Agent tags into the chart fallback version, so customers can render mismatched images such as:

```yaml
agent:      registry.datadoghq.com/agent:latest-jmx
otel-agent: registry.datadoghq.com/ddot-collector:7.78.3
```

The same mismatch happens with `agents.image.tag=latest`, including the values-style JMX configuration:

```yaml
agents:
  image:
    tag: latest
    tagSuffix: jmx
```

## Change

Preserve `ddot-collector:latest` when the Agent image is configured as `latest`, `latest-jmx`, or `latest` with `agents.image.tagSuffix=jmx`.

## Validation

- `GOCACHE=/private/tmp/codex-go-build-cache go test -C test ./datadog -run Test_ddotCollectorImage -count=1`
- `.github/helm-docs.sh`
