### PR TITLE
[PROF-15317] allow helm to use logging seccomp

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Datadog changelog
+
+## 3.233.0
+
+* [PROF-15317] allow helm to use logging seccomp ([#2775](https://github.com/DataDog/helm-charts/pull/2775)).
+
 ## 3.232.0
 
 * Deprecate the GPU monitoring eBPF probes. They are now disabled by default even when `datadog.gpuMonitoring.privilegedMode` is enabled, and are expected to be removed in a future release.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.232.0
+version: 3.233.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.232.0](https://img.shields.io/badge/Version-3.232.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.233.0](https://img.shields.io/badge/Version-3.233.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -854,6 +854,7 @@ helm install <RELEASE_NAME> \
 | datadog.hostProfiler.enabled | bool | `false` | Enable the Host Profiler. This feature is experimental and subject to change. |
 | datadog.hostProfiler.image | string | `""` | Image the Host Profiler. This parameter is experimental and will be removed once official image is available. |
 | datadog.hostProfiler.imagePullPolicy | string | `""` | Pull policy for the Host Profiler image. Defaults to agents.image.pullPolicy when unset. |
+| datadog.hostProfiler.loggingSeccomp | bool | `false` | Use the seccomp profile that also permits logging syscalls |
 | datadog.hostProfiler.seccomp | object | `{"enabled":true}` | Seccomp profile configuration for the Host Profiler |
 | datadog.hostProfiler.seccomp.enabled | bool | `true` | Apply the localhost seccomp profile to the host-profiler container and run the init container that installs it on the node. Disable to run the host-profiler container Unconfined (no init container, no profile installed on the node). |
 | datadog.hostProfiler.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -301,7 +301,7 @@ Return the seccomp profile filename for the host-profiler, scoped to the image r
 to avoid races when multiple host-profiler versions coexist on the same node.
 */}}
 {{- define "host-profiler-seccomp-name" -}}
-host-profiler-{{ include "ddot-ebpf-image" . | sha256sum | trunc 8 }}
+host-profiler-{{ include "ddot-ebpf-image" . | sha256sum | trunc 8 }}{{- if .Values.datadog.hostProfiler.loggingSeccomp }}-logging{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/datadog/templates/_host-profiler-init.yaml
+++ b/charts/datadog/templates/_host-profiler-init.yaml
@@ -3,10 +3,18 @@
 {{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.initContainers.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | indent 2 }}
   image: "{{ include "ddot-ebpf-image" . }}"
   imagePullPolicy: {{ .Values.datadog.hostProfiler.imagePullPolicy | default .Values.agents.image.pullPolicy }}
+  {{- $dst := printf "/host%s/%s" .Values.datadog.hostProfiler.seccompRoot (include "host-profiler-seccomp-name" .) }}
   command:
+  {{- if .Values.datadog.hostProfiler.loggingSeccomp }}
+  # Prefer the logging profile, falling back to the default if the image predates it.
+  - sh
+  - -c
+  - if [ -f /etc/dd-host-profiler/logging-seccomp.json ]; then cp /etc/dd-host-profiler/logging-seccomp.json {{ $dst }}; else cp /etc/dd-host-profiler/seccomp.json {{ $dst }}; fi
+  {{- else }}
   - cp
   - /etc/dd-host-profiler/seccomp.json
-  - /host{{ .Values.datadog.hostProfiler.seccompRoot }}/{{ include "host-profiler-seccomp-name" . }}
+  - {{ $dst }}
+  {{- end }}
   volumeMounts:
   - name: host-profiler-seccomp-root
     mountPath: /host{{ .Values.datadog.hostProfiler.seccompRoot }}

--- a/charts/datadog/templates/_host-profiler-init.yaml
+++ b/charts/datadog/templates/_host-profiler-init.yaml
@@ -6,10 +6,9 @@
   {{- $dst := printf "/host%s/%s" .Values.datadog.hostProfiler.seccompRoot (include "host-profiler-seccomp-name" .) }}
   command:
   {{- if .Values.datadog.hostProfiler.loggingSeccomp }}
-  # Prefer the logging profile, falling back to the default if the image predates it.
   - sh
   - -c
-  - if [ -f /etc/dd-host-profiler/logging-seccomp.json ]; then cp /etc/dd-host-profiler/logging-seccomp.json {{ $dst }}; else cp /etc/dd-host-profiler/seccomp.json {{ $dst }}; fi
+  - "if [ -f /etc/dd-host-profiler/logging-seccomp.json ]; then cp /etc/dd-host-profiler/logging-seccomp.json {{ $dst }}; else echo 'WARNING: logging-seccomp.json not found in image, falling back to default seccomp profile'; cp /etc/dd-host-profiler/seccomp.json {{ $dst }}; fi"
   {{- else }}
   - cp
   - /etc/dd-host-profiler/seccomp.json

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -820,6 +820,8 @@ datadog:
       enabled: true
     # datadog.hostProfiler.seccompRoot -- Specify the seccomp profile root directory
     seccompRoot: /var/lib/kubelet/seccomp
+    # datadog.hostProfiler.loggingSeccomp -- Use the seccomp profile that also permits logging syscalls
+    loggingSeccomp: false
     # datadog.hostProfiler.apparmor -- Specify an AppArmor profile for the host-profiler container (e.g. "localhost/datadog-host-profiler").
     ## Only used when agents.podSecurity.apparmor.enabled is true.
     apparmor: unconfined

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -134,6 +134,21 @@ func TestHostProfilerSCC(t *testing.T) {
 		"SCC should allow the hashed seccomp profile")
 }
 
+func TestHostProfilerLoggingSeccomp(t *testing.T) {
+	overrides := copyMap(hostProfilerBaseOverrides)
+	overrides["datadog.hostProfiler.loggingSeccomp"] = "true"
+	ds := renderHostProfilerDaemonSet(t, overrides)
+	initContainer, ok := getContainer(t, ds.Spec.Template.Spec.InitContainers, "host-profiler-seccomp-setup")
+	require.True(t, ok)
+
+	// Prefer the logging profile, falling back to the default if the image predates it.
+	cmd := strings.Join(initContainer.Command, " ")
+	assert.Contains(t, cmd, "if [ -f /etc/dd-host-profiler/logging-seccomp.json ]",
+		"init container should guard the logging profile copy; command: %v", initContainer.Command)
+	assert.Contains(t, cmd, "cp /etc/dd-host-profiler/logging-seccomp.json")
+	assert.Contains(t, cmd, "cp /etc/dd-host-profiler/seccomp.json", "should fall back to the default profile")
+}
+
 func containsString(slice []string, s string) bool {
 	for _, v := range slice {
 		if strings.Contains(v, s) {

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -138,15 +138,18 @@ func TestHostProfilerLoggingSeccomp(t *testing.T) {
 	overrides := copyMap(hostProfilerBaseOverrides)
 	overrides["datadog.hostProfiler.loggingSeccomp"] = "true"
 	ds := renderHostProfilerDaemonSet(t, overrides)
+
 	initContainer, ok := getContainer(t, ds.Spec.Template.Spec.InitContainers, "host-profiler-seccomp-setup")
 	require.True(t, ok)
-
-	// Prefer the logging profile, falling back to the default if the image predates it.
 	cmd := strings.Join(initContainer.Command, " ")
-	assert.Contains(t, cmd, "if [ -f /etc/dd-host-profiler/logging-seccomp.json ]",
-		"init container should guard the logging profile copy; command: %v", initContainer.Command)
 	assert.Contains(t, cmd, "cp /etc/dd-host-profiler/logging-seccomp.json")
-	assert.Contains(t, cmd, "cp /etc/dd-host-profiler/seccomp.json", "should fall back to the default profile")
+	assert.Contains(t, cmd, "cp /etc/dd-host-profiler/seccomp.json")
+	assert.Contains(t, cmd, "WARNING: logging-seccomp.json not found in image, falling back to default seccomp profile")
+
+	hpContainer, ok := getContainer(t, ds.Spec.Template.Spec.Containers, "host-profiler")
+	require.True(t, ok)
+	require.NotNil(t, hpContainer.SecurityContext.SeccompProfile)
+	assert.Regexp(t, `^host-profiler-[0-9a-f]{8}-logging$`, *hpContainer.SecurityContext.SeccompProfile.LocalhostProfile)
 }
 
 func containsString(slice []string, s string) bool {


### PR DESCRIPTION
#### What this PR does / why we need it:

Introduces a new boolean setting to let customers enable a seccomp profile that logs denials.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits