### PR TITLE
[byoc] Update CloudPrem Helm chart to 0.4.7

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.7
+
+* Enable random split prefixes by default for all Quickwit processes with `QW_RANDOM_SPLIT_PREFIX=true`.
+* Add HorizontalPodAutoscaler support for compactors
+* Preserve an explicit `use_metastore_read_replica` setting instead of always defaulting it to `true`, allowing a read-only metastore to be disabled safely without disrupting searchers still using it.
+
 ## 0.4.6
 
 * Update Docker image to `v0.1.32`.

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.4.6
+version: 0.4.7
 # This is the version of the "application". Right now, we follow the image version.
 appVersion: v0.1.32
 home: https://www.datadoghq.com/

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.32](https://img.shields.io/badge/AppVersion-v0.1.32-informational?style=flat-square)
+![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.32](https://img.shields.io/badge/AppVersion-v0.1.32-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/templates/_helpers.tpl
+++ b/charts/cloudprem/templates/_helpers.tpl
@@ -398,13 +398,14 @@ Quickwit environment
 
 {{/*
 Merge default environment variables (NO_COLOR, QW_DISABLE_INGEST_V1, QW_DISABLE_TELEMETRY,
-QW_LOG_FORMAT) with user-provided values. Supports both legacy map and list formats.
+QW_LOG_FORMAT, QW_RANDOM_SPLIT_PREFIX) with user-provided values. Supports both legacy map
+and list formats.
 User-provided values take precedence over defaults.
 Defaults are stored as a list (not a dict) to guarantee deterministic rendering order
 and avoid spurious rollouts from manifest drift.
 */}}
 {{- define "quickwit.environmentDefaults" -}}
-{{- $defaults := list (dict "name" "NO_COLOR" "value" "true") (dict "name" "QW_DISABLE_INGEST_V1" "value" "true") (dict "name" "QW_DISABLE_TELEMETRY" "value" "true") (dict "name" "QW_LOG_FORMAT" "value" "DDG") -}}
+{{- $defaults := list (dict "name" "NO_COLOR" "value" "true") (dict "name" "QW_DISABLE_INGEST_V1" "value" "true") (dict "name" "QW_DISABLE_TELEMETRY" "value" "true") (dict "name" "QW_LOG_FORMAT" "value" "DDG") (dict "name" "QW_RANDOM_SPLIT_PREFIX" "value" "true") -}}
 {{- $envs := list -}}
 {{- $keys := list -}}
 {{- if kindIs "map" . -}}

--- a/charts/cloudprem/templates/compactor-deployment.yaml
+++ b/charts/cloudprem/templates/compactor-deployment.yaml
@@ -13,7 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if and (hasKey .Values.compactor "replicaCount") (not .Values.compactor.autoscaling.enabled) }}
   replicas: {{ .Values.compactor.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "quickwit.compactor.selectorLabels" . | nindent 6 }}

--- a/charts/cloudprem/templates/configmap.yaml
+++ b/charts/cloudprem/templates/configmap.yaml
@@ -27,10 +27,18 @@
 
 {{- if .Values.metastore_ro.enabled }}
   {{- $searcherConfig := $config.searcher | default dict }}
-  {{- $_ := set $searcherConfig "use_metastore_read_replica" true }}
+  {{- /*
+  Preserve an explicit value so a read-only metastore can be disabled safely:
+  first set use_metastore_read_replica to false while metastore_ro remains
+  enabled, wait for all searchers to use the primary metastore, then disable
+  metastore_ro. Disabling metastore_ro first would shut down a replica that
+  searchers may still be using.
+  */}}
+  {{- if not (hasKey $searcherConfig "use_metastore_read_replica") }}
+    {{- $_ := set $searcherConfig "use_metastore_read_replica" true }}
+  {{- end }}
   {{- $_ := set $config "searcher" $searcherConfig }}
 {{- end }}
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/cloudprem/templates/hpa.yaml
+++ b/charts/cloudprem/templates/hpa.yaml
@@ -51,3 +51,30 @@ spec:
     {{- toYaml .Values.searcher.autoscaling.behavior | nindent 4 }}
   {{- end }}
 {{- end }}
+{{- if and .Values.enableStandaloneCompactors .Values.compactor.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "quickwit.fullname" . }}-compactor
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor-hpa
+  {{- with .Values.compactor.autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "quickwit.fullname" . }}-compactor
+  minReplicas: {{ .Values.compactor.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.compactor.autoscaling.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.compactor.autoscaling.metrics | nindent 4 }}
+  {{- if .Values.compactor.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.compactor.autoscaling.behavior | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cloudprem/values.yaml
+++ b/charts/cloudprem/values.yaml
@@ -969,7 +969,29 @@ enableStandaloneCompactors: false
 # Dedicated compactor workers. Only deployed when `enableStandaloneCompactors` is
 # true (there is intentionally no separate `compactor.enabled` toggle).
 compactor:
+  # When autoscaling is enabled, replicaCount is ignored.
   replicaCount: 1
+
+  # Enable and configure autoscaling using Horizontal Pod Autoscaler (HPA).
+  # Only takes effect when `enableStandaloneCompactors` is also true.
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 10
+    metrics:
+      # Compaction is a "throughput game", so we aim for high CPU utilization
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 60
+      # scaleDown:
+      #   stabilizationWindowSeconds: 300
 
   # Extra env for compactor
   # Legacy map format (e.g. extraEnv: { KEY: VALUE }) is also supported for backward compatibility.


### PR DESCRIPTION
- enable random split prefixes by default
- add HPA support for the compactor
- preserve an explicit metastore read-replica setting on searchers so it can be disabled safely