### PR TITLE
[datadog-operator] Update for operator v1.29.0

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.25.0
+
+* Update Datadog Operator chart for 1.29.0.
+
 ## 2.25.0-dev.4
 
 * Update Datadog Operator chart for 1.29.0-rc.3.

--- a/charts/datadog-operator/Chart.lock
+++ b/charts/datadog-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.23.0-dev.2
-digest: sha256:0069fe306391c06d352a289c3d5ecb1b26ab5e65dc1842e8f94c67ef0564d2c7
-generated: "2026-07-20T22:40:34.254566449Z"
+  version: 2.23.0
+digest: sha256:4f9a825f6738b3c410c5609d75c18830372c31b27fed555ed15c5a8b1983d868
+generated: "2026-08-04T21:39:45.189938-04:00"

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
   email: support@datadoghq.com
 dependencies:
 - name: datadog-crds
-  version: 2.23.0-dev.2
+  version: 2.23.0
   alias: datadogCRDs
   repository: https://helm.datadoghq.com
   condition: installCRDs

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.25.0-dev.4
-appVersion: 1.29.0-rc.3
+version: 2.25.0
+appVersion: 1.29.0
 description: Datadog Operator
 keywords:
 - monitoring

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.25.0-dev.4](https://img.shields.io/badge/Version-2.25.0--dev.4-informational?style=flat-square) ![AppVersion: 1.29.0-rc.3](https://img.shields.io/badge/AppVersion-1.29.0--rc.3-informational?style=flat-square)
+![Version: 2.25.0](https://img.shields.io/badge/Version-2.25.0-informational?style=flat-square) ![AppVersion: 1.29.0](https://img.shields.io/badge/AppVersion-1.29.0-informational?style=flat-square)
 
 ## Values
 
@@ -43,7 +43,7 @@
 | image.doNotCheckTag | bool | `false` | Permit skipping operator image tag compatibility with the chart. |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Operator image |
 | image.repository | string | `"registry.datadoghq.com/operator"` | Repository to use for Datadog Operator image |
-| image.tag | string | `"1.29.0-rc.3"` | Define the Datadog Operator version to use |
+| image.tag | string | `"1.29.0"` | Define the Datadog Operator version to use |
 | imagePullSecrets | list | `[]` | Datadog Operator repository pullSecret (ex: specify docker registry credentials) |
 | installCRDs | bool | `true` | Set to true to deploy the Datadog's CRDs |
 | introspection.enabled | bool | `false` | If true, enables introspection feature (beta). Requires v1.4.0+ |

--- a/charts/datadog-operator/templates/_helpers.tpl
+++ b/charts/datadog-operator/templates/_helpers.tpl
@@ -186,6 +186,6 @@ Check operator image tag version.
 {{- $parts := split "@" $tag -}}
 {{- index $parts "_0"}}
 {{- else -}}
-{{ "1.29.0-rc.3" }}
+{{ "1.29.0" }}
 {{- end -}}
 {{- end -}}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -47,7 +47,7 @@ image:
   # image.repository -- Repository to use for Datadog Operator image
   repository: registry.datadoghq.com/operator
   # image.tag -- Define the Datadog Operator version to use
-  tag: 1.29.0-rc.3
+  tag: 1.29.0
   # image.pullPolicy -- Define the pullPolicy for Datadog Operator image
   pullPolicy: IfNotPresent
   # image.doNotCheckTag -- Permit skipping operator image tag compatibility with the chart.

--- a/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
+++ b/test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.17.3
   name: datadogagents.datadoghq.com
   labels:
-    helm.sh/chart: 'datadogCRDs-2.23.0-dev.2'
+    helm.sh/chart: 'datadogCRDs-2.23.0'
     app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'datadogCRDs'
     app.kubernetes.io/instance: 'datadog-operator'

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -94,3 +94,4 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       volumes:
+

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.25.0-dev.4
+    helm.sh/chart: datadog-operator-2.25.0
     app.kubernetes.io/instance: datadog-operator
-    app.kubernetes.io/version: "1.29.0-rc.3"
+    app.kubernetes.io/version: "1.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator 
       containers:
         - name: datadog-operator
-          image: "registry.datadoghq.com/operator:1.29.0-rc.3"
+          image: "registry.datadoghq.com/operator:1.29.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -94,4 +94,3 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       volumes:
-

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -292,7 +292,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "registry.datadoghq.com/operator:1.29.0-rc.3", operatorContainer.Image)
+	assert.Equal(t, "registry.datadoghq.com/operator:1.29.0", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 }


### PR DESCRIPTION
Final (GA) `datadog-operator` chart update for Datadog Operator **v1.29.0** — strips `-dev` per the release convention.

| | |
| --- | --- |
| chart version | `2.25.0-dev.4` -> `2.25.0` |
| appVersion | `1.29.0-rc.3` -> `1.29.0` |
| `datadog-crds` dependency | `2.23.0-dev.2` -> `2.23.0` (GA, published by #2837) |

### Commits

1. `1ad86335` — produced by the release automation: the `Operator Release - Chart Scripts` job (run [30965075447](https://github.com/DataDog/helm-charts/actions/runs/30965075447), dispatched by Atlas workflow `3c175b14-fea0-4019-af25-c51926666ad0`), pushed as `github-actions[bot]`.
2. `5c783241` — pins the `datadog-crds` GA dependency and regenerates `Chart.lock` + the two test baselines.

The second commit was needed because the automation dispatched the operator chart job ~3 minutes after the crds job, before `datadog-crds 2.23.0` had been merged and published to helm.datadoghq.com — so `helm dependency update` could not resolve the GA version and left `Chart.yaml` and `Chart.lock` on `2.23.0-dev.2`. Regenerated with `helm dependency update` once #2837 was merged and `2.23.0` was published; both files now show `2.23.0`.

This PR was also opened manually — the worker attempted PR creation ~1s after dispatching its job, before the commit was pushed, and failed with `422 No commits between main and operator-release/datadog-operator/v1.29.0` (same race as datadog-operator#3325 and #2837).
