### PR TITLE
[datadog] Bump default AppSec sidecar image tag to v2.8.2

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.223.3
+
+* Bump the default App & API Protection (AppSec) sidecar processor image tag (`datadog.appsec.injector.sidecar.imageTag`) from `v2.6.0` to `v2.8.2`.
+
 ## 3.223.2
 
 * Clarify `datadog.env` and `datadog.envDict` that environment variables set with these options only propagate to the node Agent containers only.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.223.2
+version: 3.223.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.223.2](https://img.shields.io/badge/Version-3.223.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.223.3](https://img.shields.io/badge/Version-3.223.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -782,7 +782,7 @@ helm install <RELEASE_NAME> \
 | datadog.appsec.injector.sidecar.bodyParsingSizeLimit | int | `0` | Request body parsing size limit in bytes for the AppSec sidecar processor. Set to 0 to leave it unset (default agent behavior). Set to a negative value (e.g. -1) to disable body parsing entirely. |
 | datadog.appsec.injector.sidecar.healthPort | int | `8081` | Health check port for the AppSec sidecar processor |
 | datadog.appsec.injector.sidecar.image | string | `"ghcr.io/datadog/dd-trace-go/service-extensions-callout"` | Container image for the AppSec sidecar processor |
-| datadog.appsec.injector.sidecar.imageTag | string | `"v2.6.0"` | Image tag for the AppSec sidecar processor |
+| datadog.appsec.injector.sidecar.imageTag | string | `"v2.8.2"` | Image tag for the AppSec sidecar processor |
 | datadog.appsec.injector.sidecar.port | int | `8080` | Listening port for the AppSec sidecar processor |
 | datadog.appsec.injector.sidecar.resources.limits.cpu | string | `""` | Optional CPU limit for the AppSec sidecar processor |
 | datadog.appsec.injector.sidecar.resources.limits.memory | string | `""` | Optional memory limit for the AppSec sidecar processor |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -738,7 +738,7 @@ datadog:
         # datadog.appsec.injector.sidecar.image -- Container image for the AppSec sidecar processor
         image: "ghcr.io/datadog/dd-trace-go/service-extensions-callout"
         # datadog.appsec.injector.sidecar.imageTag -- Image tag for the AppSec sidecar processor
-        imageTag: "v2.6.0"
+        imageTag: "v2.8.2"
         # datadog.appsec.injector.sidecar.port -- Listening port for the AppSec sidecar processor
         port: 8080
         # datadog.appsec.injector.sidecar.healthPort -- Health check port for the AppSec sidecar processor

--- a/test/datadog/appsec_injector_test.go
+++ b/test/datadog/appsec_injector_test.go
@@ -95,7 +95,7 @@ func Test_AppSecInjector_Enabled_RendersDefaultOptions(t *testing.T) {
 		ddAppsecProxyAutoDetectEnvVar:      "true",
 		ddAppsecInjectorEnabledEnvVar:      "true",
 		ddAppsecSidecarImageEnvVar:         "ghcr.io/datadog/dd-trace-go/service-extensions-callout",
-		ddAppsecSidecarImageTagEnvVar:      "v2.6.0",
+		ddAppsecSidecarImageTagEnvVar:      "v2.8.2",
 		ddAppsecSidecarPortEnvVar:          "8080",
 		ddAppsecSidecarHealthPortEnvVar:    "8081",
 		ddAppsecSidecarReqCPUEnvVar:        "10m",


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the default App & API Protection (AppSec) Envoy sidecar processor image tag (`datadog.appsec.injector.sidecar.imageTag`) from `v2.6.0` to `v2.8.2`.

This image (`ghcr.io/datadog/dd-trace-go/service-extensions-callout`) is the AppSec processor injected as an Envoy External Processing (`ext_proc`) sidecar. Keeping the default on a recent stable release picks up the latest fixes and improvements in `dd-trace-go`.

#### Which issue this PR fixes
  - fixes #

#### Special notes for your reviewer:

- The AppSec injector is disabled by default (`datadog.appsec.injector.enabled: false`), so this only changes the default rendered tag when the feature is explicitly enabled. No baseline manifest diffs result from this change (`make update-test-baselines-datadog-agent` produces no changes).
- Chart bumped `3.223.0` → `3.223.1` (patch). README regenerated via `.github/helm-docs.sh`.

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (`datadog/patch-version`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received :white_check_mark: from a member of your team
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
