### PR TITLE
fix(otel-agent): use unique otelconfPath on Windows to avoid duplicate volumeMount

### DIFF
--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -474,7 +474,7 @@ Return agent config path
 /etc/otel-agent
 {{- end -}}
 {{- if eq .Values.targetSystem "windows" -}}
-C:/ProgramData/Datadog
+C:/ProgramData/Datadog/otel-agent
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## What does this PR do?

Fixes the `datadog.otelconfPath` Helm template to use a unique directory on Windows (`C:/ProgramData/Datadog/otel-agent`) instead of the same path as `datadog.confPath` (`C:/ProgramData/Datadog`).

## Motivation

When `datadog.otelCollector.enabled=true` with `targetSystem=windows`, the rendered DaemonSet has two volumeMounts on the otel-agent container pointing to the same `mountPath`:

```yaml
volumeMounts:
  - name: config
    mountPath: C:/ProgramData/Datadog    # from datadog.confPath
  - name: otelconfig
    mountPath: C:/ProgramData/Datadog    # from datadog.otelconfPath — DUPLICATE
```

Kubernetes rejects this:
```
The DaemonSet "datadog-agent-windows" is invalid:
spec.template.spec.containers[3].volumeMounts[3].mountPath:
Invalid value: "C:/ProgramData/Datadog": must be unique
```

This makes it impossible to deploy DDOT on Windows via the Helm chart.

## Reproducer

```bash
helm template test datadog/datadog \
  --set targetSystem=windows \
  --set 'datadog.otelCollector.enabled=true' \
  --set 'datadog.apiKeyExistingSecret=x' | \
  kubectl apply --dry-run=server -f -
```

## The fix

On Linux, these paths are already distinct (`/etc/datadog-agent` vs `/etc/otel-agent`). This PR applies the same pattern on Windows:

| Template | Before | After |
|---|---|---|
| `datadog.confPath` (windows) | `C:/ProgramData/Datadog` | unchanged |
| `datadog.otelconfPath` (windows) | `C:/ProgramData/Datadog` | `C:/ProgramData/Datadog/otel-agent` |