### PR TITLE
[synthetics-private-location] bump image version to 1.72.0

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.17.31
+
+* Update private location image version to `1.72.0`.
+
 ## 0.17.30
 
 * Update private location image version to `1.71.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.17.30
-appVersion: 1.71.0
+version: 0.17.31
+appVersion: 1.72.0
 description: Datadog Synthetics Private Location
 keywords:
 - monitoring

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.17.30](https://img.shields.io/badge/Version-0.17.30-informational?style=flat-square) ![AppVersion: 1.71.0](https://img.shields.io/badge/AppVersion-1.71.0-informational?style=flat-square)
+![Version: 0.17.31](https://img.shields.io/badge/Version-0.17.31-informational?style=flat-square) ![AppVersion: 1.72.0](https://img.shields.io/badge/AppVersion-1.72.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations/?tab=helmchart).
 
@@ -41,7 +41,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | hostAliases | list | `[]` | Add entries to Datadog Synthetics Private Location PODs' /etc/hosts |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Synthetics Private Location image |
 | image.repository | string | `"gcr.io/datadoghq/synthetics-private-location-worker"` | Repository to use for Datadog Synthetics Private Location image |
-| image.tag | string | `"1.71.0"` | Define the Datadog Synthetics Private Location version to use |
+| image.tag | string | `"1.72.0"` | Define the Datadog Synthetics Private Location version to use |
 | imagePullSecrets | list | `[]` | Datadog Synthetics Private Location repository pullSecret (ex: specify docker registry credentials) |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Synthetics Private Location on specific nodes |

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -15,7 +15,7 @@ image:
   # image.pullPolicy -- Define the pullPolicy for Datadog Synthetics Private Location image
   pullPolicy: IfNotPresent
   # image.tag -- Define the Datadog Synthetics Private Location version to use
-  tag: 1.71.0
+  tag: 1.72.0
 
 # dnsPolicy -- DNS Policy to set to the Datadog Synthetics Private Location PODs
 dnsPolicy: ClusterFirst


### PR DESCRIPTION
#### What this PR does / why we need it:

The Synthetics Private Location worker was updated to version `1.72.0`.
This PR bumps the `appVersion` in the `synthetics-private-location` chart to `1.72.0`, bumps the chart `version` patch component (`0.17.30` -> `0.17.31`), updates `image.tag`, and refreshes the `CHANGELOG.md` / `README.md` (validated with `.github/helm-docs.sh` — no diff).

#### Which issue this PR fixes

None

#### Special notes for your reviewer:

Patch bump only (no breaking changes in this release).

Merge process: a coworker reviews and then comments `/merge` to trigger the merge. Direct button merge has been unavailable for this chart since version 1.54.0.

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (`synthetics-private-location/patch-version`)
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
