### PR TITLE
[PROF-15238] Seccomp toggle for Host Profiler

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.231.0
+
+* [PROF-15238] Seccomp toggle for Host Profiler ([#2755](https://github.com/DataDog/helm-charts/pull/2755)).
+
 ## 3.230.1
 
 * Update `fips.image.tag` to `1.1.28` fixing CVEs and updating packages.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.230.1
+version: 3.231.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.230.1](https://img.shields.io/badge/Version-3.230.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.231.0](https://img.shields.io/badge/Version-3.231.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.231.0](https://img.shields.io/badge/Version-3.231.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.230.1](https://img.shields.io/badge/Version-3.230.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.230.1](https://img.shields.io/badge/Version-3.230.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.231.0](https://img.shields.io/badge/Version-3.231.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -852,6 +852,8 @@ helm install <RELEASE_NAME> \
 | datadog.hostProfiler.enabled | bool | `false` | Enable the Host Profiler. This feature is experimental and subject to change. |
 | datadog.hostProfiler.image | string | `""` | Image the Host Profiler. This parameter is experimental and will be removed once official image is available. |
 | datadog.hostProfiler.imagePullPolicy | string | `""` | Pull policy for the Host Profiler image. Defaults to agents.image.pullPolicy when unset. |
+| datadog.hostProfiler.seccomp | object | `{"enabled":true}` | Seccomp profile configuration for the Host Profiler |
+| datadog.hostProfiler.seccomp.enabled | bool | `true` | Apply the localhost seccomp profile to the host-profiler container and run the init container that installs it on the node. Disable to run the host-profiler container Unconfined (no init container, no profile installed on the node). |
 | datadog.hostProfiler.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.ignoreAutoConfig | list | `[]` | List of integration to ignore auto_conf.yaml. |

--- a/charts/datadog/templates/_container-host-profiler.yaml
+++ b/charts/datadog/templates/_container-host-profiler.yaml
@@ -9,7 +9,7 @@
   command:
     - "host-profiler"
     - "--core-config={{ template "datadog.confPath" .  }}/datadog.yaml"
-{{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.hostProfiler.securityContext "targetSystem" .Values.targetSystem "seccomp" (printf "localhost/%s" (include "host-profiler-seccomp-name" .)) "kubeversion" .Capabilities.KubeVersion.Version "apparmor" (and .Values.agents.podSecurity.apparmor.enabled .Values.datadog.hostProfiler.apparmor)) | nindent 2 }}
+{{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.hostProfiler.securityContext "targetSystem" .Values.targetSystem "seccomp" (ternary (printf "localhost/%s" (include "host-profiler-seccomp-name" .)) "" (eq (include "should-enable-host-profiler-seccomp" .) "true")) "kubeversion" .Capabilities.KubeVersion.Version "apparmor" (and .Values.agents.podSecurity.apparmor.enabled .Values.datadog.hostProfiler.apparmor)) | nindent 2 }}
   resources:
 {{ toYaml .Values.agents.containers.hostProfiler.resources | indent 4 }}
 {{- if or .Values.datadog.envFrom .Values.agents.containers.hostProfiler.envFrom }}

--- a/charts/datadog/templates/_container-host-profiler.yaml
+++ b/charts/datadog/templates/_container-host-profiler.yaml
@@ -9,7 +9,7 @@
   command:
     - "host-profiler"
     - "--core-config={{ template "datadog.confPath" .  }}/datadog.yaml"
-{{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.hostProfiler.securityContext "targetSystem" .Values.targetSystem "seccomp" (ternary (printf "localhost/%s" (include "host-profiler-seccomp-name" .)) "" (eq (include "should-enable-host-profiler-seccomp" .) "true")) "kubeversion" .Capabilities.KubeVersion.Version "apparmor" (and .Values.agents.podSecurity.apparmor.enabled .Values.datadog.hostProfiler.apparmor)) | nindent 2 }}
+{{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.hostProfiler.securityContext "targetSystem" .Values.targetSystem "seccomp" (include "host-profiler-seccomp-profile" .) "kubeversion" .Capabilities.KubeVersion.Version "apparmor" (and .Values.agents.podSecurity.apparmor.enabled .Values.datadog.hostProfiler.apparmor)) | nindent 2 }}
   resources:
 {{ toYaml .Values.agents.containers.hostProfiler.resources | indent 4 }}
 {{- if or .Values.datadog.envFrom .Values.agents.containers.hostProfiler.envFrom }}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -76,7 +76,7 @@
     type: DirectoryOrCreate
   name: apmsocket
 {{- end }}
-{{- if eq (include "should-enable-host-profiler" .) "true" }}
+{{- if eq (include "should-enable-host-profiler-seccomp" .) "true" }}
 - hostPath:
     path: {{ .Values.datadog.hostProfiler.seccompRoot }}
   name: host-profiler-seccomp-root

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -284,6 +284,19 @@ false
 {{- end -}}
 
 {{/*
+Return the seccomp profile to apply to the host-profiler container: the hashed localhost
+profile when seccomp is enabled, otherwise "unconfined" so the container runs without a
+seccomp profile.
+*/}}
+{{- define "host-profiler-seccomp-profile" -}}
+{{- if eq (include "should-enable-host-profiler-seccomp" .) "true" -}}
+localhost/{{ include "host-profiler-seccomp-name" . }}
+{{- else -}}
+unconfined
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the seccomp profile filename for the host-profiler, scoped to the image ref
 to avoid races when multiple host-profiler versions coexist on the same node.
 */}}

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -271,6 +271,19 @@ false
 {{- end -}}
 
 {{/*
+Return true if the host-profiler seccomp profile (and its setup init container) should be
+applied. Requires the host-profiler to be enabled and the seccomp toggle to not be disabled
+(defaults to enabled).
+*/}}
+{{- define "should-enable-host-profiler-seccomp" -}}
+{{- if and (eq (include "should-enable-host-profiler" .) "true") (ne (toString .Values.datadog.hostProfiler.seccomp.enabled) "false") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the seccomp profile filename for the host-profiler, scoped to the image ref
 to avoid races when multiple host-profiler versions coexist on the same node.
 */}}

--- a/charts/datadog/templates/agent-scc.yaml
+++ b/charts/datadog/templates/agent-scc.yaml
@@ -29,7 +29,7 @@ seLinuxContext:
 # system-probe requires some specific seccomp and capabilities
 seccompProfiles:
 {{ toYaml .Values.agents.podSecurity.seccompProfiles | indent 2 }}
-{{- if eq (include "should-enable-host-profiler" .) "true" }}
+{{- if eq (include "should-enable-host-profiler-seccomp" .) "true" }}
   - "localhost/{{ include "host-profiler-seccomp-name" . }}"
 {{- end }}
 allowedCapabilities:

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -182,7 +182,7 @@ spec:
         {{- if eq .Values.targetSystem "linux" }}
           {{- include "containers-init-linux" . | nindent 6 -}}
         {{- end }}
