### PR TITLE
Update crds for operator 1.29.0-rc.1

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.23.0-dev.1
+
+* Update CRDs from Datadog Operator v1.29.0-rc.1 release candidate tag.
+
 ## 2.22.0
 
 * Update CRDs from Datadog Operator v1.28.0.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.22.0
+version: 2.23.0-dev.1
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.22.0](https://img.shields.io/badge/Version-2.22.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.23.0-dev.1](https://img.shields.io/badge/Version-2.23.0--dev.1-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentinternals_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentinternals_v1.yaml
@@ -1070,6 +1070,11 @@ spec:
                         enabled:
                           type: boolean
                       type: object
+                    kubernetesActions:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     liveContainerCollection:
                       properties:
                         enabled:
@@ -1968,7 +1973,7 @@ spec:
                           type: string
                         config:
                           additionalProperties:
-                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
                           type: object
                         enableGlobalPermissions:
                           type: boolean
@@ -5478,6 +5483,11 @@ spec:
                                       type: string
                                   type: object
                               type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        kubernetesActions:
+                          properties:
                             enabled:
                               type: boolean
                           type: object

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagentprofiles_v1.yaml
@@ -1069,6 +1069,11 @@ spec:
                             enabled:
                               type: boolean
                           type: object
+                        kubernetesActions:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                         liveContainerCollection:
                           properties:
                             enabled:
@@ -1967,7 +1972,7 @@ spec:
                               type: string
                             config:
                               additionalProperties:
-                                type: string
+                                x-kubernetes-preserve-unknown-fields: true
                               type: object
                             enableGlobalPermissions:
                               type: boolean

--- a/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadogagents_v1.yaml
@@ -1074,6 +1074,11 @@ spec:
                         enabled:
                           type: boolean
                       type: object
+                    kubernetesActions:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     liveContainerCollection:
                       properties:
                         enabled:
@@ -1972,7 +1977,7 @@ spec:
                           type: string
                         config:
                           additionalProperties:
-                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
                           type: object
                         enableGlobalPermissions:
                           type: boolean
@@ -4435,6 +4440,8 @@ spec:
                       format: int32
                       type: integer
                   type: object
+                clusterProvider:
+                  type: string
                 conditions:
                   items:
                     properties:
@@ -5539,6 +5546,11 @@ spec:
                                       type: string
                                   type: object
                               type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        kubernetesActions:
+                          properties:
                             enabled:
                               type: boolean
                           type: object

--- a/charts/datadog-crds/templates/datadoghq.com_datadoginstrumentations_v1.yaml
+++ b/charts/datadog-crds/templates/datadoghq.com_datadoginstrumentations_v1.yaml
@@ -74,12 +74,9 @@ spec:
                       items:
                         description: DatadogInstrumentationCheckConfig defines an Autodiscovery check configuration.
                         properties:
-                          containerImage:
-                            description: ContainerImage identifies container image names this check applies to.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: set
+                          containerName:
+                            description: ContainerName identifies the container name this check applies to.
+                            type: string
                           initConfig:
                             description: InitConfig is the integration-specific Autodiscovery init_config payload.
                             type: object
@@ -94,81 +91,86 @@ spec:
                           integration:
                             description: Integration is the Datadog integration name, for example redisdb.
                             type: string
-                          logs:
-                            description: Logs contains log collection configuration payloads for this integration.
+                        required:
+                          - integration
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    logs:
+                      description: Logs configures Datadog Agent log collection for the target workload.
+                      items:
+                        description: DatadogInstrumentationLogConfig defines Agent log collection configuration fields.
+                        properties:
+                          channel_path:
+                            description: ChannelPath is the Windows event channel path when type is windows_event.
+                            type: string
+                          containerName:
+                            description: ContainerName identifies the container name this log configuration applies to.
+                            type: string
+                          encoding:
+                            description: |-
+                              Encoding sets the file encoding when type is file.
+                              Common values include utf-16-le, utf-16-be, and shift-jis.
+                            type: string
+                          exclude_paths:
+                            description: ExcludePaths lists matching files to exclude when type is file and path contains a wildcard.
                             items:
-                              description: DatadogInstrumentationLogConfig defines Agent log collection configuration fields.
-                              properties:
-                                channel_path:
-                                  description: ChannelPath is the Windows event channel path when type is windows_event.
-                                  type: string
-                                encoding:
-                                  description: |-
-                                    Encoding sets the file encoding when type is file.
-                                    Common values include utf-16-le, utf-16-be, and shift-jis.
-                                  type: string
-                                exclude_paths:
-                                  description: ExcludePaths lists matching files to exclude when type is file and path contains a wildcard.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: set
-                                exclude_units:
-                                  description: ExcludeUnits lists journald units to exclude when type is journald.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: set
-                                include_units:
-                                  description: IncludeUnits lists journald units to include when type is journald.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: set
-                                log_processing_rules:
-                                  description: LogProcessingRules contains Agent log processing rules for this log source.
-                                  items:
-                                    type: object
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                path:
-                                  description: Path is the file path for gathering logs when type is file or journald.
-                                  type: string
-                                port:
-                                  description: Port is the port for listening to logs when type is tcp or udp.
-                                  format: int32
-                                  type: integer
-                                service:
-                                  description: Service sets the log service name.
-                                  type: string
-                                source:
-                                  description: Source sets the log source name.
-                                  type: string
-                                sourcecategory:
-                                  description: SourceCategory sets the source category attribute.
-                                  type: string
-                                start_position:
-                                  description: |-
-                                    StartPosition sets where the Agent starts reading for file and journald tailers.
-                                    Common values include beginning, end, forceBeginning, and forceEnd.
-                                  type: string
-                                tags:
-                                  description: Tags sets additional tags on collected logs.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: set
-                                type:
-                                  description: Type is the type of log input source. Common values include tcp, udp, file, windows_event, docker, and journald.
-                                  type: string
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          exclude_units:
+                            description: ExcludeUnits lists journald units to exclude when type is journald.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          include_units:
+                            description: IncludeUnits lists journald units to include when type is journald.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          log_processing_rules:
+                            description: LogProcessingRules contains Agent log processing rules for this log source.
+                            items:
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
                             type: array
                             x-kubernetes-list-type: atomic
+                          path:
+                            description: Path is the file path for gathering logs when type is file or journald.
+                            type: string
+                          port:
+                            description: Port is the port for listening to logs when type is tcp or udp.
+                            format: int32
+                            type: integer
+                          service:
+                            description: Service sets the log service name.
+                            type: string
+                          source:
+                            description: Source sets the log source name.
+                            type: string
+                          sourcecategory:
+                            description: SourceCategory sets the source category attribute.
+                            type: string
+                          start_position:
+                            description: |-
+                              StartPosition sets where the Agent starts reading for file and journald tailers.
+                              Common values include beginning, end, forceBeginning, and forceEnd.
+                            type: string
+                          tags:
+                            description: Tags sets additional tags on collected logs.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          type:
+                            description: Type is the type of log input source. Common values include tcp, udp, file, windows_event, docker, and journald.
+                            type: string
                         required:
-                          - integration
+                          - containerName
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       type: array
                       x-kubernetes-list-type: atomic
                   type: object

--- a/crds/datadoghq.com_datadogagentinternals.yaml
+++ b/crds/datadoghq.com_datadogagentinternals.yaml
@@ -1058,6 +1058,11 @@ spec:
                         enabled:
                           type: boolean
                       type: object
+                    kubernetesActions:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     liveContainerCollection:
                       properties:
                         enabled:
@@ -1956,7 +1961,7 @@ spec:
                           type: string
                         config:
                           additionalProperties:
-                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
                           type: object
                         enableGlobalPermissions:
                           type: boolean
@@ -5466,6 +5471,11 @@ spec:
                                       type: string
                                   type: object
                               type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        kubernetesActions:
+                          properties:
                             enabled:
                               type: boolean
                           type: object

--- a/crds/datadoghq.com_datadogagentprofiles.yaml
+++ b/crds/datadoghq.com_datadogagentprofiles.yaml
@@ -1057,6 +1057,11 @@ spec:
                             enabled:
                               type: boolean
                           type: object
+                        kubernetesActions:
+                          properties:
+                            enabled:
+                              type: boolean
+                          type: object
                         liveContainerCollection:
                           properties:
                             enabled:
@@ -1955,7 +1960,7 @@ spec:
                               type: string
                             config:
                               additionalProperties:
-                                type: string
+                                x-kubernetes-preserve-unknown-fields: true
                               type: object
                             enableGlobalPermissions:
                               type: boolean

--- a/crds/datadoghq.com_datadogagents.yaml
+++ b/crds/datadoghq.com_datadogagents.yaml
@@ -1062,6 +1062,11 @@ spec:
                         enabled:
                           type: boolean
                       type: object
+                    kubernetesActions:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     liveContainerCollection:
                       properties:
                         enabled:
@@ -1960,7 +1965,7 @@ spec:
                           type: string
                         config:
                           additionalProperties:
-                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
                           type: object
                         enableGlobalPermissions:
                           type: boolean
@@ -4423,6 +4428,8 @@ spec:
                       format: int32
                       type: integer
                   type: object
+                clusterProvider:
+                  type: string
                 conditions:
                   items:
                     properties:
@@ -5527,6 +5534,11 @@ spec:
                                       type: string
                                   type: object
                               type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        kubernetesActions:
+                          properties:
                             enabled:
                               type: boolean
                           type: object

--- a/crds/datadoghq.com_datadoginstrumentations.yaml
+++ b/crds/datadoghq.com_datadoginstrumentations.yaml
@@ -62,12 +62,9 @@ spec:
                       items:
                         description: DatadogInstrumentationCheckConfig defines an Autodiscovery check configuration.
                         properties:
-                          containerImage:
-                            description: ContainerImage identifies container image names this check applies to.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: set
+                          containerName:
+                            description: ContainerName identifies the container name this check applies to.
+                            type: string
                           initConfig:
                             description: InitConfig is the integration-specific Autodiscovery init_config payload.
                             type: object
@@ -82,81 +79,86 @@ spec:
                           integration:
                             description: Integration is the Datadog integration name, for example redisdb.
                             type: string
-                          logs:
-                            description: Logs contains log collection configuration payloads for this integration.
+                        required:
+                          - integration
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    logs:
+                      description: Logs configures Datadog Agent log collection for the target workload.
+                      items:
+                        description: DatadogInstrumentationLogConfig defines Agent log collection configuration fields.
+                        properties:
+                          channel_path:
+                            description: ChannelPath is the Windows event channel path when type is windows_event.
+                            type: string
+                          containerName:
+                            description: ContainerName identifies the container name this log configuration applies to.
+                            type: string
+                          encoding:
+                            description: |-
+                              Encoding sets the file encoding when type is file.
+                              Common values include utf-16-le, utf-16-be, and shift-jis.
+                            type: string
+                          exclude_paths:
+                            description: ExcludePaths lists matching files to exclude when type is file and path contains a wildcard.
                             items:
-                              description: DatadogInstrumentationLogConfig defines Agent log collection configuration fields.
-                              properties:
-                                channel_path:
-                                  description: ChannelPath is the Windows event channel path when type is windows_event.
-                                  type: string
-                                encoding:
-                                  description: |-
-                                    Encoding sets the file encoding when type is file.
-                                    Common values include utf-16-le, utf-16-be, and shift-jis.
-                                  type: string
-                                exclude_paths:
-                                  description: ExcludePaths lists matching files to exclude when type is file and path contains a wildcard.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: set
-                                exclude_units:
-                                  description: ExcludeUnits lists journald units to exclude when type is journald.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: set
-                                include_units:
-                                  description: IncludeUnits lists journald units to include when type is journald.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: set
-                                log_processing_rules:
-                                  description: LogProcessingRules contains Agent log processing rules for this log source.
-                                  items:
-                                    type: object
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                path:
-                                  description: Path is the file path for gathering logs when type is file or journald.
-                                  type: string
-                                port:
-                                  description: Port is the port for listening to logs when type is tcp or udp.
-                                  format: int32
-                                  type: integer
-                                service:
-                                  description: Service sets the log service name.
-                                  type: string
-                                source:
-                                  description: Source sets the log source name.
-                                  type: string
-                                sourcecategory:
-                                  description: SourceCategory sets the source category attribute.
-                                  type: string
-                                start_position:
-                                  description: |-
-                                    StartPosition sets where the Agent starts reading for file and journald tailers.
-                                    Common values include beginning, end, forceBeginning, and forceEnd.
-                                  type: string
-                                tags:
-                                  description: Tags sets additional tags on collected logs.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: set
-                                type:
-                                  description: Type is the type of log input source. Common values include tcp, udp, file, windows_event, docker, and journald.
-                                  type: string
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          exclude_units:
+                            description: ExcludeUnits lists journald units to exclude when type is journald.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          include_units:
+                            description: IncludeUnits lists journald units to include when type is journald.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          log_processing_rules:
+                            description: LogProcessingRules contains Agent log processing rules for this log source.
+                            items:
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
                             type: array
                             x-kubernetes-list-type: atomic
+                          path:
+                            description: Path is the file path for gathering logs when type is file or journald.
+                            type: string
+                          port:
+                            description: Port is the port for listening to logs when type is tcp or udp.
+                            format: int32
+                            type: integer
+                          service:
+                            description: Service sets the log service name.
+                            type: string
+                          source:
+                            description: Source sets the log source name.
+                            type: string
+                          sourcecategory:
+                            description: SourceCategory sets the source category attribute.
+                            type: string
+                          start_position:
+                            description: |-
+                              StartPosition sets where the Agent starts reading for file and journald tailers.
+                              Common values include beginning, end, forceBeginning, and forceEnd.
+                            type: string
+                          tags:
+                            description: Tags sets additional tags on collected logs.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          type:
+                            description: Type is the type of log input source. Common values include tcp, udp, file, windows_event, docker, and journald.
+                            type: string
                         required:
-                          - integration
+                          - containerName
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       type: array
                       x-kubernetes-list-type: atomic
                   type: object


### PR DESCRIPTION
## What does this PR do?

Updates the `datadog-crds` chart to `2.23.0-dev.1` with CRDs from Datadog Operator `v1.29.0-rc.1`.

Part of the Datadog Operator `v1.29.0-rc.1` release. Created manually because the Atlas `OperatorRelease` worker could not tag the release (the tag was created manually due to a bot tag-creation permission issue), so it did not auto-open the helm chart PRs.

## Changes
- `datadog-crds` chart: `2.22.0` -> `2.23.0-dev.1`
- Updated CRDs: `datadogagents`, `datadogagentinternals`, `datadogagentprofiles`, `datadoginstrumentations`