### PR TITLE
Add cumulativetodelta processor to default DDOT Collector metrics pipelines

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.232.0
+
+* Add the `cumulativetodelta` processor to the default DDOT Collector metrics pipelines (standalone Agent and Gateway), converting cumulative counters and histograms to delta upstream of the Datadog exporter. This prepares DDOT for the metrics v3 payload format, where the exporter no longer performs this conversion internally.
+
 ## 3.231.6
 
 * Add `privateActionRunner.apiKeyOnlyEnrollment` for node agent and cluster agent, wiring it to `api_key_only_enrollment` in the PAR ConfigMap and `DD_PRIVATE_ACTION_RUNNER_API_KEY_ONLY_ENROLLMENT` in the cluster agent deployment respectively.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.231.6
+version: 3.232.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.231.6](https://img.shields.io/badge/Version-3.231.6-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.232.0](https://img.shields.io/badge/Version-3.232.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_otel_agent_config.yaml
+++ b/charts/datadog/templates/_otel_agent_config.yaml
@@ -65,6 +65,7 @@ otel-config.yaml: {{- if .Values.datadog.otelCollector.config }} {{ toYaml .Valu
     processors:
       infraattributes:
         cardinality: 2
+      cumulativetodelta:
       filter/drop-prometheus-internal-metrics:
         metrics:
           exclude:
@@ -87,11 +88,11 @@ otel-config.yaml: {{- if .Values.datadog.otelCollector.config }} {{ toYaml .Valu
           exporters: [datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector]
-          processors: [infraattributes]
+          processors: [infraattributes, cumulativetodelta]
           exporters: [datadog]
         metrics/prometheus:
           receivers: [prometheus]
-          processors: [filter/drop-prometheus-internal-metrics, infraattributes]
+          processors: [filter/drop-prometheus-internal-metrics, infraattributes, cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]

--- a/charts/datadog/templates/_otel_agent_gateway_config.yaml
+++ b/charts/datadog/templates/_otel_agent_gateway_config.yaml
@@ -22,6 +22,7 @@ otel-gateway-config.yaml: {{- if .Values.otelAgentGateway.config }} {{ toYaml .V
           batch:
             flush_timeout: 10s
     processors:
+      cumulativetodelta:
     extensions:
       health_check:
         endpoint: 0.0.0.0:{{ .Values.otelAgentGateway.containers.otelAgent.healthPort }}
@@ -40,6 +41,7 @@ otel-gateway-config.yaml: {{- if .Values.otelAgentGateway.config }} {{ toYaml .V
           exporters: [datadog]
         metrics:
           receivers: [otlp]
+          processors: [cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -184,6 +184,7 @@ data:
     processors:
       infraattributes:
         cardinality: 2
+      cumulativetodelta:
       filter/drop-prometheus-internal-metrics:
         metrics:
           exclude:
@@ -206,11 +207,11 @@ data:
           exporters: [datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector]
-          processors: [infraattributes]
+          processors: [infraattributes, cumulativetodelta]
           exporters: [datadog]
         metrics/prometheus:
           receivers: [prometheus]
-          processors: [filter/drop-prometheus-internal-metrics, infraattributes]
+          processors: [filter/drop-prometheus-internal-metrics, infraattributes, cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -169,6 +169,7 @@ data:
     processors:
       infraattributes:
         cardinality: 2
+      cumulativetodelta:
       filter/drop-prometheus-internal-metrics:
         metrics:
           exclude:
@@ -191,11 +192,11 @@ data:
           exporters: [datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector]
-          processors: [infraattributes]
+          processors: [infraattributes, cumulativetodelta]
           exporters: [datadog]
         metrics/prometheus:
           receivers: [prometheus]
-          processors: [filter/drop-prometheus-internal-metrics, infraattributes]
+          processors: [filter/drop-prometheus-internal-metrics, infraattributes, cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -169,6 +169,7 @@ data:
     processors:
       infraattributes:
         cardinality: 2
+      cumulativetodelta:
       filter/drop-prometheus-internal-metrics:
         metrics:
           exclude:
@@ -191,11 +192,11 @@ data:
           exporters: [datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector]
-          processors: [infraattributes]
+          processors: [infraattributes, cumulativetodelta]
           exporters: [datadog]
         metrics/prometheus:
           receivers: [prometheus]
-          processors: [filter/drop-prometheus-internal-metrics, infraattributes]
+          processors: [filter/drop-prometheus-internal-metrics, infraattributes, cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -141,6 +141,7 @@ data:
     processors:
       infraattributes:
         cardinality: 2
+      cumulativetodelta:
       filter/drop-prometheus-internal-metrics:
         metrics:
           exclude:
@@ -163,11 +164,11 @@ data:
           exporters: [datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector]
-          processors: [infraattributes]
+          processors: [infraattributes, cumulativetodelta]
           exporters: [datadog]
         metrics/prometheus:
           receivers: [prometheus]
-          processors: [filter/drop-prometheus-internal-metrics, infraattributes]
+          processors: [filter/drop-prometheus-internal-metrics, infraattributes, cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -141,6 +141,7 @@ data:
     processors:
       infraattributes:
         cardinality: 2
+      cumulativetodelta:
       filter/drop-prometheus-internal-metrics:
         metrics:
           exclude:
@@ -163,11 +164,11 @@ data:
           exporters: [datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector]
-          processors: [infraattributes]
+          processors: [infraattributes, cumulativetodelta]
           exporters: [datadog]
         metrics/prometheus:
           receivers: [prometheus]
-          processors: [filter/drop-prometheus-internal-metrics, infraattributes]
+          processors: [filter/drop-prometheus-internal-metrics, infraattributes, cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -184,6 +184,7 @@ data:
           batch:
             flush_timeout: 10s
     processors:
+      cumulativetodelta:
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133
@@ -200,6 +201,7 @@ data:
           exporters: [datadog]
         metrics:
           receivers: [otlp]
+          processors: [cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -184,6 +184,7 @@ data:
           batch:
             flush_timeout: 10s
     processors:
+      cumulativetodelta:
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133
@@ -200,6 +201,7 @@ data:
           exporters: [datadog]
         metrics:
           receivers: [otlp]
+          processors: [cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -169,6 +169,7 @@ data:
     processors:
       infraattributes:
         cardinality: 2
+      cumulativetodelta:
       filter/drop-prometheus-internal-metrics:
         metrics:
           exclude:
@@ -191,11 +192,11 @@ data:
           exporters: [datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector]
-          processors: [infraattributes]
+          processors: [infraattributes, cumulativetodelta]
           exporters: [datadog]
         metrics/prometheus:
           receivers: [prometheus]
-          processors: [filter/drop-prometheus-internal-metrics, infraattributes]
+          processors: [filter/drop-prometheus-internal-metrics, infraattributes, cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -169,6 +169,7 @@ data:
     processors:
       infraattributes:
         cardinality: 2
+      cumulativetodelta:
       filter/drop-prometheus-internal-metrics:
         metrics:
           exclude:
@@ -191,11 +192,11 @@ data:
           exporters: [datadog, datadog/connector]
         metrics:
           receivers: [otlp, datadog/connector]
-          processors: [infraattributes]
+          processors: [infraattributes, cumulativetodelta]
           exporters: [datadog]
         metrics/prometheus:
           receivers: [prometheus]
-          processors: [filter/drop-prometheus-internal-metrics, infraattributes]
+          processors: [filter/drop-prometheus-internal-metrics, infraattributes, cumulativetodelta]
           exporters: [datadog]
         logs:
           receivers: [otlp]


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the `cumulativetodelta` processor to the default DDOT сollector configuration rendered by the `datadog` chart, in the metrics pipelines that export to the Datadog exporter:
- standalone Agent config: `metrics` and `metrics/prometheus` pipelines;
- Gateway config: `metrics` pipeline.

DDOT is moving to the metrics v3 payload format. In v3 the Datadog exporter stops converting cumulative counters to delta internally, so a `cumulativetodelta` processor in the pipeline becomes mandatory. Adding it to the default config now is safe before v3 — the exporter consumes already-delta input directly, without a second conversion — and prepares the chart for the v3 switch.

#### Special notes for your reviewer:

Placement — the processor is added only where the `datadog` exporter is present:
- It is not added to the daemonset Agent config used in gateway mode, because that config
  forwards metrics to the Gateway over `otlphttp`; the Gateway performs the conversion. This
  matches the chart's existing minimal-forwarding-agent design.
- It is not added to `traces`/`logs` pipelines. The processor only implements metrics
  processing, and the collector fails to start if it is placed in a traces/logs pipeline.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For datadog or datadog-operator chart or value changes, update the test baselines (run: make update-test-baselines)
- [ ] For datadog chart changes, received ✅ from a member of your team

https://datadoghq.atlassian.net/browse/OTAGENT-1178