-        {{- if eq (include "should-enable-host-profiler" .) "true" }}
+        {{- if eq (include "should-enable-host-profiler-seccomp" .) "true" }}
           {{ include "host-profiler-seccomp-init" . | nindent 6 }}
         {{- end }}
         {{- if and (eq (include "should-enable-system-probe" .) "true")  (eq .Values.datadog.systemProbe.seccomp "localhost/system-probe") }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -813,7 +813,7 @@ datadog:
     imagePullPolicy: ""
     # datadog.hostProfiler.seccomp -- Seccomp profile configuration for the Host Profiler
     seccomp:
-      # datadog.hostProfiler.seccomp.enabled -- Apply the localhost seccomp profile to the host-profiler container and run the init container that installs it on the node. Disable to run without a seccomp profile.
+      # datadog.hostProfiler.seccomp.enabled -- Apply the localhost seccomp profile to the host-profiler container and run the init container that installs it on the node. Disable to run the host-profiler container Unconfined (no init container, no profile installed on the node).
       enabled: true
     # datadog.hostProfiler.seccompRoot -- Specify the seccomp profile root directory
     seccompRoot: /var/lib/kubelet/seccomp

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -811,6 +811,10 @@ datadog:
     image: ""
     # datadog.hostProfiler.imagePullPolicy -- Pull policy for the Host Profiler image. Defaults to agents.image.pullPolicy when unset.
     imagePullPolicy: ""
+    # datadog.hostProfiler.seccomp -- Seccomp profile configuration for the Host Profiler
+    seccomp:
+      # datadog.hostProfiler.seccomp.enabled -- Apply the localhost seccomp profile to the host-profiler container and run the init container that installs it on the node. Disable to run without a seccomp profile.
+      enabled: true
     # datadog.hostProfiler.seccompRoot -- Specify the seccomp profile root directory
     seccompRoot: /var/lib/kubelet/seccomp
     # datadog.hostProfiler.apparmor -- Specify an AppArmor profile for the host-profiler container (e.g. "localhost/datadog-host-profiler").

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -45,12 +45,25 @@ func TestHostProfilerSeccomp(t *testing.T) {
 	profileRef := *hpContainer.SecurityContext.SeccompProfile.LocalhostProfile
 	assert.Regexp(t, `^host-profiler-[0-9a-f]{8}$`, profileRef)
 
+	// seccomp-root volume must be present.
+	var seccompVolume *corev1.Volume
+	for i := range ds.Spec.Template.Spec.Volumes {
+		if ds.Spec.Template.Spec.Volumes[i].Name == "host-profiler-seccomp-root" {
+			seccompVolume = &ds.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, seccompVolume, "host-profiler-seccomp-root volume should be present when seccomp is enabled")
+	require.NotNil(t, seccompVolume.HostPath, "host-profiler-seccomp-root volume should be a hostPath volume")
+	assert.Equal(t, "/var/lib/kubelet/seccomp", seccompVolume.HostPath.Path)
+
 	// Init container copies to the matching hashed filename.
 	initContainer, ok := getContainer(t, ds.Spec.Template.Spec.InitContainers, "host-profiler-seccomp-setup")
-	require.True(t, ok, "host-profiler-seccomp-setup init container should be present")
+	require.True(t, ok, "host-profiler-seccomp-setup init container should be present when seccomp is enabled")
 	assert.Equal(t, "myreg/host-profiler:v1.2.3", initContainer.Image)
 	assert.True(t, containsString(initContainer.Command, "/host/var/lib/kubelet/seccomp/"+profileRef),
 		"init container cp destination should match the seccomp profile name; command: %v", initContainer.Command)
+
 }
 
 func TestHostProfilerSeccompDisabled(t *testing.T) {

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -53,6 +53,30 @@ func TestHostProfilerSeccomp(t *testing.T) {
 		"init container cp destination should match the seccomp profile name; command: %v", initContainer.Command)
 }
 
+func TestHostProfilerSeccompDisabled(t *testing.T) {
+	overrides := copyMap(hostProfilerBaseOverrides)
+	overrides["datadog.hostProfiler.seccomp.enabled"] = "false"
+
+	ds := renderHostProfilerDaemonSet(t, overrides)
+
+	// Container must not carry a seccomp profile, but other hardening still applies.
+	hpContainer, ok := getContainer(t, ds.Spec.Template.Spec.Containers, "host-profiler")
+	require.True(t, ok, "host-profiler container should be present")
+	require.NotNil(t, hpContainer.SecurityContext)
+	assert.Nil(t, hpContainer.SecurityContext.SeccompProfile,
+		"host-profiler should have no seccomp profile when datadog.hostProfiler.seccomp.enabled=false")
+
+	// Seccomp setup init container must be absent.
+	_, ok = getContainer(t, ds.Spec.Template.Spec.InitContainers, "host-profiler-seccomp-setup")
+	assert.False(t, ok, "host-profiler-seccomp-setup init container should be absent when seccomp is disabled")
+
+	// seccomp-root volume must be absent.
+	for _, v := range ds.Spec.Template.Spec.Volumes {
+		assert.NotEqual(t, "host-profiler-seccomp-root", v.Name,
+			"host-profiler-seccomp-root volume should be absent when seccomp is disabled")
+	}
+}
+
 func TestHostProfilerSeccompDifferentImages(t *testing.T) {
 	overridesV1 := copyMap(hostProfilerBaseOverrides)
 	overridesV2 := copyMap(hostProfilerBaseOverrides)

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -72,12 +72,16 @@ func TestHostProfilerSeccompDisabled(t *testing.T) {
 
 	ds := renderHostProfilerDaemonSet(t, overrides)
 
-	// Container must not carry a seccomp profile, but other hardening still applies.
+	// Container must run Unconfined, but other hardening still applies.
 	hpContainer, ok := getContainer(t, ds.Spec.Template.Spec.Containers, "host-profiler")
 	require.True(t, ok, "host-profiler container should be present")
 	require.NotNil(t, hpContainer.SecurityContext)
-	assert.Nil(t, hpContainer.SecurityContext.SeccompProfile,
-		"host-profiler should have no seccomp profile when datadog.hostProfiler.seccomp.enabled=false")
+	require.NotNil(t, hpContainer.SecurityContext.SeccompProfile,
+		"host-profiler should carry a seccomp profile when datadog.hostProfiler.seccomp.enabled=false")
+	assert.Equal(t, corev1.SeccompProfileTypeUnconfined, hpContainer.SecurityContext.SeccompProfile.Type,
+		"host-profiler should run Unconfined when datadog.hostProfiler.seccomp.enabled=false")
+	assert.Nil(t, hpContainer.SecurityContext.SeccompProfile.LocalhostProfile,
+		"Unconfined profile should not reference a localhost profile")
 
 	// Seccomp setup init container must be absent.
 	_, ok = getContainer(t, ds.Spec.Template.Spec.InitContainers, "host-profiler-seccomp-setup")


### PR DESCRIPTION
#### What this PR does / why we need it:

Add a setting to toggle off the seccomp initContainer and enablement for Host Profiler to allow users to run the profiler unprivileged without the seccomp


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits