### PR TITLE
[CONTP-1780] Add untaint controller config to datadog operator

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.25.0
 
-* Add `untaintController.enabled` (default `false`) to enable the Datadog Operator Untaint controller. When enabled, the operator is granted `patch` permission on nodes and started with `-untaintControllerEnabled=true` (requires operator v1.28.0+).
+* Add `untaintController` configuration to enable the Datadog Operator Untaint controller (requires operator v1.28.0+). When `untaintController.enabled` is `true`, the operator is granted `patch` permission on nodes and started with `-untaintControllerEnabled=true`. Additional tuning is exposed via `untaintController.waitForCSIDriver`, `untaintController.timeout`, `untaintController.schedulingTimeout`, `untaintController.timeoutPolicy`, and `untaintController.eventsEnabled`.
 
 ## 2.24.0
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.25.0
+
+* Add `untaintController.enabled` (default `false`) to enable the Datadog Operator Untaint controller. When enabled, the operator is granted `patch` permission on nodes and started with `-untaintControllerEnabled=true` (requires operator v1.28.0+).
+
 ## 2.24.0
 
 * Update Datadog Operator chart for 1.28.0.

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.25.0-dev.2
+## 2.25.0
 
 * Add `untaintController` configuration to enable the Datadog Operator Untaint controller (requires operator v1.28.0+). When `untaintController.enabled` is `true`, the operator is granted `patch` permission on nodes and started with `-untaintControllerEnabled=true`. Additional tuning is exposed via `untaintController.waitForCSIDriver`, `untaintController.timeout`, `untaintController.schedulingTimeout`, `untaintController.timeoutPolicy`, and `untaintController.eventsEnabled`. See [documentation](https://github.com/DataDog/datadog-operator/blob/main/docs/untaint_controller.md) for more details.
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.25.0
+## 2.25.0-dev.2
 
 * Add `untaintController` configuration to enable the Datadog Operator Untaint controller (requires operator v1.28.0+). When `untaintController.enabled` is `true`, the operator is granted `patch` permission on nodes and started with `-untaintControllerEnabled=true`. Additional tuning is exposed via `untaintController.waitForCSIDriver`, `untaintController.timeout`, `untaintController.schedulingTimeout`, `untaintController.timeoutPolicy`, and `untaintController.eventsEnabled`. See [documentation](https://github.com/DataDog/datadog-operator/blob/main/docs/untaint_controller.md) for more details.
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.25.0
 
-* Add `untaintController` configuration to enable the Datadog Operator Untaint controller (requires operator v1.28.0+). When `untaintController.enabled` is `true`, the operator is granted `patch` permission on nodes and started with `-untaintControllerEnabled=true`. Additional tuning is exposed via `untaintController.waitForCSIDriver`, `untaintController.timeout`, `untaintController.schedulingTimeout`, `untaintController.timeoutPolicy`, and `untaintController.eventsEnabled`.
+* Add `untaintController` configuration to enable the Datadog Operator Untaint controller (requires operator v1.28.0+). When `untaintController.enabled` is `true`, the operator is granted `patch` permission on nodes and started with `-untaintControllerEnabled=true`. Additional tuning is exposed via `untaintController.waitForCSIDriver`, `untaintController.timeout`, `untaintController.schedulingTimeout`, `untaintController.timeoutPolicy`, and `untaintController.eventsEnabled`. See [documentation](https://github.com/DataDog/datadog-operator/blob/main/docs/untaint_controller.md) for more details.
+
 
 ## 2.24.0
 

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.24.0
+version: 2.25.0
 appVersion: 1.28.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.25.0
+version: 2.25.0-dev.2
 appVersion: 1.29.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.25.0-dev.2
+version: 2.25.0
 appVersion: 1.29.0-rc.1
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.25.0](https://img.shields.io/badge/Version-2.25.0-informational?style=flat-square) ![AppVersion: 1.29.0-rc.1](https://img.shields.io/badge/AppVersion-1.29.0--rc.1-informational?style=flat-square)
+![Version: 2.25.0-dev.2](https://img.shields.io/badge/Version-2.25.0--dev.2-informational?style=flat-square) ![AppVersion: 1.29.0-rc.1](https://img.shields.io/badge/AppVersion-1.29.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -72,6 +72,11 @@
 | supportExtendedDaemonset | string | `"false"` | If true, supports using ExtendedDaemonSet CRD |
 | tolerations | list | `[]` | Allows to schedule Datadog Operator on tainted nodes |
 | untaintController.enabled | bool | `false` | Enables the Untaint controller, which removes the `agent.datadoghq.com/not-ready=presence:NoSchedule` startup taint from nodes once the Agent is ready. Grants the operator `patch` permission on nodes. Requires v1.28.0+ |
+| untaintController.eventsEnabled | bool | `false` | Emit Kubernetes Events on Nodes for taint removals and timeout decisions. |
+| untaintController.schedulingTimeout | string | `""` | Scheduling timeout (Go duration, e.g. "5m") applied when no Agent pod has scheduled on the node. Empty uses the operator default (5m). |
+| untaintController.timeout | string | `""` | Readiness timeout (Go duration, e.g. "10m") after which the timeout policy is applied even if the Agent is not Ready. Empty uses the operator default (10m). |
+| untaintController.timeoutPolicy | string | `""` | Action when a timeout fires: "remove" (untaint the node anyway) or "keep" (leave the taint and emit a Warning event). Empty uses the operator default (remove). |
+| untaintController.waitForCSIDriver | bool | `false` | When true (requires untaintController.enabled), the taint is removed only after both the node Agent and Datadog CSI node-server pods are Ready. The operator's Pod cache must cover the CSI namespaces (DD_CSIDRIVER_WATCH_NAMESPACE). Requires v1.28.0+ |
 | volumeMounts | list | `[]` | Specify additional volumes to mount in the container |
 | volumes | list | `[]` | Specify additional volumes to mount in the container |
 | watchNamespaces | list | `[]` | Restricts the Operator to watch its managed resources on specific namespaces unless CRD-specific watchNamespaces properties are set |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.25.0-dev.2](https://img.shields.io/badge/Version-2.25.0--dev.2-informational?style=flat-square) ![AppVersion: 1.29.0-rc.1](https://img.shields.io/badge/AppVersion-1.29.0--rc.1-informational?style=flat-square)
+![Version: 2.25.0](https://img.shields.io/badge/Version-2.25.0-informational?style=flat-square) ![AppVersion: 1.29.0-rc.1](https://img.shields.io/badge/AppVersion-1.29.0--rc.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.24.0](https://img.shields.io/badge/Version-2.24.0-informational?style=flat-square) ![AppVersion: 1.28.0](https://img.shields.io/badge/AppVersion-1.28.0-informational?style=flat-square)
+![Version: 2.25.0](https://img.shields.io/badge/Version-2.25.0-informational?style=flat-square) ![AppVersion: 1.28.0](https://img.shields.io/badge/AppVersion-1.28.0-informational?style=flat-square)
 
 ## Values
 
@@ -71,6 +71,7 @@
 | site | string | `nil` | The site of the Datadog intake to send data to (documentation: https://docs.datadoghq.com/getting_started/site/) |
 | supportExtendedDaemonset | string | `"false"` | If true, supports using ExtendedDaemonSet CRD |
 | tolerations | list | `[]` | Allows to schedule Datadog Operator on tainted nodes |
+| untaintController.enabled | bool | `false` | Enables the Untaint controller, which removes the `agent.datadoghq.com/not-ready=presence:NoSchedule` startup taint from nodes once the Agent is ready. Grants the operator `patch` permission on nodes. Requires v1.28.0+ |
 | volumeMounts | list | `[]` | Specify additional volumes to mount in the container |
 | volumes | list | `[]` | Specify additional volumes to mount in the container |
 | watchNamespaces | list | `[]` | Restricts the Operator to watch its managed resources on specific namespaces unless CRD-specific watchNamespaces properties are set |

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -599,13 +599,15 @@ rules:
   - patch
   - update
 {{- end }}
-{{- if .Values.datadogAgentProfile.enabled }}
+{{- if or .Values.datadogAgentProfile.enabled .Values.untaintController.enabled }}
 - apiGroups:
   - ""
   resources:
   - nodes
   verbs:
   - patch
+{{- end }}
+{{- if .Values.datadogAgentProfile.enabled }}
 - apiGroups:
   - datadoghq.com
   resources:
@@ -641,14 +643,6 @@ rules:
   - get
   - patch
   - update
-{{- end }}
-{{- if .Values.untaintController.enabled }}
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - patch
 {{- end }}
 {{- if .Values.datadogDashboard.enabled }}
 - apiGroups:

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -642,6 +642,14 @@ rules:
   - patch
   - update
 {{- end }}
+{{- if .Values.untaintController.enabled }}
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
+{{- end }}
 {{- if .Values.datadogDashboard.enabled }}
 - apiGroups:
   - datadoghq.com

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -145,6 +145,24 @@ spec:
             - name: DD_REGISTRY_OVERRIDE_AZURE
               value: "true"
             {{- end }}
+            {{- if and (semverCompare ">=1.28.0-0" $version) .Values.untaintController.enabled }}
+            {{- if .Values.untaintController.timeout }}
+            - name: DD_UNTAINT_CONTROLLER_TIMEOUT
+              value: {{ .Values.untaintController.timeout | quote }}
+            {{- end }}
+            {{- if .Values.untaintController.schedulingTimeout }}
+            - name: DD_UNTAINT_CONTROLLER_SCHEDULING_TIMEOUT
+              value: {{ .Values.untaintController.schedulingTimeout | quote }}
+            {{- end }}
+            {{- if .Values.untaintController.timeoutPolicy }}
+            - name: DD_UNTAINT_CONTROLLER_TIMEOUT_POLICY
+              value: {{ .Values.untaintController.timeoutPolicy | quote }}
+            {{- end }}
+            {{- if .Values.untaintController.eventsEnabled }}
+            - name: DD_UNTAINT_CONTROLLER_EVENTS_ENABLED
+              value: "true"
+            {{- end }}
+            {{- end }}
             {{- range .Values.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}
@@ -197,6 +215,9 @@ spec:
           {{- end }}
           {{- if (semverCompare ">=1.28.0-0" $version) }}
             - "-untaintControllerEnabled={{ .Values.untaintController.enabled }}"
+          {{- if .Values.untaintController.enabled }}
+            - "-untaintControllerWaitForCSIDriver={{ .Values.untaintController.waitForCSIDriver }}"
+          {{- end }}
           {{- end }}
           ports:
             - name: metrics

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -195,6 +195,9 @@ spec:
           {{- if (semverCompare ">=1.26.0-0" $version) }}
             - "-datadogCSIDriverEnabled={{ .Values.datadogCSIDriver.enabled }}"
           {{- end }}
+          {{- if (semverCompare ">=1.28.0-0" $version) }}
+            - "-untaintControllerEnabled={{ .Values.untaintController.enabled }}"
+          {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -110,6 +110,16 @@ remoteConfiguration:
 untaintController:
   # untaintController.enabled -- Enables the Untaint controller, which removes the `agent.datadoghq.com/not-ready=presence:NoSchedule` startup taint from nodes once the Agent is ready. Grants the operator `patch` permission on nodes. Requires v1.28.0+
   enabled: false
+  # untaintController.waitForCSIDriver -- When true (requires untaintController.enabled), the taint is removed only after both the node Agent and Datadog CSI node-server pods are Ready. The operator's Pod cache must cover the CSI namespaces (DD_CSIDRIVER_WATCH_NAMESPACE). Requires v1.28.0+
+  waitForCSIDriver: false
+  # untaintController.timeout -- Readiness timeout (Go duration, e.g. "10m") after which the timeout policy is applied even if the Agent is not Ready. Empty uses the operator default (10m).
+  timeout: ""
+  # untaintController.schedulingTimeout -- Scheduling timeout (Go duration, e.g. "5m") applied when no Agent pod has scheduled on the node. Empty uses the operator default (5m).
+  schedulingTimeout: ""
+  # untaintController.timeoutPolicy -- Action when a timeout fires: "remove" (untaint the node anyway) or "keep" (leave the taint and emit a Warning event). Empty uses the operator default (remove).
+  timeoutPolicy: ""
+  # untaintController.eventsEnabled -- Emit Kubernetes Events on Nodes for taint removals and timeout decisions.
+  eventsEnabled: false
 # registryMigrationMode -- Controls gradual migration of Agent image pulls to
 # registry.datadoghq.com. When enabled, DD_REGISTRY_OVERRIDE_* environment variables
 # are added to the Datadog Operator deployment to pull Agent images from the global

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -107,6 +107,9 @@ datadogSLO:
 remoteConfiguration:
   # remoteConfiguration.enabled -- If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set.
   enabled: false
+untaintController:
+  # untaintController.enabled -- Enables the Untaint controller, which removes the `agent.datadoghq.com/not-ready=presence:NoSchedule` startup taint from nodes once the Agent is ready. Grants the operator `patch` permission on nodes. Requires v1.28.0+
+  enabled: false
 # registryMigrationMode -- Controls gradual migration of Agent image pulls to
 # registry.datadoghq.com. When enabled, DD_REGISTRY_OVERRIDE_* environment variables
 # are added to the Datadog Operator deployment to pull Agent images from the global

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.24.0
+    helm.sh/chart: datadog-operator-2.25.0
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.28.0"
     app.kubernetes.io/managed-by: Helm
@@ -77,6 +77,7 @@ spec:
             - "-datadogGenericResourceEnabled=false"
             - "-remoteConfigEnabled=false"
             - "-datadogCSIDriverEnabled=true"
+            - "-untaintControllerEnabled=false"
           ports:
             - name: metrics
               containerPort: 8383

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -205,10 +205,14 @@ func Test_operator_chart(t *testing.T) {
 				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 				assert.Contains(t, operatorContainer.Args, "-untaintControllerEnabled=false")
 				assert.NotContains(t, operatorContainer.Args, "-untaintControllerEnabled=true")
+				// waitForCSIDriver flag and tuning env vars only render when the controller is enabled.
+				assert.NotContains(t, operatorContainer.Args, "-untaintControllerWaitForCSIDriver=false")
+				assert.Nil(t, FindEnvVarByName(operatorContainer.Env, "DD_UNTAINT_CONTROLLER_TIMEOUT"))
+				assert.Nil(t, FindEnvVarByName(operatorContainer.Env, "DD_UNTAINT_CONTROLLER_EVENTS_ENABLED"))
 			},
 		},
 		{
-			name: "untaintController enabled sets flag",
+			name: "untaintController enabled sets flags",
 			command: common.HelmCommand{
 				ReleaseName: "datadog-operator",
 				ChartPath:   "../../charts/datadog-operator",
@@ -224,6 +228,48 @@ func Test_operator_chart(t *testing.T) {
 				common.Unmarshal(t, manifest, &deployment)
 				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 				assert.Contains(t, operatorContainer.Args, "-untaintControllerEnabled=true")
+				assert.Contains(t, operatorContainer.Args, "-untaintControllerWaitForCSIDriver=false")
+				// Tuning env vars are omitted (operator defaults apply) unless explicitly set.
+				assert.Nil(t, FindEnvVarByName(operatorContainer.Env, "DD_UNTAINT_CONTROLLER_TIMEOUT"))
+				assert.Nil(t, FindEnvVarByName(operatorContainer.Env, "DD_UNTAINT_CONTROLLER_EVENTS_ENABLED"))
+			},
+		},
+		{
+			name: "untaintController full configuration",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"untaintController.enabled":           "true",
+					"untaintController.waitForCSIDriver":  "true",
+					"untaintController.timeout":           "2m",
+					"untaintController.schedulingTimeout": "3m",
+					"untaintController.timeoutPolicy":     "keep",
+					"untaintController.eventsEnabled":     "true",
+				},
+			},
+			skipTest: SkipTest,
+			assertions: func(t *testing.T, manifest string) {
+				var deployment appsv1.Deployment
+				common.Unmarshal(t, manifest, &deployment)
+				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+				assert.Contains(t, operatorContainer.Args, "-untaintControllerEnabled=true")
+				assert.Contains(t, operatorContainer.Args, "-untaintControllerWaitForCSIDriver=true")
+
+				timeout := FindEnvVarByName(operatorContainer.Env, "DD_UNTAINT_CONTROLLER_TIMEOUT")
+				assert.NotNil(t, timeout)
+				assert.Equal(t, "2m", timeout.Value)
+				schedulingTimeout := FindEnvVarByName(operatorContainer.Env, "DD_UNTAINT_CONTROLLER_SCHEDULING_TIMEOUT")
+				assert.NotNil(t, schedulingTimeout)
+				assert.Equal(t, "3m", schedulingTimeout.Value)
+				timeoutPolicy := FindEnvVarByName(operatorContainer.Env, "DD_UNTAINT_CONTROLLER_TIMEOUT_POLICY")
+				assert.NotNil(t, timeoutPolicy)
+				assert.Equal(t, "keep", timeoutPolicy.Value)
+				eventsEnabled := FindEnvVarByName(operatorContainer.Env, "DD_UNTAINT_CONTROLLER_EVENTS_ENABLED")
+				assert.NotNil(t, eventsEnabled)
+				assert.Equal(t, "true", eventsEnabled.Value)
 			},
 		},
 	}

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/DataDog/helm-charts/test/common"
 )
@@ -188,6 +189,43 @@ func Test_operator_chart(t *testing.T) {
 				assert.Equal(t, "unknown", installToolEnv.Value)
 			},
 		},
+		{
+			name: "untaintController disabled by default",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides:   map[string]string{},
+			},
+			skipTest: SkipTest,
+			assertions: func(t *testing.T, manifest string) {
+				var deployment appsv1.Deployment
+				common.Unmarshal(t, manifest, &deployment)
+				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+				assert.Contains(t, operatorContainer.Args, "-untaintControllerEnabled=false")
+				assert.NotContains(t, operatorContainer.Args, "-untaintControllerEnabled=true")
+			},
+		},
+		{
+			name: "untaintController enabled sets flag",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"untaintController.enabled": "true",
+				},
+			},
+			skipTest: SkipTest,
+			assertions: func(t *testing.T, manifest string) {
+				var deployment appsv1.Deployment
+				common.Unmarshal(t, manifest, &deployment)
+				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+				assert.Contains(t, operatorContainer.Args, "-untaintControllerEnabled=true")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -252,6 +290,64 @@ func verifyWatchNamespaces(t *testing.T, manifest string) {
 	assert.Equal(t, "monitor-ns", monitorNsEnv.Value)
 	assert.Equal(t, "", sloNsEnv.Value)
 	assert.Nil(t, dapNsEnv)
+}
+
+func Test_operator_untaint_controller_rbac(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides map[string]string
+		wantPatch bool
+	}{
+		{
+			name:      "untaintController disabled -- no nodes patch rule",
+			overrides: map[string]string{},
+			wantPatch: false,
+		},
+		{
+			name:      "untaintController enabled -- nodes patch rule present",
+			overrides: map[string]string{"untaintController.enabled": "true"},
+			wantPatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := common.RenderChart(t, common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/clusterrole.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides:   tt.overrides,
+			})
+			assert.Nil(t, err, "couldn't render template")
+
+			var clusterRole rbacv1.ClusterRole
+			common.Unmarshal(t, manifest, &clusterRole)
+			assert.Equal(t, tt.wantPatch, hasNodesPatchRule(clusterRole.Rules),
+				"unexpected presence of nodes patch rule")
+		})
+	}
+}
+
+func hasNodesPatchRule(rules []rbacv1.PolicyRule) bool {
+	for _, rule := range rules {
+		if !containsString(rule.APIGroups, "") || !containsString(rule.Resources, "nodes") {
+			continue
+		}
+		if len(rule.Verbs) == 1 && rule.Verbs[0] == "patch" {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
 }
 
 func FindEnvVarByName(envs []v1.EnvVar, name string) *v1.EnvVar {

--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -406,7 +406,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -591,6 +591,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -634,6 +635,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -721,14 +739,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -749,7 +759,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -768,12 +780,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -803,11 +832,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -902,6 +957,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2496,7 +2558,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2561,7 +2623,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `untaintController.enabled` to allow enabling untaint controller, in addition to other configuration options documented [in readme.md](https://github.com/DataDog/datadog-operator/blob/main/docs/untaint_controller.md).

#### Special notes for your reviewer:

After merging this PR, we should bump operator chart version in datadog chart dependency in [this](https://github.com/DataDog/helm-charts/pull/2782) PR and merge it.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits