### PR TITLE
[datadog] Fix GKE COS system-probe NVML mount

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.231.3
+
+* Mount GKE COS NVIDIA driver libraries at system-probe's `HOST_ROOT` path so GPU monitoring can find NVML when `providers.gke.cos=true`.
+
 ## 3.231.2
 
 * Update the Go Dynamic Instrumentation cache volume mount to `/opt/datadog-agent/run/system-probe/dynamic-instrumentation`, matching the Agent's relocation of that writable state out of `/tmp`, so the SymDB upload cache, probe tombstone, and decompressed debug info persist across container restarts again.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.231.2
+version: 3.231.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.231.2](https://img.shields.io/badge/Version-3.231.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.231.3](https://img.shields.io/badge/Version-3.231.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.231.3](https://img.shields.io/badge/Version-3.231.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.231.4](https://img.shields.io/badge/Version-3.231.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -150,9 +150,6 @@
       mountPath: /var/run/nvidia-container-devices/all
 {{- if .Values.providers.gke.cos }}
     - name: gke-nvidia-driver-lib64
-      mountPath: /host/run/nvidia/driver/usr/lib/x86_64-linux-gnu
-      readOnly: true
-    - name: gke-nvidia-driver-lib64
       mountPath: /host/root/run/nvidia/driver/usr/lib/x86_64-linux-gnu
       readOnly: true
 {{- end }}

--- a/charts/datadog/templates/_container-system-probe.yaml
+++ b/charts/datadog/templates/_container-system-probe.yaml
@@ -152,6 +152,9 @@
     - name: gke-nvidia-driver-lib64
       mountPath: /host/run/nvidia/driver/usr/lib/x86_64-linux-gnu
       readOnly: true
+    - name: gke-nvidia-driver-lib64
+      mountPath: /host/root/run/nvidia/driver/usr/lib/x86_64-linux-gnu
+      readOnly: true
 {{- end }}
 {{- if .Values.datadog.gpuMonitoring.configureCgroupPerms }}
     - name: host-systemd-transient

--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -2305,9 +2305,6 @@ spec:
               readOnly: false
             - mountPath: /var/run/nvidia-container-devices/all
               name: gpu-devices
-            - mountPath: /host/run/nvidia/driver/usr/lib/x86_64-linux-gnu
-              name: gke-nvidia-driver-lib64
-              readOnly: true
             - mountPath: /host/root/run/nvidia/driver/usr/lib/x86_64-linux-gnu
               name: gke-nvidia-driver-lib64
               readOnly: true

--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -2308,6 +2308,9 @@ spec:
             - mountPath: /host/run/nvidia/driver/usr/lib/x86_64-linux-gnu
               name: gke-nvidia-driver-lib64
               readOnly: true
+            - mountPath: /host/root/run/nvidia/driver/usr/lib/x86_64-linux-gnu
+              name: gke-nvidia-driver-lib64
+              readOnly: true
             - mountPath: /host/root/run/systemd/transient
               name: host-systemd-transient
               readOnly: false


### PR DESCRIPTION
#### What this PR does / why we need it:

Mounts the GKE COS NVIDIA driver library volume at system-probe's `HOST_ROOT` path so GPU monitoring can find NVML when `providers.gke.cos=true`.

#### Which issue this PR fixes

#### Special notes for your reviewer:

Validated on a GKE COS T4 cluster: the Agent GPU check found NVML and emitted GPU metrics, while system-probe required this `HOST_ROOT` path for its own NVML lookup.

#### Checklist
- [ ] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commits/signing-commits