### PR TITLE
[datadog] Update Default Agent Version to 7.80.1

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.223.1
+
+* Update Default Agent Version to 7.80.1.
+
 ## 3.223.0
 
 * [CONTP-1710] Install DatadogInstrumentation CRD and add RBAC permissions when controller is enabled ([#2717](https://github.com/DataDog/helm-charts/pull/2717)).

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.223.2
+## 3.223.1
 
 * Update Default Agent Version to 7.80.1.
 

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Datadog changelog
 
-## 3.223.1
+## 3.223.2
 
 * Update Default Agent Version to 7.80.1.
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.223.1
+version: 3.223.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.223.2
+version: 3.223.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.223.0
+version: 3.223.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.223.1](https://img.shields.io/badge/Version-3.223.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.223.2](https://img.shields.io/badge/Version-3.223.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.223.0](https://img.shields.io/badge/Version-3.223.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.223.1](https://img.shields.io/badge/Version-3.223.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -554,7 +554,7 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.78.3"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.80.1"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | agents.lifecycle | object | `{}` | Configure the lifecycle of the Agent. Note: The `exec` lifecycle handler is not supported in GKE Autopilot. |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
@@ -647,7 +647,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"7.78.3"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"7.80.1"` | Cluster Agent image tag to use |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
 | clusterAgent.metricsProvider.aggregator | string | `"avg"` | Define the aggregator the cluster agent will use to process the metrics. The options are (avg, min, max, sum) |
@@ -714,7 +714,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
-| clusterChecksRunner.image.tag | string | `"7.78.3"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.80.1"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |
 | clusterChecksRunner.networkPolicy.create | bool | `false` | If true, create a NetworkPolicy for the cluster checks runners. DEPRECATED. Use datadog.networkPolicy.create instead |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.223.2](https://img.shields.io/badge/Version-3.223.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.223.1](https://img.shields.io/badge/Version-3.223.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -10,7 +10,7 @@
 {{- $version = "6.55.1" -}}
 {{- end -}}
 {{- if and (eq $length 1) (or (eq $version "7") (eq $version "latest")) -}}
-{{- $version = "7.78.3" -}}
+{{- $version = "7.80.1" -}}
 {{- end -}}
 {{- $version -}}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1511,7 +1511,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 7.78.3
+    tag: 7.80.1
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2128,7 +2128,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.78.3
+    tag: 7.80.1
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2809,7 +2809,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.78.3
+    tag: 7.80.1
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -2273,7 +2273,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2346,7 +2346,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -2273,7 +2273,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2346,7 +2346,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -1879,7 +1879,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2033,7 +2033,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2110,7 +2110,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2220,7 +2220,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2259,7 +2259,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2286,7 +2286,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2606,7 +2606,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2663,7 +2663,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2676,7 +2676,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2875,7 +2875,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2948,7 +2948,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -1846,7 +1846,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2002,7 +2002,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2081,7 +2081,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2191,7 +2191,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2232,7 +2232,7 @@ spec:
               value: '[{"products":["global"],"rules":{"containers":["container.name == \"redis\""]}},{"products":["logs","metrics"],"rules":{"pods":["pod.name.startsWith(''nginx'')"]}}]'
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2259,7 +2259,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2647,7 +2647,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2720,7 +2720,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -1969,7 +1969,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2042,7 +2042,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -1983,7 +1983,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2056,7 +2056,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -1914,7 +1914,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
               value: agent
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-              value: 7.78.3
+              value: 7.80.1
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -1979,7 +1979,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2052,7 +2052,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -1971,7 +1971,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2044,7 +2044,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -1845,7 +1845,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1999,7 +1999,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2082,7 +2082,7 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2203,7 +2203,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2242,7 +2242,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2269,7 +2269,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2663,7 +2663,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2736,7 +2736,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -1874,7 +1874,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2028,7 +2028,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2111,7 +2111,7 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2278,7 +2278,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -2321,7 +2321,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2360,7 +2360,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2387,7 +2387,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2785,7 +2785,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2858,7 +2858,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -1844,7 +1844,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1998,7 +1998,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2079,7 +2079,7 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2189,7 +2189,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2228,7 +2228,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2255,7 +2255,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2646,7 +2646,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2719,7 +2719,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -1915,7 +1915,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2069,7 +2069,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2146,7 +2146,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2256,7 +2256,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2295,7 +2295,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2325,7 +2325,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2648,7 +2648,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2705,7 +2705,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2718,7 +2718,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2917,7 +2917,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2990,7 +2990,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -1844,7 +1844,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1998,7 +1998,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2075,7 +2075,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2185,7 +2185,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2224,7 +2224,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2251,7 +2251,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2639,7 +2639,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2712,7 +2712,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -1844,7 +1844,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1998,7 +1998,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2075,7 +2075,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2185,7 +2185,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2224,7 +2224,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2251,7 +2251,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2639,7 +2639,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2712,7 +2712,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -966,7 +966,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1071,7 +1071,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1097,7 +1097,7 @@ spec:
           command:
             - pwsh
             - -Command
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1139,7 +1139,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1353,7 +1353,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1426,7 +1426,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
@@ -1571,7 +1571,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1639,7 +1639,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1691,7 +1691,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2001,7 +2001,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2074,7 +2074,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -1571,7 +1571,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1639,7 +1639,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1691,7 +1691,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2001,7 +2001,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2074,7 +2074,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -1573,7 +1573,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1650,7 +1650,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1702,7 +1702,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2018,7 +2018,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2091,7 +2091,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -1610,7 +1610,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1688,7 +1688,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1739,7 +1739,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2007,7 +2007,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2070,7 +2070,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2089,7 +2089,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2298,7 +2298,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2377,7 +2377,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -1582,7 +1582,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1660,7 +1660,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1709,7 +1709,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2043,7 +2043,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2122,7 +2122,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -1830,7 +1830,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1954,7 +1954,7 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2057,7 +2057,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2108,7 +2108,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2141,7 +2141,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2514,7 +2514,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2593,7 +2593,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1834,7 +1834,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1979,7 +1979,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -2065,7 +2065,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2172,7 +2172,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2223,7 +2223,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2256,7 +2256,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2629,7 +2629,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2708,7 +2708,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1834,7 +1834,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1979,7 +1979,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -2065,7 +2065,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2172,7 +2172,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2223,7 +2223,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2256,7 +2256,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2629,7 +2629,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2708,7 +2708,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1830,7 +1830,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1950,7 +1950,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2053,7 +2053,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2104,7 +2104,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2137,7 +2137,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2507,7 +2507,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2586,7 +2586,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -1879,7 +1879,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1996,7 +1996,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2143,7 +2143,7 @@ spec:
               value: "true"
             - name: DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR
               value: tcp://127.0.0.1:5102
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 12
@@ -2206,7 +2206,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2257,7 +2257,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2290,7 +2290,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2594,7 +2594,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2657,7 +2657,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2676,7 +2676,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2885,7 +2885,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2964,7 +2964,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -1882,7 +1882,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2032,7 +2032,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2111,7 +2111,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2214,7 +2214,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2265,7 +2265,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2298,7 +2298,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2602,7 +2602,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2665,7 +2665,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2684,7 +2684,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2893,7 +2893,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2972,7 +2972,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -1863,7 +1863,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1983,7 +1983,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2086,7 +2086,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2137,7 +2137,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2170,7 +2170,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2474,7 +2474,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2537,7 +2537,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2556,7 +2556,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2765,7 +2765,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2844,7 +2844,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -1865,7 +1865,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1998,7 +1998,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2101,7 +2101,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2152,7 +2152,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2185,7 +2185,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2498,7 +2498,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2561,7 +2561,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2580,7 +2580,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2789,7 +2789,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2868,7 +2868,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -1948,7 +1948,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2068,7 +2068,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2222,7 +2222,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.78.3
+          image: gcr.io/datadoghq/ddot-collector:7.80.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2262,7 +2262,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2313,7 +2313,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2346,7 +2346,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2656,7 +2656,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2719,7 +2719,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2738,7 +2738,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.78.3
+          image: gcr.io/datadoghq/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2947,7 +2947,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3026,7 +3026,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.78.3
+          image: gcr.io/datadoghq/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -1855,7 +1855,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2017,7 +2017,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2098,7 +2098,7 @@ spec:
               value: "8125"
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2221,7 +2221,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2260,7 +2260,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2287,7 +2287,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2688,7 +2688,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2761,7 +2761,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -1909,7 +1909,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2063,7 +2063,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2140,7 +2140,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2250,7 +2250,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2289,7 +2289,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2316,7 +2316,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2704,7 +2704,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2777,7 +2777,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1848,7 +1848,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2002,7 +2002,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2104,7 +2104,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2184,7 +2184,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2298,7 +2298,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2337,7 +2337,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2364,7 +2364,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2755,7 +2755,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2828,7 +2828,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -1933,7 +1933,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2087,7 +2087,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2164,7 +2164,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2318,7 +2318,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.78.3
+          image: registry.datadoghq.com/ddot-collector:7.80.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2375,7 +2375,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2414,7 +2414,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2441,7 +2441,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2835,7 +2835,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2908,7 +2908,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -1858,7 +1858,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2012,7 +2012,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2089,7 +2089,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2243,7 +2243,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.78.3
+          image: registry.datadoghq.com/ddot-collector:7.80.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2294,7 +2294,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2333,7 +2333,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2360,7 +2360,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2754,7 +2754,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2827,7 +2827,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -1929,7 +1929,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2083,7 +2083,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2160,7 +2160,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2314,7 +2314,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.78.3
+          image: registry.datadoghq.com/ddot-collector:7.80.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2369,7 +2369,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2408,7 +2408,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2435,7 +2435,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2829,7 +2829,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2902,7 +2902,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1881,7 +1881,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2035,7 +2035,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2112,7 +2112,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2266,7 +2266,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.78.3
+          image: registry.datadoghq.com/ddot-collector:7.80.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2329,7 +2329,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2368,7 +2368,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2395,7 +2395,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2798,7 +2798,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2871,7 +2871,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -1929,7 +1929,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2083,7 +2083,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2160,7 +2160,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2314,7 +2314,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.78.3
+          image: registry.datadoghq.com/ddot-collector:7.80.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2368,7 +2368,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2407,7 +2407,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2434,7 +2434,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2831,7 +2831,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2904,7 +2904,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -1929,7 +1929,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2083,7 +2083,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2160,7 +2160,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2314,7 +2314,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.78.3
+          image: registry.datadoghq.com/ddot-collector:7.80.1
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2365,7 +2365,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2404,7 +2404,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2431,7 +2431,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2825,7 +2825,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2898,7 +2898,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -1844,7 +1844,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1998,7 +1998,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2075,7 +2075,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2185,7 +2185,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2224,7 +2224,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2251,7 +2251,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2639,7 +2639,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2712,7 +2712,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -1847,7 +1847,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2003,7 +2003,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2082,7 +2082,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2192,7 +2192,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2233,7 +2233,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2260,7 +2260,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2650,7 +2650,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2723,7 +2723,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -1858,7 +1858,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2044,7 +2044,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2121,7 +2121,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2231,7 +2231,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2270,7 +2270,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2297,7 +2297,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2703,7 +2703,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2776,7 +2776,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -1877,7 +1877,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2033,7 +2033,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2115,7 +2115,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2229,7 +2229,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2274,7 +2274,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2307,7 +2307,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2632,7 +2632,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2689,7 +2689,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2708,7 +2708,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2917,7 +2917,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2994,7 +2994,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           securityContext:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1849,7 +1849,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2003,7 +2003,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2105,7 +2105,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2187,7 +2187,7 @@ spec:
               value: /host/root
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2358,7 +2358,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -2401,7 +2401,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2440,7 +2440,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2467,7 +2467,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2866,7 +2866,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2939,7 +2939,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -1856,7 +1856,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2024,7 +2024,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2129,7 +2129,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2210,7 +2210,7 @@ spec:
               value: /host/root
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2283,7 +2283,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2324,7 +2324,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2351,7 +2351,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2705,7 +2705,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2778,7 +2778,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1848,7 +1848,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2002,7 +2002,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2104,7 +2104,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2184,7 +2184,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2298,7 +2298,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2337,7 +2337,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2364,7 +2364,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2755,7 +2755,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2828,7 +2828,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -1845,7 +1845,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1999,7 +1999,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2078,7 +2078,7 @@ spec:
               value: /host/root
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2245,7 +2245,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -2288,7 +2288,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2327,7 +2327,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2354,7 +2354,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2750,7 +2750,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2823,7 +2823,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -1845,7 +1845,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1999,7 +1999,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2078,7 +2078,7 @@ spec:
               value: /host/root
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2199,7 +2199,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2238,7 +2238,7 @@ spec:
               value: "false"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2265,7 +2265,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.78.3
+          image: registry.datadoghq.com/agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2659,7 +2659,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2732,7 +2732,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.78.3
+          image: registry.datadoghq.com/cluster-agent:7.80.1
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the default Datadog Agent version from 7.78.3 to 7.80.1 across all image tags:
- `agents.image.tag`
- `clusterAgent.image.tag`
- `clusterChecksRunner.image.tag`

Also bumps the `get-agent-version` fallback for bare `7`/`latest` tags in `_helpers.tpl` to 7.80.1 -- the `check-agent-version-drift` CI check (added since the last bump PRs) requires it to stay in sync with the image tags.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Routine agent version bump. The `_helpers.tpl` change is just keeping the `latest`/`7` fallback in lockstep, which `check-agent-version-drift` enforces. No baseline diffs resulted from it since the fixtures use pinned tags.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)