### PR TITLE
[CONTP-1968] Require Agent 7.82 to enable the DatadogInstrumentation controller

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.236.0
+
+* [CONTP-1968] Require Agent and Cluster Agent version 7.82.0 or later before enabling the DatadogInstrumentation CRD controller.
+
 ## 3.235.0
 
 * Bump Datadog Operator chart dependency to 2.25.0.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.235.0
+version: 3.236.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.235.0](https://img.shields.io/badge/Version-3.235.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.236.0](https://img.shields.io/badge/Version-3.236.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -860,7 +860,7 @@ helm install <RELEASE_NAME> \
 | datadog.hostProfiler.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.ignoreAutoConfig | list | `[]` | List of integration to ignore auto_conf.yaml. |
-| datadog.instrumentationCrd.enabled | string | `nil` | Enable the DatadogInstrumentation CRD controller and reconciliation platform. Requires version 7.80.0 or later of both cluster and node agent. |
+| datadog.instrumentationCrd.enabled | string | `nil` | Enable the DatadogInstrumentation CRD controller and reconciliation platform. Requires version 7.82.0 or later of both cluster and node agent. |
 | datadog.kubeStateMetricsCore.annotationsAsTags | object | `{}` | Extra annotations to collect from resources and to turn into datadog tag. |
 | datadog.kubeStateMetricsCore.collectApiServicesMetrics | bool | `false` | Enable watching apiservices objects and collecting their corresponding metrics kubernetes_state.apiservice.* (Requires Cluster Agent 7.45.0+) |
 | datadog.kubeStateMetricsCore.collectConfigMaps | bool | `true` | Enable watching configmap objects and collecting their corresponding metrics kubernetes_state.configmap.* |

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -860,7 +860,7 @@ helm install <RELEASE_NAME> \
 | datadog.hostProfiler.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |
 | datadog.hostVolumeMountPropagation | string | `"None"` | Allow to specify the `mountPropagation` value on all volumeMounts using HostPath |
 | datadog.ignoreAutoConfig | list | `[]` | List of integration to ignore auto_conf.yaml. |
-| datadog.instrumentationCrd.enabled | string | `nil` | Enable the DatadogInstrumentation CRD controller and reconciliation platform. Requires version 7.82.0 or later of both cluster and node agent. |
+| datadog.instrumentationCrd.enabled | bool | `nil` | Enable the DatadogInstrumentation CRD controller and reconciliation platform. Requires version 7.82.0 or later of both cluster and node agent. |
 | datadog.kubeStateMetricsCore.annotationsAsTags | object | `{}` | Extra annotations to collect from resources and to turn into datadog tag. |
 | datadog.kubeStateMetricsCore.collectApiServicesMetrics | bool | `false` | Enable watching apiservices objects and collecting their corresponding metrics kubernetes_state.apiservice.* (Requires Cluster Agent 7.45.0+) |
 | datadog.kubeStateMetricsCore.collectConfigMaps | bool | `true` | Enable watching configmap objects and collecting their corresponding metrics kubernetes_state.configmap.* |

--- a/charts/datadog/templates/_container-agent.yaml
+++ b/charts/datadog/templates/_container-agent.yaml
@@ -284,9 +284,9 @@
       value: {{ .Values.datadog.networkMonitoring.enabled | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.datadog.instrumentationCrd.enabled }}
+    {{- if eq (include "should-enable-instrumentation-crd-controller" .) "true" }}
     - name: DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED
-      value: {{ .Values.datadog.instrumentationCrd.enabled | quote }}
+      value: "true"
     {{- end }}
     {{- if (((.Values.datadog.autoscaling).workload).enabled) }}
     - name: DD_AUTOSCALING_FAILOVER_ENABLED

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -16,6 +16,18 @@
 {{- end -}}
 
 {{/*
+  Returns Cluster Agent version based on image tag. This assumes `clusterAgent.image.doNotCheckTag` is false.
+*/}}
+{{- define "get-cluster-agent-version" -}}
+{{- $version := .Values.clusterAgent.image.tag | toString -}}
+{{- $length := len (split "." $version) -}}
+{{- if and (eq $length 1) (eq $version "latest") -}}
+{{- $version = "7.81.1" -}}
+{{- end -}}
+{{- $version -}}
+{{- end -}}
+
+{{/*
   Returns a semver-ish version for discovery defaulting.
   Discovery reuses the chart's existing agent-version resolution for supported tags.
   If that resolution still returns a non-semver-ish value, discovery treats it as latest.
@@ -120,11 +132,7 @@ false
 
 {{- define "check-dca-version" -}}
 {{- if not .Values.clusterAgent.image.doNotCheckTag -}}
-{{- $version := .Values.clusterAgent.image.tag | toString -}}
-{{- $length := len (split "." $version) -}}
-{{- if and (eq $length 1) (eq $version "latest") -}}
-{{- $version = "1.20.0" -}}
-{{- end -}}
+{{- $version := include "get-cluster-agent-version" . -}}
 {{- if not (semverCompare ">=1.20.0-0" $version) -}}
 {{- fail "This version of the chart requires a cluster agent image 1.20.0 or greater. If you want to force and skip this check, use `--set clusterAgent.image.doNotCheckTag=true`" -}}
 {{- end -}}
@@ -246,6 +254,25 @@ Create chart name and version as used by the chart label.
 */}}
 {{- define "datadog.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return true if the DatadogInstrumentation CRD controller should be enabled.
+Requires datadog.instrumentationCrd.enabled and both the node Agent and Cluster Agent to be
+version 7.82.0 or newer; otherwise falls back to disabled.
+*/}}
+{{- define "should-enable-instrumentation-crd-controller" -}}
+{{- if .Values.datadog.instrumentationCrd.enabled -}}
+{{- $agentVersionOK := or .Values.agents.image.doNotCheckTag (semverCompare ">=7.82.0-0" (include "get-agent-version" .)) -}}
+{{- $dcaVersionOK := or .Values.clusterAgent.image.doNotCheckTag (semverCompare ">=7.82.0-0" (include "get-cluster-agent-version" .)) -}}
+{{- if and $agentVersionOK $dcaVersionOK -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- else -}}
+false
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -498,9 +498,9 @@ spec:
             value: {{ .Values.datadog.prometheusScrape.version | quote }}
           {{- end }}
           {{- end }}
-          {{- if .Values.datadog.instrumentationCrd.enabled }}
+          {{- if eq (include "should-enable-instrumentation-crd-controller" .) "true" }}
           - name: DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED
-            value: {{ .Values.datadog.instrumentationCrd.enabled | quote }}
+            value: "true"
           {{- end }}
           {{- if (((.Values.datadog.autoscaling).workload).enabled) }}
           - name: DD_AUTOSCALING_WORKLOAD_ENABLED

--- a/charts/datadog/templates/cluster-agent-rbac.yaml
+++ b/charts/datadog/templates/cluster-agent-rbac.yaml
@@ -50,7 +50,7 @@ rules:
   verbs:
   - list
   - watch
-{{- if .Values.datadog.instrumentationCrd.enabled }}
+{{- if eq (include "should-enable-instrumentation-crd-controller" .) "true" }}
 - apiGroups:
   - "datadoghq.com"
   resources:

--- a/charts/datadog/values.schema.json
+++ b/charts/datadog/values.schema.json
@@ -11,6 +11,17 @@
     "datadog": {
       "type": "object",
       "properties": {
+        "instrumentationCrd": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        },
         "apm": {
           "type": "object",
           "properties": {

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1467,7 +1467,7 @@ datadog:
 
   instrumentationCrd:
     # datadog.instrumentationCrd.enabled -- Enable the DatadogInstrumentation CRD controller and reconciliation platform.
-    # Requires version 7.80.0 or later of both cluster and node agent.
+    # Requires version 7.82.0 or later of both cluster and node agent.
     enabled:
 
   dataPlane:

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1466,7 +1466,7 @@ datadog:
     enabled: false
 
   instrumentationCrd:
-    # datadog.instrumentationCrd.enabled -- Enable the DatadogInstrumentation CRD controller and reconciliation platform.
+    # datadog.instrumentationCrd.enabled -- (bool) Enable the DatadogInstrumentation CRD controller and reconciliation platform.
     # Requires version 7.82.0 or later of both cluster and node agent.
     enabled:
 

--- a/test/datadog/instrumentation_crd_test.go
+++ b/test/datadog/instrumentation_crd_test.go
@@ -1,0 +1,163 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/DataDog/helm-charts/test/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+const instrumentationCRDControllerEnabledEnvVar = "DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED"
+
+func Test_instrumentationCRDControllerVersionGate(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides map[string]string
+		enabled   bool
+	}{
+		{
+			name: "disabled with supported versions",
+			overrides: map[string]string{
+				"datadog.instrumentationCrd.enabled": "false",
+				"agents.image.tag":                   "7.82.0",
+				"clusterAgent.image.tag":             "7.82.0",
+			},
+			enabled: false,
+		},
+		{
+			name: "enabled at minimum versions",
+			overrides: map[string]string{
+				"datadog.instrumentationCrd.enabled": "true",
+				"agents.image.tag":                   "7.82.0",
+				"clusterAgent.image.tag":             "7.82.0",
+			},
+			enabled: true,
+		},
+		{
+			name: "enabled with prerelease versions",
+			overrides: map[string]string{
+				"datadog.instrumentationCrd.enabled": "true",
+				"agents.image.tag":                   "7.82.0-rc.1",
+				"clusterAgent.image.tag":             "7.82.0-rc.1",
+			},
+			enabled: true,
+		},
+		{
+			name: "disabled below minimum node agent version",
+			overrides: map[string]string{
+				"datadog.instrumentationCrd.enabled": "true",
+				"agents.image.tag":                   "7.81.9",
+				"clusterAgent.image.tag":             "7.82.0",
+			},
+			enabled: false,
+		},
+		{
+			name: "disabled below minimum cluster agent version",
+			overrides: map[string]string{
+				"datadog.instrumentationCrd.enabled": "true",
+				"agents.image.tag":                   "7.82.0",
+				"clusterAgent.image.tag":             "7.81.9",
+			},
+			enabled: false,
+		},
+		{
+			name: "floating node agent tag follows get-agent-version policy",
+			overrides: map[string]string{
+				"datadog.instrumentationCrd.enabled": "true",
+				"agents.image.tag":                   "latest-jmx",
+				"clusterAgent.image.tag":             "7.82.0",
+			},
+			enabled: false,
+		},
+		{
+			name: "floating cluster agent tag follows get-cluster-agent-version policy",
+			overrides: map[string]string{
+				"datadog.instrumentationCrd.enabled": "true",
+				"agents.image.tag":                   "7.82.0",
+				"clusterAgent.image.tag":             "latest",
+			},
+			enabled: false,
+		},
+		{
+			name: "enabled when both tag checks are skipped",
+			overrides: map[string]string{
+				"datadog.instrumentationCrd.enabled": "true",
+				"agents.image.tag":                   "custom-agent-tag",
+				"agents.image.doNotCheckTag":         "true",
+				"clusterAgent.image.tag":             "custom-cluster-agent-tag",
+				"clusterAgent.image.doNotCheckTag":   "true",
+			},
+			enabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := common.RenderChart(t, common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides:   instrumentationCRDOverrides(tt.overrides),
+			})
+			require.NoError(t, err, "couldn't render chart")
+
+			assertInstrumentationCRDControllerState(t, manifest, tt.enabled)
+		})
+	}
+}
+
+func instrumentationCRDOverrides(overrides map[string]string) map[string]string {
+	merged := map[string]string{
+		"datadog.apiKeyExistingSecret": "datadog-secret",
+		"datadog.appKeyExistingSecret": "datadog-secret",
+	}
+	for key, value := range overrides {
+		merged[key] = value
+	}
+	return merged
+}
+
+func assertInstrumentationCRDControllerState(t *testing.T, manifest string, enabled bool) {
+	t.Helper()
+
+	var daemonset appsv1.DaemonSet
+	require.True(t, decodeResourceByKindAndName(manifest, "DaemonSet", "datadog", &daemonset))
+	agentContainer, found := getContainer(t, daemonset.Spec.Template.Spec.Containers, "agent")
+	require.True(t, found)
+	assert.Equal(t, enabled, hasEnvVar(agentContainer.Env, instrumentationCRDControllerEnabledEnvVar))
+
+	var deployment appsv1.Deployment
+	require.True(t, decodeResourceByKindAndName(manifest, "Deployment", "datadog-cluster-agent", &deployment))
+	clusterAgentContainer, found := getContainer(t, deployment.Spec.Template.Spec.Containers, "cluster-agent")
+	require.True(t, found)
+	assert.Equal(t, enabled, hasEnvVar(clusterAgentContainer.Env, instrumentationCRDControllerEnabledEnvVar))
+
+	var clusterRole rbacv1.ClusterRole
+	require.True(t, decodeResourceByKindAndName(manifest, "ClusterRole", "datadog-cluster-agent", &clusterRole))
+	assert.Equal(t, enabled, clusterRoleHasResource(clusterRole.Rules, "datadoginstrumentations"))
+	assert.Equal(t, enabled, clusterRoleHasResource(clusterRole.Rules, "datadoginstrumentations/status"))
+}
+
+func hasEnvVar(envVars []corev1.EnvVar, name string) bool {
+	for _, envVar := range envVars {
+		if envVar.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func clusterRoleHasResource(rules []rbacv1.PolicyRule, resource string) bool {
+	for _, rule := range rules {
+		for _, candidate := range rule.Resources {
+			if candidate == resource {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/test/datadog/instrumentation_crd_test.go
+++ b/test/datadog/instrumentation_crd_test.go
@@ -110,6 +110,20 @@ func Test_instrumentationCRDControllerVersionGate(t *testing.T) {
 	}
 }
 
+func Test_instrumentationCRDControllerRejectsStringEnabled(t *testing.T) {
+	_, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides:   instrumentationCRDOverrides(nil),
+		OverridesJson: map[string]string{
+			"datadog.instrumentationCrd.enabled": `"false"`,
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "datadog.instrumentationCrd.enabled")
+}
+
 func instrumentationCRDOverrides(overrides map[string]string) map[string]string {
 	merged := map[string]string{
 		"datadog.apiKeyExistingSecret": "datadog-secret",


### PR DESCRIPTION
#### What this PR does / why we need it:

Gates the DatadogInstrumentation CRD controller on Agent and Cluster Agent version 7.82.0 or later. This keeps the controller disabled when either version is unsupported, unless tag checks are explicitly skipped.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits 