### PR TITLE
[datadog] Add backends RBAC for Envoy Gateway AppSec UDS sidecar mode

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.223.4
+
+* Grant the Cluster Agent `backends` (`gateway.envoyproxy.io`) RBAC permissions (`get`, `create`, `delete`) when `datadog.appsec.injector.enabled` is set. This is required for the Envoy Gateway App & API Protection (AppSec) UDS sidecar mode, which creates and deletes a `Backend` resource for the ext_proc endpoint.
+
 ## 3.223.3
 
 * Bump the default App & API Protection (AppSec) sidecar processor image tag (`datadog.appsec.injector.sidecar.imageTag`) from `v2.6.0` to `v2.8.2`.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.223.3
+version: 3.223.4
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.223.3](https://img.shields.io/badge/Version-3.223.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.223.4](https://img.shields.io/badge/Version-3.223.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -293,6 +293,7 @@ rules:
     - "gateway.envoyproxy.io"
   resources:
     - envoyextensionpolicies
+    - backends
   verbs:
     - get
     - delete

--- a/test/datadog/appsec_injector_test.go
+++ b/test/datadog/appsec_injector_test.go
@@ -227,6 +227,87 @@ func Test_AppSecInjector_RBAC_IncludesIstioGatewaysRule(t *testing.T) {
 	assert.True(t, hasGatewaysRule, "expected networking.istio.io/gateways rule")
 }
 
+func Test_AppSecInjector_RBAC_IncludesEnvoyGatewayBackendsRule(t *testing.T) {
+	manifest, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/cluster-agent-rbac.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"datadog.apiKeyExistingSecret":    "datadog-secret",
+			"datadog.appKeyExistingSecret":    "datadog-secret",
+			"datadog.appsec.injector.enabled": "true",
+		},
+	})
+	require.NoError(t, err, "failed to render cluster-agent-rbac.yaml")
+
+	var clusterRole rbacv1.ClusterRole
+	for _, doc := range strings.Split(manifest, "---") {
+		if strings.Contains(doc, "kind: ClusterRole") && strings.Contains(doc, "name: datadog-cluster-agent\n") {
+			common.Unmarshal(t, doc, &clusterRole)
+			break
+		}
+	}
+	require.NotEmpty(t, clusterRole.Rules, "cluster-agent ClusterRole should have rules")
+
+	var hasEnvoyExtensionPoliciesRule, hasBackendsRule bool
+	for _, rule := range clusterRole.Rules {
+		isEnvoyGatewayGroup := false
+		for _, apiGroup := range rule.APIGroups {
+			if apiGroup == "gateway.envoyproxy.io" {
+				isEnvoyGatewayGroup = true
+			}
+		}
+		if !isEnvoyGatewayGroup {
+			continue
+		}
+		for _, resource := range rule.Resources {
+			switch resource {
+			case "envoyextensionpolicies":
+				hasEnvoyExtensionPoliciesRule = true
+				assert.ElementsMatch(t, []string{"get", "delete", "create"}, rule.Verbs,
+					"gateway.envoyproxy.io/envoyextensionpolicies rule should have get/delete/create verbs")
+			case "backends":
+				hasBackendsRule = true
+				assert.ElementsMatch(t, []string{"get", "delete", "create"}, rule.Verbs,
+					"gateway.envoyproxy.io/backends rule should have get/delete/create verbs")
+			}
+		}
+	}
+	assert.True(t, hasEnvoyExtensionPoliciesRule, "expected gateway.envoyproxy.io/envoyextensionpolicies rule")
+	assert.True(t, hasBackendsRule, "expected gateway.envoyproxy.io/backends rule for Envoy Gateway UDS sidecar mode")
+}
+
+func Test_AppSecInjector_RBAC_Disabled_OmitsEnvoyGatewayRule(t *testing.T) {
+	manifest, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/cluster-agent-rbac.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"datadog.apiKeyExistingSecret": "datadog-secret",
+			"datadog.appKeyExistingSecret": "datadog-secret",
+		},
+	})
+	require.NoError(t, err, "failed to render cluster-agent-rbac.yaml")
+
+	var clusterRole rbacv1.ClusterRole
+	for _, doc := range strings.Split(manifest, "---") {
+		if strings.Contains(doc, "kind: ClusterRole") && strings.Contains(doc, "name: datadog-cluster-agent\n") {
+			common.Unmarshal(t, doc, &clusterRole)
+			break
+		}
+	}
+	require.NotEmpty(t, clusterRole.Rules, "cluster-agent ClusterRole should have rules")
+
+	for _, rule := range clusterRole.Rules {
+		for _, apiGroup := range rule.APIGroups {
+			assert.NotEqual(t, "gateway.envoyproxy.io", apiGroup,
+				"should not have gateway.envoyproxy.io rule when AppSec injector is disabled")
+		}
+	}
+}
+
 func Test_AppSecInjector_RBAC_IncludesNginxRules(t *testing.T) {
 	manifest, err := common.RenderChart(t, common.HelmCommand{
 		ReleaseName: "datadog",


### PR DESCRIPTION
#### What this PR does / why we need it:

A new feature in `datadog-agent` ([DataDog/datadog-agent#52348](https://github.com/DataDog/datadog-agent/pull/52348)) lets the Cluster Agent run Envoy Gateway App & API Protection (AppSec) in **sidecar mode over a Unix Domain Socket (UDS)**. In this mode the controller creates and deletes a **`Backend` (`gateway.envoyproxy.io`)** resource (the UDS ext_proc endpoint) in addition to the `EnvoyExtensionPolicy` it already manages.

The `datadog.appsec.injector.enabled` RBAC block in `charts/datadog/templates/cluster-agent-rbac.yaml` granted `envoyextensionpolicies` under `gateway.envoyproxy.io` but **not `backends`**. As a result, with `datadog.appsec.injector.mode: sidecar` the Cluster Agent failed with:

```
backends.gateway.envoyproxy.io is forbidden: User "system:serviceaccount:datadog:datadog-cluster-agent" cannot create resource "backends" in API group "gateway.envoyproxy.io"
```

This PR adds `backends` (verbs `get`, `create`, `delete`) to the existing `gateway.envoyproxy.io` rule. `envoyextensionpolicies` and `backends` share the same verb set, so they are merged into a single rule.

No values-surface change: this is gated by the already-existing `datadog.appsec.injector.enabled` toggle and is needed whenever `datadog.appsec.injector.mode: sidecar` is used with the `envoy-gateway` proxy.

#### Special notes for your reviewer:

- **No baseline manifest diff.** `make update-test-baselines-datadog-agent` produces no changes because no baseline values fixture sets `datadog.appsec.injector.enabled: true`. (The `envoyextensionpolicies` rule that appears in baselines comes from the `datadog-operator` subchart's ClusterRole, not this block.) RBAC rendering for the injector is instead covered by unit tests in `test/datadog/appsec_injector_test.go`.
- Added `Test_AppSecInjector_RBAC_IncludesEnvoyGatewayBackendsRule` (asserts `envoyextensionpolicies` + `backends` with `get/delete/create`) and `Test_AppSecInjector_RBAC_Disabled_OmitsEnvoyGatewayRule`.
- Version bumped as a **patch** (`3.223.3` → `3.223.4`): this fixes the existing injector feature with no new value surface. Reviewers preferring a minor bump can relabel.
- A self-contained reference ClusterRole/Binding lives in the agent repo at `pkg/clusteragent/appsec/envoygateway/testdata/sidecar-uds/00-rbac.yaml`.
- Behavior note: an AppSec-enabled Envoy Gateway now defaults to `sidecar` injection; `external` mode (Service + ReferenceGrant) keeps the prior behavior and does not need the `backends` rule.

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (`datadog/patch-version`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`) — ran `make update-test-baselines-datadog-agent`; no baseline diff (see notes above)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs — not applicable (no values changes)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md` — not applicable (no values changes)

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
