### PR TITLE
Update CloudPrem Helm chart to 0.4.3

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Add global `volumes` and `volumeMounts` values that apply to all components, merged with the existing per-component `extraVolumes`/`extraVolumeMounts`.
+* Add global `topologySpreadConstraints` applied to all workload pods and merged with per-component topology spread constraints.
+* Merge upstream Quickwit Helm chart version 0.8.5.
+
 ## 0.4.2
 
 * Update Docker image to `v0.1.29`.

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -4,7 +4,7 @@ description: Datadog CloudPrem
 type: application
 version: 0.4.2
 # This is the version of the "application". Right now, we follow the image version.
-appVersion: v0.1.29
+appVersion: v0.1.30
 home: https://www.datadoghq.com/
 icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 maintainers:

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.29](https://img.shields.io/badge/AppVersion-v0.1.29-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.30](https://img.shields.io/badge/AppVersion-v0.1.30-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/templates/_helpers.tpl
+++ b/charts/cloudprem/templates/_helpers.tpl
@@ -184,7 +184,10 @@ Quickwit ports
   protocol: UDP
 - name: cloudprem
   containerPort: 7283
-  protocol:  TCP
+  protocol: TCP
+- name: health
+  containerPort: 7284
+  protocol: TCP
 {{- end }}
 
 

--- a/charts/cloudprem/templates/control-plane-deployment.yaml
+++ b/charts/cloudprem/templates/control-plane-deployment.yaml
@@ -93,7 +93,7 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
             {{- end }}
-            {{- with .Values.control_plane.extraVolumeMounts }}
+            {{- with concat (.Values.volumeMounts | default list) (.Values.control_plane.extraVolumeMounts | default list) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
@@ -112,23 +112,24 @@ spec:
           configMap:
             name: {{ .name }}
         {{- end }}
-        {{- with .Values.control_plane.extraVolumes }}
+        {{- with concat (.Values.volumes | default list) (.Values.control_plane.extraVolumes | default list) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.control_plane.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.control_plane.affinity .Values.affinity }}
+      {{- with merge (dict) (.Values.control_plane.affinity | default dict) (.Values.affinity | default dict) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := concat .Values.tolerations .Values.control_plane.tolerations | compact | uniq }}
+      {{- $tolerations := concat (.Values.tolerations | default list) (.Values.control_plane.tolerations | default list) | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
-      {{- with .Values.control_plane.topologySpreadConstraints }}
+      {{- $tsc := concat (.Values.topologySpreadConstraints | default list) (.Values.control_plane.topologySpreadConstraints | default list) | compact }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml $tsc | nindent 8 }}
       {{- end }}
       {{- if .Values.control_plane.runtimeClassName }}
       runtimeClassName: {{ .Values.control_plane.runtimeClassName | quote }}

--- a/charts/cloudprem/templates/indexer-statefulset.yaml
+++ b/charts/cloudprem/templates/indexer-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
             {{- end }}
-            {{- with .Values.indexer.extraVolumeMounts }}
+            {{- with concat (.Values.volumeMounts | default list) (.Values.indexer.extraVolumeMounts | default list) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
@@ -143,23 +143,24 @@ spec:
           configMap:
             name: {{ .name }}
         {{- end }}
-        {{- with .Values.indexer.extraVolumes }}
+        {{- with concat (.Values.volumes | default list) (.Values.indexer.extraVolumes | default list) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.indexer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.indexer.affinity .Values.affinity }}
+      {{- with merge (dict) (.Values.indexer.affinity | default dict) (.Values.affinity | default dict) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := concat .Values.tolerations .Values.indexer.tolerations | compact | uniq }}
+      {{- $tolerations := concat (.Values.tolerations | default list) (.Values.indexer.tolerations | default list) | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
-      {{- with .Values.indexer.topologySpreadConstraints }}
+      {{- $tsc := concat (.Values.topologySpreadConstraints | default list) (.Values.indexer.topologySpreadConstraints | default list) | compact }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml $tsc | nindent 8 }}
       {{- end }}
       {{- if .Values.indexer.runtimeClassName }}
       runtimeClassName: {{ .Values.indexer.runtimeClassName | quote }}

--- a/charts/cloudprem/templates/ingress/internal.yaml
+++ b/charts/cloudprem/templates/ingress/internal.yaml
@@ -15,6 +15,7 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internal
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/healthcheck-path: /health/readyz
+    alb.ingress.kubernetes.io/healthcheck-port: "7284"
     {{- else if regexMatch "nginx" $ingressClassName }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     {{- end }}

--- a/charts/cloudprem/templates/intake-deployment.yaml
+++ b/charts/cloudprem/templates/intake-deployment.yaml
@@ -90,7 +90,7 @@ spec:
               mountPath: /quickwit/
             - name: data
               mountPath: /quickwit/qwdata
-            {{- with .Values.intake.extraVolumeMounts }}
+            {{- with concat (.Values.volumeMounts | default list) (.Values.intake.extraVolumeMounts | default list) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
@@ -106,23 +106,24 @@ spec:
             name: {{ include "quickwit.fullname" . }}-intake
         - name: data
           emptyDir: {}
-        {{- with .Values.intake.extraVolumes }}
+        {{- with concat (.Values.volumes | default list) (.Values.intake.extraVolumes | default list) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.intake.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.intake.affinity .Values.affinity }}
+      {{- with merge (dict) (.Values.intake.affinity | default dict) (.Values.affinity | default dict) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := concat .Values.tolerations .Values.intake.tolerations | compact | uniq }}
+      {{- $tolerations := concat (.Values.tolerations | default list) (.Values.intake.tolerations | default list) | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
-      {{- with .Values.intake.topologySpreadConstraints }}
+      {{- $tsc := concat (.Values.topologySpreadConstraints | default list) (.Values.intake.topologySpreadConstraints | default list) | compact }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml $tsc | nindent 8 }}
       {{- end }}
       {{- if .Values.intake.runtimeClassName }}
       runtimeClassName: {{ .Values.intake.runtimeClassName | quote }}

--- a/charts/cloudprem/templates/janitor-deployment.yaml
+++ b/charts/cloudprem/templates/janitor-deployment.yaml
@@ -93,7 +93,7 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
             {{- end }}
-            {{- with .Values.janitor.extraVolumeMounts }}
+            {{- with concat (.Values.volumeMounts | default list) (.Values.janitor.extraVolumeMounts | default list) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
@@ -112,23 +112,24 @@ spec:
           configMap:
             name: {{ .name }}
         {{- end }}
-        {{- with .Values.janitor.extraVolumes }}
+        {{- with concat (.Values.volumes | default list) (.Values.janitor.extraVolumes | default list) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.janitor.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.janitor.affinity .Values.affinity }}
+      {{- with merge (dict) (.Values.janitor.affinity | default dict) (.Values.affinity | default dict) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := concat .Values.tolerations .Values.janitor.tolerations | compact | uniq }}
+      {{- $tolerations := concat (.Values.tolerations | default list) (.Values.janitor.tolerations | default list) | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
-      {{- with .Values.janitor.topologySpreadConstraints }}
+      {{- $tsc := concat (.Values.topologySpreadConstraints | default list) (.Values.janitor.topologySpreadConstraints | default list) | compact }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml $tsc | nindent 8 }}
       {{- end }}
       {{- if .Values.janitor.runtimeClassName }}
       runtimeClassName: {{ .Values.janitor.runtimeClassName | quote }}

--- a/charts/cloudprem/templates/job-create-indices.yaml
+++ b/charts/cloudprem/templates/job-create-indices.yaml
@@ -77,7 +77,7 @@ spec:
           - name: index
             mountPath: /quickwit/{{ . }}
             subPath: {{ . }}
-          {{- with $.Values.bootstrap.indexes.extraVolumeMounts }}
+          {{- with concat ($.Values.volumeMounts | default list) ($.Values.bootstrap.indexes.extraVolumeMounts | default list) }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
         resources:
@@ -95,18 +95,18 @@ spec:
             items:
               - key: {{ . }}
                 path: {{ . }}
-         {{- with $.Values.bootstrap.indexes.extraVolumes }}
+         {{- with concat ($.Values.volumes | default list) ($.Values.bootstrap.indexes.extraVolumes | default list) }}
            {{- toYaml . | nindent 8 }}
          {{- end }}
       {{- with $.Values.bootstrap.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) $.Values.bootstrap.affinity $.Values.affinity }}
+      {{- with merge (dict) ($.Values.bootstrap.affinity | default dict) ($.Values.affinity | default dict) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := concat $.Values.tolerations $.Values.bootstrap.tolerations | compact | uniq }}
+      {{- $tolerations := concat ($.Values.tolerations | default list) ($.Values.bootstrap.tolerations | default list) | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if $.Values.bootstrap.runtimeClassName }}

--- a/charts/cloudprem/templates/job-create-sources.yaml
+++ b/charts/cloudprem/templates/job-create-sources.yaml
@@ -73,7 +73,7 @@ spec:
             mountPath: /quickwit/{{ .source.source_id }}.yaml
             subPath: {{ .source.source_id }}.yaml
           {{- end }}
-          {{- with $.Values.bootstrap.sources.extraVolumeMounts }}
+          {{- with concat ($.Values.volumeMounts | default list) ($.Values.bootstrap.sources.extraVolumeMounts | default list) }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
         resources:
@@ -91,18 +91,18 @@ spec:
             items:
               - key: {{ .source.source_id }}.yaml
                 path: {{ .source.source_id }}.yaml
-         {{- with $.Values.bootstrap.sources.extraVolumes }}
+         {{- with concat ($.Values.volumes | default list) ($.Values.bootstrap.sources.extraVolumes | default list) }}
            {{- toYaml . | nindent 8 }}
          {{- end }}
       {{- with $.Values.bootstrap.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) $.Values.bootstrap.affinity $.Values.affinity }}
+      {{- with merge (dict) ($.Values.bootstrap.affinity | default dict) ($.Values.affinity | default dict) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := concat $.Values.tolerations $.Values.bootstrap.tolerations | compact | uniq }}
+      {{- $tolerations := concat ($.Values.tolerations | default list) ($.Values.bootstrap.tolerations | default list) | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if $.Values.bootstrap.runtimeClassName }}

--- a/charts/cloudprem/templates/metastore-deployment.yaml
+++ b/charts/cloudprem/templates/metastore-deployment.yaml
@@ -91,7 +91,7 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
             {{- end }}
-            {{- with .Values.metastore.extraVolumeMounts }}
+            {{- with concat (.Values.volumeMounts | default list) (.Values.metastore.extraVolumeMounts | default list) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
@@ -110,23 +110,24 @@ spec:
           configMap:
             name: {{ .name }}
         {{- end }}
-        {{- with .Values.metastore.extraVolumes }}
+        {{- with concat (.Values.volumes | default list) (.Values.metastore.extraVolumes | default list) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.metastore.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.metastore.affinity .Values.affinity }}
+      {{- with merge (dict) (.Values.metastore.affinity | default dict) (.Values.affinity | default dict) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := concat .Values.tolerations .Values.metastore.tolerations | compact | uniq }}
+      {{- $tolerations := concat (.Values.tolerations | default list) (.Values.metastore.tolerations | default list) | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
-      {{- with .Values.metastore.topologySpreadConstraints }}
+      {{- $tsc := concat (.Values.topologySpreadConstraints | default list) (.Values.metastore.topologySpreadConstraints | default list) | compact }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml $tsc | nindent 8 }}
       {{- end }}
       {{- if .Values.metastore.runtimeClassName }}
       runtimeClassName: {{ .Values.metastore.runtimeClassName | quote }}

--- a/charts/cloudprem/templates/searcher-statefulset.yaml
+++ b/charts/cloudprem/templates/searcher-statefulset.yaml
@@ -107,7 +107,7 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
             {{- end }}
-            {{- with .Values.searcher.extraVolumeMounts }}
+            {{- with concat (.Values.volumeMounts | default list) (.Values.searcher.extraVolumeMounts | default list) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
@@ -145,23 +145,24 @@ spec:
           configMap:
             name: {{ .name }}
         {{- end }}
-        {{- with .Values.searcher.extraVolumes }}
+        {{- with concat (.Values.volumes | default list) (.Values.searcher.extraVolumes | default list) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.searcher.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.searcher.affinity .Values.affinity }}
+      {{- with merge (dict) (.Values.searcher.affinity | default dict) (.Values.affinity | default dict) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := concat .Values.tolerations .Values.searcher.tolerations | compact | uniq }}
+      {{- $tolerations := concat (.Values.tolerations | default list) (.Values.searcher.tolerations | default list) | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
-      {{- with .Values.searcher.topologySpreadConstraints }}
+      {{- $tsc := concat (.Values.topologySpreadConstraints | default list) (.Values.searcher.topologySpreadConstraints | default list) | compact }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml $tsc | nindent 8 }}
       {{- end }}
       {{- if .Values.searcher.runtimeClassName }}
       runtimeClassName: {{ .Values.searcher.runtimeClassName | quote }}

--- a/charts/cloudprem/templates/service.yaml
+++ b/charts/cloudprem/templates/service.yaml
@@ -38,6 +38,9 @@ spec:
     - port: 7283
       targetPort: cloudprem
       name: cloudprem
+    - port: 7284
+      targetPort: health
+      name: health
   selector:
     {{- include "quickwit.searcher.selectorLabels" . | nindent 4 }}
 {{- end }}
@@ -77,6 +80,9 @@ spec:
       protocol: UDP
     - name: tcp-cloudprem
       port: 7283
+      protocol: TCP
+    - name: tcp-health
+      port: 7284
       protocol: TCP
   selector:
     {{- include "quickwit.selectorLabels" . | nindent 4 }}
@@ -119,6 +125,10 @@ spec:
       {{- if and (eq $type "NodePort") .Values.indexer.grpcNodePort }}
       nodePort: {{ .Values.indexer.grpcNodePort }}
       {{- end }}
+    - port: 7284
+      targetPort: health
+      protocol: TCP
+      name: health
   selector:
     {{- include "quickwit.indexer.selectorLabels" . | nindent 4 }}
 {{- end }}
@@ -160,6 +170,10 @@ spec:
       {{- if and (eq $type "NodePort") .Values.metastore.grpcNodePort }}
       nodePort: {{ .Values.metastore.grpcNodePort }}
       {{- end }}
+    - port: 7284
+      targetPort: health
+      protocol: TCP
+      name: health
   selector:
     {{- include "quickwit.metastore.selectorLabels" . | nindent 4 }}
 ---
@@ -201,6 +215,10 @@ spec:
       {{- if and (eq $type "NodePort") .Values.control_plane.grpcNodePort }}
       nodePort: {{ .Values.control_plane.grpcNodePort }}
       {{- end }}
+    - port: 7284
+      targetPort: health
+      protocol: TCP
+      name: health
   selector:
     {{- include "quickwit.control_plane.selectorLabels" . | nindent 4 }}
 {{- end }}
@@ -243,6 +261,10 @@ spec:
       {{- if and (eq $type "NodePort") .Values.janitor.grpcNodePort }}
       nodePort: {{ .Values.janitor.grpcNodePort }}
       {{- end }}
+    - port: 7284
+      targetPort: health
+      protocol: TCP
+      name: health
   selector:
     {{- include "quickwit.janitor.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/cloudprem/values.yaml
+++ b/charts/cloudprem/values.yaml
@@ -166,6 +166,15 @@ tolerations: []
 # Global affinity settings applied to all deployments
 affinity: {}
 
+# -- Configure topology spread constraints applied to all workload Pods.
+topologySpreadConstraints: []
+
+# volumes -- Additional volumes to use with all Pods. Merged with per-component `extraVolumes`.
+volumes: []
+
+# volumeMounts -- Additional volumes to mount into all Quickwit containers. Merged with per-component `extraVolumeMounts`.
+volumeMounts: []
+
 searcher:
   # -- Pod size for the searcher. Determines resource limits/requests and config tuning parameters. Valid values: medium, large, xlarge, 2xlarge, 4xlarge, 6xlarge, 8xlarge.
   podSize: xlarge
@@ -215,19 +224,19 @@ searcher:
   startupProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
     failureThreshold: 12
     periodSeconds: 5
 
   livenessProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
 
   readinessProbe:
     httpGet:
       path: /health/readyz
-      port: rest
+      port: health
 
   # StatefulSet allows you to relax its ordering guarantees
   #   - OrderedReady
@@ -356,19 +365,19 @@ indexer:
   startupProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
     failureThreshold: 12
     periodSeconds: 5
 
   livenessProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
 
   readinessProbe:
     httpGet:
       path: /health/readyz
-      port: rest
+      port: health
 
   # StatefulSet allows you to relax its ordering guarantees
   #   - OrderedReady
@@ -502,19 +511,19 @@ metastore:
   startupProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
     failureThreshold: 12
     periodSeconds: 5
 
   livenessProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
 
   readinessProbe:
     httpGet:
       path: /health/readyz
-      port: rest
+      port: health
 
   # Override args for starting container
   args: []
@@ -585,19 +594,19 @@ control_plane:
   startupProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
     failureThreshold: 12
     periodSeconds: 5
 
   livenessProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
 
   readinessProbe:
     httpGet:
       path: /health/readyz
-      port: rest
+      port: health
 
   # Override args for starting container
   args: []
@@ -664,19 +673,19 @@ janitor:
   startupProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
     failureThreshold: 12
     periodSeconds: 5
 
   livenessProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
 
   readinessProbe:
     httpGet:
       path: /health/readyz
-      port: rest
+      port: health
 
   # Override args for starting container
   args: []
@@ -916,6 +925,9 @@ config:
   listen_address: 0.0.0.0
   gossip_listen_port: 7282
   cloudprem_listen_port: 7283
+  health:
+    # Dedicated plaintext health check server used by health checks.
+    listen_port: 7284
   data_dir: /quickwit/qwdata
   grpc:
     keep_alive:


### PR DESCRIPTION
Updates CloudPrem chart to version 0.4.3

Changes:
- Global volumes and volumeMounts for all components
- Global topologySpreadConstraints support
- Merge upstream Quickwit Helm chart 0.8.5

See charts/cloudprem/CHANGELOG.md for details.