### PR TITLE
[byoc] Update CloudPrem Helm chart to 0.4.4

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.4.4
+
+* Disable `serviceAccount.automountServiceAccountToken` by default to reduce token exposure on pods that don't need Kubernetes API access.
+* Enable `securityContext.readOnlyRootFilesystem` by default across all workloads for defense-in-depth hardening.
+
 ## 0.4.3
 
 * Add global `volumes` and `volumeMounts` values that apply to all components, merged with the existing per-component `extraVolumes`/`extraVolumeMounts`.

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.4.3
+version: 0.4.4
 # This is the version of the "application". Right now, we follow the image version.
 appVersion: v0.1.30
 home: https://www.datadoghq.com/

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.30](https://img.shields.io/badge/AppVersion-v0.1.30-informational?style=flat-square)
+![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.30](https://img.shields.io/badge/AppVersion-v0.1.30-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/templates/serviceaccount.yaml
+++ b/charts/cloudprem/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "quickwit.serviceAccountName" . }}
   labels:

--- a/charts/cloudprem/values.yaml
+++ b/charts/cloudprem/values.yaml
@@ -102,6 +102,7 @@ serviceAccount:
   # - eks.amazonaws.com/role-arn: arn:<aws.partition>:iam::<aws.accountId>:role/<serviceAccount.eksRoleName>
   # - eks.amazonaws.com/sts-regional-endpoints: "true"
   eksRoleName: cloudprem
+  automountServiceAccountToken: false
   extraAnnotations: {}
 
 annotations: {}
@@ -114,6 +115,7 @@ podSecurityContext:
 securityContext:
   runAsNonRoot: true
   runAsUser: 1005
+  readOnlyRootFilesystem: true
 
 # If enabled, we index Cloudprem (well, pomsky/quickwit) traces within Cloudprem
 tracingEnabled: false


### PR DESCRIPTION
Updates CloudPrem chart to version 0.4.4.

- Disables `serviceAccount.automountServiceAccountToken` by default
- Enables `securityContext.readOnlyRootFilesystem` by default across all workloads