### PR TITLE
feat(datadog): enable cluster-agent RC for on-demand SSI

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Datadog changelog
 
+## 3.239.1
+
+* Expose `datadog.apm.instrumentation.onDemand` (default `true`) and set `DD_APM_INSTRUMENTATION_ON_DEMAND` on the Cluster Agent.
+* Enable Cluster Agent Remote Configuration when the admission controller is enabled and on-demand SSI is on, so `APM_POLICIES` Remote Config rules work without `clusterAgent.admissionController.remoteInstrumentation.enabled`.
+
 ## 3.239.0
 
 * Add `operator.untaintController.enabled` (default `false`). When enabled, the node Agent DaemonSet tolerates the `agent.datadoghq.com/not-ready=presence:NoSchedule` startup taint and the Datadog Operator untaint controller is enabled to remove that taint once the Agent is ready. Requires Operator v1.28.0+. See [documentation](https://github.com/DataDog/datadog-operator/blob/main/docs/untaint_controller.md) for more details.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.239.0
+version: 3.239.1
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.239.0](https://img.shields.io/badge/Version-3.239.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.239.1](https://img.shields.io/badge/Version-3.239.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -765,6 +765,7 @@ helm install <RELEASE_NAME> \
 | datadog.apm.instrumentation.injector.imageTag | string | `""` | The image tag to use for the APM Injector (preview). |
 | datadog.apm.instrumentation.language_detection.enabled | bool | `true` | Run language detection to automatically detect languages of user workloads (preview). |
 | datadog.apm.instrumentation.libVersions | object | `{}` | Inject specific version of tracing libraries with Single Step Instrumentation. |
+| datadog.apm.instrumentation.onDemand | bool | `true` | Keep the SSI admission webhook available for runtime workload selection (annotations and Remote Config APM_POLICIES). Matches the agent default (true). |
 | datadog.apm.instrumentation.skipKPITelemetry | bool | `false` | Disable generating Configmap for APM Instrumentation KPIs |
 | datadog.apm.instrumentation.targets | list | `[]` | Enable target based workload selection. Requires Cluster Agent 7.64.0+.  ddTraceConfigs[]valueFrom Requires Cluster Agent 7.66.0+. |
 | datadog.apm.port | int | `8126` | Override the trace Agent port |

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -1473,7 +1473,7 @@ false
 Returns whether Remote Configuration should be enabled in the cluster agent
 */}}
 {{- define "clusterAgent-remoteConfiguration-enabled" -}}
-{{- if and .Values.remoteConfiguration.enabled (or .Values.clusterAgent.admissionController.remoteInstrumentation.enabled .Values.clusterAgent.privateActionRunner.enabled (((.Values.datadog.autoscaling).workload).enabled) .Values.datadog.kubernetesActions.enabled) (not .Values.providers.gke.gdc ) -}}
+{{- if and .Values.remoteConfiguration.enabled (or .Values.clusterAgent.admissionController.remoteInstrumentation.enabled (and .Values.clusterAgent.admissionController.enabled .Values.datadog.apm.instrumentation.onDemand) .Values.clusterAgent.privateActionRunner.enabled (((.Values.datadog.autoscaling).workload).enabled) .Values.datadog.kubernetesActions.enabled) (not .Values.providers.gke.gdc ) -}}
 true
 {{- else -}}
 false

--- a/charts/datadog/templates/cluster-agent-deployment.yaml
+++ b/charts/datadog/templates/cluster-agent-deployment.yaml
@@ -311,6 +311,8 @@ spec:
           - name: DD_APM_INSTRUMENTATION_ENABLED
             value: {{ .Values.datadog.apm.instrumentation.enabled | quote }}
           {{- end }}
+          - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+            value: {{ .Values.datadog.apm.instrumentation.onDemand | quote }}
           {{- if .Values.datadog.apm.instrumentation.enabledNamespaces }}
           - name: DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES
             value: {{ .Values.datadog.apm.instrumentation.enabledNamespaces | toJson | quote }}

--- a/charts/datadog/values.schema.json
+++ b/charts/datadog/values.schema.json
@@ -39,6 +39,9 @@
                 "enabled": {
                   "type": "boolean"
                 },
