### PR TITLE
Stop rendering unsupported Operator settings

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.26.0-dev.4
+
+* Stop rendering unsupported ExtendedDaemonSet and registry override settings ([#2875](https://github.com/DataDog/helm-charts/pull/2875)).
+
 ## 2.26.0-dev.3
 
 * Update Datadog Operator chart for 1.30.0-rc.2.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.26.0-dev.3
+version: 2.26.0-dev.4
 appVersion: 1.30.0-rc.2
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.26.0-dev.3](https://img.shields.io/badge/Version-2.26.0--dev.3-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
+![Version: 2.26.0-dev.4](https://img.shields.io/badge/Version-2.26.0--dev.4-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -58,7 +58,6 @@
 | podLabels | object | `{}` | Allows setting additional labels for for Datadog Operator PODs |
 | priorityClassName | string | `nil` | Allows setting the priority class name for Datadog Operator PODs |
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |
-| registryMigrationMode | string | `"auto"` | Controls gradual migration of Agent image pulls to registry.datadoghq.com. When enabled, DD_REGISTRY_OVERRIDE_* environment variables are added to the Datadog Operator deployment to pull Agent images from the global CDN-backed registry.datadoghq.com based on the global.site setting, unless global.registry is specified in the DatadogAgent custom resource (which takes precedence). This has no effect on sites not covered by the active overrides. More sites will be enabled by default in future helm-chart releases. "auto" (default): enable overrides for sites where migration is rolled out.   Currently enabled: AP1 (ap1.datadoghq.com), EU1 (datadoghq.eu), US1 (datadoghq.com), US5 (us5.datadoghq.com). "all": enable all per-site overrides (AP1, US1, EU1, US3, US5). "" or unset: disable all overrides. |
 | remoteConfiguration.enabled | bool | `false` | If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set. |
 | replicaCount | int | `1` | Number of instances of Datadog Operator |
 | resources | object | `{}` | Set resources requests/limits for Datadog Operator PODs |

--- a/charts/datadog-operator/templates/_helpers.tpl
+++ b/charts/datadog-operator/templates/_helpers.tpl
@@ -167,17 +167,6 @@ Return the appropriate apiVersion for PodDisruptionBudget policy APIs.
 {{- end -}}
 
 {{/*
-Return the registry migration mode.
-*/}}
-{{- define "datadog-registry-mode" -}}
-{{- $mode := .Values.registryMigrationMode -}}
-{{- if and $mode (not (has $mode (list "auto" "all"))) -}}
-  {{- fail (printf "registryMigrationMode must be \"auto\" or \"all\". Got: %q" $mode) -}}
-{{- end -}}
-{{- $mode -}}
-{{- end -}}
-
-{{/*
 Check operator image tag version.
 */}}
 {{- define "check-image-tag" -}}

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -168,7 +168,9 @@ spec:
               value: {{ .value | quote }}
             {{- end }}
           args:
-            - "-supportExtendedDaemonset={{ .Values.supportExtendedDaemonset }}"
+          {{- if and (eq (toString .Values.supportExtendedDaemonset) "true") (semverCompare "<1.31.0-0" $version) }}
+            - "-supportExtendedDaemonset=true"
+          {{- end }}
             - "-logEncoder=json"
             - "-metrics-addr=:{{ .Values.metricsPort }}"
             - "-loglevel={{ .Values.logLevel }}"

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -132,19 +132,6 @@ spec:
             - name: DD_URL
               value: {{ default .Values.dd_url (include "get-endpoint-config-data-key" (list . "dd-url")) }}
             {{- end }}
-            {{- $registryMode := include "datadog-registry-mode" . }}
-            {{- if or (eq $registryMode "auto") (eq $registryMode "all") }}
-            - name: DD_REGISTRY_OVERRIDE_ASIA
-              value: "true"
-            - name: DD_REGISTRY_OVERRIDE_EU
-              value: "true"
-            - name: DD_REGISTRY_OVERRIDE_DEFAULT
-              value: "true"
-            {{- end }}
-            {{- if eq $registryMode "all" }}
-            - name: DD_REGISTRY_OVERRIDE_AZURE
-              value: "true"
-            {{- end }}
             {{- if and (semverCompare ">=1.28.0-0" $version) .Values.untaintController.enabled }}
             {{- if .Values.untaintController.timeout }}
             - name: DD_UNTAINT_CONTROLLER_TIMEOUT

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -122,19 +122,6 @@ untaintController:
   timeoutPolicy: ""
   # untaintController.eventsEnabled -- Emit Kubernetes Events on Nodes for taint removals and timeout decisions.
   eventsEnabled: false
-# registryMigrationMode -- Controls gradual migration of Agent image pulls to
-# registry.datadoghq.com. When enabled, DD_REGISTRY_OVERRIDE_* environment variables
-# are added to the Datadog Operator deployment to pull Agent images from the global
-# CDN-backed registry.datadoghq.com based on the global.site setting, unless
-# global.registry is specified in the DatadogAgent custom resource (which takes precedence).
-# This has no effect on sites not covered by the active overrides.
-# More sites will be enabled by default in future helm-chart releases.
-# "auto" (default): enable overrides for sites where migration is rolled out.
-#   Currently enabled: AP1 (ap1.datadoghq.com), EU1 (datadoghq.eu), US1 (datadoghq.com), US5 (us5.datadoghq.com).
-# "all": enable all per-site overrides (AP1, US1, EU1, US3, US5).
-# "" or unset: disable all overrides.
-registryMigrationMode: "auto"
-
 deployment:
   # deployment.annotations -- Allows setting additional annotations for the deployment resource
   annotations: {}

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -56,12 +56,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
-            - name: DD_REGISTRY_OVERRIDE_ASIA
-              value: "true"
-            - name: DD_REGISTRY_OVERRIDE_EU
-              value: "true"
-            - name: DD_REGISTRY_OVERRIDE_DEFAULT
-              value: "true"
           args:
             - "-logEncoder=json"
             - "-metrics-addr=:8383"

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -63,7 +63,6 @@ spec:
             - name: DD_REGISTRY_OVERRIDE_DEFAULT
               value: "true"
           args:
-            - "-supportExtendedDaemonset=false"
             - "-logEncoder=json"
             - "-metrics-addr=:8383"
             - "-loglevel=info"

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -58,6 +58,87 @@ func Test_operator_chart(t *testing.T) {
 			skipTest:   SkipTest,
 		},
 		{
+			name: "ExtendedDaemonSet support renders its flag when enabled on a supported prerelease Operator version",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"supportExtendedDaemonset": "true",
+				},
+			},
+			assertions: func(t *testing.T, manifest string) {
+				var deployment appsv1.Deployment
+				common.Unmarshal(t, manifest, &deployment)
+				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+				assert.Contains(t, operatorContainer.Args, "-supportExtendedDaemonset=true")
+				assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=false")
+			},
+			skipTest: SkipTest,
+		},
+		{
+			name: "ExtendedDaemonSet support renders its flag when enabled on Operator 1.30.0",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"image.tag":                "1.30.0",
+					"supportExtendedDaemonset": "true",
+				},
+			},
+			assertions: func(t *testing.T, manifest string) {
+				var deployment appsv1.Deployment
+				common.Unmarshal(t, manifest, &deployment)
+				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+				assert.Contains(t, operatorContainer.Args, "-supportExtendedDaemonset=true")
+			},
+			skipTest: SkipTest,
+		},
+		{
+			name: "ExtendedDaemonSet support does not render its flag on Operator 1.31.0",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"image.tag":                "1.31.0",
+					"supportExtendedDaemonset": "true",
+				},
+			},
+			assertions: func(t *testing.T, manifest string) {
+				var deployment appsv1.Deployment
+				common.Unmarshal(t, manifest, &deployment)
+				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+				assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=false")
+				assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=true")
+			},
+			skipTest: SkipTest,
+		},
+		{
+			name: "ExtendedDaemonSet support does not render its flag when explicitly disabled",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"supportExtendedDaemonset": "false",
+				},
+			},
+			assertions: func(t *testing.T, manifest string) {
+				var deployment appsv1.Deployment
+				common.Unmarshal(t, manifest, &deployment)
+				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+				assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=false")
+				assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=true")
+			},
+			skipTest: SkipTest,
+		},
+		{
 			name: "livenessProbe is correctly configured",
 			command: common.HelmCommand{
 				ReleaseName: "datadog-operator",
@@ -295,6 +376,8 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, "registry.datadoghq.com/operator:1.30.0-rc.2", operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
+	assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=false")
+	assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=true")
 }
 
 func verifyAll(t *testing.T, manifest string) {

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -184,70 +184,6 @@ func Test_operator_chart(t *testing.T) {
 			skipTest:   SkipTest,
 		},
 		{
-			name: "registryMigration auto: ASIA, EU, and DEFAULT overrides are set",
-			command: common.HelmCommand{
-				ReleaseName: "datadog-operator",
-				ChartPath:   "../../charts/datadog-operator",
-				ShowOnly:    []string{"templates/deployment.yaml"},
-				Values:      []string{"../../charts/datadog-operator/values.yaml"},
-				Overrides:   map[string]string{},
-			},
-			assertions: func(t *testing.T, manifest string) {
-				var deployment appsv1.Deployment
-				common.Unmarshal(t, manifest, &deployment)
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				assert.NotNil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_ASIA"), "ASIA should be set")
-				assert.NotNil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_EU"), "EU should be set")
-				assert.NotNil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_DEFAULT"), "DEFAULT should be set")
-				assert.Nil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_AZURE"), "AZURE should not be set")
-			},
-			skipTest: SkipTest,
-		},
-		{
-			name: "registryMigration disabled: no overrides set",
-			command: common.HelmCommand{
-				ReleaseName: "datadog-operator",
-				ChartPath:   "../../charts/datadog-operator",
-				ShowOnly:    []string{"templates/deployment.yaml"},
-				Values:      []string{"../../charts/datadog-operator/values.yaml"},
-				Overrides: map[string]string{
-					"registryMigrationMode": "",
-				},
-			},
-			assertions: func(t *testing.T, manifest string) {
-				var deployment appsv1.Deployment
-				common.Unmarshal(t, manifest, &deployment)
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				assert.Nil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_ASIA"), "ASIA should not be set")
-				assert.Nil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_DEFAULT"), "DEFAULT should not be set")
-				assert.Nil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_EU"), "EU should not be set")
-				assert.Nil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_AZURE"), "AZURE should not be set")
-			},
-			skipTest: SkipTest,
-		},
-		{
-			name: "registryMigration all: all overrides set",
-			command: common.HelmCommand{
-				ReleaseName: "datadog-operator",
-				ChartPath:   "../../charts/datadog-operator",
-				ShowOnly:    []string{"templates/deployment.yaml"},
-				Values:      []string{"../../charts/datadog-operator/values.yaml"},
-				Overrides: map[string]string{
-					"registryMigrationMode": "all",
-				},
-			},
-			assertions: func(t *testing.T, manifest string) {
-				var deployment appsv1.Deployment
-				common.Unmarshal(t, manifest, &deployment)
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				assert.NotNil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_ASIA"), "ASIA should be set")
-				assert.NotNil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_DEFAULT"), "DEFAULT should be set")
-				assert.NotNil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_EU"), "EU should be set")
-				assert.NotNil(t, FindEnvVarByName(env, "DD_REGISTRY_OVERRIDE_AZURE"), "AZURE should be set")
-			},
-			skipTest: SkipTest,
-		},
-		{
 			name: "Operator image tag with digest",
 			command: common.HelmCommand{
 				ReleaseName: "datadog-operator",
@@ -378,6 +314,10 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 	assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=false")
 	assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=true")
+	assert.Nil(t, FindEnvVarByName(operatorContainer.Env, "DD_REGISTRY_OVERRIDE_ASIA"))
+	assert.Nil(t, FindEnvVarByName(operatorContainer.Env, "DD_REGISTRY_OVERRIDE_EU"))
+	assert.Nil(t, FindEnvVarByName(operatorContainer.Env, "DD_REGISTRY_OVERRIDE_DEFAULT"))
+	assert.Nil(t, FindEnvVarByName(operatorContainer.Env, "DD_REGISTRY_OVERRIDE_AZURE"))
 }
 
 func verifyAll(t *testing.T, manifest string) {


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the Datadog Operator chart for settings removed from the Operator as part of CONTP-1895 and earlier cleanup:

- Renders `-supportExtendedDaemonset=true` only when the value is enabled and the Operator image version is earlier than 1.31.0. The semver gate includes the 1.30 release line and suppresses the removed flag starting with 1.31 prereleases.
- Never renders `-supportExtendedDaemonset=false`.
- Removes the Operator chart `registryMigrationMode` value and helper, along with the unsupported `DD_REGISTRY_OVERRIDE_*` environment variables, removed in https://github.com/DataDog/datadog-operator/pull/3240 (`1.29`)

#### Which issue this PR fixes

- Related to [CONTP-1895](https://datadoghq.atlassian.net/browse/CONTP-1895)

```Containers:
  datadog-operator:
    Container ID:  containerd://db2cba63b555a0bd7e9e3356f5a6108cbe32553e72cb85ca032c09928f2ca893
    Image:         tbdatadog/operator:remove-eds
    Image ID:      docker.io/tbdatadog/operator@sha256:a11bd7292e6434780d9854193eae87faee4c685a17e46fec657745b4b87785e9
    Port:          8383/TCP (metrics)
    Host Port:     0/TCP (metrics)
    Args:
      -supportExtendedDaemonset=false
      -logEncoder=json
      -metrics-addr=:8383
      -loglevel=debug
      -operatorMetricsEnabled=true
      -introspectionEnabled=false
      -datadogAgentProfileEnabled=false
      -datadogMonitorEnabled=false
      -datadogAgentEnabled=true
      -datadogSLOEnabled=false
      -datadogDashboardEnabled=false
      -datadogGenericResourceEnabled=false
      -remoteConfigEnabled=false
      -datadogCSIDriverEnabled=true
      -untaintControllerEnabled=false
```

making the operator CLBO:

```
ubuntu@ip-10-1-57-7:~$ k logs datadog-operator-linux-568cf995bb-zfv8f -f
flag provided but not defined: -supportExtendedDaemonset
Usage of /manager:
  -createControllerRevisions
        Enable creation of ControllerRevision snapshots on each DDA spec change
  -datadogAgentEnabled
        Enable the DatadogAgent controller (default true)
```


#### Special notes for your reviewer:

Regression tests cover the disabled value, supported 1.30 prerelease and stable versions, and rejection at 1.31.0.

#### Checklist

- [x] All commits are signed and show as Verified on GitHub
- [x] `datadog-operator/patch-version` label has been added
- [x] The datadog-operator deployment test baseline has been updated
- [x] Chart unit tests and Helm lint pass
- [x] Documentation was regenerated with helm-docs
- [x] The changelog describes both changes

[CONTP-1895]: https://datadoghq.atlassian.net/browse/CONTP-1895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