### PR TITLE
[datadog] Fix Go Dynamic Instrumentation cache volume mount path

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.230.1
+
+* Update the Go Dynamic Instrumentation cache volume mount to `/opt/datadog-agent/run/system-probe/dynamic-instrumentation`, matching the Agent's relocation of that writable state out of `/tmp`, so the SymDB upload cache, probe tombstone, and decompressed debug info persist across container restarts again.
+
 ## 3.230.0
 
 * Bump Datadog Operator chart dependency to 2.24.0.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.230.0
+version: 3.230.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.230.0](https://img.shields.io/badge/Version-3.230.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.230.1](https://img.shields.io/badge/Version-3.230.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -178,7 +178,7 @@
 {{- end }}
 {{- if .Values.datadog.dynamicInstrumentationGo.enabled }}
     - name: dynamic-instrumentation-cache-dir
-      mountPath: /tmp/datadog-agent/system-probe/dynamic-instrumentation
+      mountPath: /opt/datadog-agent/run/system-probe/dynamic-instrumentation
 {{- end }}
 {{- if eq (include "runtime-compilation-enabled" .) "true" }}
     - name: runtime-compiler-output-dir


### PR DESCRIPTION
#### What this PR does / why we need it:

The Agent recently changed where the Go Dynamic Instrumentation feature stores its working files. This chart was still setting up storage at the old location, so those files were landing somewhere temporary that gets wiped every time the container restarts.

This updates the chart to point at the new location, so the files are kept in proper storage again and survive restarts like they used to.

#### Which issue this PR fixes


#### Special notes for your reviewer:

- This just realigns the chart with a change already made in the Agent. Nothing new is added, and no settings change for users.

#### Checklist

  - [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
  - [ ] Chart Version semver bump label has been added (`datadog/patch-version`)
  - [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
  - [ ] For `datadog` chart changes, received ✅ from a member of your team
  - [x] `CHANGELOG.md` has been updated
  - [x] Variables are documented in the `README.md` (no new variables; version bumped)

  [1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits