### PR TITLE
DDOT should use the same tag as the agent unless overriden

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.240.5
+
+* DDOT should use the same tag as the agent unless overriden ([#2876](https://github.com/DataDog/helm-charts/pull/2876)).
+
 ## 3.240.4
 
 * default to true for direct send if doNotCheckTag ([#2861](https://github.com/DataDog/helm-charts/pull/2861)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.240.4
+version: 3.240.5
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -555,8 +555,8 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.82.3"` | Define the Agent version to use |
-| agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
+| agents.image.tag | string | `"7.82.3"` | Define the Agent version to use Set a pinned version here. Do not append build variants: put `full` or `jmx` in `agents.image.tagSuffix`, and enable FIPS with `useFIPSAgent`. To stay on the latest stable Agent, leave this unset and upgrade the chart periodically. |
+| agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag This is the supported place for build variants like `full` or `jmx`; set them here rather than appending them to `agents.image.tag`. |
 | agents.instanceLabelOverride | string | `nil` | Override the `app.kubernetes.io/instance` label on the Agent daemonset and pods. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label. |
 | agents.lifecycle | object | `{}` | Configure the lifecycle of the Agent. Note: The `exec` lifecycle handler is not supported in GKE Autopilot. |
 | agents.localService.forceLocalServiceEnabled | bool | `false` | Force the creation of the internal traffic policy service to target the agent running on the local node. By default, the internal traffic service is created only on Kubernetes 1.22+ where the feature became beta and enabled by default. This option allows to force the creation of the internal traffic service on kubernetes 1.21 where the feature was alpha and required a feature gate to be explicitly enabled. |
@@ -1167,7 +1167,7 @@ helm install <RELEASE_NAME> \
 | registryMigrationMode | string | `"auto"` | Controls gradual migration of default image registry to registry.datadoghq.com, replacing site-specific regional mirrors (GCR, ACR). This setting has no effect when `registry` is explicitly set. GKE Autopilot and GKE GDC clusters are excluded and always use their site-specific gcr.io variant. US1-FED (ddog-gov.com) is excluded and always uses public.ecr.aws/datadog. US3 (us3.datadoghq.com) is excluded and always uses datadoghq.azurecr.io. |
 | remoteConfiguration.enabled | bool | `true` | Set to true to enable remote configuration on the Cluster Agent (if set) and the node agent. Can be overridden if `datadog.remoteConfiguration.enabled` Preferred way to enable Remote Configuration. |
 | targetSystem | string | `"linux"` | Target OS for this deployment (possible values: linux, windows) |
-| useFIPSAgent | bool | `false` | Setting useFIPSAgent to true makes the helm chart use Agent images that are FIPS-compliant for use in GOVCLOUD environments. Setting this to true disables the fips-proxy sidecar and is the recommended method for enabling FIPS compliance. |
+| useFIPSAgent | bool | `false` | Setting useFIPSAgent to true makes the helm chart use Agent images that are FIPS-compliant for use in GOVCLOUD environments. Setting this to true disables the fips-proxy sidecar and is the recommended method for enabling FIPS compliance. Enable FIPS with this flag; do not embed `-fips` in `agents.image.tag`. |
 
 ## Configuration options for Windows deployments
 <a name="windows-config"></a>

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.240.4](https://img.shields.io/badge/Version-3.240.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.240.5](https://img.shields.io/badge/Version-3.240.5-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -692,10 +692,13 @@ Return a remote otel-agent based on `.Values` (passed as .)
       {{- if semverCompare "<7.67.0" (include "get-agent-version" .) -}}
         {{- fail "datadog.otelCollector.useStandaloneImage is only supported for agent versions 7.67.0+. Please bump the agent version to 7.67.0+ or set datadog.otelCollector.useStandaloneImage to false and set agents.image.tagSuffix to `-full`" -}}
       {{- end -}}
-      {{- $ddotTag := include "get-agent-version" . -}}
-      {{- if eq (.Values.agents.image.tag | toString | trimSuffix "-jmx") "latest" -}}
-        {{- $ddotTag = "latest" -}}
-      {{- end -}}
+      {{/*
+      Preserve the raw Agent tag so floating tags (e.g. `latest`, `7`) stay in sync with the Agent image.
+      `get-agent-version` is only for the semver guards above; using it as the tag would pin floating tags
+      to the chart fallback version and produce a mismatched ddot-collector image. The `-jmx` suffix is
+      dropped since the ddot-collector image has no `-jmx` variant.
+      */}}
+      {{- $ddotTag := .Values.agents.image.tag | toString | trimSuffix "-jmx" -}}
       {{- $ddotImage := dict "name" "ddot-collector" "tag" $ddotTag -}}
       {{- if and (eq (include "use-fips-images" .Values) "true") (not .Values.agents.image.doNotCheckTag) (semverCompare "<7.78.0" (include "get-agent-version" .)) -}}
         {{- fail "The standalone FIPS ddot-collector image is not available before 7.78.0. Upgrade agents.image.tag to 7.78.0+, set useFIPSAgent to false, or set agents.image.doNotCheckTag to true." -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -2073,6 +2073,7 @@ existingClusterAgent:
 
 # useFIPSAgent -- Setting useFIPSAgent to true makes the helm chart use Agent images that are FIPS-compliant for use in GOVCLOUD environments.
 # Setting this to true disables the fips-proxy sidecar and is the recommended method for enabling FIPS compliance.
+# Enable FIPS with this flag; do not embed `-fips` in `agents.image.tag`.
 useFIPSAgent: false
 
 ## fips is used to enable and configure the fips-proxy sidecar.
@@ -2159,17 +2160,19 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
+    # Set a pinned version here. Do not append build variants: put `full` or `jmx` in `agents.image.tagSuffix`, and enable FIPS with `useFIPSAgent`. To stay on the latest stable Agent, leave this unset and upgrade the chart periodically.
     tag: 7.82.3
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
 
     # agents.image.tagSuffix -- Suffix to append to Agent tag
+    # This is the supported place for build variants like `full` or `jmx`; set them here rather than appending them to `agents.image.tag`.
 
     ## Ex:
     ##  jmx        to enable jmx fetch collection
     ##  servercore to get Windows images based on servercore
-    ##  full       to get as many features as possible, currently ddot-collector and jmx (e.g. 7.67.0-full)
+    ##  full       to get as many features as possible, currently ddot-collector and jmx
     tagSuffix: ""
 
     # agents.image.repository -- Override default registry + image.name for Agent

--- a/test/datadog/otel_agent_test.go
+++ b/test/datadog/otel_agent_test.go
@@ -343,28 +343,6 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 		},
 		{
-			name: "useStandaloneImage true with latest-jmx agent tag and FIPS",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				ShowOnly:    []string{"templates/daemonset.yaml"},
-				Values:      []string{"../../charts/datadog/values.yaml"},
-				Overrides: map[string]string{
-					"datadog.apiKeyExistingSecret":             "datadog-secret",
-					"datadog.appKeyExistingSecret":             "datadog-secret",
-					"datadog.otelCollector.enabled":            "true",
-					"datadog.otelCollector.useStandaloneImage": "true",
-					"agents.image.tag":                         "latest-jmx",
-					"useFIPSAgent":                             "true",
-				},
-			},
-			expectError: false,
-			assertion: func(t *testing.T, manifest string) {
-				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:latest-jmx-fips")
-				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:latest-fips")
-			},
-		},
-		{
 			name: "useStandaloneImage true with floating 7 agent tag and full tagSuffix",
 			command: common.HelmCommand{
 				ReleaseName: "datadog",
@@ -451,28 +429,6 @@ func Test_ddotCollectorImage(t *testing.T) {
 			expectError: false,
 			assertion: func(t *testing.T, manifest string) {
 				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7-fips-full")
-				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7-fips")
-			},
-		},
-		{
-			name: "useStandaloneImage true with floating 7-jmx agent tag and FIPS",
-			command: common.HelmCommand{
-				ReleaseName: "datadog",
-				ChartPath:   "../../charts/datadog",
-				ShowOnly:    []string{"templates/daemonset.yaml"},
-				Values:      []string{"../../charts/datadog/values.yaml"},
-				Overrides: map[string]string{
-					"datadog.apiKeyExistingSecret":             "datadog-secret",
-					"datadog.appKeyExistingSecret":             "datadog-secret",
-					"datadog.otelCollector.enabled":            "true",
-					"datadog.otelCollector.useStandaloneImage": "true",
-					"agents.image.tag":                         "7-jmx",
-					"useFIPSAgent":                             "true",
-				},
-			},
-			expectError: false,
-			assertion: func(t *testing.T, manifest string) {
-				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7-jmx-fips")
 				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7-fips")
 			},
 		},

--- a/test/datadog/otel_agent_test.go
+++ b/test/datadog/otel_agent_test.go
@@ -189,6 +189,294 @@ func Test_ddotCollectorImage(t *testing.T) {
 			},
 		},
 		{
+			name: "useStandaloneImage true with floating 7 agent tag",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7")
+			},
+		},
+		{
+			name: "useStandaloneImage true with floating 7-jmx agent tag",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7-jmx",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7-jmx")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7")
+			},
+		},
+		{
+			name: "useStandaloneImage true with floating 7 agent tag and jmx tagSuffix",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7",
+					"agents.image.tagSuffix":                   "jmx",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7-jmx")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7")
+			},
+		},
+		{
+			name: "useStandaloneImage true with latest agent tag and full tagSuffix",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "latest",
+					"agents.image.tagSuffix":                   "full",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:latest-full")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:latest")
+			},
+		},
+		{
+			name: "useStandaloneImage true with latest agent tag and FIPS",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "latest",
+					"useFIPSAgent":                             "true",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:latest-fips")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:latest-fips")
+			},
+		},
+		{
+			name: "useStandaloneImage true with latest agent tag, jmx tagSuffix and FIPS",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "latest",
+					"agents.image.tagSuffix":                   "jmx",
+					"useFIPSAgent":                             "true",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:latest-fips-jmx")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:latest-fips")
+			},
+		},
+		{
+			name: "useStandaloneImage true with latest agent tag, full tagSuffix and FIPS",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "latest",
+					"agents.image.tagSuffix":                   "full",
+					"useFIPSAgent":                             "true",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:latest-fips-full")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:latest-fips")
+			},
+		},
+		{
+			name: "useStandaloneImage true with latest-jmx agent tag and FIPS",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "latest-jmx",
+					"useFIPSAgent":                             "true",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:latest-jmx-fips")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:latest-fips")
+			},
+		},
+		{
+			name: "useStandaloneImage true with floating 7 agent tag and full tagSuffix",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7",
+					"agents.image.tagSuffix":                   "full",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7-full")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7")
+			},
+		},
+		{
+			name: "useStandaloneImage true with floating 7 agent tag and FIPS",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7",
+					"useFIPSAgent":                             "true",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7-fips")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7-fips")
+			},
+		},
+		{
+			name: "useStandaloneImage true with floating 7 agent tag, jmx tagSuffix and FIPS",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7",
+					"agents.image.tagSuffix":                   "jmx",
+					"useFIPSAgent":                             "true",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7-fips-jmx")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7-fips")
+			},
+		},
+		{
+			name: "useStandaloneImage true with floating 7 agent tag, full tagSuffix and FIPS",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7",
+					"agents.image.tagSuffix":                   "full",
+					"useFIPSAgent":                             "true",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7-fips-full")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7-fips")
+			},
+		},
+		{
+			name: "useStandaloneImage true with floating 7-jmx agent tag and FIPS",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"datadog.appKeyExistingSecret":             "datadog-secret",
+					"datadog.otelCollector.enabled":            "true",
+					"datadog.otelCollector.useStandaloneImage": "true",
+					"agents.image.tag":                         "7-jmx",
+					"useFIPSAgent":                             "true",
+				},
+			},
+			expectError: false,
+			assertion: func(t *testing.T, manifest string) {
+				verifyAgentImage(t, manifest, "registry.datadoghq.com/agent:7-jmx-fips")
+				verifyOtelImage(t, manifest, "registry.datadoghq.com/ddot-collector:7-fips")
+			},
+		},
+		{
 			name: "useStandaloneImage true with agent version 7.66.0 should fail",
 			command: common.HelmCommand{
 				ReleaseName: "datadog",


### PR DESCRIPTION
#### What this PR does / why we need it:

- Do NOT use get-agent-version for actual tags, it's only for version gates
- Recommend leaving the tag unset, relying on `tagSuffix` and `useFIPSAgent` to select variants.

#### Which issue this PR fixes

[OTAGENT-1309](https://datadoghq.atlassian.net/browse/OTAGENT-1309)

#### Special notes for your reviewer:

Supersedes https://github.com/DataDog/helm-charts/pull/2703

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [x] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

[OTAGENT-1309]: https://datadoghq.atlassian.net/browse/OTAGENT-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