### PR TITLE
Update CloudPrem Helm chart to 0.4.5

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4.5
+
+* Update Docker image to `v0.1.31`.
+* Add `indexer.volumeAttributesClass` and `searcher.volumeAttributesClass` values to provision a Kubernetes `VolumeAttributesClass` for the indexer/searcher persistent volumes, allowing tuning of volume attributes such as IOPS and throughput. Disabled by default; requires Kubernetes >= 1.31 and a mandatory `driverName` when enabled.
+* Fix the Kubernetes advertise address by setting the `KUBERNETES_POD_IP` environment variable from the pod IP (`status.podIP`) instead of the pod name.
+
 ## 0.4.4
 
 * Disable `serviceAccount.automountServiceAccountToken` by default to reduce token exposure on pods that don't need Kubernetes API access.

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.4.4
+version: 0.4.5
 # This is the version of the "application". Right now, we follow the image version.
-appVersion: v0.1.30
+appVersion: v0.1.31
 home: https://www.datadoghq.com/
 icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 maintainers:

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.30](https://img.shields.io/badge/AppVersion-v0.1.30-informational?style=flat-square)
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.31](https://img.shields.io/badge/AppVersion-v0.1.31-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/templates/_helpers.tpl
+++ b/charts/cloudprem/templates/_helpers.tpl
@@ -159,6 +159,33 @@ Intake container ports
 {{- end }}
 
 {{/*
+VolumeAttributesClass name for the indexer.
+*/}}
+{{- define "quickwit.indexer.vacName" -}}
+{{- printf "%s-indexer-vac" .Release.Name }}
+{{- end }}
+
+{{/*
+VolumeAttributesClass name for the searcher.
+*/}}
+{{- define "quickwit.searcher.vacName" -}}
+{{- printf "%s-searcher-vac" .Release.Name }}
+{{- end }}
+
+{{/*
+VolumeAttributesClass apiVersion, auto-detected from cluster capabilities.
+*/}}
+{{- define "quickwit.volumeAttributesClass.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "storage.k8s.io/v1/VolumeAttributesClass" -}}
+storage.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "storage.k8s.io/v1beta1/VolumeAttributesClass" -}}
+storage.k8s.io/v1beta1
+{{- else -}}
+{{- fail "VolumeAttributesClass is not available on this cluster (requires Kubernetes >= 1.31)" }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "quickwit.serviceAccountName" -}}
@@ -214,7 +241,7 @@ Quickwit environment
 - name: KUBERNETES_POD_IP
   valueFrom:
     fieldRef:
-      fieldPath: metadata.name
+      fieldPath: status.podIP
 - name: KUBERNETES_LIMITS_CPU
   valueFrom:
     resourceFieldRef:

--- a/charts/cloudprem/templates/indexer-statefulset.yaml
+++ b/charts/cloudprem/templates/indexer-statefulset.yaml
@@ -182,5 +182,8 @@ spec:
       {{- if .Values.indexer.persistentVolume.storageClass }}
         storageClassName: "{{ .Values.indexer.persistentVolume.storageClass }}"
       {{- end }}
+      {{- if .Values.indexer.volumeAttributesClass.enabled }}
+        volumeAttributesClassName: {{ include "quickwit.indexer.vacName" . | quote }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/cloudprem/templates/searcher-statefulset.yaml
+++ b/charts/cloudprem/templates/searcher-statefulset.yaml
@@ -184,5 +184,8 @@ spec:
       {{- if .Values.searcher.persistentVolume.storageClass }}
         storageClassName: "{{ .Values.searcher.persistentVolume.storageClass }}"
       {{- end }}
+      {{- if .Values.searcher.volumeAttributesClass.enabled }}
+        volumeAttributesClassName: {{ include "quickwit.searcher.vacName" . | quote }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/cloudprem/templates/volumeattributesclass.yaml
+++ b/charts/cloudprem/templates/volumeattributesclass.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.indexer.volumeAttributesClass.enabled }}
+apiVersion: {{ include "quickwit.volumeAttributesClass.apiVersion" . }}
+kind: VolumeAttributesClass
+metadata:
+  name: {{ include "quickwit.indexer.vacName" . }}
+driverName: {{ .Values.indexer.volumeAttributesClass.driverName }}
+{{- with .Values.indexer.volumeAttributesClass.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- if .Values.searcher.volumeAttributesClass.enabled }}
+---
+apiVersion: {{ include "quickwit.volumeAttributesClass.apiVersion" . }}
+kind: VolumeAttributesClass
+metadata:
+  name: {{ include "quickwit.searcher.vacName" . }}
+driverName: {{ .Values.searcher.volumeAttributesClass.driverName }}
+{{- with .Values.searcher.volumeAttributesClass.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/cloudprem/values.yaml
+++ b/charts/cloudprem/values.yaml
@@ -220,6 +220,14 @@ searcher:
     # storage: "1Gi"
     # storageClass: ""
 
+  volumeAttributesClass:
+    enabled: false
+    # driverName is mandatory when volumeAttributesClass is enabled.
+    # driverName: ebs.csi.aws.com
+    # parameters:
+    #   iops: "3000"
+    #   throughput: "125"
+
   updateStrategy: {}
     # type: RollingUpdate
 
@@ -473,6 +481,14 @@ indexer:
     annotations: {}
     # storage: "1Gi"
     # storageClass: ""
+
+  volumeAttributesClass:
+    enabled: false
+    # driverName is mandatory when volumeAttributesClass is enabled.
+    # driverName: ebs.csi.aws.com
+    # parameters:
+    #   iops: "3000"
+    #   throughput: "125"
 
 metastore:
   replicaCount: 2


### PR DESCRIPTION
Updates CloudPrem chart to version 0.4.5.

### Changes
* Update Docker image to `v0.1.31`.
* Add `indexer.volumeAttributesClass` and `searcher.volumeAttributesClass` values to provision a Kubernetes `VolumeAttributesClass` for the indexer/searcher persistent volumes (tune IOPS/throughput). Disabled by default; requires Kubernetes >= 1.31 and a mandatory `driverName` when enabled.
* Fix the Kubernetes advertise address by setting `KUBERNETES_POD_IP` from the pod IP (`status.podIP`) instead of the pod name.