### PR TITLE
Propagate DD_LOGS_ENABLED to the trace-agent container

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.230.1
+
+* Fix `DD_LOGS_ENABLED` not being propagated to the `trace-agent` container, which caused Dynamic Instrumentation (Live Debugger) and Exception Replay payloads to be silently dropped when `datadog.logs.enabled` is `true`.
+
 ## 3.230.0
 
 * Bump Datadog Operator chart dependency to 2.24.0.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.230.0
+version: 3.230.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.230.0](https://img.shields.io/badge/Version-3.230.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.230.1](https://img.shields.io/badge/Version-3.230.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_container-trace-agent.yaml
+++ b/charts/datadog/templates/_container-trace-agent.yaml
@@ -50,6 +50,8 @@
       value: {{ .Values.agents.containers.traceAgent.logLevel | default .Values.datadog.logLevel | quote }}
     - name: DD_APM_ENABLED
       value: "true"
+    - name: DD_LOGS_ENABLED
+      value: {{ (default false (or .Values.datadog.logs.enabled .Values.datadog.logsEnabled)) | quote }}
     - name: DD_APM_NON_LOCAL_TRAFFIC
       value: "true"
     - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -1853,6 +1853,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -1853,6 +1853,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -2135,6 +2135,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -2104,6 +2104,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -2101,6 +2101,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -2130,6 +2130,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -2100,6 +2100,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -2171,6 +2171,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -2100,6 +2100,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -2100,6 +2100,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -2136,6 +2136,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -2119,6 +2119,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -406,7 +406,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -591,6 +591,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -634,6 +635,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -721,14 +739,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -749,7 +759,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -768,12 +780,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -803,11 +832,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -902,6 +957,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -1859,8 +1921,6 @@ spec:
                   name: datadog-cluster-agent
             - name: DD_APM_ENABLED
               value: "true"
-            - name: DD_LOGS_ENABLED
-              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT
@@ -2500,7 +2560,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2565,7 +2625,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -1859,6 +1859,8 @@ spec:
                   name: datadog-cluster-agent
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT
@@ -2060,6 +2062,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -2165,6 +2165,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -2104,6 +2104,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -2189,6 +2189,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -2114,6 +2114,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -2185,6 +2185,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -1657,6 +1657,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -1657,6 +1657,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -1712,6 +1712,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -1712,6 +1712,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -2137,6 +2137,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -2185,6 +2185,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -2185,6 +2185,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -2100,6 +2100,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -2105,6 +2105,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -2146,6 +2146,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -2135,6 +2135,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -2105,6 +2105,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -2126,6 +2126,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "true"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -2104,6 +2104,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -2101,6 +2101,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -2101,6 +2101,8 @@ spec:
               value: INFO
             - name: DD_APM_ENABLED
               value: "true"
+            - name: DD_LOGS_ENABLED
+              value: "false"
             - name: DD_APM_NON_LOCAL_TRAFFIC
               value: "true"
             - name: DD_APM_RECEIVER_PORT


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
 - Fixes #2779: the `trace-agent` container never received `DD_LOGS_ENABLED`, so datadog-agent 7.80+'s debugger-proxy gate (`logs_enabled || log_enabled || apm_config.debugger_logs_enabled_override`) always evaluated false there, silently dropping Live Debugger / Exception Replay payloads even with `datadog.logs.enabled: true`.
  - Adds `DD_LOGS_ENABLED` to the trace-agent container's env, mirroring the existing logic used for the core `agent` container (`datadog.logs.enabled` / `datadog.logsEnabled`).
  - Bumps chart version to 3.230.1 and adds a CHANGELOG entry.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits