### PR TITLE
[observability-pipelines-worker] 2.20.2 release

### DIFF
--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.20.3
+
+* Official image `2.20.2`
+
 ## 2.20.2
 
 * Official image `2.20.1`

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: 2.20.2
+version: 2.20.3
 description: Observability Pipelines Worker
 type: application
 keywords:
@@ -13,7 +13,7 @@ icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 maintainers:
   - name: Datadog
     email: support@datadoghq.com
-appVersion: "2.20.1"
+appVersion: "2.20.2"
 annotations:
   artifacthub.io/links: |
     - name: Chart Source

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.20.2](https://img.shields.io/badge/Version-2.20.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.20.1](https://img.shields.io/badge/AppVersion-2.20.1-informational?style=flat-square)
+![Version: 2.20.3](https://img.shields.io/badge/Version-2.20.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.20.2](https://img.shields.io/badge/AppVersion-2.20.2-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 
@@ -116,7 +116,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | image.pullPolicy | string | `"IfNotPresent"` | Specify the [pullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy). |
 | image.pullSecrets | list | `[]` | Specify the [imagePullSecrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod). |
 | image.repository | string | `"gcr.io/datadoghq"` | Specify the image repository to use. |
-| image.tag | string | `"2.20.1"` | Specify the image tag to use. |
+| image.tag | string | `"2.20.2"` | Specify the image tag to use. |
 | ingress.annotations | object | `{}` | Specify annotations for the Ingress. |
 | ingress.className | string | `""` | Specify the [ingressClassName](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress), requires Kubernetes >= 1.18. |
 | ingress.enabled | bool | `false` | If **true**, create an Ingress resource. |

--- a/charts/observability-pipelines-worker/values.yaml
+++ b/charts/observability-pipelines-worker/values.yaml
@@ -62,7 +62,7 @@ image:
   # image.name -- Specify the image name to use (relative to `image.repository`).
   name: observability-pipelines-worker
   # image.tag -- Specify the image tag to use.
-  tag: 2.20.1
+  tag: 2.20.2
   # image.digest -- (string) Specify the image digest to use; takes precedence over `image.tag`.
   digest:
   ## Currently, we offer images at:


### PR DESCRIPTION
## Summary
- Bumps the OPW Helm chart to track the newly-released `2.20.2` image (chart `version: 2.20.3`, `appVersion`/`image.tag: 2.20.2`).

## Test plan
- [x] `helm template` renders cleanly with the new default `image.tag`
- [x] Confirm `observability-pipelines-worker:2.20.2` image is actually published before marking ready for review