### PR TITLE
[datadog] Update datadog-csi-driver chart dependency to 0.15.0

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 3.219.0
+
+* Update `datadog-csi-driver` chart dependency from `0.13.0` to `0.15.0`:
+  * `0.14.0`: annotate `CSIDriver` with `csi.datadoghq.com/apm-enabled` for SSI injection gating.
+  * `0.15.0`: enable SSI on GKE Autopilot.
+
 ## 3.218.0
 
 * [CONTP-1682] Include v1.0.5 GKE Autopilot Allowlist: operator and otelCollector feature gates support ([#2674](https://github.com/DataDog/helm-charts/pull/2674)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.218.0
+version: 3.219.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.218.0](https://img.shields.io/badge/Version-3.218.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.219.0](https://img.shields.io/badge/Version-3.219.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -32,7 +32,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 | Repository | Name | Version |
 |------------|------|---------|
 | https://helm.datadoghq.com | datadog-crds | 2.20.0 |
-| https://helm.datadoghq.com | datadog-csi-driver | 0.13.0 |
+| https://helm.datadoghq.com | datadog-csi-driver | 0.15.0 |
 | https://helm.datadoghq.com | operator(datadog-operator) | 2.22.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 2.13.2
 - name: datadog-csi-driver
   repository: https://helm.datadoghq.com
-  version: 0.13.0
+  version: 0.15.0
 - name: datadog-operator
   repository: https://helm.datadoghq.com
   version: 2.22.0
-digest: sha256:3f6124df58b9baaa8343612d23085db8ad47acf91c5a107bdea8bbd562941d9b
-generated: "2026-05-21T10:22:20.750091+02:00"
+digest: sha256:d0c347f2762daecf2fd767bb0dd47400f1afad6419b90749da456fa18a368399
+generated: "2026-06-05T09:10:09.690907288+02:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: datadog.kubeStateMetricsEnabled
   - name: datadog-csi-driver
-    version: 0.13.0
+    version: 0.15.0
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the `datadog-csi-driver` subchart from `0.13.0` to `0.15.0`:

- **0.14.0**: Sets the `csi.datadoghq.com/apm-enabled` annotation on the `k8s.csi.datadoghq.com` `CSIDriver` resource based on `apm.enabled`. The cluster-agent admission controller reads this annotation (via the `workloadmeta-kubeapiserver` `CSIDriver` collector) to decide whether SSI library injection can use CSI mode.
- **0.15.0**: Enables Single Step Instrumentation (SSI) on GKE Autopilot >= `1.32.1-gke.1729000` by always rendering the `storage-dir` volume and `DD_APM_ENABLED` env var, and switches the `AllowlistSynchronizer` from `v1.0.1` to the new `v1.1.0` `WorkloadAllowlist`.

#### Special notes for your reviewer:

Pure dependency bump — no changes to the `datadog` chart templates or values. Both subchart releases (`0.14.0` and `0.15.0`) have been merged to `main` and published to https://helm.datadoghq.com.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits