### PR TITLE
Add component to CloudPrem OTLP resources

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.5.1
+
+* Add the CloudPrem component name to OpenTelemetry resource attributes.
+
 ## 0.5.0
 
 * **Breaking**: remove the `medium` pod size. `indexer.podSize` / `searcher.podSize` now accept `large`, `xlarge`, `2xlarge`, `4xlarge`, `6xlarge`, and `8xlarge` only; rendering fails with an explicit error if any other size is set. Move to `large` before upgrading.

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.5.0
+version: 0.5.1
 # This is the version of the "application". Right now, we follow the image version.
 appVersion: v0.1.32
 home: https://www.datadoghq.com/

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.32](https://img.shields.io/badge/AppVersion-v0.1.32-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.32](https://img.shields.io/badge/AppVersion-v0.1.32-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/templates/_helpers.tpl
+++ b/charts/cloudprem/templates/_helpers.tpl
@@ -367,7 +367,7 @@ Quickwit environment
 - name: BYOC_TELEMETRY_ENABLED
   value: "true"
 - name: OTEL_RESOURCE_ATTRIBUTES
-  value: {{ printf "cluster_id=%s,node_id=$(QW_NODE_ID),host.name=$(KUBERNETES_NODE_NAME),chart.version=%s" $clusterID .Chart.Version | quote }}
+  value: {{ printf "cluster_id=%s,node_id=$(QW_NODE_ID),host.name=$(KUBERNETES_NODE_NAME),component=$(KUBERNETES_COMPONENT),chart.version=%s" $clusterID .Chart.Version | quote }}
 - name: OTEL_EXPORTER_OTLP_PROTOCOL
   value: "http/protobuf"
 - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT


### PR DESCRIPTION
## Summary

Add the CloudPrem workload component to `OTEL_RESOURCE_ATTRIBUTES` using the existing `KUBERNETES_COMPONENT` downward-API environment variable.

This replaces the broader Pomsky-side implementation in DataDog/pomsky#729 for the OTLP telemetry path. The OpenTelemetry SDK reads `OTEL_RESOURCE_ATTRIBUTES`, so no application-level configuration plumbing is needed.

After rebasing onto chart `0.5.0`, the new `component` attribute is composed with the existing `chart.version` attribute. The chart is bumped to `0.5.1` as required by the repository release checks.

## Validation

- `helm lint charts/cloudprem --values charts/cloudprem/ci/kubeconform-values.yaml`
- Rendered the indexer with BYOC telemetry enabled and verified `OTEL_RESOURCE_ATTRIBUTES` contains both `component=$(KUBERNETES_COMPONENT)` and `chart.version=0.5.1`.
- Verified `KUBERNETES_COMPONENT` is declared before `OTEL_RESOURCE_ATTRIBUTES`.
- `git diff --check`
