### PR TITLE
[observability-pipelines-worker] expose termination grace period to the worker

### DIFF
--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.19.0
+
+* [observability-pipelines-worker] expose termination grace period to the worker ([#2776](https://github.com/DataDog/helm-charts/pull/2776)).
+
 ## 2.18.0
 
 * Official image `2.18.0`

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: 2.18.0
+version: 2.19.0
 description: Observability Pipelines Worker
 type: application
 keywords:

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.18.0](https://img.shields.io/badge/Version-2.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
+![Version: 2.19.0](https://img.shields.io/badge/Version-2.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 

--- a/charts/observability-pipelines-worker/templates/_pod.tpl
+++ b/charts/observability-pipelines-worker/templates/_pod.tpl
@@ -73,6 +73,8 @@ containers:
       - name: DD_PROXY_NO_PROXY
         value: {{ .Values.datadog.proxy.noProxy | join "," | quote }}
       {{- end }}
+      - name: GRACEFUL_SHUTDOWN_LIMIT_SECS
+        value: {{ .Values.terminationGracePeriodSeconds | quote }}
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 6 }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

in 2.19, OPW will honor a termination grace period provided through an environment variable. This commit exposes the pod termination grace period to the worker.

Previously this limit was hardcoded to 60s.

OPW will stay up and try to drain its buffers for up to the configured threshold before exiting. This is useful when the pod termination grace period is longer than 60s. Before this change, the worker would not take advantage of this extra time.

Note: this is not released in the worker yet, and will be part of 2.19.

Note: for now this duplicates the pod termination grace period config, but maybe more control would be useful?

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits