### PR TITLE
fix(datadog): regenerate gpu_monitoring_cos baseline for operator 1.28.0

### DIFF
--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -406,7 +406,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -591,6 +591,7 @@ rules:
       - create
       - get
       - list
+      - patch
       - watch
   - apiGroups:
       - autoscaling
@@ -634,6 +635,23 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+      - consul.hashicorp.com
+      - core.haproxy.org
+      - datadoghq.com
+      - gateway.envoyproxy.io
+      - ingress.v1.haproxy.org
+      - karpenter.azure.com
+      - kuma.io
+      - mesh.consul.hashicorp.com
+      - policy.linkerd.io
+      - traefik.containo.us
+    resources:
+      - '*'
+    verbs:
+      - list
       - watch
   - apiGroups:
       - coordination.k8s.io
@@ -721,14 +739,6 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - datadoghq.com
-      - karpenter.azure.com
-    resources:
-      - '*'
-    verbs:
-      - list
-      - watch
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
@@ -749,7 +759,9 @@ rules:
   - apiGroups:
       - gateway.envoyproxy.io
     resources:
+      - backends
       - envoyextensionpolicies
+      - envoypatchpolicies
     verbs:
       - create
       - delete
@@ -768,12 +780,29 @@ rules:
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
+      - grpcroutes
+      - listenersets
+      - tlsroutes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
       - referencegrants
     verbs:
       - create
       - delete
       - get
       - patch
+  - apiGroups:
+      - k8s.nginx.org
+    resources:
+      - virtualserverroutes
+      - virtualservers
+    verbs:
+      - list
+      - watch
   - apiGroups:
       - karpenter.sh
     resources:
@@ -803,11 +832,37 @@ rules:
   - apiGroups:
       - networking.istio.io
     resources:
+      - destinationrules
+      - serviceentries
+      - sidecars
+      - virtualservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
       - envoyfilters
     verbs:
       - create
       - delete
       - get
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -902,6 +957,13 @@ rules:
       - volumeattachments
     verbs:
       - get
+      - list
+      - watch
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+    verbs:
       - list
       - watch
   - apiGroups:
@@ -2496,7 +2558,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.27.0
+    app.kubernetes.io/version: 1.28.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2561,7 +2623,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.27.0
+          image: registry.datadoghq.com/operator:1.28.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## What this PR does / why we need it

The `test/datadog/baseline/manifests/gpu_monitoring_cos.yaml` baseline was left at Datadog Operator **1.27.0** while the rest of the `datadog` chart moved to **1.28.0**. As a result, **any** PR that touches `charts/datadog/**` or `test/datadog/**` fails the `build` job of the **Go Test Datadog** workflow on `Test_baseline_inputs/gpu_monitoring_cos.yaml` (e.g. #2755). The drift is on `main` today.

### Root cause

- #2764 (`a777a61d`, merged Jul 3) added the `gpu_monitoring_cos.yaml` baseline while the operator was still `1.27.0`.
- #2771 (`d859a217`, merged Jul 6) bumped `operator.image.tag` to `1.28.0` and ran `make update-test-baselines` — but its branch predated #2764, so it regenerated `gpu_monitoring.yaml` and never saw the newly-added `gpu_monitoring_cos.yaml`.
- The two PRs merged cleanly, leaving a stale baseline on `main`.

### The fix

Regenerated with `make update-test-baselines-datadog-agent`. The diff is confined to `gpu_monitoring_cos.yaml`:
- `app.kubernetes.io/version` `1.27.0` → `1.28.0` and operator image `registry.datadoghq.com/operator:1.27.0` → `1.28.0`
- Operator `ClusterRole` RBAC changes carried by the `datadog-operator` `2.23` → `2.24` subchart bump (added `patch` verb, new service-mesh/ingress apiGroups, restructured the `datadoghq.com`/`karpenter.azure.com` rule)

No chart changed, so this is a test-only, no-version-bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)