### PR TITLE
Include Agent Delivery for Baseline tests codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,5 +29,8 @@ charts/private-action-runner                           @DataDog/action-platform
 crds/ @DataDog/container-platform @DataDog/agent-delivery
 
 # Tests
-test/datadog-operator                                  @DataDog/container-platform
-test/private-action-runner                             @DataDog/action-platform
+test/datadog-operator                                           @DataDog/container-platform
+test/datadog-operator/baseline/DatadogAgent_CRD_default.yaml    @DataDog/container-platform @DataDog/agent-delivery
+test/datadog-operator/baseline/Operator_Deployment_default.yaml @DataDog/container-platform @DataDog/agent-delivery
+test/datadog-operator/operator_deployment_test.go               @DataDog/container-platform @DataDog/agent-delivery
+test/private-action-runner                                      @DataDog/action-platform


### PR DESCRIPTION
#### What this PR does / why we need it:

Give agent delivery ownership for baseline unit tests which also get updated during Operator releases.

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits