### PR TITLE
Allow specifying priorityClassName in datadog-operator

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.25.1
+
+* Add the ability to configure `priorityClassName` in the operator deployment
+
 ## 2.25.0
 
 * Update Datadog Operator chart for 1.29.0.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.25.0
+version: 2.25.1
 appVersion: 1.29.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -37,7 +37,6 @@
 | datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | deployment.annotations | object | `{}` | Allows setting additional annotations for the deployment resource |
-| deployment.priorityClassName | string | `nil` | Allows setting the priority class name for the deployment resource |
 | dnsConfig | object | `{}` | Specify DNS configuration options for Datadog Operator PODs |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |
 | fullnameOverride | string | `""` |  |
@@ -57,6 +56,7 @@
 | operatorMetricsEnabled | string | `"true"` | Enable forwarding of Datadog Operator metrics and events to Datadog. |
 | podAnnotations | object | `{}` | Allows setting additional annotations for Datadog Operator PODs |
 | podLabels | object | `{}` | Allows setting additional labels for for Datadog Operator PODs |
+| priorityClassName | string | `nil` | Allows setting the priority class name for Datadog Operator PODs |
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |
 | registryMigrationMode | string | `"auto"` | Controls gradual migration of Agent image pulls to registry.datadoghq.com. When enabled, DD_REGISTRY_OVERRIDE_* environment variables are added to the Datadog Operator deployment to pull Agent images from the global CDN-backed registry.datadoghq.com based on the global.site setting, unless global.registry is specified in the DatadogAgent custom resource (which takes precedence). This has no effect on sites not covered by the active overrides. More sites will be enabled by default in future helm-chart releases. "auto" (default): enable overrides for sites where migration is rolled out.   Currently enabled: AP1 (ap1.datadoghq.com), EU1 (datadoghq.eu), US1 (datadoghq.com), US5 (us5.datadoghq.com). "all": enable all per-site overrides (AP1, US1, EU1, US3, US5). "" or unset: disable all overrides. |
 | remoteConfiguration.enabled | bool | `false` | If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set. |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.25.0](https://img.shields.io/badge/Version-2.25.0-informational?style=flat-square) ![AppVersion: 1.29.0](https://img.shields.io/badge/AppVersion-1.29.0-informational?style=flat-square)
+![Version: 2.25.1](https://img.shields.io/badge/Version-2.25.1-informational?style=flat-square) ![AppVersion: 1.29.0](https://img.shields.io/badge/AppVersion-1.29.0-informational?style=flat-square)
 
 ## Values
 
@@ -37,6 +37,7 @@
 | datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
 | deployment.annotations | object | `{}` | Allows setting additional annotations for the deployment resource |
+| deployment.priorityClassName | string | `nil` | Allows setting the priority class name for the deployment resource |
 | dnsConfig | object | `{}` | Specify DNS configuration options for Datadog Operator PODs |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |
 | fullnameOverride | string | `""` |  |

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -257,7 +257,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
     {{- end }}
       volumes:
       {{- if .Values.volumes }}

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -256,7 +256,7 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.deployment.priorityClassName }}
+    {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}
       volumes:

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -256,6 +256,9 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.deployment.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
       volumes:
       {{- if .Values.volumes }}
       {{- toYaml .Values.volumes | nindent 6 }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -136,8 +136,6 @@ registryMigrationMode: "auto"
 deployment:
   # deployment.annotations -- Allows setting additional annotations for the deployment resource
   annotations: {}
-  # deployment.priorityClassName -- Allows setting the priority class name for the deployment resource
-  priorityClassName:
 rbac:
   # rbac.create -- Specifies whether the RBAC resources should be created
   create: true
@@ -170,7 +168,8 @@ nodeSelector:
 tolerations: []
 # affinity -- Allows to specify affinity for Datadog Operator PODs
 affinity: {}
-
+# priorityClassName -- Allows setting the priority class name for Datadog Operator PODs
+priorityClassName:
 # dnsConfig -- Specify DNS configuration options for Datadog Operator PODs
 dnsConfig: {}
 #  options:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -136,6 +136,8 @@ registryMigrationMode: "auto"
 deployment:
   # deployment.annotations -- Allows setting additional annotations for the deployment resource
   annotations: {}
+  # deployment.priorityClassName -- Allows setting the priority class name for the deployment resource
+  priorityClassName:
 rbac:
   # rbac.create -- Specifies whether the RBAC resources should be created
   create: true

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.25.0
+    helm.sh/chart: datadog-operator-2.25.1
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.29.0"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
> Repo branch for contribution by @josh-ferrell's contribution https://github.com/DataDog/helm-charts/pull/2468

#### What this PR does / why we need it:
Allows the end user to configure the priorityClassName in the datadog-operator deployment.

#### Which issue this PR fixes
#1413

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits