### PR TITLE
Update FIPS proxy version references to 1.1.28

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.230.1
+
+* Update `fips.image.tag` to `1.1.28` fixing CVEs and updating packages.
+
+
 ## 3.230.0
 
 * Bump Datadog Operator chart dependency to 2.24.0.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.230.0
+version: 3.230.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.230.0](https://img.shields.io/badge/Version-3.230.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.230.1](https://img.shields.io/badge/Version-3.230.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -1050,7 +1050,7 @@ helm install <RELEASE_NAME> \
 | fips.image.name | string | `"fips-proxy"` |  |
 | fips.image.pullPolicy | string | `"IfNotPresent"` | Datadog the FIPS sidecar image pull policy |
 | fips.image.repository | string | `nil` | Override default registry + image.name for the FIPS sidecar container. |
-| fips.image.tag | string | `"1.1.27"` | Define the FIPS sidecar container version to use. |
+| fips.image.tag | string | `"1.1.28"` | Define the FIPS sidecar container version to use. |
 | fips.local_address | string | `"127.0.0.1"` | Set local IP address. This setting is only used for the fips-proxy sidecar. |
 | fips.port | int | `9803` | Specifies which port is used by the containers to communicate to the FIPS sidecar. This setting is only used for the fips-proxy sidecar. |
 | fips.portRange | int | `15` | Specifies the number of ports used, defaults to 13 https://github.com/DataDog/datadog-agent/blob/7.44.x/pkg/config/config.go#L1564-L1577. This setting is only used for the fips-proxy sidecar. |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2094,7 +2094,7 @@ fips:
     name: fips-proxy
 
     # fips.image.tag -- Define the FIPS sidecar container version to use.
-    tag: 1.1.27
+    tag: 1.1.28
 
     # fips.image.pullPolicy -- Datadog the FIPS sidecar image pull policy
     pullPolicy: IfNotPresent

--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -406,7 +406,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -591,6 +591,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -634,6 +635,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -721,14 +739,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -749,7 +759,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -768,12 +780,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -803,11 +832,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -902,6 +957,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2496,7 +2558,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2561,7 +2623,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
#### What this PR does / why we need it:

Update FIPS proxy version to 1.1.28 to match last release

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits