### PR TITLE
Update CloudPrem Helm chart to 0.5.2

### DIFF
--- a/charts/cloudprem/CHANGELOG.md
+++ b/charts/cloudprem/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.5.2
+
+* Update Docker image to `v0.1.33`.
+* Enable document clustering by default (`config.docs_clustering`) so indexers group similar logs together for better compression, using structure plus `source`, `status`, and tokenized `message` fingerprints.
+* Set indexer `QW_INGEST_DECOMMISSION_TIMEOUT` and standalone-compactor `QW_COMPACTOR_DECOMMISSION_TIMEOUT` to 90% of each workload's `terminationGracePeriodSeconds` so decommission finishes before Kubernetes sends SIGKILL (from oss/main, quickwit-oss/helm-charts#184).
+
 ## 0.5.1
 
 * Add the CloudPrem component name to OpenTelemetry resource attributes.

--- a/charts/cloudprem/Chart.yaml
+++ b/charts/cloudprem/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: cloudprem
 description: Datadog CloudPrem
 type: application
-version: 0.5.1
+version: 0.5.2
 # This is the version of the "application". Right now, we follow the image version.
-appVersion: v0.1.32
+appVersion: v0.1.33
 home: https://www.datadoghq.com/
 icon: https://static.datadoghq.com/static/images/logos/_datadog_avatar.svg
 maintainers:

--- a/charts/cloudprem/README.md
+++ b/charts/cloudprem/README.md
@@ -1,6 +1,6 @@
 # CloudPrem
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.32](https://img.shields.io/badge/AppVersion-v0.1.32-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.33](https://img.shields.io/badge/AppVersion-v0.1.33-informational?style=flat-square)
 
 ## Using the Datadog Helm repository
 

--- a/charts/cloudprem/templates/compactor-deployment.yaml
+++ b/charts/cloudprem/templates/compactor-deployment.yaml
@@ -61,6 +61,9 @@ spec:
           args: ["run", "--service", "compactor"]
           {{- end }}
           env:
+            {{- /* Supported by Quickwit edge and the upcoming 0.10 release. */}}
+            - name: QW_COMPACTOR_DECOMMISSION_TIMEOUT
+              value: {{ printf "%ds" (div (mul .Values.compactor.terminationGracePeriodSeconds 9) 10) | quote }}
             {{- include "quickwit.environment" . | nindent 12 }}
             {{- with (include "quickwit.extraEnv" .Values.compactor.extraEnv) }}
             {{- . | nindent 12 }}

--- a/charts/cloudprem/templates/indexer-statefulset.yaml
+++ b/charts/cloudprem/templates/indexer-statefulset.yaml
@@ -72,6 +72,9 @@ spec:
           args: ["run", "--service", "indexer"]
           {{- end }}
           env:
+            {{- /* Supported by Quickwit edge and the upcoming 0.10 release. */}}
+            - name: QW_INGEST_DECOMMISSION_TIMEOUT
+              value: {{ printf "%ds" (div (mul .Values.indexer.terminationGracePeriodSeconds 9) 10) | quote }}
             {{- include "quickwit.environment" . | nindent 12 }}
             {{- if .Values.indexer.persistentVolume.enabled }}
             {{- if .Values.indexer.persistentVolume.storageClass }}

--- a/charts/cloudprem/values.yaml
+++ b/charts/cloudprem/values.yaml
@@ -445,7 +445,9 @@ indexer:
     #       - -c
     #       - sleep 30
 
-  # Long grace period is recommended to wait for all index commit_timeout_secs and splits to be published
+  # Long grace period is recommended to wait for all index commit_timeout_secs and splits to be published.
+  # With Quickwit edge or the upcoming 0.10 release, the ingester decommission timeout
+  # is set to 90% of this value.
   # See https://quickwit.io/docs/configuration/index-config#indexing-settings
   terminationGracePeriodSeconds: 300
 
@@ -1092,7 +1094,8 @@ compactor:
 
   # Grace period to let in-flight merges finish publishing on shutdown. Unfinished
   # merges are simply rescheduled by the planner after a heartbeat timeout, so this
-  # does not need to be as long as the indexer's.
+  # does not need to be as long as the indexer's. With Quickwit edge or the upcoming
+  # 0.10 release, the compactor decommission timeout is set to 90% of this value.
   terminationGracePeriodSeconds: 60
 
   runtimeClassName: ""
@@ -1176,9 +1179,6 @@ config:
       interval: 30s
       timeout: 10s
 
-  # postgres:
-  #   max_num_connections: 50
-
   # storage:
     # s3:
       # endpoint: "http://custom-s3-endpoint"
@@ -1195,6 +1195,19 @@ config:
   # indexer:
   #   split_store_max_num_bytes: 200G
   #   split_store_max_num_splits: 10000
+  # Docs clustering settings
+  docs_clustering:
+  - fingerprint:
+      - kind: structure
+  - fingerprint:
+      - kind: raw
+        path: source
+  - fingerprint:
+      - kind: raw
+        path: status
+  - fingerprint:
+      - kind: tokenized
+        path: message
   # Ingest API settings
   # ingest_api:
   #   max_queue_memory_usage: 2GiB
@@ -1204,6 +1217,10 @@ config:
   #   fast_field_cache_capacity: 10G
   #   split_footer_cache_capacity: 1G
   #   max_num_concurrent_split_streams: 100
+  # Metastore settings
+  # metastore:
+  #   postgres:
+  #     max_num_connections: 50
 
 # Seed configuration
 seed:


### PR DESCRIPTION
## Summary
- update CloudPrem to chart version `0.5.2` and app version `v0.1.33`
- enable document clustering by default
- set indexer and standalone-compactor decommission timeouts to 90% of their termination grace periods
- preserve the CloudPrem component in OpenTelemetry resource attributes
- regenerate the README version badges

Supersedes #2863 with the complete chart sync from `DataDog/pomsky-helm-charts`.

## Validation
- `helm lint charts/cloudprem`
- `helm template cloudprem charts/cloudprem`
- rendered standalone compactor and custom grace periods; both decommission timeout values resolve to 90%
- `git diff --check`