### PR TITLE
Omit DogStatsD socket on GKE Autopilot without CSI

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.223.3
+
+* On GKE Autopilot clusters using WorkloadAllowlist, render the DogStatsD socket volume as the allowlisted `/var/run/datadog` hostPath even when the Datadog CSI driver is disabled.
+
 ## 3.223.2
 
 * Clarify `datadog.env` and `datadog.envDict` that environment variables set with these options only propagate to the node Agent containers only.

--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.223.3
 
-* On GKE Autopilot clusters using WorkloadAllowlist, render the DogStatsD socket volume as the allowlisted `/var/run/datadog` hostPath even when the Datadog CSI driver is disabled.
+* Omit the DogStatsD socket volume on GKE Autopilot when the Datadog CSI driver is disabled.
 
 ## 3.223.2
 

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.223.2
+version: 3.223.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.223.2](https://img.shields.io/badge/Version-3.223.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.223.3](https://img.shields.io/badge/Version-3.223.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/NOTES.txt
+++ b/charts/datadog/templates/NOTES.txt
@@ -428,11 +428,21 @@ The option is overriden to avoid mounting volumes that are not allowed which wou
 
 {{- end }}
 
-{{- if and .Values.datadog.dogstatsd.useSocketVolume (not .Values.datadog.csi.enabled)}}
+{{- if and .Values.datadog.dogstatsd.useSocketVolume (not .Values.datadog.csi.enabled) }}
 
-##############################################################################################################################################
-####   WARNING: dogstatsd with Unix socket is not supported on GKE Autopilot if Datadog CSI Driver is inactive. See datadog.csi.enabled   ####
-##############################################################################################################################################
+{{- if eq (include "gke-autopilot-workloadallowlists-enabled" .) "true" }}
+
+################################################################################################################################################
+####   WARNING: dogstatsd with Unix socket on GKE Autopilot requires Datadog CSI Driver for application workloads. See datadog.csi.enabled   ####
+################################################################################################################################################
+
+{{- else }}
+
+#####################################################################################################################################
+####   WARNING: dogstatsd with Unix socket is not supported on legacy GKE Autopilot clusters using AllowlistedV2Workload.   ####
+#####################################################################################################################################
+
+{{- end }}
 
 {{- end }}
 

--- a/charts/datadog/templates/_container-agent-data-plane.yaml
+++ b/charts/datadog/templates/_container-agent-data-plane.yaml
@@ -75,10 +75,12 @@
       readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
-    {{- if not .Values.providers.gke.gdc }}
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: false
+    {{- end }}
+    {{- if not .Values.providers.gke.gdc }}
     - name: procdir
       mountPath: /host/proc
       mountPropagation: {{ .Values.datadog.hostVolumeMountPropagation }}

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -328,10 +328,12 @@
     - name: gpu-devices
       mountPath: /var/run/nvidia-container-devices/all
     {{- end }}
-    {{- if not .Values.providers.gke.gdc }}
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: false
+    {{- end }}
+    {{- if not .Values.providers.gke.gdc }}
     {{- if eq (include "should-enable-system-probe" .) "true" }}
     - name: sysprobe-socket-dir
       mountPath: /var/run/sysprobe

--- a/charts/datadog/templates/_container-otel-agent.yaml
+++ b/charts/datadog/templates/_container-otel-agent.yaml
@@ -117,9 +117,11 @@
     - name: tmpdir
       mountPath: /tmp
       readOnly: false # Need RW for tmp directory
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: true
+    {{- end }}
     {{- if and .Values.datadog.otelCollector.logs.enabled (eq (include "should-mount-logs-for-otel-agent" .) "true") }}
     - name: logpodpath
       mountPath: /var/log/pods

--- a/charts/datadog/templates/_container-private-action-runner.yaml
+++ b/charts/datadog/templates/_container-private-action-runner.yaml
@@ -41,7 +41,7 @@
           name: {{ .Values.datadog.privateActionRunner.identityFromExistingSecret }}
           key: private_key
     {{- end }}
-    {{- if eq .Values.targetSystem "linux" }}
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
     {{- end }}
@@ -66,7 +66,7 @@
     - name: tmpdir
       mountPath: /tmp
       readOnly: false
-    {{- if not .Values.providers.gke.gdc }}
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: false

--- a/charts/datadog/templates/_container-process-agent.yaml
+++ b/charts/datadog/templates/_container-process-agent.yaml
@@ -69,7 +69,7 @@
     - name: DD_NETWORK_PATH_COLLECTOR_PATHTEST_MAX_PER_MINUTE
       value: {{ .Values.datadog.networkPath.collector.pathtestMaxPerMinute | quote }}
     {{- end }}
-    {{- if eq .Values.targetSystem "linux" }}
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
     {{- end }}
@@ -90,7 +90,7 @@
       readOnly: true
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
-    {{- if or (not .Values.providers.gke.autopilot) (and .Values.providers.gke.autopilot .Values.datadog.csi.enabled) }}
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: true # write access to /var/run/datadog is not needed because the process agent only writes to the socket file, not to the parent directory

--- a/charts/datadog/templates/_container-security-agent.yaml
+++ b/charts/datadog/templates/_container-security-agent.yaml
@@ -63,7 +63,7 @@
     - name: DD_RUNTIME_SECURITY_CONFIG_USE_SECRUNTIME_TRACK
       value: {{ .Values.datadog.securityAgent.runtime.useSecruntimeTrack | quote }}
     {{- end }}
-    {{- if eq .Values.targetSystem "linux" }}
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
     {{- end }}
@@ -80,9 +80,11 @@
     - name: auth-token
       mountPath: {{ template "datadog.confPath" . }}/auth
       readOnly: true
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: false # Need RW for UDS DSD socket
+    {{- end }}
     {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     - name: tmpdir

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -58,7 +58,7 @@
     - name: DD_APM_RECEIVER_SOCKET
       value: {{ .Values.datadog.apm.socketPath | quote }}
     {{- end }}
-    {{- if eq .Values.targetSystem "linux" }}
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
     {{- end }}
@@ -115,7 +115,7 @@
     - name: tmpdir
       mountPath: /tmp
       readOnly: false # Need RW for tmp directory
-    {{- if not .Values.providers.gke.gdc }}
+    {{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
     - name: dsdsocket
       mountPath: {{ (dir .Values.datadog.dogstatsd.socketPath) }}
       readOnly: false # Need RW for UDS DSD socket

--- a/charts/datadog/templates/_containers-common-env.yaml
+++ b/charts/datadog/templates/_containers-common-env.yaml
@@ -204,7 +204,7 @@ Return a list of env-vars if the cluster-agent is enabled
 - name: DD_DOGSTATSD_TAGS
   value: {{ tpl (.Values.datadog.dogstatsd.tags | join " " | quote) . }}
 {{- end }}
-{{- if and (eq .Values.targetSystem "linux") (not .Values.providers.gke.gdc) }}
+{{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
 - name: DD_DOGSTATSD_SOCKET
   value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
 {{- end }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -49,6 +49,7 @@
 {{- if eq (include "should-enable-fips-proxy" . ) "true" }}
 {{ include "linux-container-fips-proxy-cfg-volume" . }}
 {{- end }}
+{{- if eq (include "should-render-dsd-socket-volume" .) "true" }}
 {{- if eq (include "should-mount-hostPath-for-dsd-socket" .) "true" }}
 - hostPath:
     path: {{ .Values.datadog.dogstatsd.hostSocketPath }}
@@ -57,6 +58,7 @@
 {{- else }}
 - emptyDir: {}
   name: dsdsocket
+{{- end }}
 {{- end }}
 {{- if .Values.providers.eks.ec2.useHostnameFromFile }}
 - hostPath:

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -856,13 +856,23 @@ false
 {{- end -}}
 
 {{/*
-Return true if hostPath should be used for DSD socket. On GKE Autopilot without CSI, only use hostPath when
-WorkloadAllowlists are enabled.
+Return true if the DSD socket volume should be rendered.
 */}}
-{{- define "should-mount-hostPath-for-dsd-socket" -}}
+{{- define "should-render-dsd-socket-volume" -}}
 {{- if or .Values.providers.gke.gdc (eq .Values.targetSystem "windows") -}}
 false
-{{- else if and .Values.providers.gke.autopilot (not .Values.datadog.csi.enabled) (eq (include "gke-autopilot-workloadallowlists-enabled" .) "false") -}}
+{{- else if and .Values.providers.gke.autopilot (not .Values.datadog.csi.enabled) -}}
+false
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if hostPath should be used for DSD socket.
+*/}}
+{{- define "should-mount-hostPath-for-dsd-socket" -}}
+{{- if eq (include "should-render-dsd-socket-volume" .) "false" -}}
 false
 {{- else if .Values.datadog.dogstatsd.useSocketVolume -}}
 true

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -856,13 +856,15 @@ false
 {{- end -}}
 
 {{/*
-Return true hostPath should be use for DSD socket. Return always false on GKE Autopilot in case CSI driver is not enabled, and on GDC.
+Return true if hostPath should be used for DSD socket. On GKE Autopilot without CSI, only use hostPath when
+WorkloadAllowlists are enabled.
 */}}
 {{- define "should-mount-hostPath-for-dsd-socket" -}}
-{{- if or (and .Values.providers.gke.autopilot (not .Values.datadog.csi.enabled)) .Values.providers.gke.gdc (eq .Values.targetSystem "windows") -}}
+{{- if or .Values.providers.gke.gdc (eq .Values.targetSystem "windows") -}}
 false
-{{- end -}}
-{{- if .Values.datadog.dogstatsd.useSocketVolume -}}
+{{- else if and .Values.providers.gke.autopilot (not .Values.datadog.csi.enabled) (eq (include "gke-autopilot-workloadallowlists-enabled" .) "false") -}}
+false
+{{- else if .Values.datadog.dogstatsd.useSocketVolume -}}
 true
 {{- else -}}
 false

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -1567,8 +1567,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1664,9 +1662,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
@@ -1788,8 +1783,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - emptyDir: {}
-          name: dsdsocket
         - hostPath:
             path: /etc/passwd
           name: passwd

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -1539,8 +1539,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1636,9 +1634,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
@@ -1758,8 +1753,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - emptyDir: {}
-          name: dsdsocket
         - hostPath:
             path: /etc/passwd
           name: passwd

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -2180,7 +2180,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - emptyDir: {}
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
           name: dsdsocket
         - configMap:
             name: datadog-system-probe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -1787,8 +1787,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1887,9 +1885,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
               readOnly: true
@@ -2180,10 +2175,6 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - hostPath:
-            path: /var/run/datadog
-            type: DirectoryOrCreate
-          name: dsdsocket
         - configMap:
             name: datadog-system-probe-config
           name: sysprobe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1787,8 +1787,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1891,9 +1889,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
               readOnly: true
@@ -1975,8 +1970,6 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
           image: gcr.io/datadoghq/agent:7.80.1
@@ -2295,10 +2288,6 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - hostPath:
-            path: /var/run/datadog
-            type: DirectoryOrCreate
-          name: dsdsocket
         - configMap:
             name: datadog-system-probe-config
           name: sysprobe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -2295,7 +2295,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - emptyDir: {}
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
           name: dsdsocket
         - configMap:
             name: datadog-system-probe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1787,8 +1787,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1891,9 +1889,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
               readOnly: true
@@ -1975,8 +1970,6 @@ spec:
               value: "true"
             - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
               value: "true"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
           image: gcr.io/datadoghq/agent:7.80.1
@@ -2295,10 +2288,6 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - hostPath:
-            path: /var/run/datadog
-            type: DirectoryOrCreate
-          name: dsdsocket
         - configMap:
             name: datadog-system-probe-config
           name: sysprobe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -2295,7 +2295,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - emptyDir: {}
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
           name: dsdsocket
         - configMap:
             name: datadog-system-probe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -2176,7 +2176,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - emptyDir: {}
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
           name: dsdsocket
         - configMap:
             name: datadog-system-probe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1787,8 +1787,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1887,9 +1885,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
               readOnly: true
@@ -2176,10 +2171,6 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - hostPath:
-            path: /var/run/datadog
-            type: DirectoryOrCreate
-          name: dsdsocket
         - configMap:
             name: datadog-system-probe-config
           name: sysprobe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -1836,8 +1836,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1933,9 +1931,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
               readOnly: true
@@ -2188,9 +2183,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /host/proc
               mountPropagation: None
               name: procdir
@@ -2329,10 +2321,6 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - hostPath:
-            path: /var/run/datadog
-            type: DirectoryOrCreate
-          name: dsdsocket
         - configMap:
             name: datadog-system-probe-config
           name: sysprobe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -2329,7 +2329,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - emptyDir: {}
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
           name: dsdsocket
         - configMap:
             name: datadog-system-probe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -2337,7 +2337,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - emptyDir: {}
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
           name: dsdsocket
         - configMap:
             name: datadog-system-probe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -1820,8 +1820,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1939,9 +1937,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
               readOnly: true
@@ -2015,8 +2010,6 @@ spec:
               value: "true"
             - name: DD_APM_RECEIVER_PORT
               value: "8126"
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_INSTRUMENTATION_INSTALL_TIME
               valueFrom:
                 configMapKeyRef:
@@ -2064,9 +2057,6 @@ spec:
               readOnly: false
             - mountPath: /tmp
               name: tmpdir
-              readOnly: false
-            - mountPath: /var/run/datadog
-              name: dsdsocket
               readOnly: false
             - mountPath: /host/var/run/containerd
               mountPropagation: None
@@ -2337,10 +2327,6 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - hostPath:
-            path: /var/run/datadog
-            type: DirectoryOrCreate
-          name: dsdsocket
         - configMap:
             name: datadog-system-probe-config
           name: sysprobe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -2209,7 +2209,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - emptyDir: {}
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
           name: dsdsocket
         - configMap:
             name: datadog-system-probe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -1820,8 +1820,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1920,9 +1918,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
               readOnly: true
@@ -2209,10 +2204,6 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - hostPath:
-            path: /var/run/datadog
-            type: DirectoryOrCreate
-          name: dsdsocket
         - configMap:
             name: datadog-system-probe-config
           name: sysprobe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -1820,8 +1820,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1922,9 +1920,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
               readOnly: true
@@ -2224,10 +2219,6 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - hostPath:
-            path: /var/run/datadog
-            type: DirectoryOrCreate
-          name: dsdsocket
         - configMap:
             name: datadog-system-probe-config
           name: sysprobe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -2224,7 +2224,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - emptyDir: {}
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
           name: dsdsocket
         - configMap:
             name: datadog-system-probe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -1903,8 +1903,6 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_TAG_CARDINALITY
               value: low
-            - name: DD_DOGSTATSD_SOCKET
-              value: /var/run/datadog/dsd.socket
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -2005,9 +2003,6 @@ spec:
               mountPropagation: None
               name: runtimesocketdir
               readOnly: true
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: false
             - mountPath: /var/run/sysprobe
               name: sysprobe-socket-dir
               readOnly: true
@@ -2248,9 +2243,6 @@ spec:
             - mountPath: /tmp
               name: tmpdir
               readOnly: false
-            - mountPath: /var/run/datadog
-              name: dsdsocket
-              readOnly: true
             - mountPath: /host/var/run/containerd
               mountPropagation: None
               name: runtimesocketdir
@@ -2385,10 +2377,6 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - hostPath:
-            path: /var/run/datadog
-            type: DirectoryOrCreate
-          name: dsdsocket
         - configMap:
             name: datadog-system-probe-config
           name: sysprobe-config

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -2385,7 +2385,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release-file
-        - emptyDir: {}
+        - hostPath:
+            path: /var/run/datadog
+            type: DirectoryOrCreate
           name: dsdsocket
         - configMap:
             name: datadog-system-probe-config

--- a/test/datadog/gke_autopilot_allowlistedv2workload_test.go
+++ b/test/datadog/gke_autopilot_allowlistedv2workload_test.go
@@ -64,6 +64,7 @@ func verifyDaemonsetAutopilotAllowlistedV2WorkloadMinimal(t *testing.T, manifest
 
 	assert.Equal(t, 1, len(ds.Spec.Template.Spec.Containers))
 	assert.Equal(t, ds.Spec.Template.Spec.Containers[0].Name, "agent")
+	requireEmptyDirVolume(t, ds, "dsdsocket")
 
 	volumeNames := common.GetVolumeNames(ds)
 

--- a/test/datadog/gke_autopilot_allowlistedv2workload_test.go
+++ b/test/datadog/gke_autopilot_allowlistedv2workload_test.go
@@ -64,7 +64,8 @@ func verifyDaemonsetAutopilotAllowlistedV2WorkloadMinimal(t *testing.T, manifest
 
 	assert.Equal(t, 1, len(ds.Spec.Template.Spec.Containers))
 	assert.Equal(t, ds.Spec.Template.Spec.Containers[0].Name, "agent")
-	requireEmptyDirVolume(t, ds, "dsdsocket")
+	requireNoVolume(t, ds, "dsdsocket")
+	requireNoEnvVar(t, ds, "DD_DOGSTATSD_SOCKET")
 
 	volumeNames := common.GetVolumeNames(ds)
 

--- a/test/datadog/gke_autopilot_workloadallowlist_test.go
+++ b/test/datadog/gke_autopilot_workloadallowlist_test.go
@@ -85,7 +85,8 @@ func Test_autopilotWorkloadAllowlistConfigs(t *testing.T) {
 				var ds appsv1.DaemonSet
 				common.Unmarshal(t, manifest, &ds)
 				requireContainerNames(t, ds, "agent", "system-probe")
-				requireHostPathVolume(t, ds, "dsdsocket", "/var/run/datadog")
+				requireNoVolume(t, ds, "dsdsocket")
+				requireNoEnvVar(t, ds, "DD_DOGSTATSD_SOCKET")
 				verifyAutopilotWorkloadAllowlistConstraints(t, manifest)
 			},
 		},
@@ -109,7 +110,8 @@ func Test_autopilotWorkloadAllowlistConfigs(t *testing.T) {
 				var ds appsv1.DaemonSet
 				common.Unmarshal(t, manifest, &ds)
 				requireContainerNames(t, ds, "agent", "system-probe", "agent-data-plane")
-				requireHostPathVolume(t, ds, "dsdsocket", "/var/run/datadog")
+				requireNoVolume(t, ds, "dsdsocket")
+				requireNoEnvVar(t, ds, "DD_DOGSTATSD_SOCKET")
 				verifyAutopilotWorkloadAllowlistConstraints(t, manifest)
 			},
 		},
@@ -137,7 +139,8 @@ func Test_autopilotWorkloadAllowlistConfigs(t *testing.T) {
 				var ds appsv1.DaemonSet
 				common.Unmarshal(t, manifest, &ds)
 				requireContainerNames(t, ds, "agent", "process-agent", "system-probe")
-				requireHostPathVolume(t, ds, "dsdsocket", "/var/run/datadog")
+				requireNoVolume(t, ds, "dsdsocket")
+				requireNoEnvVar(t, ds, "DD_DOGSTATSD_SOCKET")
 				verifyAutopilotWorkloadAllowlistConstraints(t, manifest)
 			},
 		},
@@ -251,6 +254,25 @@ func requireEmptyDirVolume(t *testing.T, ds appsv1.DaemonSet, name string) {
 		return
 	}
 	assert.Fail(t, fmt.Sprintf("expected volume %q to be present", name))
+}
+
+func requireNoVolume(t *testing.T, ds appsv1.DaemonSet, name string) {
+	t.Helper()
+	for _, volume := range ds.Spec.Template.Spec.Volumes {
+		assert.NotEqual(t, name, volume.Name, fmt.Sprintf("expected volume %q to be omitted", name))
+	}
+}
+
+func requireNoEnvVar(t *testing.T, ds appsv1.DaemonSet, name string) {
+	t.Helper()
+	for _, container := range ds.Spec.Template.Spec.Containers {
+		_, found := findEnvVar(container.Env, name)
+		assert.False(t, found, fmt.Sprintf("container %q should not set env var %q", container.Name, name))
+	}
+	for _, initContainer := range ds.Spec.Template.Spec.InitContainers {
+		_, found := findEnvVar(initContainer.Env, name)
+		assert.False(t, found, fmt.Sprintf("init container %q should not set env var %q", initContainer.Name, name))
+	}
 }
 
 // verifyAutopilotWorkloadAllowlistConstraints checks that the rendered DaemonSet

--- a/test/datadog/gke_autopilot_workloadallowlist_test.go
+++ b/test/datadog/gke_autopilot_workloadallowlist_test.go
@@ -85,6 +85,7 @@ func Test_autopilotWorkloadAllowlistConfigs(t *testing.T) {
 				var ds appsv1.DaemonSet
 				common.Unmarshal(t, manifest, &ds)
 				requireContainerNames(t, ds, "agent", "system-probe")
+				requireHostPathVolume(t, ds, "dsdsocket", "/var/run/datadog")
 				verifyAutopilotWorkloadAllowlistConstraints(t, manifest)
 			},
 		},
@@ -108,6 +109,7 @@ func Test_autopilotWorkloadAllowlistConfigs(t *testing.T) {
 				var ds appsv1.DaemonSet
 				common.Unmarshal(t, manifest, &ds)
 				requireContainerNames(t, ds, "agent", "system-probe", "agent-data-plane")
+				requireHostPathVolume(t, ds, "dsdsocket", "/var/run/datadog")
 				verifyAutopilotWorkloadAllowlistConstraints(t, manifest)
 			},
 		},
@@ -135,6 +137,7 @@ func Test_autopilotWorkloadAllowlistConfigs(t *testing.T) {
 				var ds appsv1.DaemonSet
 				common.Unmarshal(t, manifest, &ds)
 				requireContainerNames(t, ds, "agent", "process-agent", "system-probe")
+				requireHostPathVolume(t, ds, "dsdsocket", "/var/run/datadog")
 				verifyAutopilotWorkloadAllowlistConstraints(t, manifest)
 			},
 		},
@@ -222,6 +225,32 @@ func requireContainerNames(t *testing.T, ds appsv1.DaemonSet, expected ...string
 	}
 	assert.Equal(t, len(expected), len(names),
 		fmt.Sprintf("unexpected containers present: %v", names))
+}
+
+func requireHostPathVolume(t *testing.T, ds appsv1.DaemonSet, name, path string) {
+	t.Helper()
+	for _, volume := range ds.Spec.Template.Spec.Volumes {
+		if volume.Name != name {
+			continue
+		}
+		if assert.NotNil(t, volume.HostPath, fmt.Sprintf("expected volume %q to be a hostPath", name)) {
+			assert.Equal(t, path, volume.HostPath.Path)
+		}
+		return
+	}
+	assert.Fail(t, fmt.Sprintf("expected volume %q to be present", name))
+}
+
+func requireEmptyDirVolume(t *testing.T, ds appsv1.DaemonSet, name string) {
+	t.Helper()
+	for _, volume := range ds.Spec.Template.Spec.Volumes {
+		if volume.Name != name {
+			continue
+		}
+		assert.NotNil(t, volume.EmptyDir, fmt.Sprintf("expected volume %q to be an emptyDir", name))
+		return
+	}
+	assert.Fail(t, fmt.Sprintf("expected volume %q to be present", name))
 }
 
 // verifyAutopilotWorkloadAllowlistConstraints checks that the rendered DaemonSet

--- a/test/datadog/gke_gdc_test.go
+++ b/test/datadog/gke_gdc_test.go
@@ -64,6 +64,7 @@ func verifyDaemonsetGDCConstraints(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(ds.Spec.Template.Spec.Containers), "GDC only supports the core agent container")
 
 	volumeNames := common.GetVolumeNames(ds)
+	assert.False(t, common.Contains("dsdsocket", volumeNames), "GDC should not mount the DogStatsD socket volume")
 
 	for _, volume := range ds.Spec.Template.Spec.Volumes {
 		if volume.HostPath != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

Omit the DogStatsD Unix socket configuration from Datadog Agent DaemonSet containers on GKE Autopilot when the Datadog CSI driver is disabled.

Without the CSI driver, the chart should not render the `dsdsocket` volume, its mounts, or `DD_DOGSTATSD_SOCKET`. Otherwise the Agent is configured to create `/var/run/datadog/dsd.socket` while running with a read-only root filesystem and no writable socket directory. In that Autopilot configuration, DogStatsD should use the existing UDP port instead of Unix Domain Socket.

This PR:
- Adds `should-render-dsd-socket-volume` and uses it consistently for the DogStatsD socket volume, mounts, and env vars.
- Keeps GDC and Windows behavior omitting the DogStatsD socket volume.
- Updates the GKE Autopilot NOTES warning for non-CSI socket usage.
- Refreshes the GKE Autopilot baseline manifests and adds tests that assert `dsdsocket` and `DD_DOGSTATSD_SOCKET` are omitted in the affected Autopilot DaemonSets.

#### Which issue this PR fixes

TON-612

#### Special notes for your reviewer:

Validation run locally:

```sh
go test -C test ./datadog -run 'Test_autopilot(WorkloadAllowlist|AllowlistedV2Workload)' -count=1
go test -C test ./datadog -run 'Test_baseline_inputs/gke_autopilot' -count=1
go test -C test ./datadog -run 'Test_gdcConfigs' -count=1
git diff --check
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
