### PR TITLE
Update datadog chart for operator 1.28.0

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 3.230.0
+
+* Bump Datadog Operator chart dependency to 2.24.0.
+* Bump Datadog CRD chart dependency to 2.22.0.
+* Bump Operator image tag to 1.28.0.
+
 ## 3.229.0
 
 * Add `agents.instanceLabelOverride`, `clusterAgent.instanceLabelOverride`, and `clusterChecksRunner.instanceLabelOverride` to override the `app.kubernetes.io/instance` label on the corresponding workloads. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.229.0
+version: 3.230.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.229.0](https://img.shields.io/badge/Version-3.229.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.230.0](https://img.shields.io/badge/Version-3.230.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -31,9 +31,9 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://helm.datadoghq.com | datadog-crds | 2.21.0 |
+| https://helm.datadoghq.com | datadog-crds | 2.22.0 |
 | https://helm.datadoghq.com | datadog-csi-driver | 0.15.0 |
-| https://helm.datadoghq.com | operator(datadog-operator) | 2.23.1 |
+| https://helm.datadoghq.com | operator(datadog-operator) | 2.24.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 
 ## Quick start
@@ -1084,7 +1084,7 @@ helm install <RELEASE_NAME> \
 | operator.datadogGenericResource.enabled | bool | `false` | Enables the Datadog Generic Resource controller |
 | operator.datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | operator.datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
-| operator.image.tag | string | `"1.27.0"` | Define the Datadog Operator version to use |
+| operator.image.tag | string | `"1.28.0"` | Define the Datadog Operator version to use |
 | otelAgentGateway.additionalLabels | object | `{}` | Adds labels to the Agent Gateway Deployment and pods |
 | otelAgentGateway.affinity | object | `{}` | Allow the Gateway Deployment to schedule using affinity rules |
 | otelAgentGateway.autoscaling.annotations | object | `{}` | annotations for OTel Agent Gateway HPA |

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.21.0
+  version: 2.22.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
@@ -10,6 +10,6 @@ dependencies:
   version: 0.15.0
 - name: datadog-operator
   repository: https://helm.datadoghq.com
-  version: 2.23.1
-digest: sha256:e228ba99fd6ff82d75b0988c7ba7aadac15c1a0cc15a3e3409ec34ac0b39ff63
-generated: "2026-06-08T14:59:32.273659-04:00"
+  version: 2.24.0
+digest: sha256:485d460d597e3a735dbe6d983250615a864af7619ced5a6dad774fe8c260452e
+generated: "2026-07-02T16:09:38.887087-04:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: datadog-crds
-    version: 2.21.0
+    version: 2.22.0
     repository: https://helm.datadoghq.com
     # Ordering matters here. Helm uses the first condition with a defined (non-nil) value. Conditions with an
     # explicit false default (e.g. clusterAgent.metricsProvider.useDatadogMetrics) must come last, otherwise
@@ -17,7 +17,7 @@ dependencies:
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator
-    version: 2.23.1
+    version: 2.24.0
     repository: https://helm.datadoghq.com
     condition: datadog.operator.enabled
     alias: operator

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -3073,7 +3073,7 @@ clusterChecksRunner:
 operator:
   image:
     # operator.image.tag -- Define the Datadog Operator version to use
-    tag: 1.27.0
+    tag: 1.28.0
 
   datadogAgent:
     # operator.datadogAgent.enabled -- Enables Datadog Agent controller

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -333,6 +333,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -376,6 +377,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -463,14 +481,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -491,7 +501,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -510,12 +522,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -545,11 +574,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -644,6 +699,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2078,7 +2140,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2143,7 +2205,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -333,6 +333,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -376,6 +377,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -463,14 +481,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -491,7 +501,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -510,12 +522,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -545,11 +574,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -644,6 +699,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2078,7 +2140,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2143,7 +2205,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -418,7 +418,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -603,6 +603,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -646,6 +647,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -733,14 +751,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -761,7 +771,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -780,12 +792,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -815,11 +844,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -914,6 +969,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2479,7 +2541,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2544,7 +2606,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2452,7 +2514,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2517,7 +2579,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -414,7 +414,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -599,6 +599,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -642,6 +643,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -729,14 +747,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -757,7 +767,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -776,12 +788,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -811,11 +840,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -910,6 +965,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -1779,7 +1841,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1844,7 +1906,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -414,7 +414,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -599,6 +599,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -642,6 +643,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -729,14 +747,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -757,7 +767,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -776,12 +788,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -811,11 +840,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -910,6 +965,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -1779,7 +1841,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1844,7 +1906,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -414,7 +414,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -599,6 +599,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -642,6 +643,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -729,14 +747,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -757,7 +767,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -776,12 +788,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -811,11 +840,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -910,6 +965,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -1779,7 +1841,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1844,7 +1906,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -414,7 +414,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -599,6 +599,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -642,6 +643,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -729,14 +747,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -757,7 +767,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -776,12 +788,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -811,11 +840,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -910,6 +965,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -1779,7 +1841,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1844,7 +1906,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -587,6 +587,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -630,6 +631,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -717,14 +735,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -745,7 +755,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -764,12 +776,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -799,11 +828,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -898,6 +953,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2468,7 +2530,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2533,7 +2595,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -587,6 +587,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -630,6 +631,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -717,14 +735,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -745,7 +755,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -764,12 +776,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -799,11 +828,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -898,6 +953,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2586,7 +2648,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2651,7 +2713,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2451,7 +2513,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2516,7 +2578,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -454,7 +454,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -639,6 +639,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -682,6 +683,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -769,14 +787,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -797,7 +807,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -816,12 +828,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -851,11 +880,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -950,6 +1005,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2521,7 +2583,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2586,7 +2648,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2444,7 +2506,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2509,7 +2571,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2444,7 +2506,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2509,7 +2571,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -333,6 +333,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -376,6 +377,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -463,14 +481,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -491,7 +501,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -510,12 +522,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -545,11 +574,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -644,6 +699,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -1800,7 +1862,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1865,7 +1927,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -333,6 +333,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -376,6 +377,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -463,14 +481,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -491,7 +501,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -510,12 +522,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -545,11 +574,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -644,6 +699,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -1800,7 +1862,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1865,7 +1927,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -333,6 +333,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -376,6 +377,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -463,14 +481,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -491,7 +501,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -510,12 +522,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -545,11 +574,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -644,6 +699,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -1817,7 +1879,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1882,7 +1944,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -163,7 +163,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -348,6 +348,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -391,6 +392,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -478,14 +496,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -506,7 +516,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -525,12 +537,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -560,11 +589,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -659,6 +714,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -1874,7 +1936,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1939,7 +2001,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -333,6 +333,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -376,6 +377,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -463,14 +481,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -491,7 +501,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -510,12 +522,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -545,11 +574,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -644,6 +699,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -1844,7 +1906,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1909,7 +1971,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2315,7 +2377,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2380,7 +2442,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2430,7 +2492,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2495,7 +2557,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2430,7 +2492,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2495,7 +2557,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2308,7 +2370,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2373,7 +2435,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -601,6 +601,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -644,6 +645,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -731,14 +749,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -759,7 +769,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -778,12 +790,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -813,11 +842,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -912,6 +967,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2461,7 +2523,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2526,7 +2588,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -601,6 +601,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -644,6 +645,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -731,14 +749,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -759,7 +769,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -778,12 +790,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -813,11 +842,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -912,6 +967,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2469,7 +2531,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2534,7 +2596,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -601,6 +601,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -644,6 +645,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -731,14 +749,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -759,7 +769,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -778,12 +790,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -813,11 +842,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -912,6 +967,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2341,7 +2403,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2406,7 +2468,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -601,6 +601,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -644,6 +645,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -731,14 +749,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -759,7 +769,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -778,12 +790,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -813,11 +842,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -912,6 +967,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2365,7 +2427,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2430,7 +2492,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -487,7 +487,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -672,6 +672,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -715,6 +716,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -802,14 +820,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -830,7 +840,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -849,12 +861,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -884,11 +913,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -983,6 +1038,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2523,7 +2585,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2588,7 +2650,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -406,7 +406,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -591,6 +591,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -634,6 +635,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -721,14 +739,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -749,7 +759,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -768,12 +780,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -803,11 +832,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -902,6 +957,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2493,7 +2555,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2558,7 +2620,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -445,7 +445,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -630,6 +630,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -673,6 +674,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -760,14 +778,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -788,7 +798,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -807,12 +819,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -842,11 +871,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -941,6 +996,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2509,7 +2571,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2574,7 +2636,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2560,7 +2622,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2625,7 +2687,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -657,6 +657,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -700,6 +701,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -787,14 +805,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -815,7 +825,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -834,12 +846,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -869,11 +898,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -968,6 +1023,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2640,7 +2702,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2705,7 +2767,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2559,7 +2621,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2624,7 +2686,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -657,6 +657,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -700,6 +701,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -787,14 +805,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -815,7 +825,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -834,12 +846,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -869,11 +898,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -968,6 +1023,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2634,7 +2696,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2699,7 +2761,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -629,6 +629,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -672,6 +673,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -759,14 +777,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -787,7 +797,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -806,12 +818,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -841,11 +870,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -940,6 +995,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2099,7 +2161,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2164,7 +2226,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -629,6 +629,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -672,6 +673,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -759,14 +777,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -787,7 +797,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -806,12 +818,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -841,11 +870,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -940,6 +995,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2099,7 +2161,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2164,7 +2226,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -660,6 +660,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -703,6 +704,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -790,14 +808,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -818,7 +828,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -837,12 +849,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -872,11 +901,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -971,6 +1026,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2156,7 +2218,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2221,7 +2283,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -660,6 +660,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -703,6 +704,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -790,14 +808,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -818,7 +828,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -837,12 +849,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -872,11 +901,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -971,6 +1026,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2156,7 +2218,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2221,7 +2283,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -424,7 +424,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -609,6 +609,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -652,6 +653,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -739,14 +757,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -767,7 +777,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -786,12 +798,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -821,11 +850,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -920,6 +975,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2603,7 +2665,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2668,7 +2730,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -657,6 +657,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -700,6 +701,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -787,14 +805,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -815,7 +825,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -834,12 +846,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -869,11 +898,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -968,6 +1023,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2636,7 +2698,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2701,7 +2763,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -657,6 +657,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -700,6 +701,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -787,14 +805,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -815,7 +825,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -834,12 +846,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -869,11 +898,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -968,6 +1023,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2630,7 +2692,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2695,7 +2757,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2444,7 +2506,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2509,7 +2571,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -587,6 +587,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -630,6 +631,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -717,14 +735,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -745,7 +755,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -764,12 +776,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -799,11 +828,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -898,6 +953,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2453,7 +2515,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2518,7 +2580,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2508,7 +2570,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2573,7 +2635,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -601,6 +601,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -644,6 +645,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -731,14 +749,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -759,7 +769,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -778,12 +790,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -813,11 +842,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -912,6 +967,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2505,7 +2567,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2570,7 +2632,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -587,6 +587,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -630,6 +631,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -717,14 +735,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -745,7 +755,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -764,12 +776,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -799,11 +828,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -898,6 +953,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2669,7 +2731,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2734,7 +2796,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2510,7 +2572,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2575,7 +2637,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -586,6 +586,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -629,6 +630,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -716,14 +734,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -744,7 +754,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -763,12 +775,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -798,11 +827,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -897,6 +952,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2560,7 +2622,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2625,7 +2687,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -587,6 +587,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -630,6 +631,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -717,14 +735,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -745,7 +755,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -764,12 +776,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -799,11 +828,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -898,6 +953,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2553,7 +2615,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2618,7 +2680,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -587,6 +587,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -630,6 +631,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -717,14 +735,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -745,7 +755,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -764,12 +776,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -799,11 +828,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -898,6 +953,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2464,7 +2526,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2529,7 +2591,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
#### What this PR does / why we need it:

Update datadog chart for operator 1.28.0

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits