### PR TITLE
[datadog] Release Operator v1.27.0

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 3.221.0
+
+* Bump Datadog Operator chart dependency to 2.23.0.
+* Bump Datadog CRD chart dependency to 2.21.0.
+* Bump Operator image tag to 1.27.0.
+
 ## 3.220.0
 
 * [Host Profiler] Remove seccomp configmap and use profile baked into image ([#2698](https://github.com/DataDog/helm-charts/pull/2698)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.220.0
+version: 3.221.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1062,7 +1062,7 @@ helm install <RELEASE_NAME> \
 | operator.datadogAgentInternal.enabled | bool | `true` | Enables the Datadog Agent Internal controller |
 | operator.datadogCRDs.crds.datadogAgentInternals | bool | `true` | Set to true to deploy the DatadogAgentInternals CRD |
 | operator.datadogCRDs.crds.datadogAgents | bool | `true` | Set to true to deploy the DatadogAgents CRD |
-| operator.datadogCRDs.crds.datadogCSIDrivers | bool | `false` | Set to true to deploy the DatadogCSIDriver CRD |
+| operator.datadogCRDs.crds.datadogCSIDrivers | bool | `true` | Set to true to deploy the DatadogCSIDriver CRD |
 | operator.datadogCRDs.crds.datadogDashboards | bool | `true` | Set to true to deploy the DatadogDashboard CRD |
 | operator.datadogCRDs.crds.datadogGenericResources | bool | `true` | Set to true to deploy the DatadogGenericResource CRD |
 | operator.datadogCRDs.crds.datadogInstrumentations | bool | `false` | Set to true to deploy the DatadogInstrumentations CRD |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -33,7 +33,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 |------------|------|---------|
 | https://helm.datadoghq.com | datadog-crds | 2.21.0 |
 | https://helm.datadoghq.com | datadog-csi-driver | 0.15.0 |
-| https://helm.datadoghq.com | operator(datadog-operator) | 2.23.0 |
+| https://helm.datadoghq.com | operator(datadog-operator) | 2.23.1 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 
 ## Quick start
@@ -744,6 +744,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.volumeMounts | list | `[]` | Specify additional volumes to mount in the cluster checks container |
 | clusterChecksRunner.volumes | list | `[]` | Specify additional volumes to mount in the cluster checks container |
 | commonLabels | object | `{}` | Labels to apply to all resources |
+| datadog-crds.crds.datadogInstrumentations | bool | `true` |  |
 | datadog-crds.crds.datadogMetrics | bool | `true` | Set to true to deploy the DatadogMetrics CRD |
 | datadog-crds.crds.datadogPodAutoscalerClusterProfiles | bool | `true` |  |
 | datadog-crds.crds.datadogPodAutoscalers | bool | `true` | Set to true to deploy the DatadogPodAutoscalers CRD |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.220.0](https://img.shields.io/badge/Version-3.220.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.221.0](https://img.shields.io/badge/Version-3.221.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -31,9 +31,9 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://helm.datadoghq.com | datadog-crds | 2.20.0 |
+| https://helm.datadoghq.com | datadog-crds | 2.21.0 |
 | https://helm.datadoghq.com | datadog-csi-driver | 0.15.0 |
-| https://helm.datadoghq.com | operator(datadog-operator) | 2.22.0 |
+| https://helm.datadoghq.com | operator(datadog-operator) | 2.23.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 
 ## Quick start
@@ -1065,6 +1065,7 @@ helm install <RELEASE_NAME> \
 | operator.datadogCRDs.crds.datadogCSIDrivers | bool | `false` | Set to true to deploy the DatadogCSIDriver CRD |
 | operator.datadogCRDs.crds.datadogDashboards | bool | `true` | Set to true to deploy the DatadogDashboard CRD |
 | operator.datadogCRDs.crds.datadogGenericResources | bool | `true` | Set to true to deploy the DatadogGenericResource CRD |
+| operator.datadogCRDs.crds.datadogInstrumentations | bool | `false` | Set to true to deploy the DatadogInstrumentations CRD |
 | operator.datadogCRDs.crds.datadogMetrics | bool | `false` | Set to true to deploy the DatadogMetrics CRD |
 | operator.datadogCRDs.crds.datadogMonitors | bool | `true` | Set to true to deploy the DatadogMonitors CRD |
 | operator.datadogCRDs.crds.datadogPodAutoscalerClusterProfiles | bool | `false` |  |
@@ -1075,7 +1076,7 @@ helm install <RELEASE_NAME> \
 | operator.datadogGenericResource.enabled | bool | `false` | Enables the Datadog Generic Resource controller |
 | operator.datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | operator.datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
-| operator.image.tag | string | `"1.26.0"` | Define the Datadog Operator version to use |
+| operator.image.tag | string | `"1.27.0"` | Define the Datadog Operator version to use |
 | otelAgentGateway.additionalLabels | object | `{}` | Adds labels to the Agent Gateway Deployment and pods |
 | otelAgentGateway.affinity | object | `{}` | Allow the Gateway Deployment to schedule using affinity rules |
 | otelAgentGateway.autoscaling.annotations | object | `{}` | annotations for OTel Agent Gateway HPA |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1059,8 +1059,8 @@ helm install <RELEASE_NAME> \
 | kubeVersionOverride | string | `nil` | Override Kubernetes version detection. Useful for GitOps tools like FluxCD that don't expose the real cluster version to Helm |
 | nameOverride | string | `nil` | Override name of app |
 | operator.datadogAgent.enabled | bool | `true` | Enables Datadog Agent controller |
-| operator.datadogAgentInternal.enabled | bool | `false` | Enables the Datadog Agent Internal controller |
-| operator.datadogCRDs.crds.datadogAgentInternals | bool | `false` | Set to true to deploy the DatadogAgentInternals CRD |
+| operator.datadogAgentInternal.enabled | bool | `true` | Enables the Datadog Agent Internal controller |
+| operator.datadogCRDs.crds.datadogAgentInternals | bool | `true` | Set to true to deploy the DatadogAgentInternals CRD |
 | operator.datadogCRDs.crds.datadogAgents | bool | `true` | Set to true to deploy the DatadogAgents CRD |
 | operator.datadogCRDs.crds.datadogCSIDrivers | bool | `false` | Set to true to deploy the DatadogCSIDriver CRD |
 | operator.datadogCRDs.crds.datadogDashboards | bool | `true` | Set to true to deploy the DatadogDashboard CRD |

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.15.0
 - name: datadog-operator
   repository: https://helm.datadoghq.com
-  version: 2.23.0
-digest: sha256:ee5ba01c91ee60ac66bd1e2ee9295a8f8418c3b008bfc334f30a8f1e094ad064
-generated: "2026-06-05T12:41:34.286373-04:00"
+  version: 2.23.1
+digest: sha256:c8b70ae968670ca301686b103841d8b6462084430ee8d7063d32749207aecc45
+generated: "2026-06-08T08:55:11.332249-04:00"

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.20.0
+  version: 2.21.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
@@ -10,6 +10,6 @@ dependencies:
   version: 0.15.0
 - name: datadog-operator
   repository: https://helm.datadoghq.com
-  version: 2.22.0
-digest: sha256:d0c347f2762daecf2fd767bb0dd47400f1afad6419b90749da456fa18a368399
-generated: "2026-06-05T09:10:09.690907288+02:00"
+  version: 2.23.0
+digest: sha256:ee5ba01c91ee60ac66bd1e2ee9295a8f8418c3b008bfc334f30a8f1e094ad064
+generated: "2026-06-05T12:41:34.286373-04:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -14,7 +14,7 @@ dependencies:
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator
-    version: 2.23.0
+    version: 2.23.1
     repository: https://helm.datadoghq.com
     condition: datadog.operator.enabled
     alias: operator

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: datadog-crds
-    version: 2.20.0
+    version: 2.21.0
     repository: https://helm.datadoghq.com
     condition: datadog.autoscaling.workload.enabled,clusterAgent.metricsProvider.useDatadogMetrics
     tags:
@@ -14,7 +14,7 @@ dependencies:
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator
-    version: 2.22.0
+    version: 2.23.0
     repository: https://helm.datadoghq.com
     condition: datadog.operator.enabled
     alias: operator

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -3048,7 +3048,7 @@ operator:
 
   datadogAgentInternal:
     # operator.datadogAgentInternal.enabled -- Enables the Datadog Agent Internal controller
-    enabled: false
+    enabled: true
 
   datadogDashboard:
     # operator.datadogDashboard.enabled -- Enables the Datadog Dashboard controller
@@ -3088,7 +3088,7 @@ operator:
       # operator.datadogCRDs.crds.datadogPodAutoscalerClusterProfile -- Set to false to deploy the DatadogPodAutoscalerClusterProfiles CRD
       datadogPodAutoscalerClusterProfiles: false
       # operator.datadogCRDs.crds.datadogAgentInternals -- Set to true to deploy the DatadogAgentInternals CRD
-      datadogAgentInternals: false
+      datadogAgentInternals: true
       # operator.datadogCRDs.crds.datadogCSIDrivers -- Set to true to deploy the DatadogCSIDriver CRD
       datadogCSIDrivers: false
       # operator.datadogCRDs.crds.datadogInstrumentations -- Set to true to deploy the DatadogInstrumentations CRD

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -3102,6 +3102,8 @@ datadog-crds:
     datadogPodAutoscalers: true
     # crds.datadogPodAutoscalerClusterProfile -- Set to true to deploy the DatadogPodAutoscalerClusterProfiles CRD
     datadogPodAutoscalerClusterProfiles: true
+    # crds.datadogInstrumentations -- Set to true to deploy the DatadogInstrumentations CRD
+    datadogInstrumentations: true
 
 kube-state-metrics:
   # kube-state-metrics.image.repository -- Default kube-state-metrics image repository.

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -3090,7 +3090,7 @@ operator:
       # operator.datadogCRDs.crds.datadogAgentInternals -- Set to true to deploy the DatadogAgentInternals CRD
       datadogAgentInternals: true
       # operator.datadogCRDs.crds.datadogCSIDrivers -- Set to true to deploy the DatadogCSIDriver CRD
-      datadogCSIDrivers: false
+      datadogCSIDrivers: true
       # operator.datadogCRDs.crds.datadogInstrumentations -- Set to true to deploy the DatadogInstrumentations CRD
       datadogInstrumentations: false
 

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -3040,7 +3040,7 @@ clusterChecksRunner:
 operator:
   image:
     # operator.image.tag -- Define the Datadog Operator version to use
-    tag: 1.26.0
+    tag: 1.27.0
 
   datadogAgent:
     # operator.datadogAgent.enabled -- Enables Datadog Agent controller
@@ -3091,6 +3091,8 @@ operator:
       datadogAgentInternals: false
       # operator.datadogCRDs.crds.datadogCSIDrivers -- Set to true to deploy the DatadogCSIDriver CRD
       datadogCSIDrivers: false
+      # operator.datadogCRDs.crds.datadogInstrumentations -- Set to true to deploy the DatadogInstrumentations CRD
+      datadogInstrumentations: false
 
 datadog-crds:
   crds:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -649,6 +649,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -429,6 +429,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -445,15 +462,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -638,6 +646,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1935,7 +1983,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1974,8 +2022,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2001,7 +2048,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -649,6 +649,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -429,6 +429,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -445,15 +462,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -638,6 +646,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1935,7 +1983,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1974,8 +2022,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2001,7 +2048,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -418,7 +418,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -699,6 +699,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -715,15 +732,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -908,6 +916,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2336,7 +2384,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2375,8 +2423,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2402,7 +2449,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -919,6 +919,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2309,7 +2357,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2348,8 +2396,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2375,7 +2422,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -414,7 +414,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -695,6 +695,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -711,15 +728,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -904,6 +912,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1636,7 +1684,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1675,8 +1723,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1702,7 +1749,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -915,6 +915,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -414,7 +414,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -695,6 +695,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -711,15 +728,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -904,6 +912,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1636,7 +1684,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1675,8 +1723,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1702,7 +1749,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -915,6 +915,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -414,7 +414,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -695,6 +695,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -711,15 +728,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -904,6 +912,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1636,7 +1684,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1675,8 +1723,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1702,7 +1749,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -915,6 +915,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -414,7 +414,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -695,6 +695,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -711,15 +728,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -904,6 +912,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1636,7 +1684,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1675,8 +1723,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1702,7 +1749,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -915,6 +915,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -683,6 +683,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -699,15 +716,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -892,6 +900,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2325,7 +2373,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2364,8 +2412,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2391,7 +2438,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -903,6 +903,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -683,6 +683,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -699,15 +716,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -892,6 +900,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2443,7 +2491,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2482,8 +2530,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2509,7 +2556,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -903,6 +903,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2308,7 +2356,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2347,8 +2395,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2374,7 +2421,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -454,7 +454,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -735,6 +735,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -751,15 +768,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -944,6 +952,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2378,7 +2426,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2417,8 +2465,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2444,7 +2491,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -955,6 +955,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2301,7 +2349,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2340,8 +2388,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2367,7 +2414,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2301,7 +2349,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2340,8 +2388,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2367,7 +2414,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -429,6 +429,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -445,15 +462,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -638,6 +646,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1657,7 +1705,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1696,8 +1744,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1723,7 +1770,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
@@ -649,6 +649,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -429,6 +429,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -445,15 +462,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -638,6 +646,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1657,7 +1705,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1696,8 +1744,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1723,7 +1770,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -649,6 +649,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -429,6 +429,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -445,15 +462,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -638,6 +646,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1674,7 +1722,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1713,8 +1761,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1740,7 +1787,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -649,6 +649,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -664,6 +664,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -163,7 +163,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -444,6 +444,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -460,15 +477,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -653,6 +661,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1731,7 +1779,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1770,8 +1818,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1797,7 +1844,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -429,6 +429,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -445,15 +462,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -638,6 +646,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1701,7 +1749,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1740,8 +1788,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1767,7 +1814,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -649,6 +649,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2172,7 +2220,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2211,8 +2259,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2238,7 +2285,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2287,7 +2335,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2326,8 +2374,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2353,7 +2400,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2287,7 +2335,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2326,8 +2374,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2353,7 +2400,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2165,7 +2213,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2204,8 +2252,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2231,7 +2278,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -697,6 +697,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -713,15 +730,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -906,6 +914,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2318,7 +2366,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2357,8 +2405,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2384,7 +2431,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -917,6 +917,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -697,6 +697,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -713,15 +730,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -906,6 +914,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2326,7 +2374,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2365,8 +2413,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2392,7 +2439,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -917,6 +917,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -697,6 +697,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -713,15 +730,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -906,6 +914,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2198,7 +2246,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2237,8 +2285,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2264,7 +2311,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -917,6 +917,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -917,6 +917,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -697,6 +697,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -713,15 +730,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -906,6 +914,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2222,7 +2270,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2261,8 +2309,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2288,7 +2335,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -988,6 +988,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -487,7 +487,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -768,6 +768,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -784,15 +801,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -977,6 +985,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2380,7 +2428,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2419,8 +2467,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2446,7 +2493,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -907,6 +907,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -406,7 +406,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -687,6 +687,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -703,15 +720,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -896,6 +904,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2350,7 +2398,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2389,8 +2437,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2416,7 +2463,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -445,7 +445,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -726,6 +726,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -742,15 +759,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -935,6 +943,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2366,7 +2414,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2405,8 +2453,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2432,7 +2479,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -946,6 +946,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2417,7 +2465,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2456,8 +2504,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2483,7 +2530,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -753,6 +753,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -769,15 +786,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -962,6 +970,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2497,7 +2545,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2536,8 +2584,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2563,7 +2610,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -973,6 +973,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2416,7 +2464,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2455,8 +2503,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2482,7 +2529,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -753,6 +753,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -769,15 +786,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -962,6 +970,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2491,7 +2539,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2530,8 +2578,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2557,7 +2604,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -973,6 +973,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -725,6 +725,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -741,15 +758,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -934,6 +942,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2019,7 +2067,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2058,8 +2106,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2085,7 +2132,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -945,6 +945,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -725,6 +725,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -741,15 +758,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -934,6 +942,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2019,7 +2067,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2058,8 +2106,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2085,7 +2132,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -945,6 +945,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -976,6 +976,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -756,6 +756,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -772,15 +789,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -965,6 +973,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2076,7 +2124,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2115,8 +2163,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2142,7 +2189,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -976,6 +976,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -756,6 +756,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -772,15 +789,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -965,6 +973,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2076,7 +2124,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2115,8 +2163,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2142,7 +2189,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -925,6 +925,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -424,7 +424,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -705,6 +705,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -721,15 +738,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -914,6 +922,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2460,7 +2508,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2499,8 +2547,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2526,7 +2573,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -753,6 +753,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -769,15 +786,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -962,6 +970,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2493,7 +2541,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2532,8 +2580,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2559,7 +2606,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -973,6 +973,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -753,6 +753,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -769,15 +786,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -962,6 +970,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2487,7 +2535,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2526,8 +2574,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2553,7 +2600,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -973,6 +973,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2301,7 +2349,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2340,8 +2388,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2367,7 +2414,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -903,6 +903,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -683,6 +683,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -699,15 +716,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -892,6 +900,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2310,7 +2358,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2349,8 +2397,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2376,7 +2423,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2365,7 +2413,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2404,8 +2452,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2431,7 +2478,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -697,6 +697,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -713,15 +730,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -906,6 +914,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2362,7 +2410,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2401,8 +2449,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2428,7 +2475,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -917,6 +917,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -683,6 +683,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -699,15 +716,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -892,6 +900,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2526,7 +2574,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2565,8 +2613,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2592,7 +2639,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -903,6 +903,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2367,7 +2415,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2406,8 +2454,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2433,7 +2480,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -682,6 +682,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -698,15 +715,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -891,6 +899,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2417,7 +2465,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2456,8 +2504,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2483,7 +2530,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -902,6 +902,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -683,6 +683,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -699,15 +716,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -892,6 +900,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2410,7 +2458,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2449,8 +2497,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2476,7 +2523,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -903,6 +903,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -683,6 +683,23 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadoginstrumentations
+      - extendeddaemonsetreplicasets
+      - watermarkpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadoginstrumentations/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogmetrics
     verbs:
       - create
@@ -699,15 +716,6 @@ rules:
       - datadogpodautoscalers/status
     verbs:
       - '*'
-  - apiGroups:
-      - datadoghq.com
-    resources:
-      - extendeddaemonsetreplicasets
-      - watermarkpodautoscalers
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - datadoghq.com
       - karpenter.azure.com
@@ -892,6 +900,46 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers
+      - datadogcsidrivers/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogcsidrivers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resourceNames:
+      - k8s.csi.datadoghq.com
+    resources:
+      - csidrivers
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2321,7 +2369,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.26.0
+    app.kubernetes.io/version: 1.27.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2360,8 +2408,7 @@ spec:
             - -datadogDashboardEnabled=false
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
-            - -datadogAgentInternalEnabled=false
-            - -datadogCSIDriverEnabled=false
+            - -datadogCSIDriverEnabled=true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2387,7 +2434,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.26.0
+          image: registry.datadoghq.com/operator:1.27.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -903,6 +903,38 @@ rules:
   - apiGroups:
       - datadoghq.com
     resources:
+      - datadogagentinternals
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - datadogagentinternals/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datadoghq.com
+    resources:
       - datadogcsidrivers
       - datadogcsidrivers/finalizers
     verbs:


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps `datadog/datadog` chart to new operator `v1.27` release chart.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits