### PR TITLE
[datadog-operator] Update chart for 1.29.0-rc.3

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.25.0-dev.4
+
+* Update Datadog Operator chart for 1.29.0-rc.3.
+
 ## 2.25.0-dev.3
 
 * Update Datadog Operator chart for 1.29.0-rc.2.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.25.0-dev.3
-appVersion: 1.29.0-rc.2
+version: 2.25.0-dev.4
+appVersion: 1.29.0-rc.3
 description: Datadog Operator
 keywords:
 - monitoring

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.25.0-dev.3](https://img.shields.io/badge/Version-2.25.0--dev.3-informational?style=flat-square) ![AppVersion: 1.29.0-rc.2](https://img.shields.io/badge/AppVersion-1.29.0--rc.2-informational?style=flat-square)
+![Version: 2.25.0-dev.4](https://img.shields.io/badge/Version-2.25.0--dev.4-informational?style=flat-square) ![AppVersion: 1.29.0-rc.3](https://img.shields.io/badge/AppVersion-1.29.0--rc.3-informational?style=flat-square)
 
 ## Values
 
@@ -43,7 +43,7 @@
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"registry.datadoghq.com/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.29.0-rc.2"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.29.0-rc.3"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |

--- a/charts/datadog-operator/templates/_helpers.tpl
+++ b/charts/datadog-operator/templates/_helpers.tpl
@@ -186,6 +186,6 @@ Check operator image tag version.
 {{- $parts := split "@" $tag -}}
 {{- index $parts "_0"}}
 {{- else -}}
-{{ "1.29.0-rc.2" }}
+{{ "1.29.0-rc.3" }}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog-operator/templates/clusterrole.yaml
+++ b/charts/datadog-operator/templates/clusterrole.yaml
@@ -135,6 +135,12 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - deployments/status
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
   - replicasets
   verbs:
   - get

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: registry.datadoghq.com/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.29.0-rc.2
+  tag: 1.29.0-rc.3
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
   # image.doNotCheckTag -- Permit skipping operator image tag compatibility with the chart.

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.25.0-dev.3
+    helm.sh/chart: datadog-operator-2.25.0-dev.4
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.29.0-rc.2"
+    app.kubernetes.io/version: "1.29.0-rc.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator 
       containers:
         - name: datadog-operator
-          image: "registry.datadoghq.com/operator:1.29.0-rc.2"
+          image: "registry.datadoghq.com/operator:1.29.0-rc.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -94,3 +94,4 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       volumes:
+

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -292,7 +292,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "registry.datadoghq.com/operator:1.29.0-rc.2", operatorContainer.Image)
+	assert.Equal(t, "registry.datadoghq.com/operator:1.29.0-rc.3", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
Public datadog-operator Helm chart update for Datadog Operator v1.29.0-rc.3.

- Chart version 2.25.0-dev.3 -> 2.25.0-dev.4
- appVersion -> 1.29.0-rc.3
- RBAC: add `apps/deployments/status: get` (operator #3282)
- CRDs unchanged since rc.2 -> no datadog-crds PR needed; dep stays 2.23.0-dev.2

Sample prior PR: helm-charts#2805 (rc.2).