### PR TITLE
[datadog-operator] Release 1.27.1 addressing CVE-2026-39821

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.23.2
+
+* Update Datadog Operator image tag to 1.27.1.
+
 ## 2.24.0-dev.1
 
 * Update Datadog Operator chart for 1.28.0-rc.1.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.22.0-dev.1
-digest: sha256:b0a8d2f6d4b6b6a0105c7f903f644d3e67536239138599c72c9886601accee11
-generated: "2026-06-05T15:31:17.468779-04:00"
+  version: 2.21.0
+digest: sha256:01217c826aeb763a1ba97c33d379ab87eeaf6db910c2d5954fdeb88eb90974de
+generated: "2026-06-04T20:36:56.178936-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.24.0-dev.1
-appVersion: 1.28.0-rc.1
+version: 2.23.2
+appVersion: 1.27.1
 description: Datadog Operator
 keywords:
 - monitoring
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: 2.22.0-dev.1
+  version: 2.21.0
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.24.0-dev.1](https://img.shields.io/badge/Version-2.24.0--dev.1-informational?style=flat-square) ![AppVersion: 1.28.0-rc.1](https://img.shields.io/badge/AppVersion-1.28.0--rc.1-informational?style=flat-square)
+![Version: 2.23.2](https://img.shields.io/badge/Version-2.23.2-informational?style=flat-square) ![AppVersion: 1.27.1](https://img.shields.io/badge/AppVersion-1.27.1-informational?style=flat-square)
 
 ## Values
 
@@ -43,7 +43,7 @@
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"registry.datadoghq.com/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.28.0-rc.1"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.27.1"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |

--- a/charts/datadog-operator/templates/_helpers.tpl
+++ b/charts/datadog-operator/templates/_helpers.tpl
@@ -186,6 +186,6 @@ Check operator image tag version.
 {{- $parts := split "@" $tag -}}
 {{- index $parts "_0"}}
 {{- else -}}
-{{ "1.28.0-rc.1" }}
+{{ "1.27.1" }}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -190,7 +190,6 @@ rules:
   - create
   - get
   - list
-  - patch
   - watch
 - apiGroups:
   - autoscaling
@@ -234,23 +233,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - configuration.konghq.com
-  - consul.hashicorp.com
-  - core.haproxy.org
-  - datadoghq.com
-  - gateway.envoyproxy.io
-  - ingress.v1.haproxy.org
-  - karpenter.azure.com
-  - kuma.io
-  - mesh.consul.hashicorp.com
-  - policy.linkerd.io
-  - traefik.containo.us
-  resources:
-  - '*'
-  verbs:
-  - list
   - watch
 - apiGroups:
   - coordination.k8s.io
@@ -338,6 +320,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - datadoghq.com
+  - karpenter.azure.com
+  resources:
+  - '*'
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -358,9 +348,7 @@ rules:
 - apiGroups:
   - gateway.envoyproxy.io
   resources:
-  - backend
   - envoyextensionpolicies
-  - envoypatchpolicies
   verbs:
   - create
   - delete
@@ -379,29 +367,12 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
-  - grpcroutes
-  - listenersets
-  - tlsroutes
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
   - referencegrants
   verbs:
   - create
   - delete
   - get
   - patch
-- apiGroups:
-  - k8s.nginx.org
-  resources:
-  - virtualserverroutes
-  - virtualservers
-  verbs:
-  - list
-  - watch
 - apiGroups:
   - karpenter.sh
   resources:
@@ -431,37 +402,11 @@ rules:
 - apiGroups:
   - networking.istio.io
   resources:
-  - destinationrules
-  - serviceentries
-  - sidecars
-  - virtualservices
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - networking.istio.io
-  resources:
   - envoyfilters
   verbs:
   - create
   - delete
   - get
-- apiGroups:
-  - networking.istio.io
-  resources:
-  - gateways
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingressclasses
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -556,13 +501,6 @@ rules:
   - volumeattachments
   verbs:
   - get
-  - list
-  - watch
-- apiGroups:
-  - traefik.io
-  resources:
-  - ingressroutes
-  verbs:
   - list
   - watch
 {{- if .Values.datadogAgentInternal.enabled }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: registry.datadoghq.com/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.28.0-rc.1
+  tag: 1.27.1
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
   # image.doNotCheckTag -- Permit skipping operator image tag compatibility with the chart.

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.17.3
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-2.22.0-dev.1'
+    helm.sh/chart: 'datadogCRDs-2.21.0'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -643,11 +643,6 @@ spec:
                           properties:
                             enabled:
                               type: boolean
-                            inPlaceVerticalScaling:
-                              properties:
-                                enabled:
-                                  type: boolean
-                              type: object
                           type: object
                       type: object
                     clusterChecks:
@@ -5118,11 +5113,6 @@ spec:
                               properties:
                                 enabled:
                                   type: boolean
-                                inPlaceVerticalScaling:
-                                  properties:
-                                    enabled:
-                                      type: boolean
-                                  type: object
                               type: object
                           type: object
                         clusterChecks:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.24.0-dev.1
+    helm.sh/chart: datadog-operator-2.23.2
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.28.0-rc.1"
+    app.kubernetes.io/version: "1.27.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator 
       containers:
         - name: datadog-operator
-          image: "registry.datadoghq.com/operator:1.28.0-rc.1"
+          image: "registry.datadoghq.com/operator:1.27.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -208,7 +208,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "registry.datadoghq.com/operator:1.28.0-rc.1", operatorContainer.Image)
+	assert.Equal(t, "registry.datadoghq.com/operator:1.27.1", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Release `datadog-operator` chart `2.23.2` with Datadog Operator image `1.27.1`, keeping the chart otherwise aligned with the previously released `2.23.1` state.

This intentionally preserves the existing `2.24.0-dev.1` changelog entry, since that development release already exists and will be carried forward by the follow-up `2.24.0-dev.2` release.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Generation steps used for this PR:

```sh
git status --short && git status --branch --short
git log -5 --oneline --decorate
git diff --stat datadog-operator-2.23.1..datadog-operator-2.24.0-dev.1 -- charts/datadog-operator
git diff datadog-operator-2.23.1..datadog-operator-2.24.0-dev.1 -- charts/datadog-operator/Chart.yaml charts/datadog-operator/values.yaml charts/datadog-operator/CHANGELOG.md
git diff datadog-operator-2.24.0-dev.1..datadog-operator-2.23.1 -- charts/datadog-operator/Chart.lock charts/datadog-operator/Chart.yaml charts/datadog-operator/README.md charts/datadog-operator/templates/_helpers.tpl charts/datadog-operator/templates/clusterrole.yaml charts/datadog-operator/values.yaml | git apply
```

After applying that reverse diff, I manually updated the stable release metadata from `2.23.1` / `1.27.0` to `2.23.2` / `1.27.1` in:

```text
charts/datadog-operator/Chart.yaml
charts/datadog-operator/values.yaml
charts/datadog-operator/templates/_helpers.tpl
charts/datadog-operator/README.md
charts/datadog-operator/CHANGELOG.md
```

Then I regenerated and verified the operator test baselines:

```sh
make update-test-baselines-operator
```

Final comparison against `datadog-operator-2.23.1` showed only the intended `2.23.2` / `1.27.1` changes, the retained `2.24.0-dev.1` changelog entry, and matching operator deployment test baseline/assertion updates:

```console
git diff datadog-operator-2.23.1 -- charts/datadog-operator test/datadog-operator
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits