### PR TITLE
[byoc] Default automountServiceAccountToken to false in template

### DIFF
--- a/charts/cloudprem/templates/serviceaccount.yaml
+++ b/charts/cloudprem/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken | default false }}
 metadata:
   name: {{ include "quickwit.serviceAccountName" . }}
   labels:


### PR DESCRIPTION
Fixes a bug in the CloudPrem chart's `serviceaccount.yaml` template.

`helm upgrade --reuse-values` from a pre-0.4.4 release doesn't have `serviceAccount.automountServiceAccountToken` in its stored values, so direct interpolation rendered `automountServiceAccountToken: <no value>` — an invalid boolean for the ServiceAccount spec, breaking the upgrade. Defaults the template to `false` when unset.