### PR TITLE
[byoc] Update CloudPrem Helm chart to 0.4.8

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.8
+
+* Lower indexer HorizontalPodAutoscaler CPU target from 80% to 70% and remove the 60s scale-up stabilization window so indexers scale out immediately under load.
+
 ## 0.4.7
 
 * Enable random split prefixes by default for all Quickwit processes with `QW_RANDOM_SPLIT_PREFIX=true`.

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.4.7
+version: 0.4.8
 # This is the version of the "application". Right now, we follow the image version.
 appVersion: v0.1.32
 home: https://www.datadoghq.com/

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.32](https://img.shields.io/badge/AppVersion-v0.1.32-informational?style=flat-square)
+![Version: 0.4.8](https://img.shields.io/badge/Version-0.4.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.32](https://img.shields.io/badge/AppVersion-v0.1.32-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/values.yaml
+++ b/charts/cloudprem/values.yaml
@@ -450,10 +450,10 @@ indexer:
           name: cpu
           target:
             type: Utilization
-            averageUtilization: 80
+            averageUtilization: 70
     behavior:
       scaleUp:
-        stabilizationWindowSeconds: 60
+        stabilizationWindowSeconds: 0
         # selectPolicy: Max
         # policies:
         # - type: Percent
@@ -990,8 +990,6 @@ compactor:
     behavior:
       scaleUp:
         stabilizationWindowSeconds: 60
-      # scaleDown:
-      #   stabilizationWindowSeconds: 300
 
   # Extra env for compactor
   # Legacy map format (e.g. extraEnv: { KEY: VALUE }) is also supported for backward compatibility.


### PR DESCRIPTION
Lowers indexer HPA CPU target from 80% to 70% and removes the 60s scale-up stabilization window so indexers scale out immediately under load.