+                "onDemand": {
+                  "type": "boolean"
+                },
                 "enabledNamespaces": {
                   "$ref": "#/$defs/stringArray"
                 },

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -638,6 +638,10 @@ datadog:
       # datadog.apm.instrumentation.enabled -- Enable injecting the Datadog APM libraries into all pods in the cluster.
       enabled: false
 
+      # datadog.apm.instrumentation.onDemand -- Keep the SSI admission webhook available for runtime workload
+      # selection (annotations and Remote Config APM_POLICIES). Matches the agent default (true).
+      onDemand: true
+
       # datadog.apm.instrumentation.enabledNamespaces -- Enable injecting the Datadog APM libraries into pods in specific namespaces.
       enabledNamespaces: []
 

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -2360,7 +2360,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -2360,7 +2360,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -2960,7 +2960,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -2734,7 +2734,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -2046,7 +2046,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -2060,7 +2060,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_PROFILES
               value: '[{"env":[{"name":"DD_ORCHESTRATOR_EXPLORER_ENABLED","value":"false"},{"name":"DD_TAGS","value":"key1:value1 key2:value2"}],"resources":{"limits":{"cpu":"2","memory":"1024Mi"},"requests":{"cpu":"1","memory":"512Mi"}}}]'
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -2056,7 +2056,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
               value: 7.81.1
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -2048,7 +2048,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -2750,7 +2750,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -2870,7 +2870,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -2733,7 +2733,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -3002,7 +3002,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -2726,7 +2726,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -2726,7 +2726,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -1367,7 +1367,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
@@ -2083,6 +2083,8 @@ spec:
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -2083,6 +2083,8 @@ spec:
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -2100,6 +2100,8 @@ spec:
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -2377,7 +2377,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -2124,7 +2124,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -2597,7 +2597,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -2714,7 +2714,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -2714,7 +2714,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -2590,7 +2590,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -2968,7 +2968,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -2978,7 +2978,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -2846,7 +2846,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -2870,7 +2870,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -3032,7 +3032,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: gcr.io/datadoghq
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -2777,7 +2777,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -2780,7 +2780,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -2791,7 +2791,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -2844,7 +2844,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -2929,7 +2929,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -2848,7 +2848,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -2923,7 +2923,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -2892,7 +2892,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -2925,7 +2925,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -2919,7 +2919,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -2726,7 +2726,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -2737,7 +2737,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -2790,7 +2790,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -3002,7 +3002,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -2955,7 +2955,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -2794,7 +2794,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -2844,7 +2844,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -2837,7 +2837,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -2746,7 +2746,9 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY
               value: registry.datadoghq.com
             - name: DD_REMOTE_CONFIGURATION_ENABLED
-              value: "false"
+              value: "true"
+            - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+              value: "true"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS


### PR DESCRIPTION
## Description

On-demand SSI policies are delivered over Remote Config (`APM_POLICIES`). The
cluster-agent subscribes to that product when `apm_config.instrumentation.on_demand`
is true (agent default), but the Helm chart did not enable Remote Configuration
on the cluster-agent unless `clusterAgent.admissionController.remoteInstrumentation`
(or a few other unrelated features) was enabled.

This PR:
- exposes `datadog.apm.instrumentation.onDemand` (default `true`, matching the agent)
- sets `DD_APM_INSTRUMENTATION_ON_DEMAND` on the cluster-agent from that value
- updates `clusterAgent-remoteConfiguration-enabled` to return `true` when the
  admission controller is enabled and on-demand SSI is on

With chart defaults (`remoteConfiguration.enabled`, `admissionController.enabled`,
and `onDemand` all true), the cluster-agent polls Remote Config without requiring
`remoteInstrumentation.enabled`.

## Related Issue

Follow-up to SSI on-demand RC E2E work in datadog-agent.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] CI / tooling
- [ ] Documentation

## Checklist

- [x] Documentation updated if needed
- [x] Tests added or updated
- [ ] No unintended breaking changes

## How Has This Been Tested?

- `make update-test-baselines-datadog-agent` (baseline manifests updated)
- `.github/helm-docs.sh`

## Additional Notes

This changes default cluster-agent installs to set `DD_REMOTE_CONFIGURATION_ENABLED=true`
when admission controller + onDemand are enabled (both default to true). Expected
side effect: cluster-agent starts polling RC in more default installs.

Related datadog-agent E2E PR can drop its `DD_REMOTE_CONFIGURATION_ENABLED` workaround
once this chart version is published and pinned in the E2E framework.