### PR TITLE
[CONTP-1612] Add untaintToleration opt in option

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.227.0
+
+* Add `agents.untaintToleration.enabled` (default `false`). When enabled, the node Agent DaemonSet tolerates the `agent.datadoghq.com/not-ready=presence:NoSchedule` startup taint, letting the Agent schedule on nodes held by the Datadog Operator untaint controller until the Agent is ready. Use this on Helm-managed clusters where the operator is not managing the Agent.
+
 ## 3.226.0
 
 * Add `agents.containers.agent.command` value to override the default `agent run` entrypoint of the agent container. When unset, the agent container continues to run `agent run` as before. Setting this value on GKE Autopilot or GDC is rejected at template render time to avoid breaking the Datadog WorkloadAllowlist constraint.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.226.0
+version: 3.227.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.226.0](https://img.shields.io/badge/Version-3.226.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.227.0](https://img.shields.io/badge/Version-3.227.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -588,6 +588,7 @@ helm install <RELEASE_NAME> \
 | agents.shareProcessNamespace | bool | `false` | Set the process namespace sharing on the Datadog Daemonset |
 | agents.terminationGracePeriodSeconds | int | `nil` | Configure the termination grace period for the Agent |
 | agents.tolerations | list | `[]` | Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes >= 1.6) |
+| agents.untaintToleration.enabled | bool | `false` | Add a toleration for the startup taint `agent.datadoghq.com/not-ready=presence:NoSchedule` so the Agent can schedule on nodes managed by the Datadog Operator untaint controller |
 | agents.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":"10%"},"type":"RollingUpdate"}` | Allow the DaemonSet to perform a rolling update on helm update |
 | agents.useConfigMap | string | `nil` | Configures a configmap to provide the agent configuration. Use this in combination with the `agents.customAgentConfig` parameter. |
 | agents.useHostNetwork | bool | `false` | Bind ports on the hostNetwork |

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -263,6 +263,12 @@ spec:
         value: windows
         operator: Equal
       {{- end }}
+      {{- if .Values.agents.untaintToleration.enabled }}
+      - key: agent.datadoghq.com/not-ready
+        operator: Equal
+        value: presence
+        effect: NoSchedule
+      {{- end }}
       {{- if .Values.agents.tolerations }}
 {{ toYaml .Values.agents.tolerations | indent 6 }}
       {{- end }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2713,6 +2713,10 @@ agents:
   # agents.tolerations -- Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes >= 1.6)
   tolerations: []
 
+  untaintToleration:
+    # agents.untaintToleration.enabled -- Add a toleration for the startup taint `agent.datadoghq.com/not-ready=presence:NoSchedule` so the Agent can schedule on nodes managed by the Datadog Operator untaint controller
+    enabled: false
+
   # agents.nodeSelector -- Allow the DaemonSet to schedule on selected nodes
 
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/test/datadog/untaint_toleration_test.go
+++ b/test/datadog/untaint_toleration_test.go
@@ -1,0 +1,121 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/helm-charts/test/common"
+)
+
+// untaintToleration is the toleration the chart must inject so the node Agent
+// can schedule on nodes carrying the Datadog Operator untaint controller's
+// startup taint agent.datadoghq.com/not-ready=presence:NoSchedule.
+var untaintToleration = corev1.Toleration{
+	Key:      "agent.datadoghq.com/not-ready",
+	Operator: corev1.TolerationOpEqual,
+	Value:    "presence",
+	Effect:   corev1.TaintEffectNoSchedule,
+}
+
+func Test_untaintToleration(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    common.HelmCommand
+		assertions func(t *testing.T, manifest string)
+	}{
+		{
+			name: "disabled by default -- toleration absent",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret": "datadog-secret",
+					"datadog.appKeyExistingSecret": "datadog-secret",
+				},
+			},
+			assertions: verifyUntaintTolerationAbsent,
+		},
+		{
+			name: "enabled -- toleration injected",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":     "datadog-secret",
+					"datadog.appKeyExistingSecret":     "datadog-secret",
+					"agents.untaintToleration.enabled": "true",
+				},
+			},
+			assertions: verifyUntaintTolerationPresent,
+		},
+		{
+			name: "enabled alongside user tolerations -- both present",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":     "datadog-secret",
+					"datadog.appKeyExistingSecret":     "datadog-secret",
+					"agents.untaintToleration.enabled": "true",
+					"agents.tolerations[0].key":        "dedicated",
+					"agents.tolerations[0].operator":   "Exists",
+					"agents.tolerations[0].effect":     "NoSchedule",
+				},
+			},
+			assertions: verifyUntaintTolerationWithUserToleration,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := common.RenderChart(t, tt.command)
+			assert.Nil(t, err, "couldn't render template")
+			tt.assertions(t, manifest)
+		})
+	}
+}
+
+func hasToleration(tolerations []corev1.Toleration, want corev1.Toleration) bool {
+	for _, tol := range tolerations {
+		if tol == want {
+			return true
+		}
+	}
+	return false
+}
+
+func verifyUntaintTolerationAbsent(t *testing.T, manifest string) {
+	var ds appsv1.DaemonSet
+	common.Unmarshal(t, manifest, &ds)
+	assert.False(t, hasToleration(ds.Spec.Template.Spec.Tolerations, untaintToleration),
+		"untaint toleration must not be present when agents.untaintToleration.enabled is false")
+}
+
+func verifyUntaintTolerationPresent(t *testing.T, manifest string) {
+	var ds appsv1.DaemonSet
+	common.Unmarshal(t, manifest, &ds)
+	assert.True(t, hasToleration(ds.Spec.Template.Spec.Tolerations, untaintToleration),
+		"untaint toleration must be injected when agents.untaintToleration.enabled is true")
+}
+
+func verifyUntaintTolerationWithUserToleration(t *testing.T, manifest string) {
+	var ds appsv1.DaemonSet
+	common.Unmarshal(t, manifest, &ds)
+	tolerations := ds.Spec.Template.Spec.Tolerations
+	assert.True(t, hasToleration(tolerations, untaintToleration),
+		"untaint toleration must be injected")
+	assert.True(t, hasToleration(tolerations, corev1.Toleration{
+		Key:      "dedicated",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}), "user-provided agents.tolerations must be preserved alongside the untaint toleration")
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

For Helm-managed clusters (agent installed via charts/datadog, no operator managing the agent), users need to opt the agent into tolerating the startup taint so it can schedule on tainted nodes. The untaint controller's pod label selector already works for Helm-managed agents — charts/datadog uses agent.datadoghq.com/component: agent on the node agent DaemonSet — so no label change is needed, only the toleration.

In this PR, we:
- Add `agents.untaintToleration.enabled` value (default false) to values.yaml
- Inject the toleration into the agent `DaemonSet` template when enabled
- Add Helm unit test verifying the toleration appears in the rendered `DaemonSet`

#### Testing

Added unit test

Manual testing:

Deploy the agent using helm chart with the added option enabled. Ensure the toleration is added properly:

Deployed agent with:
```
agents:
  enabled: true
  untaintToleration:
    enabled: true
```

Checked that the toleration was properly added:
```
      tolerations:
      - effect: NoSchedule
        key: agent.datadoghq.com/not-ready
        operator: Equal
        value: presence
```

#### Special notes for your reviewer:

The CSI driver may also need a similar change, but since CSI is usually used as a subchart (dependency of the agent chart), and the user can already set tolerations manually on the CSI by editing `datadog_csi_driver` section in datadog values.yaml, I am keeping it for a future PR to asses if it is worth adding a separate config option for CSI or not. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits