### PR TITLE
[PROF-15646] selinux annotation on install-seccomp

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.240.2
+
+* [PROF-15646] selinux annotation on install-seccomp ([#2873](https://github.com/DataDog/helm-charts/pull/2873)).
+
 ## 3.240.1
 
 * Fix `otel-agent` (and other Agent DaemonSet containers) intermittently failing to start with `StartError` / exit code 128 and `mkdirat .../etc/datadog-agent/auth: read-only file system`. The `auth-token` volume is mounted nested inside the read-only `config` volume, so the container runtime could not create the `auth` mountpoint. It is now pre-created by the `init-volume` init container instead of relying on the `agent` container being started first.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.240.1
+version: 3.240.2
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.240.1](https://img.shields.io/badge/Version-3.240.1-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.240.2](https://img.shields.io/badge/Version-3.240.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_host-profiler-init.yaml
+++ b/charts/datadog/templates/_host-profiler-init.yaml
@@ -1,8 +1,14 @@
 {{- define "host-profiler-seccomp-init" -}}
+{{- $hostProfilerSecurityContext := .Values.agents.containers.hostProfiler.securityContext | default dict -}}
+{{- $selinuxOptions := $hostProfilerSecurityContext.seLinuxOptions | default dict -}}
+{{- $selinuxType := $selinuxOptions.type | default "spc_t" -}}
+{{- $securityContext := mergeOverwrite
+      (deepCopy (.Values.agents.containers.initContainers.securityContext | default dict))
+      (dict "seLinuxOptions" (dict "type" $selinuxType))
+-}}
 - name: host-profiler-seccomp-setup
   securityContext:
-    seLinuxOptions:
-      type: {{ .Values.agents.containers.hostProfiler.securityContext.seLinuxOptions.type | default "spc_t" }}
+{{ toYaml $securityContext | indent 4 }}
   image: "{{ include "ddot-ebpf-image" . }}"
   imagePullPolicy: {{ .Values.datadog.hostProfiler.imagePullPolicy | default .Values.agents.image.pullPolicy }}
   {{- $dst := printf "/host%s/%s" .Values.datadog.hostProfiler.seccompRoot (include "host-profiler-seccomp-name" .) }}

--- a/charts/datadog/templates/_host-profiler-init.yaml
+++ b/charts/datadog/templates/_host-profiler-init.yaml
@@ -1,6 +1,11 @@
 {{- define "host-profiler-seccomp-init" -}}
+{{- $securityContext := mergeOverwrite
+      (dict "seLinuxOptions" (dict "type" "spc_t"))
+      (.Values.agents.containers.initContainers.securityContext | default dict)
+-}}
 - name: host-profiler-seccomp-setup
-{{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.initContainers.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | indent 2 }}
+  securityContext:
+{{ toYaml $securityContext | indent 4 }}
   image: "{{ include "ddot-ebpf-image" . }}"
   imagePullPolicy: {{ .Values.datadog.hostProfiler.imagePullPolicy | default .Values.agents.image.pullPolicy }}
   {{- $dst := printf "/host%s/%s" .Values.datadog.hostProfiler.seccompRoot (include "host-profiler-seccomp-name" .) }}

--- a/charts/datadog/templates/_host-profiler-init.yaml
+++ b/charts/datadog/templates/_host-profiler-init.yaml
@@ -1,11 +1,8 @@
 {{- define "host-profiler-seccomp-init" -}}
-{{- $securityContext := mergeOverwrite
-      (dict "seLinuxOptions" (dict "type" "spc_t"))
-      (.Values.agents.containers.initContainers.securityContext | default dict)
--}}
 - name: host-profiler-seccomp-setup
   securityContext:
-{{ toYaml $securityContext | indent 4 }}
+    seLinuxOptions:
+      type: {{ .Values.agents.containers.hostProfiler.securityContext.seLinuxOptions.type | default "spc_t" }}
   image: "{{ include "ddot-ebpf-image" . }}"
   imagePullPolicy: {{ .Values.datadog.hostProfiler.imagePullPolicy | default .Values.agents.image.pullPolicy }}
   {{- $dst := printf "/host%s/%s" .Values.datadog.hostProfiler.seccompRoot (include "host-profiler-seccomp-name" .) }}

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -131,6 +131,7 @@ func TestHostProfilerSELinux(t *testing.T) {
 		// A user-provided securityContext.seLinuxOptions takes precedence over the spc_t default.
 		overrides := copyMap(hostProfilerBaseOverrides)
 		overrides["agents.containers.hostProfiler.securityContext.seLinuxOptions.type"] = "custom_t"
+		overrides["agents.containers.initContainers.securityContext.allowPrivilegeEscalation"] = "false"
 
 		ds := renderHostProfilerDaemonSet(t, overrides)
 
@@ -146,7 +147,21 @@ func TestHostProfilerSELinux(t *testing.T) {
 		require.NotNil(t, initContainer.SecurityContext)
 		require.NotNil(t, initContainer.SecurityContext.SELinuxOptions)
 		assert.Equal(t, "custom_t", initContainer.SecurityContext.SELinuxOptions.Type)
+		require.NotNil(t, initContainer.SecurityContext.AllowPrivilegeEscalation)
+		assert.False(t, *initContainer.SecurityContext.AllowPrivilegeEscalation)
 	})
+}
+
+func TestHostProfilerNilSecurityContext(t *testing.T) {
+	overrides := copyMap(hostProfilerBaseOverrides)
+	overrides["agents.containers.hostProfiler.securityContext"] = "null"
+	ds := renderHostProfilerDaemonSet(t, overrides)
+
+	initContainer, ok := getContainer(t, ds.Spec.Template.Spec.InitContainers, "host-profiler-seccomp-setup")
+	require.True(t, ok)
+	require.NotNil(t, initContainer.SecurityContext)
+	require.NotNil(t, initContainer.SecurityContext.SELinuxOptions)
+	assert.Equal(t, "spc_t", initContainer.SecurityContext.SELinuxOptions.Type)
 }
 
 func TestHostProfilerSCC(t *testing.T) {

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -63,6 +63,9 @@ func TestHostProfilerSeccomp(t *testing.T) {
 	assert.Equal(t, "myreg/host-profiler:v1.2.3", initContainer.Image)
 	assert.True(t, containsString(initContainer.Command, "/host/var/lib/kubelet/seccomp/"+profileRef),
 		"init container cp destination should match the seccomp profile name; command: %v", initContainer.Command)
+	require.NotNil(t, initContainer.SecurityContext)
+	require.NotNil(t, initContainer.SecurityContext.SELinuxOptions)
+	assert.Equal(t, "spc_t", initContainer.SecurityContext.SELinuxOptions.Type)
 
 }
 

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -140,6 +140,12 @@ func TestHostProfilerSELinux(t *testing.T) {
 		selinux := hpContainer.SecurityContext.SELinuxOptions
 		require.NotNil(t, selinux, "host-profiler seLinuxOptions")
 		assert.Equal(t, "custom_t", selinux.Type)
+
+		initContainer, ok := getContainer(t, ds.Spec.Template.Spec.InitContainers, "host-profiler-seccomp-setup")
+		require.True(t, ok)
+		require.NotNil(t, initContainer.SecurityContext)
+		require.NotNil(t, initContainer.SecurityContext.SELinuxOptions)
+		assert.Equal(t, "custom_t", initContainer.SecurityContext.SELinuxOptions.Type)
 	})
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

On SELinux setups with containerd integration, `/host/var/lib/kubelet/seccomp/` gets a `var_lib_t` label and denies operations to unprivileged containers.
On these setups, the host profiler's initcontainer fails as it was running under the default selinux profile.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits