### PR TITLE
Operator Release CRDs ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,9 @@ charts/synthetics-private-location/                    @Datadog/synthetics
 charts/observability-pipelines-worker                  @DataDog/observability-pipelines
 charts/private-action-runner                           @DataDog/action-platform
 
+# CRDs
+crds/ @DataDog/container-platform @DataDog/agent-delivery
+
 # Tests
 test/datadog-operator                                  @DataDog/container-platform
 test/private-action-runner                             @DataDog/action-platform


### PR DESCRIPTION
#### What this PR does / why we need it:

The `crds/` directory is typically only updated for Operator releases. This PR gives ownership to container-platform and agent-delivery which maintain the Operator releases.

<img width="1483" height="635" alt="image" src="https://github.com/user-attachments/assets/49c3d425-8789-4faa-ae13-6b27812d6d89" />


[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits