### PR TITLE
[CONTP-1710] Install DatadogInstrumentation CRD and add RBAC permissions when controller is enabled

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.223.0
+
+* [CONTP-1710] Install DatadogInstrumentation CRD and add RBAC permissions when controller is enabled ([#2717](https://github.com/DataDog/helm-charts/pull/2717)).
+
 ## 3.222.0
 
 * Add RBAC rules for Gateway API, service mesh, and ingress controller CRD collection, gated behind `datadog.orchestratorExplorer.networkCRDs.enabled`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.222.0
+version: 3.223.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.222.0](https://img.shields.io/badge/Version-3.222.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.223.0](https://img.shields.io/badge/Version-3.223.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -851,6 +851,7 @@ helm install <RELEASE_NAME> \
 | datadog.hostProfiler.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.ignoreAutoConfig | list | `[]` | List of integration to ignore auto_conf.yaml. |
+| datadog.instrumentationCrd.enabled | string | `nil` | Enable the DatadogInstrumentation CRD controller and reconciliation platform. Requires version 7.80.0 or later of both cluster and node agent. |
 | datadog.kubeStateMetricsCore.annotationsAsTags | object | `{}` | Extra annotations to collect from resources and to turn into datadog tag. |
 | datadog.kubeStateMetricsCore.collectApiServicesMetrics | bool | `false` | Enable watching apiservices objects and collecting their corresponding metrics kubernetes_state.apiservice.* (Requires Cluster Agent 7.45.0+) |
 | datadog.kubeStateMetricsCore.collectConfigMaps | bool | `true` | Enable watching configmap objects and collecting their corresponding metrics kubernetes_state.configmap.* |

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: datadog-operator
   repository: https://helm.datadoghq.com
   version: 2.23.1
-digest: sha256:c8b70ae968670ca301686b103841d8b6462084430ee8d7063d32749207aecc45
-generated: "2026-06-08T08:55:11.332249-04:00"
+digest: sha256:e228ba99fd6ff82d75b0988c7ba7aadac15c1a0cc15a3e3409ec34ac0b39ff63
+generated: "2026-06-08T14:59:32.273659-04:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -2,7 +2,10 @@ dependencies:
   - name: datadog-crds
     version: 2.21.0
     repository: https://helm.datadoghq.com
-    condition: datadog.autoscaling.workload.enabled,clusterAgent.metricsProvider.useDatadogMetrics
+    # Ordering matters here. Helm uses the first condition with a defined (non-nil) value. Conditions with an
+    # explicit false default (e.g. clusterAgent.metricsProvider.useDatadogMetrics) must come last, otherwise
+    # the condition stops evaluation even if the subsequent condition would've been true.
+    condition: datadog.autoscaling.workload.enabled,datadog.instrumentationCrd.enabled,clusterAgent.metricsProvider.useDatadogMetrics
     tags:
     - install-crds
   - name: kube-state-metrics

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -272,7 +272,7 @@
     {{- if .Values.datadog.instrumentationCrd.enabled }}
     - name: DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED
       value: {{ .Values.datadog.instrumentationCrd.enabled | quote }}
-    {{- end}}
+    {{- end }}
     {{- if (((.Values.datadog.autoscaling).workload).enabled) }}
     - name: DD_AUTOSCALING_FAILOVER_ENABLED
       value: {{ (((.Values.datadog.autoscaling).workload).enabled) | quote }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -269,6 +269,10 @@
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.datadog.instrumentationCrd.enabled }}
+    - name: DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED
+      value: {{ .Values.datadog.instrumentationCrd.enabled | quote }}
+    {{- end}}
     {{- if (((.Values.datadog.autoscaling).workload).enabled) }}
     - name: DD_AUTOSCALING_FAILOVER_ENABLED
       value: {{ (((.Values.datadog.autoscaling).workload).enabled) | quote }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -490,7 +490,7 @@ spec:
           {{- if .Values.datadog.instrumentationCrd.enabled }}
           - name: DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED
             value: {{ .Values.datadog.instrumentationCrd.enabled | quote }}
-          {{- end}}
+          {{- end }}
           {{- if (((.Values.datadog.autoscaling).workload).enabled) }}
           - name: DD_AUTOSCALING_WORKLOAD_ENABLED
             value: {{ (((.Values.datadog.autoscaling).workload).enabled) | quote }}

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -487,6 +487,10 @@ spec:
             value: {{ .Values.datadog.prometheusScrape.version | quote }}
           {{- end }}
           {{- end }}
+          {{- if .Values.datadog.instrumentationCrd.enabled }}
+          - name: DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED
+            value: {{ .Values.datadog.instrumentationCrd.enabled | quote }}
+          {{- end}}
           {{- if (((.Values.datadog.autoscaling).workload).enabled) }}
           - name: DD_AUTOSCALING_WORKLOAD_ENABLED
             value: {{ (((.Values.datadog.autoscaling).workload).enabled) | quote }}

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -50,6 +50,21 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - "datadoghq.com"
+  resources:
+  - "datadoginstrumentations"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "datadoghq.com"
+  resources:
+  - "datadoginstrumentations/status"
+  verbs:
+  - patch
+  - update
 {{- if .Values.datadog.collectEvents }}
 - apiGroups:
   - ""

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -50,6 +50,7 @@ rules:
   verbs:
   - list
   - watch
+{{- if $.Values.datadog.instrumentationCrd.enabled }}
 - apiGroups:
   - "datadoghq.com"
   resources:
@@ -65,6 +66,7 @@ rules:
   verbs:
   - patch
   - update
+{{- end }}
 {{- if .Values.datadog.collectEvents }}
 - apiGroups:
   - ""

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -50,7 +50,7 @@ rules:
   verbs:
   - list
   - watch
-{{- if $.Values.datadog.instrumentationCrd.enabled }}
+{{- if .Values.datadog.instrumentationCrd.enabled }}
 - apiGroups:
   - "datadoghq.com"
   resources:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1447,7 +1447,7 @@ datadog:
   instrumentationCrd:
     # datadog.instrumentationCrd.enabled -- Enable the DatadogInstrumentation CRD controller and reconciliation platform.
     # Requires version 7.80.0 or later of both cluster and node agent.
-    enabled: false
+    enabled:
 
   dataPlane:
     # datadog.dataPlane.enabled -- Whether or not the data plane is enabled

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1444,6 +1444,11 @@ datadog:
     #   - Do not install the CSI driver separately if this is enabled, or you may hit conflicts.
     enabled: false
 
+  instrumentationCrd:
+    # datadog.instrumentationCrd.enabled -- Enable the DatadogInstrumentation CRD controller and reconciliation platform.
+    # Requires version 7.80.0 or later of both cluster and node agent.
+    enabled: false
+
   dataPlane:
     # datadog.dataPlane.enabled -- Whether or not the data plane is enabled
     #


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support for installing the `DatadogInstrumentation` CRD and required RBAC permissions when `datadog.instrumentationCrd.enabled` is set.

The new datadog-crds dependency in `requirements.yaml` is intentional. Helm resolves conditions left-to-right and stops at the first non-nil value, so if any condition is true then all the CRDs would be installed, even if the other two conditions are false (and therefore unused).

Instead of having this side effect, I've opted to split out the `datadog-crds` dependency into a second one that is just for  `datadog.instrumentationCrd.enabled`, which is expected to be on by default.

#### Which issue this PR fixes
  - fixes #

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits