### PR TITLE
[datadog] Bump operator chart to 2.25.0 and CRDs chart to 2.23.0 for operator v1.29.0

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Datadog changelog
 
+## 3.235.0
+
+* Bump Datadog Operator chart dependency to 2.25.0.
+* Bump Datadog CRD chart dependency to 2.23.0.
+* Bump Operator image tag to 1.29.0.
+
 ## 3.234.0
 
 * [PROF-15441][Host Profiler] add SELinuxOptions.type defaults and setting for host profiler ([#2808](https://github.com/DataDog/helm-charts/pull/2808)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.234.0
+version: 3.235.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.234.0](https://img.shields.io/badge/Version-3.234.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.235.0](https://img.shields.io/badge/Version-3.235.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -31,9 +31,9 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://helm.datadoghq.com | datadog-crds | 2.22.0 |
+| https://helm.datadoghq.com | datadog-crds | 2.23.0 |
 | https://helm.datadoghq.com | datadog-csi-driver | 0.15.0 |
-| https://helm.datadoghq.com | operator(datadog-operator) | 2.24.0 |
+| https://helm.datadoghq.com | operator(datadog-operator) | 2.25.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 
 ## Quick start
@@ -1090,7 +1090,7 @@ helm install <RELEASE_NAME> \
 | operator.datadogGenericResource.enabled | bool | `false` | Enables the Datadog Generic Resource controller |
 | operator.datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | operator.datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
-| operator.image.tag | string | `"1.28.0"` | Define the Datadog Operator version to use |
+| operator.image.tag | string | `"1.29.0"` | Define the Datadog Operator version to use |
 | otelAgentGateway.additionalLabels | object | `{}` | Adds labels to the Agent Gateway Deployment and pods |
 | otelAgentGateway.affinity | object | `{}` | Allow the Gateway Deployment to schedule using affinity rules |
 | otelAgentGateway.autoscaling.annotations | object | `{}` | annotations for OTel Agent Gateway HPA |

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: datadog-crds
   repository: https://helm.datadoghq.com
-  version: 2.22.0
+  version: 2.23.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
@@ -10,6 +10,6 @@ dependencies:
   version: 0.15.0
 - name: datadog-operator
   repository: https://helm.datadoghq.com
-  version: 2.24.0
-digest: sha256:485d460d597e3a735dbe6d983250615a864af7619ced5a6dad774fe8c260452e
-generated: "2026-07-02T16:09:38.887087-04:00"
+  version: 2.25.0
+digest: sha256:47ee2923a2c414cf1b7c0acbe008ecbe2038b31d44f5529c7d9e60dd00a5646d
+generated: "2026-08-05T06:51:11.837232-04:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: datadog-crds
-    version: 2.22.0
+    version: 2.23.0
     repository: https://helm.datadoghq.com
     # Ordering matters here. Helm uses the first condition with a defined (non-nil) value. Conditions with an
     # explicit false default (e.g. clusterAgent.metricsProvider.useDatadogMetrics) must come last, otherwise
@@ -17,7 +17,7 @@ dependencies:
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator
-    version: 2.24.0
+    version: 2.25.0
     repository: https://helm.datadoghq.com
     condition: datadog.operator.enabled
     alias: operator

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -3094,7 +3094,7 @@ clusterChecksRunner:
 operator:
   image:
     # operator.image.tag -- Define the Datadog Operator version to use
-    tag: 1.28.0
+    tag: 1.29.0
 
   datadogAgent:
     # operator.datadogAgent.enabled -- Enables Datadog Agent controller

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -276,6 +276,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2158,7 +2164,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2198,6 +2204,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2223,7 +2230,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -276,6 +276,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2158,7 +2164,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2198,6 +2204,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2223,7 +2230,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -419,7 +419,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -546,6 +546,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2559,7 +2565,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2599,6 +2605,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2624,7 +2631,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2532,7 +2538,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2572,6 +2578,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2597,7 +2604,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -415,7 +415,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -542,6 +542,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -1849,7 +1855,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1889,6 +1895,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1914,7 +1921,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -415,7 +415,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -542,6 +542,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -1849,7 +1855,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1889,6 +1895,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1914,7 +1921,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -415,7 +415,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -542,6 +542,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -1849,7 +1855,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1889,6 +1895,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1914,7 +1921,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -415,7 +415,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -542,6 +542,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -1849,7 +1855,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1889,6 +1895,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1914,7 +1921,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -403,7 +403,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -530,6 +530,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2548,7 +2554,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2588,6 +2594,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2613,7 +2620,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -403,7 +403,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -530,6 +530,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2668,7 +2674,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2708,6 +2714,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2733,7 +2740,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2531,7 +2537,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2571,6 +2577,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2596,7 +2603,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -455,7 +455,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -582,6 +582,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2601,7 +2607,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2641,6 +2647,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2666,7 +2673,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2524,7 +2530,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2564,6 +2570,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2589,7 +2596,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2524,7 +2530,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2564,6 +2570,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2589,7 +2596,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -276,6 +276,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -1874,7 +1880,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1914,6 +1920,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1939,7 +1946,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -276,6 +276,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -1874,7 +1880,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1914,6 +1920,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1939,7 +1946,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -276,6 +276,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -1891,7 +1897,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1931,6 +1937,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1956,7 +1963,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -291,6 +291,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -1948,7 +1954,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1988,6 +1994,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2013,7 +2020,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -276,6 +276,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -1918,7 +1924,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -1958,6 +1964,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -1983,7 +1990,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2391,7 +2397,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2431,6 +2437,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2456,7 +2463,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2508,7 +2514,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2548,6 +2554,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2573,7 +2580,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2508,7 +2514,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2548,6 +2554,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2573,7 +2580,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2384,7 +2390,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2424,6 +2430,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2449,7 +2456,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -544,6 +544,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2539,7 +2545,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2579,6 +2585,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2604,7 +2611,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -544,6 +544,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2549,7 +2555,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2589,6 +2595,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2614,7 +2621,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -544,6 +544,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2417,7 +2423,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2457,6 +2463,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2482,7 +2489,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -544,6 +544,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2441,7 +2447,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2481,6 +2487,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2506,7 +2513,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -488,7 +488,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -615,6 +615,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2603,7 +2609,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2643,6 +2649,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2668,7 +2675,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -407,7 +407,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -534,6 +534,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2575,7 +2581,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2615,6 +2621,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2640,7 +2647,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -407,7 +407,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -534,6 +534,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2578,7 +2584,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2618,6 +2624,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2643,7 +2650,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -446,7 +446,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -573,6 +573,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2589,7 +2595,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2629,6 +2635,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2654,7 +2661,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2642,7 +2648,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2682,6 +2688,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2707,7 +2714,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -600,6 +600,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2727,7 +2733,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2767,6 +2773,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2792,7 +2799,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2646,7 +2652,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2686,6 +2692,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2711,7 +2718,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -600,6 +600,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2721,7 +2727,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2761,6 +2767,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2786,7 +2793,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_full.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -445,7 +445,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -572,6 +572,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2186,7 +2192,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2226,6 +2232,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2251,7 +2258,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_full_fips.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -445,7 +445,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -572,6 +572,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2186,7 +2192,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2226,6 +2232,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2251,7 +2258,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_gateway.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -476,7 +476,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -603,6 +603,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2243,7 +2249,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2283,6 +2289,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2308,7 +2315,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_gateway_fips.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -476,7 +476,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -603,6 +603,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2243,7 +2249,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2283,6 +2289,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2308,7 +2315,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -425,7 +425,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -552,6 +552,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2690,7 +2696,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2730,6 +2736,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2755,7 +2762,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -600,6 +600,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2723,7 +2729,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2763,6 +2769,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2788,7 +2795,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -600,6 +600,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2717,7 +2723,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2757,6 +2763,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2782,7 +2789,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2524,7 +2530,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2564,6 +2570,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2589,7 +2596,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -403,7 +403,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -530,6 +530,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2533,7 +2539,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2573,6 +2579,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2598,7 +2605,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2588,7 +2594,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2628,6 +2634,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2653,7 +2660,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -544,6 +544,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2585,7 +2591,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2625,6 +2631,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2650,7 +2657,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -403,7 +403,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -530,6 +530,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2753,7 +2759,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2793,6 +2799,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2818,7 +2825,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2592,7 +2598,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2632,6 +2638,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2657,7 +2664,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -529,6 +529,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2642,7 +2648,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2682,6 +2688,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2707,7 +2714,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -403,7 +403,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -530,6 +530,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2635,7 +2641,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2675,6 +2681,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2700,7 +2707,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 ---
@@ -403,7 +403,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
 rules:
   - nonResourceURLs:
@@ -530,6 +530,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
   - apiGroups:
       - apps
     resources:
@@ -2544,7 +2550,7 @@ metadata:
     app.kubernetes.io/instance: datadog
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: 1.28.0
+    app.kubernetes.io/version: 1.29.0
   name: datadog-operator
   namespace: datadog-agent
 spec:
@@ -2584,6 +2590,7 @@ spec:
             - -datadogGenericResourceEnabled=false
             - -remoteConfigEnabled=false
             - -datadogCSIDriverEnabled=true
+            - -untaintControllerEnabled=false
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -2609,7 +2616,7 @@ spec:
               value: "true"
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
-          image: registry.datadoghq.com/operator:1.28.0
+          image: registry.datadoghq.com/operator:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Final (GA) umbrella `datadog` chart update for Datadog Operator **v1.29.0**. This step is GA-only — the umbrella chart is not touched for release candidates, which is why its dependencies were still on the 1.28.0-era versions.

Generated with the documented release script:
```
./scripts/release-operator.sh datadog --operator-version 1.29.0
```

| | |
| --- | --- |
| chart version | `3.234.0` -> `3.235.0` |
| `datadog-operator` dependency | `2.24.0` -> `2.25.0` (#2838) |
| `datadog-crds` dependency | `2.22.0` -> `2.23.0` (#2837) |
| `operator.image.tag` | `1.28.0` -> `1.29.0` |
| `requirements.lock` | regenerated |

### Test baselines

51 baseline manifests were regenerated (`make update-test-baselines-datadog-agent`). Every changed line falls into one of four groups, all inherited from bumping the `datadog-operator` subchart from `2.24.0` to `2.25.0`:

* `app.kubernetes.io/version: 1.28.0` -> `1.29.0`
* `image: registry.datadoghq.com/operator:1.28.0` -> `1.29.0`
* new RBAC rule `apps` / `deployments/status` / `get` (from datadog-operator#3282)
* new operator arg `-untaintControllerEnabled=false` (from #2773)

No permissions or settings are removed.
