### PR TITLE
docs: recommend explicit cpu limits on high-core-count nodes

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.221.1
+
+* Document the impact of host CPU count on Agent memory usage on high-core-count nodes and recommend setting an explicit `agents.containers.agent.resources.limits.cpu`.
+
 ## 3.221.0
 
 * Bump Datadog Operator chart dependency to 2.23.0.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.221.0
+version: 3.221.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.221.0](https://img.shields.io/badge/Version-3.221.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.221.1](https://img.shields.io/badge/Version-3.221.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -426,6 +426,27 @@ Standard paths are:
 - Containerd socket: `/var/run/containerd/containerd.sock`
 - Cri-o socket: `/var/run/crio/crio.sock`
 
+### Resource limits on high-core-count nodes
+
+On nodes with a high logical CPU count (for example, large GPU or bare-metal hosts), the Agent's Go runtime sizes its scheduler to the host CPU count by default. This can drive memory usage proportionally and cause the Agent container to be OOM-killed even with otherwise modest workloads.
+
+Set an explicit CPU limit on the agent container so the runtime sizes to the limit rather than the host CPU count. Update your `datadog-values.yaml` file:
+
+```yaml
+agents:
+  containers:
+    agent:
+      resources:
+        requests:
+          cpu: "2"
+          memory: 512Mi
+        limits:
+          cpu: "2"
+          memory: 1Gi
+```
+
+Use an integer value for `limits.cpu` so the runtime can read it directly. If your cluster has node shapes with widely varying core counts, apply this chart per node group (with a `nodeSelector` and matching limits) rather than picking a single value that may be too low for small nodes or too high for large ones. Alternatively, deploy through the [Datadog Operator](https://docs.datadoghq.com/containers/datadog_operator/) and use [DatadogAgentProfiles](https://github.com/DataDog/datadog-operator/blob/main/docs/datadog_agent_profiles.md) to set different limits per node shape from a single install.
+
 ### Configuration required for Amazon Linux 2 based nodes
 
 Amazon Linux 2 does not support apparmor profile enforcement.
@@ -478,7 +499,7 @@ helm install <RELEASE_NAME> \
 | agents.containers.agent.logLevel | string | `nil` | Set logging verbosity, valid log levels are: trace, debug, info, warn, error, critical, and off. If not set, fall back to the value of datadog.logLevel. |
 | agents.containers.agent.ports | list | `[]` | Allows to specify extra ports (hostPorts for instance) for this container |
 | agents.containers.agent.readinessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent readiness probe settings |
-| agents.containers.agent.resources | object | `{}` | Resource requests and limits for the agent container. |
+| agents.containers.agent.resources | object | `{}` | Resource requests and limits for the agent container. On nodes with a high logical CPU count, set an explicit `limits.cpu` (integer) to prevent the Agent's Go runtime from sizing its scheduler to the host CPU count, which can otherwise cause OOM kills. |
 | agents.containers.agent.securityContext | object | `{"readOnlyRootFilesystem":true}` | Allows you to overwrite the default container SecurityContext for the agent container. |
 | agents.containers.agent.startupProbe | object | Every 15s / 6 KO / 1 OK | Override default agent startup probe settings |
 | agents.containers.agentDataPlane.env | list | `[]` | Additional environment variables for the agent-data-plane container |

--- a/charts/datadog/README.md.gotmpl
+++ b/charts/datadog/README.md.gotmpl
@@ -420,6 +420,27 @@ Standard paths are:
 - Containerd socket: `/var/run/containerd/containerd.sock`
 - Cri-o socket: `/var/run/crio/crio.sock`
 
+### Resource limits on high-core-count nodes
+
+On nodes with a high logical CPU count (for example, large GPU or bare-metal hosts), the Agent's Go runtime sizes its scheduler to the host CPU count by default. This can drive memory usage proportionally and cause the Agent container to be OOM-killed even with otherwise modest workloads.
+
+Set an explicit CPU limit on the agent container so the runtime sizes to the limit rather than the host CPU count. Update your `datadog-values.yaml` file:
+
+```yaml
+agents:
+  containers:
+    agent:
+      resources:
+        requests:
+          cpu: "2"
+          memory: 512Mi
+        limits:
+          cpu: "2"
+          memory: 1Gi
+```
+
+Use an integer value for `limits.cpu` so the runtime can read it directly. If your cluster has node shapes with widely varying core counts, apply this chart per node group (with a `nodeSelector` and matching limits) rather than picking a single value that may be too low for small nodes or too high for large ones. Alternatively, deploy through the [Datadog Operator](https://docs.datadoghq.com/containers/datadog_operator/) and use [DatadogAgentProfiles](https://github.com/DataDog/datadog-operator/blob/main/docs/datadog_agent_profiles.md) to set different limits per node shape from a single install.
+
 ### Configuration required for Amazon Linux 2 based nodes
 
 Amazon Linux 2 does not support apparmor profile enforcement.

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2260,7 +2260,7 @@ agents:
       # If not set, fall back to the value of datadog.logLevel.
       logLevel:  # INFO
 
-      # agents.containers.agent.resources -- Resource requests and limits for the agent container.
+      # agents.containers.agent.resources -- Resource requests and limits for the agent container. On nodes with a high logical CPU count, set an explicit `limits.cpu` (integer) to prevent the Agent's Go runtime from sizing its scheduler to the host CPU count, which can otherwise cause OOM kills.
       resources: {}
       #  requests:
       #    cpu: 200m


### PR DESCRIPTION
## Motivation

A customer (customer case reference #2907822) hit OOM kills on a 384-logical-CPU node. The Agent's Go runtime sizes its scheduler to `runtime.NumCPU()` by default, which drove memory usage proportionally on the high-core host. Setting `GOMAXPROCS=8` resolved it.

The customer has widely varying core counts across their fleet and cannot set a single global value. The working fix is to set `agents.containers.agent.resources.limits.cpu` per node group, but this trade-off is not currently documented anywhere in the Datadog chart. The customer asked us to document this, and this PR addresses that request for the Helm chart. A parallel PR ([DataDog/datadog-operator#3106](https://github.com/DataDog/datadog-operator/pull/3106)) covers the operator's docs.

## Approach

A new "Resource limits on high-core-count nodes" section in `charts/datadog/README.md.gotmpl` sits above the Amazon Linux 2 section. It explains the runtime behavior, shows an `agents.containers.agent.resources` snippet with an integer `limits.cpu`, and points users with heterogeneous node shapes at `DatadogAgentProfiles` via the Operator as an alternative to maintaining separate Helm installs.

The description comment on `agents.containers.agent.resources` in `charts/datadog/values.yaml` now carries the same advice inline so it surfaces in the auto-generated values table. `charts/datadog/README.md` was regenerated through `.github/helm-docs.sh`.

`charts/datadog/Chart.yaml` was patch-bumped from `3.221.0` to `3.221.1` for this docs-only change. `charts/datadog/CHANGELOG.md` has the corresponding entry.

## Verification

- [x] Ran `.github/helm-docs.sh` locally. The README diff matches the `gotmpl` + `values.yaml` changes.
- [x] Confirmed the version badge in the regenerated README reads `3.221.1`.
- [ ] Reviewer: skim the new README section for clarity and the inline values comment for length and grammar.
- [ ] Reviewer: confirm the link to the operator's DAP docs is the path you want users sent to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)