### PR TITLE
chore(datadog): bump CSI driver chart to 0.17.0

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Datadog changelog
 
+## 3.238.0
+
+* Update `datadog-csi-driver` chart dependency from `0.15.0` to `0.17.0`:
+  * `0.16.0`: set CSI driver image to `1.3.0`.
+  * `0.16.1`: migrate CSI registrar image from `k8s.gcr.io` to `registry.k8s.io`.
+  * `0.17.0`: set CSI driver image to `1.4.0` and add `apm.pullSecrets` for downloading SSI libraries from private registries.
+
 ## 3.237.1
 
 * Update `fips.image.tag` to `1.1.29` fixing CVEs and updating packages.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.237.1
+version: 3.238.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.237.1](https://img.shields.io/badge/Version-3.237.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.238.0](https://img.shields.io/badge/Version-3.238.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -32,7 +32,7 @@ Kubernetes 1.10+ or OpenShift 3.10+, note that:
 | Repository | Name | Version |
 |------------|------|---------|
 | https://helm.datadoghq.com | datadog-crds | 2.23.0 |
-| https://helm.datadoghq.com | datadog-csi-driver | 0.15.0 |
+| https://helm.datadoghq.com | datadog-csi-driver | 0.17.0 |
 | https://helm.datadoghq.com | operator(datadog-operator) | 2.25.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 2.13.2 |
 

--- a/charts/datadog/requirements.lock
+++ b/charts/datadog/requirements.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 2.13.2
 - name: datadog-csi-driver
   repository: https://helm.datadoghq.com
-  version: 0.15.0
+  version: 0.17.0
 - name: datadog-operator
   repository: https://helm.datadoghq.com
   version: 2.25.0
-digest: sha256:47ee2923a2c414cf1b7c0acbe008ecbe2038b31d44f5529c7d9e60dd00a5646d
-generated: "2026-08-05T10:54:28.159056565Z"
+digest: sha256:39775ad02445b029926d3df8f9f360b989b820d46661c7ac46cb2914e894d03b
+generated: "2026-08-12T15:57:43.428810438+02:00"

--- a/charts/datadog/requirements.yaml
+++ b/charts/datadog/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: datadog.kubeStateMetricsEnabled
   - name: datadog-csi-driver
-    version: 0.15.0
+    version: 0.17.0
     repository: https://helm.datadoghq.com
     condition: datadog.csi.enabled
   - name: datadog-operator


### PR DESCRIPTION
## Description

Bump the `datadog-csi-driver` chart dependency in the main `datadog` chart from `0.15.0` to `0.17.0`, and bump the parent chart to `3.238.0`.

This picks up:
- `0.16.0`: CSI driver image `1.3.0`
- `0.16.1`: CSI registrar image migration to `registry.k8s.io`
- `0.17.0`: CSI driver image `1.4.0` and `apm.pullSecrets` for downloading SSI libraries from private registries

## Related Issue

- https://github.com/DataDog/helm-charts/pull/2834
- https://github.com/DataDog/datadog-csi-driver/pull/105

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] CI / tooling
- [ ] Documentation

## Checklist

- [x] Documentation updated if needed
- [ ] Tests added or updated
- [x] No unintended breaking changes

## How Has This Been Tested?

- Ran `helm dependency update ./charts/datadog`
- Regenerated docs with `.github/helm-docs.sh`

## Additional Notes

Users can configure private registry credentials for SSI library downloads via the subchart values, for example:

```yaml
datadog:
  csi:
    enabled: true
datadog-csi-driver:
  apm:
    pullSecrets:
      - name: my-registry-secret
```