### PR TITLE
Rename agent-all to agent-community-eng

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -4,7 +4,7 @@ kind: mergequeue
 gitlab_check_enable: true
 github_teams_restrictions:
   - action-platform
-  - agent-all
+  - agent-community-eng
   - container-app
   - container-ecosystems
   - container-helm-chart-maintainers


### PR DESCRIPTION
#### What this PR does / why we need it:

Rename agent-all to agent-community-eng for merge queue access. This GitHub team was renamed.