### PR TITLE
[datadog-crds] Update for operator v1.29.0

### DIFF
--- a/charts/datadog-crds/CHANGELOG.md
+++ b/charts/datadog-crds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.23.0
+
+* Update CRDs from Datadog Operator v1.29.0.
+
 ## 2.23.0-dev.2
 
 * Update CRDs from Datadog Operator v1.29.0-rc.2 release candidate tag.

--- a/charts/datadog-crds/Chart.yaml
+++ b/charts/datadog-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog-crds
 description: Datadog Kubernetes CRDs chart
-version: 2.23.0-dev.2
+version: 2.23.0
 appVersion: "1"
 keywords:
 - monitoring

--- a/charts/datadog-crds/README.md
+++ b/charts/datadog-crds/README.md
@@ -1,6 +1,6 @@
 # Datadog CRDs
 
-![Version: 2.23.0-dev.2](https://img.shields.io/badge/Version-2.23.0--dev.2-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
+![Version: 2.23.0](https://img.shields.io/badge/Version-2.23.0-informational?style=flat-square) ![AppVersion: 1](https://img.shields.io/badge/AppVersion-1-informational?style=flat-square)
 
 This chart was designed to allow other "datadog" charts to share `CustomResourceDefinitions` such as the `DatadogMetric`.
 


### PR DESCRIPTION
Final (GA) `datadog-crds` chart update for Datadog Operator **v1.29.0** — strips `-dev` per the release convention.

| | |
| --- | --- |
| chart version | `2.23.0-dev.2` -> `2.23.0` |
| appVersion | `1` (unchanged) |

The commit (`406b0054`) was produced by the release automation itself — the `Operator Release - Chart Scripts` job (run [30964936036](https://github.com/DataDog/helm-charts/actions/runs/30964936036), dispatched by Atlas workflow `3c175b14-fea0-4019-af25-c51926666ad0`) pushed it as `github-actions[bot]`. No manual edits.

Only this pull request was opened by hand: the worker dispatched the chart-scripts job at 00:57:38Z and attempted to create the PR at ~00:57:39Z — before the job pushed its commit at 00:57:59Z — so PR creation failed with `422 No commits between main and operator-release/datadog-crds/v1.29.0` and was not retried. Same race as datadog-operator#3325.
