### PR TITLE
[datadog] Add apiKeyOnlyEnrollment for Private Action Runner

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.231.6
+
+* Add `privateActionRunner.apiKeyOnlyEnrollment` for node agent and cluster agent, wiring it to `api_key_only_enrollment` in the PAR ConfigMap and `DD_PRIVATE_ACTION_RUNNER_API_KEY_ONLY_ENROLLMENT` in the cluster agent deployment respectively.
+
 ## 3.231.5
 
 * Add kubernetes use endpointslice config to the node Agent.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.231.5
+version: 3.231.6
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.231.5](https://img.shields.io/badge/Version-3.231.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.231.6](https://img.shields.io/badge/Version-3.231.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -672,6 +672,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.podSecurity.securityContextConstraints.create | bool | `false` | If true, create a SCC resource for Cluster Agent pods |
 | clusterAgent.priorityClassName | string | `nil` | Name of the priorityClass to apply to the Cluster Agent |
 | clusterAgent.privateActionRunner.actionsAllowlist | list | `[]` | List of actions executable by the Private Action Runner |
+| clusterAgent.privateActionRunner.apiKeyOnlyEnrollment | bool | `false` | Enroll using only the API key, without requiring an app key |
 | clusterAgent.privateActionRunner.enabled | bool | `false` | Enable the Private Action Runner to execute workflow actions |
 | clusterAgent.privateActionRunner.identityFromExistingSecret | string | `nil` | Use existing Secret which stores the Private Action Runner URN and private key # The secret should contain 'urn' and 'private_key' keys # If set, this parameter takes precedence over "urn" and "privateKey" |
 | clusterAgent.privateActionRunner.identitySecretName | string | `"datadog-private-action-runner-identity"` | Name of the Kubernetes secret used to store PAR identity when self-enrollment is enabled # The Cluster Agent will create and manage this secret for storing the enrolled runner's URN and private key # RBAC permissions are granted specifically for this secret name |
@@ -952,6 +953,7 @@ helm install <RELEASE_NAME> \
 | datadog.podAnnotationsAsTags | object | `{}` | Provide a mapping of Kubernetes Annotations to Datadog Tags |
 | datadog.podLabelsAsTags | object | `{}` | Provide a mapping of Kubernetes Labels to Datadog Tags |
 | datadog.privateActionRunner.actionsAllowlist | list | `[]` | List of actions executable by the Private Action Runner |
+| datadog.privateActionRunner.apiKeyOnlyEnrollment | bool | `false` | Enroll using only the API key, without requiring an app key |
 | datadog.privateActionRunner.enabled | bool | `false` | Enable the Private Action Runner on the node agent to execute workflow actions |
 | datadog.privateActionRunner.identityFromExistingSecret | string | `nil` | Use existing Secret which stores the Private Action Runner URN and private key # The secret should contain 'urn' and 'private_key' keys # If set, this parameter takes precedence over "urn" and "privateKey" |
 | datadog.privateActionRunner.privateKey | string | `nil` | Private key for the Private Action Runner (required if selfEnroll is false) # This key is used to authenticate the runner with Datadog |

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -394,6 +394,10 @@ spec:
           - name: DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST
             value: {{ .Values.clusterAgent.privateActionRunner.actionsAllowlist | join "," | quote }}
           {{- end }}
+          {{- if .Values.clusterAgent.privateActionRunner.apiKeyOnlyEnrollment }}
+          - name: DD_PRIVATE_ACTION_RUNNER_API_KEY_ONLY_ENROLLMENT
+            value: "true"
+          {{- end }}
           {{- end }}
           {{- if .Values.datadog.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED

--- a/charts/datadog/templates/private-action-runner-configmap.yaml
+++ b/charts/datadog/templates/private-action-runner-configmap.yaml
@@ -25,6 +25,9 @@ data:
       private_key: {{ .Values.datadog.privateActionRunner.privateKey | quote }}
       {{- end }}
       {{- end }}
+      {{- if .Values.datadog.privateActionRunner.apiKeyOnlyEnrollment }}
+      api_key_only_enrollment: true
+      {{- end }}
       {{- if .Values.datadog.privateActionRunner.actionsAllowlist }}
       actions_allowlist:
         {{- range .Values.datadog.privateActionRunner.actionsAllowlist }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -558,6 +558,9 @@ datadog:
     #   - "com.datadoghq.http.request"
     #   - "com.datadoghq.gitlab.branches.*"
 
+    # datadog.privateActionRunner.apiKeyOnlyEnrollment -- Enroll using only the API key, without requiring an app key
+    apiKeyOnlyEnrollment: false
+
   ## Enable logs agent and provide custom configs
   logs:
     # datadog.logs.enabled -- Enables this to activate Datadog Agent log collection
@@ -1909,6 +1912,9 @@ clusterAgent:
     actionsAllowlist: []
     #   - "com.datadoghq.http.request"
     #   - "com.datadoghq.kubernetes.core.*"
+
+    # clusterAgent.privateActionRunner.apiKeyOnlyEnrollment -- Enroll using only the API key, without requiring an app key
+    apiKeyOnlyEnrollment: false
 
     # clusterAgent.privateActionRunner.k8sRemediationEnabled -- Enable k8s remediation RBAC for the Private Action Runner
     ## When enabled, a ClusterRole and ClusterRoleBinding are created granting the Cluster Agent


### PR DESCRIPTION
## Summary

- Adds `datadog.privateActionRunner.apiKeyOnlyEnrollment` value, wired to `api_key_only_enrollment` in the node agent PAR ConfigMap
- Adds `clusterAgent.privateActionRunner.apiKeyOnlyEnrollment` value, wired to `DD_PRIVATE_ACTION_RUNNER_API_KEY_ONLY_ENROLLMENT` env var in the cluster agent deployment
- Both default to `false` to preserve existing behavior

## Problem

`apiKeyOnlyEnrollment` is listed in the PAR configuration crosswalk table in the documentation as a valid Helm key, but it was not implemented in the chart templates. Setting it had no effect, requiring users to work around it with a raw `datadog.env` entry.

## Test plan

- [ ] `helm template` with `datadog.privateActionRunner.apiKeyOnlyEnrollment: true` renders `api_key_only_enrollment: true` in the PAR ConfigMap
- [ ] `helm template` with `clusterAgent.privateActionRunner.apiKeyOnlyEnrollment: true` renders `DD_PRIVATE_ACTION_RUNNER_API_KEY_ONLY_ENROLLMENT=true` in the cluster agent deployment
- [ ] Default (`false`) produces no change in rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)