### PR TITLE
Allow specifying additional deployment labels

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.26.1-dev.4
+
+* Add the ability to configure `additionalLabels` in the operator deployment
+
 ## 2.26.0-dev.4
 
 * Stop rendering unsupported ExtendedDaemonSet and registry override settings ([#2875](https://github.com/DataDog/helm-charts/pull/2875)).

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.26.0-dev.4
+version: 2.26.1-dev.4
 appVersion: 1.30.0-rc.2
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.26.0-dev.4](https://img.shields.io/badge/Version-2.26.0--dev.4-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
+![Version: 2.26.1-dev.4](https://img.shields.io/badge/Version-2.26.0--dev.4-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
 
 ## Values
 
@@ -36,6 +36,7 @@
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
+| deployment.additionalLabels | object | `{}` | Additional labels to be added to the deployment resource |
 | deployment.annotations | object | `{}` | Allows setting additional annotations for the deployment resource |
 | dnsConfig | object | `{}` | Specify DNS configuration options for Datadog Operator PODs |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
 {{- end }}
   labels:
 {{ include "datadog-operator.labels" . | indent 4 }}
+{{- if .Values.deployment.additionalLabels }}
+{{ toYaml .Values.deployment.additionalLabels | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -123,6 +123,9 @@ untaintController:
   # untaintController.eventsEnabled -- Emit Kubernetes Events on Nodes for taint removals and timeout decisions.
   eventsEnabled: false
 deployment:
+  # deployment.additionalLabels -- Additional labels to be added to the deployment resource
+  additionalLabels: {}
+    # key: "value"
   # deployment.annotations -- Allows setting additional annotations for the deployment resource
   annotations: {}
 rbac:

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.26.0-dev.3
+    helm.sh/chart: datadog-operator-2.26.1-dev.4
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.30.0-rc.2"
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows the end user to configure additional labels in the datadog-operator deployment. This is helpful when you want to utilize kube state metrics within Datadog that require `tags.datadoghq.com/*` labels on the deployment resources.
#### Which issue this PR fixes
Support Ticket 2993236

#### Special notes for your reviewer:

#### Checklist
- [X] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [X] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [X] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [X] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [X] `CHANGELOG.md` has been updated 
- [X] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits