### PR TITLE
Update operator for 1.29.0-rc.1

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.25.0-dev.1
+
+* Update Datadog Operator chart for 1.29.0-rc.1.
+
 ## 2.24.0
 
 * Update Datadog Operator chart for 1.28.0.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.22.0
-digest: sha256:ffc2d1aa91d55ae7dfcbf4295b020fa0ba5147df1a44ec5eb2ba2d67c8e68e2a
-generated: "2026-07-02T15:29:25.051983-04:00"
+  version: 2.23.0-dev.1
+digest: sha256:c0d24c588e6a6a9462bd8e1cdd7f51a28cc2c0ca93a403e73fad9f473b4cfbc1
+generated: "2026-07-09T14:24:25.254463-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.24.0
-appVersion: 1.28.0
+version: 2.25.0-dev.1
+appVersion: 1.29.0-rc.1
 description: Datadog Operator
 keywords:
 - monitoring

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: 2.22.0
+  version: 2.23.0-dev.1
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.24.0](https://img.shields.io/badge/Version-2.24.0-informational?style=flat-square) ![AppVersion: 1.28.0](https://img.shields.io/badge/AppVersion-1.28.0-informational?style=flat-square)
+![Version: 2.25.0-dev.1](https://img.shields.io/badge/Version-2.25.0--dev.1-informational?style=flat-square) ![AppVersion: 1.29.0-rc.1](https://img.shields.io/badge/AppVersion-1.29.0--rc.1-informational?style=flat-square)
 
 ## Values
 
@@ -43,7 +43,7 @@
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"registry.datadoghq.com/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.28.0"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.29.0-rc.1"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |

--- a/charts/datadog-operator/templates/_helpers.tpl
+++ b/charts/datadog-operator/templates/_helpers.tpl
@@ -186,6 +186,6 @@ Check operator image tag version.
 {{- $parts := split "@" $tag -}}
 {{- index $parts "_0"}}
 {{- else -}}
-{{ "1.28.0" }}
+{{ "1.29.0-rc.1" }}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: registry.datadoghq.com/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.28.0
+  tag: 1.29.0-rc.1
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
   # image.doNotCheckTag -- Permit skipping operator image tag compatibility with the chart.

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.17.3
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-2.22.0'
+    helm.sh/chart: 'datadogCRDs-2.23.0-dev.1'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'
@@ -1068,6 +1068,11 @@ spec:
                         enabled:
                           type: boolean
                       type: object
+                    kubernetesActions:
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
                     liveContainerCollection:
                       properties:
                         enabled:
@@ -1966,7 +1971,7 @@ spec:
                           type: string
                         config:
                           additionalProperties:
-                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
                           type: object
                         enableGlobalPermissions:
                           type: boolean
@@ -4429,6 +4434,8 @@ spec:
                       format: int32
                       type: integer
                   type: object
+                clusterProvider:
+                  type: string
                 conditions:
                   items:
                     properties:
@@ -5533,6 +5540,11 @@ spec:
                                       type: string
                                   type: object
                               type: object
+                            enabled:
+                              type: boolean
+                          type: object
+                        kubernetesActions:
+                          properties:
                             enabled:
                               type: boolean
                           type: object

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.24.0
+    helm.sh/chart: datadog-operator-2.25.0-dev.1
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.28.0"
+    app.kubernetes.io/version: "1.29.0-rc.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator 
       containers:
         - name: datadog-operator
-          image: "registry.datadoghq.com/operator:1.28.0"
+          image: "registry.datadoghq.com/operator:1.29.0-rc.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -208,7 +208,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "registry.datadoghq.com/operator:1.28.0", operatorContainer.Image)
+	assert.Equal(t, "registry.datadoghq.com/operator:1.29.0-rc.1", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
## What does this PR do?

Updates the `datadog-operator` chart to `2.25.0-dev.1` with appVersion `1.29.0-rc.1`.

Part of the Datadog Operator `v1.29.0-rc.1` release. Created manually because the Atlas `OperatorRelease` worker could not tag the release (bot tag-creation permission issue), so it did not auto-open the helm chart PRs.

## Changes
- `datadog-operator` chart: `2.24.0` -> `2.25.0-dev.1`
- appVersion: `1.28.0` -> `1.29.0-rc.1`
- `values.yaml` image tag, `_helpers.tpl` fallback, deployment test + baseline updated
- No RBAC change: `role.yaml` is identical between v1.28.0 and v1.29.0-rc.1