### PR TITLE
[PROF-15441][Host Profiler] add SELinuxOptions.type defaults and setting for host profiler

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.234.0
+
+* [PROF-15441][Host Profiler] add SELinuxOptions.type defaults and setting for host profiler ([#2808](https://github.com/DataDog/helm-charts/pull/2808)).
+
 ## 3.233.0
 
 * [PROF-15317] allow helm to use logging seccomp ([#2775](https://github.com/DataDog/helm-charts/pull/2775)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.233.0
+version: 3.234.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.233.0](https://img.shields.io/badge/Version-3.233.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.234.0](https://img.shields.io/badge/Version-3.234.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -498,7 +498,7 @@ helm install <RELEASE_NAME> \
 | agents.containers.hostProfiler.envDict | object | `{}` | Set environment variables specific to host-profiler defined in a dict |
 | agents.containers.hostProfiler.envFrom | list | `[]` | Set environment variables specific to host-profiler from configMaps and/or secrets |
 | agents.containers.hostProfiler.resources | object | `{}` | Resource requests and limits for the host-profiler container |
-| agents.containers.hostProfiler.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["BPF","PERFMON","SYS_PTRACE","SYS_RESOURCE","DAC_READ_SEARCH","SYSLOG","CHECKPOINT_RESTORE","IPC_LOCK"],"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | Allows you to overwrite the default container SecurityContext for the host-profiler container. |
+| agents.containers.hostProfiler.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["BPF","PERFMON","SYS_PTRACE","SYS_RESOURCE","DAC_READ_SEARCH","SYSLOG","CHECKPOINT_RESTORE","IPC_LOCK"],"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"seLinuxOptions":{"type":"spc_t"}}` | Allows you to overwrite the default container SecurityContext for the host-profiler container. |
 | agents.containers.hostProfiler.volumeMounts | list | `[]` | Specify additional volumes to mount in the host-profiler container |
 | agents.containers.initContainers.resources | object | `{}` | Resource requests and limits for the init containers |
 | agents.containers.initContainers.securityContext | object | `{}` | Allows you to overwrite the default container SecurityContext for the init containers. |

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2480,6 +2480,9 @@ agents:
         readOnlyRootFilesystem: true
         allowPrivilegeEscalation: false
         privileged: false
+        # spc_t so SELinux-enforcing nodes don't block host-profiler's cross-process /proc access.
+        seLinuxOptions:
+          type: spc_t
         capabilities:
           drop:
             - ALL

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -110,6 +110,38 @@ func TestHostProfilerSeccompDifferentImages(t *testing.T) {
 	assert.NotEqual(t, profile1, profile2, "different images should produce different seccomp profile names")
 }
 
+func TestHostProfilerSELinux(t *testing.T) {
+	t.Run("default_spc_t", func(t *testing.T) {
+		// SELinux defaults to spc_t so SELinux-enforcing nodes don't block the cross-process
+		// /proc access the host-profiler needs.
+		ds := renderHostProfilerDaemonSet(t, hostProfilerBaseOverrides)
+
+		hpContainer, ok := getContainer(t, ds.Spec.Template.Spec.Containers, "host-profiler")
+		require.True(t, ok)
+		require.NotNil(t, hpContainer.SecurityContext)
+		selinux := hpContainer.SecurityContext.SELinuxOptions
+		if assert.NotNil(t, selinux, "host-profiler seLinuxOptions") {
+			assert.Equal(t, "spc_t", selinux.Type)
+		}
+	})
+
+	t.Run("user_securityContext_overrides_default", func(t *testing.T) {
+		// A user-provided securityContext.seLinuxOptions takes precedence over the spc_t default.
+		overrides := copyMap(hostProfilerBaseOverrides)
+		overrides["agents.containers.hostProfiler.securityContext.seLinuxOptions.type"] = "custom_t"
+
+		ds := renderHostProfilerDaemonSet(t, overrides)
+
+		hpContainer, ok := getContainer(t, ds.Spec.Template.Spec.Containers, "host-profiler")
+		require.True(t, ok)
+		require.NotNil(t, hpContainer.SecurityContext)
+		selinux := hpContainer.SecurityContext.SELinuxOptions
+		if assert.NotNil(t, selinux, "host-profiler seLinuxOptions") {
+			assert.Equal(t, "custom_t", selinux.Type)
+		}
+	})
+}
+
 func TestHostProfilerSCC(t *testing.T) {
 	overrides := copyMap(hostProfilerBaseOverrides)
 	overrides["agents.podSecurity.securityContextConstraints.create"] = "true"

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -120,9 +120,8 @@ func TestHostProfilerSELinux(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, hpContainer.SecurityContext)
 		selinux := hpContainer.SecurityContext.SELinuxOptions
-		if assert.NotNil(t, selinux, "host-profiler seLinuxOptions") {
-			assert.Equal(t, "spc_t", selinux.Type)
-		}
+		require.NotNil(t, selinux, "host-profiler seLinuxOptions")
+		assert.Equal(t, "spc_t", selinux.Type)
 	})
 
 	t.Run("user_securityContext_overrides_default", func(t *testing.T) {
@@ -136,9 +135,8 @@ func TestHostProfilerSELinux(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, hpContainer.SecurityContext)
 		selinux := hpContainer.SecurityContext.SELinuxOptions
-		if assert.NotNil(t, selinux, "host-profiler seLinuxOptions") {
-			assert.Equal(t, "custom_t", selinux.Type)
-		}
+		require.NotNil(t, selinux, "host-profiler seLinuxOptions")
+		assert.Equal(t, "custom_t", selinux.Type)
 	})
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `securityContext.seLinuxOptions.type: spc_t` out of the box.
Users can override this value through their usual value override file.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Based on https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/6986172492/Accepted+Handling+of+LSMs+across+OSes.

Setting `seLinuxOptions.type: spc_t` alongside apparmor was tested on:
- eks ubuntu / bottlerocket nodes
- on rel-env
- on stingchameleon and charcadet (experimental clusters)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits