### PR TITLE
Grant asm-go MQ access

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -18,6 +18,7 @@ github_teams_restrictions:
   - profiling-full-host
   - injection-platform
   - containers-tee
+  - asm-go
 github_users_restrictions:
   - cahillsf
   - clamoriniere


### PR DESCRIPTION
#### What this PR does / why we need it:

Grants the `asm-go` GitHub team access to the merge queue by adding it to `github_teams_restrictions` in `repository.datadog.yml`.

Mirrors #2701 (which granted `containers-tee` MQ access).

#### Special notes for your reviewer:

Config-only change to `repository.datadog.yml` (merge queue restrictions). No chart code or values are modified, so no version bump, test baseline update, helm-docs, or `CHANGELOG.md` entry is required.

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
