### PR TITLE
set csi driver default image to 1.3.0

### DIFF
--- a/charts/datadog-csi-driver/CHANGELOG.md
+++ b/charts/datadog-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.16.0
+
+* Set csi driver image to `1.3.0`
+
 ## 0.15.0
 
 * Enable Single Step Instrumentation (SSI) on GKE Autopilot >= 1.32.1-gke.1729000 by rendering `storage-dir` and `DD_APM_ENABLED`. The DaemonSet now matches the new `datadog-datadog-csi-driver-daemonset-exemption-v1.1.0` WorkloadAllowlist (which exempts the new `storage-dir` hostPath and the `DD_APM_ENABLED` env var), replacing `v1.0.1` in the `AllowlistSynchronizer`.

--- a/charts/datadog-csi-driver/Chart.yaml
+++ b/charts/datadog-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datadog-csi-driver
 description: Datadog CSI Driver helm chart
 type: application
-version: 0.15.0
+version: 0.16.0
 appVersion: "0.1.0"
 maintainers:
   - name: Datadog

--- a/charts/datadog-csi-driver/README.md
+++ b/charts/datadog-csi-driver/README.md
@@ -1,6 +1,6 @@
 # datadog-csi-driver
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Datadog CSI Driver helm chart
 
@@ -24,7 +24,7 @@ Datadog CSI Driver helm chart
 | image.pullPolicy | string | `"IfNotPresent"` | CSI driver image pullPolicy |
 | image.pullSecrets | list | `[]` | CSI driver repository pullSecret (for example: specify Docker registry credentials) |
 | image.repository | string | `"gcr.io/datadoghq/csi-driver"` | Override default registry + image.name for CSI driver |
-| image.tag | string | `"1.2.2"` | CSI driver image tag to use |
+| image.tag | string | `"1.3.0"` | CSI driver image tag to use |
 | labels | object | `{}` | Configure the labels for the csi driver daemonset pods. |
 | nameOverride | string | `""` | Allows overriding the name of the chart. If set, this value replaces the default chart name. |
 | nodeAffinity | object | `{}` | Configure the nodeAffinity for the csi driver daemonset pods. |

--- a/charts/datadog-csi-driver/values.yaml
+++ b/charts/datadog-csi-driver/values.yaml
@@ -13,7 +13,7 @@ fullnameOverride: ""
 ## Define the Datadog CSI Driver image to work with
 image:
   # image.tag -- CSI driver image tag to use
-  tag: 1.2.2
+  tag: 1.3.0
 
   # image.repository -- Override default registry + image.name for CSI driver
   repository: gcr.io/datadoghq/csi-driver

--- a/test/datadog-csi-driver/baseline/CSI_Driver_annotation_and_securitycontext.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_annotation_and_securitycontext.yaml
@@ -44,7 +44,7 @@ spec:
         runAsUser: 0
       containers:
         - name: csi-node-driver
-          image: "gcr.io/datadoghq/csi-driver:1.2.2"
+          image: "gcr.io/datadoghq/csi-driver:1.3.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/test/datadog-csi-driver/baseline/CSI_Driver_default.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_default.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: csi-node-driver
-          image: "gcr.io/datadoghq/csi-driver:1.2.2"
+          image: "gcr.io/datadoghq/csi-driver:1.3.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/test/datadog-csi-driver/baseline/CSI_Driver_gke_autopilot_workloadallowlist.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_gke_autopilot_workloadallowlist.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: csi-node-driver
-          image: "gcr.io/datadoghq/csi-driver:1.2.2"
+          image: "gcr.io/datadoghq/csi-driver:1.3.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/test/datadog-csi-driver/baseline/CSI_Driver_legacy_gke_autopilot.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_legacy_gke_autopilot.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: csi-node-driver
-          image: "gcr.io/datadoghq/csi-driver:1.2.2"
+          image: "gcr.io/datadoghq/csi-driver:1.3.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/test/datadog-csi-driver/baseline/CSI_Driver_nodeselector_and_nodeaffinity.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_nodeselector_and_nodeaffinity.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: csi-node-driver
-          image: "gcr.io/datadoghq/csi-driver:1.2.2"
+          image: "gcr.io/datadoghq/csi-driver:1.3.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/test/datadog-csi-driver/baseline/CSI_Driver_resources.yaml
+++ b/test/datadog-csi-driver/baseline/CSI_Driver_resources.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: csi-node-driver
-          image: "gcr.io/datadoghq/csi-driver:1.2.2"
+          image: "gcr.io/datadoghq/csi-driver:1.3.0"
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
See title.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits