### PR TITLE
feat(datadog-operator): enable Linux ADP default

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.26.0-dev.3
 
 * Update Datadog Operator chart for 1.30.0-rc.2.
+* Enable ADP by default for Linux Operator-managed workloads when `spec.features.dataPlane.enabled` is unset. Opt out with `defaultDataPlaneEnabled.linux: false` or an explicit `spec.features.dataPlane.enabled: false` in the DatadogAgent CRD.
 
 ## 2.26.0-dev.2
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.26.0-dev.5
+
+* feat(datadog-operator): enable Linux ADP default ([#2879](https://github.com/DataDog/helm-charts/pull/2879)).
+
 ## 2.26.0-dev.4
 
 * Stop rendering unsupported ExtendedDaemonSet and registry override settings ([#2875](https://github.com/DataDog/helm-charts/pull/2875)).

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 2.26.0-dev.3
 
 * Update Datadog Operator chart for 1.30.0-rc.2.
-* Enable ADP by default for Linux Operator-managed workloads when `spec.features.dataPlane.enabled` is unset. Opt out with `defaultDataPlaneEnabled.linux: false` or an explicit `spec.features.dataPlane.enabled: false` in the DatadogAgent CRD.
 
 ## 2.26.0-dev.2
 

--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.26.1
+
+* feat(datadog-operator): enable Linux ADP default ([#2879](https://github.com/DataDog/helm-charts/pull/2879)).
+
 ## 2.26.0
 
 * Update Datadog Operator chart for 1.30.0.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.26.0-dev.4
+version: 2.26.0-dev.5
 appVersion: 1.30.0-rc.2
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.26.0
+version: 2.26.1
 appVersion: 1.30.0
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.26.0-dev.4](https://img.shields.io/badge/Version-2.26.0--dev.4-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
+![Version: 2.26.0-dev.3](https://img.shields.io/badge/Version-2.26.0--dev.3-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
 
 ## Values
 
@@ -59,6 +59,7 @@
 | podLabels | object | `{}` | Allows setting additional labels for for Datadog Operator PODs |
 | priorityClassName | string | `nil` | Allows setting the priority class name for Datadog Operator PODs |
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |
+| registryMigrationMode | string | `"auto"` | Controls gradual migration of Agent image pulls to registry.datadoghq.com. When enabled, DD_REGISTRY_OVERRIDE_* environment variables are added to the Datadog Operator deployment to pull Agent images from the global CDN-backed registry.datadoghq.com based on the global.site setting, unless global.registry is specified in the DatadogAgent custom resource (which takes precedence). This has no effect on sites not covered by the active overrides. More sites will be enabled by default in future helm-chart releases. "auto" (default): enable overrides for sites where migration is rolled out.   Currently enabled: AP1 (ap1.datadoghq.com), EU1 (datadoghq.eu), US1 (datadoghq.com), US5 (us5.datadoghq.com). "all": enable all per-site overrides (AP1, US1, EU1, US3, US5). "" or unset: disable all overrides. |
 | remoteConfiguration.enabled | bool | `false` | If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set. |
 | replicaCount | int | `1` | Number of instances of Datadog Operator |
 | resources | object | `{}` | Set resources requests/limits for Datadog Operator PODs |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -36,6 +36,7 @@
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
+| defaultDataPlaneEnabled.linux | bool | `true` | Enables Agent Data Plane by default for Linux Operator-managed workloads when `spec.features.dataPlane.enabled` is absent. An explicit `spec.features.dataPlane.enabled` setting overrides this value. Windows is not affected and is handled separately. |
 | deployment.annotations | object | `{}` | Allows setting additional annotations for the deployment resource |
 | dnsConfig | object | `{}` | Specify DNS configuration options for Datadog Operator PODs |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -36,7 +36,7 @@
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
-| defaultDataPlaneEnabled.linux | bool | `true` | Enables Agent Data Plane by default for Linux Operator-managed workloads using Agent 7.81 or later when `spec.features.dataPlane.enabled` is absent. An explicit `spec.features.dataPlane.enabled` setting overrides this value. Windows is not affected and is handled separately. |
+| defaultDataPlaneEnabled.linux | bool | `true` | Enables Agent Data Plane by default for Linux Operator-managed workloads using Agent 7.83 or later when `spec.features.dataPlane.enabled` is absent. An explicit `spec.features.dataPlane.enabled` setting overrides this value. Windows is not affected and is handled separately. |
 | deployment.annotations | object | `{}` | Allows setting additional annotations for the deployment resource |
 | dnsConfig | object | `{}` | Specify DNS configuration options for Datadog Operator PODs |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.26.0-dev.4](https://img.shields.io/badge/Version-2.26.0--dev.4-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
+![Version: 2.26.0-dev.5](https://img.shields.io/badge/Version-2.26.0--dev.5-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -36,7 +36,7 @@
 | datadogMonitor.enabled | bool | `false` | Enables the Datadog Monitor controller |
 | datadogSLO.enabled | bool | `false` | Enables the Datadog SLO controller |
 | dd_url | string | `nil` | The host of the Datadog intake server to send Agent data to, only set this option if you need the Agent to send data to a custom URL |
-| defaultDataPlaneEnabled.linux | bool | `true` | Enables Agent Data Plane by default for Linux Operator-managed workloads when `spec.features.dataPlane.enabled` is absent. An explicit `spec.features.dataPlane.enabled` setting overrides this value. Windows is not affected and is handled separately. |
+| defaultDataPlaneEnabled.linux | bool | `true` | Enables Agent Data Plane by default for Linux Operator-managed workloads using Agent 7.81 or later when `spec.features.dataPlane.enabled` is absent. An explicit `spec.features.dataPlane.enabled` setting overrides this value. Windows is not affected and is handled separately. |
 | deployment.annotations | object | `{}` | Allows setting additional annotations for the deployment resource |
 | dnsConfig | object | `{}` | Specify DNS configuration options for Datadog Operator PODs |
 | env | list | `[]` | Define any environment variables to be passed to the operator. |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.26.0-dev.3](https://img.shields.io/badge/Version-2.26.0--dev.3-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
+![Version: 2.26.0-dev.4](https://img.shields.io/badge/Version-2.26.0--dev.4-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
 
 ## Values
 
@@ -59,7 +59,6 @@
 | podLabels | object | `{}` | Allows setting additional labels for for Datadog Operator PODs |
 | priorityClassName | string | `nil` | Allows setting the priority class name for Datadog Operator PODs |
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |
-| registryMigrationMode | string | `"auto"` | Controls gradual migration of Agent image pulls to registry.datadoghq.com. When enabled, DD_REGISTRY_OVERRIDE_* environment variables are added to the Datadog Operator deployment to pull Agent images from the global CDN-backed registry.datadoghq.com based on the global.site setting, unless global.registry is specified in the DatadogAgent custom resource (which takes precedence). This has no effect on sites not covered by the active overrides. More sites will be enabled by default in future helm-chart releases. "auto" (default): enable overrides for sites where migration is rolled out.   Currently enabled: AP1 (ap1.datadoghq.com), EU1 (datadoghq.eu), US1 (datadoghq.com), US5 (us5.datadoghq.com). "all": enable all per-site overrides (AP1, US1, EU1, US3, US5). "" or unset: disable all overrides. |
 | remoteConfiguration.enabled | bool | `false` | If true, enables Remote Configuration in the Datadog Operator (beta). Requires clusterName, API and App keys to be set. |
 | replicaCount | int | `1` | Number of instances of Datadog Operator |
 | resources | object | `{}` | Set resources requests/limits for Datadog Operator PODs |

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.26.0](https://img.shields.io/badge/Version-2.26.0-informational?style=flat-square) ![AppVersion: 1.30.0](https://img.shields.io/badge/AppVersion-1.30.0-informational?style=flat-square)
+![Version: 2.26.1](https://img.shields.io/badge/Version-2.26.1-informational?style=flat-square) ![AppVersion: 1.30.0](https://img.shields.io/badge/AppVersion-1.30.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -132,6 +132,8 @@ spec:
             - name: DD_URL
               value: {{ default .Values.dd_url (include "get-endpoint-config-data-key" (list . "dd-url")) }}
             {{- end }}
+            - name: DD_DEFAULT_DATA_PLANE_LINUX_ENABLED
+              value: {{ .Values.defaultDataPlaneEnabled.linux | quote }}
             {{- if and (semverCompare ">=1.28.0-0" $version) .Values.untaintController.enabled }}
             {{- if .Values.untaintController.timeout }}
             - name: DD_UNTAINT_CONTROLLER_TIMEOUT
@@ -162,7 +164,6 @@ spec:
             - "-metrics-addr=:{{ .Values.metricsPort }}"
             - "-loglevel={{ .Values.logLevel }}"
             - "-operatorMetricsEnabled={{ .Values.operatorMetricsEnabled }}"
-            - "-defaultDataPlaneLinuxEnabled={{ .Values.defaultDataPlaneEnabled.linux }}"
           {{- if .Values.secretBackend.command }}
             - "-secretBackendCommand={{ .Values.secretBackend.command }}"
           {{- end }}

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -173,6 +173,7 @@ spec:
             - "-metrics-addr=:{{ .Values.metricsPort }}"
             - "-loglevel={{ .Values.logLevel }}"
             - "-operatorMetricsEnabled={{ .Values.operatorMetricsEnabled }}"
+            - "-defaultDataPlaneLinuxEnabled={{ .Values.defaultDataPlaneEnabled.linux }}"
           {{- if .Values.secretBackend.command }}
             - "-secretBackendCommand={{ .Values.secretBackend.command }}"
           {{- end }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -74,6 +74,9 @@ datadogAgentProfile:
 supportExtendedDaemonset: "false"
 # operatorMetricsEnabled -- Enable forwarding of Datadog Operator metrics and events to Datadog.
 operatorMetricsEnabled: "true"
+defaultDataPlaneEnabled:
+  # defaultDataPlaneEnabled.linux -- Enables Agent Data Plane by default for Linux Operator-managed workloads when `spec.features.dataPlane.enabled` is absent. An explicit `spec.features.dataPlane.enabled` setting overrides this value. Windows is not affected and is handled separately.
+  linux: true
 # metricsPort -- Port used for OpenMetrics endpoint
 metricsPort: 8383
 secretBackend:

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -75,7 +75,7 @@ supportExtendedDaemonset: "false"
 # operatorMetricsEnabled -- Enable forwarding of Datadog Operator metrics and events to Datadog.
 operatorMetricsEnabled: "true"
 defaultDataPlaneEnabled:
-  # defaultDataPlaneEnabled.linux -- Enables Agent Data Plane by default for Linux Operator-managed workloads using Agent 7.81 or later when `spec.features.dataPlane.enabled` is absent. An explicit `spec.features.dataPlane.enabled` setting overrides this value. Windows is not affected and is handled separately.
+  # defaultDataPlaneEnabled.linux -- Enables Agent Data Plane by default for Linux Operator-managed workloads using Agent 7.83 or later when `spec.features.dataPlane.enabled` is absent. An explicit `spec.features.dataPlane.enabled` setting overrides this value. Windows is not affected and is handled separately.
   linux: true
 # metricsPort -- Port used for OpenMetrics endpoint
 metricsPort: 8383

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -75,7 +75,7 @@ supportExtendedDaemonset: "false"
 # operatorMetricsEnabled -- Enable forwarding of Datadog Operator metrics and events to Datadog.
 operatorMetricsEnabled: "true"
 defaultDataPlaneEnabled:
-  # defaultDataPlaneEnabled.linux -- Enables Agent Data Plane by default for Linux Operator-managed workloads when `spec.features.dataPlane.enabled` is absent. An explicit `spec.features.dataPlane.enabled` setting overrides this value. Windows is not affected and is handled separately.
+  # defaultDataPlaneEnabled.linux -- Enables Agent Data Plane by default for Linux Operator-managed workloads using Agent 7.81 or later when `spec.features.dataPlane.enabled` is absent. An explicit `spec.features.dataPlane.enabled` setting overrides this value. Windows is not affected and is handled separately.
   linux: true
 # metricsPort -- Port used for OpenMetrics endpoint
 metricsPort: 8383

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -68,6 +68,7 @@ spec:
             - "-metrics-addr=:8383"
             - "-loglevel=info"
             - "-operatorMetricsEnabled=true"
+            - "-defaultDataPlaneLinuxEnabled=true"
             - "-introspectionEnabled=false"
             - "-datadogAgentProfileEnabled=false"
             - "-datadogMonitorEnabled=false"

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.26.0-dev.4
+    helm.sh/chart: datadog-operator-2.26.0-dev.5
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.30.0-rc.2"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.26.0-dev.3
+    helm.sh/chart: datadog-operator-2.26.0-dev.4
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.30.0-rc.2"
     app.kubernetes.io/managed-by: Helm
@@ -56,12 +56,13 @@ spec:
                   fieldPath: metadata.namespace
             - name: DD_TOOL_VERSION
               value: helm
+            - name: DD_DEFAULT_DATA_PLANE_LINUX_ENABLED
+              value: "true"
           args:
             - "-logEncoder=json"
             - "-metrics-addr=:8383"
             - "-loglevel=info"
             - "-operatorMetricsEnabled=true"
-            - "-defaultDataPlaneLinuxEnabled=true"
             - "-introspectionEnabled=false"
             - "-datadogAgentProfileEnabled=false"
             - "-datadogMonitorEnabled=false"

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -58,8 +58,8 @@ func Test_operator_chart(t *testing.T) {
 				var deployment appsv1.Deployment
 				common.Unmarshal(t, manifest, &deployment)
 				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
-				assert.Contains(t, operatorContainer.Args, "-defaultDataPlaneLinuxEnabled=true")
-				assert.NotContains(t, operatorContainer.Args, "-defaultDataPlaneLinuxEnabled=false")
+				assert.Contains(t, operatorContainer.Env, v1.EnvVar{Name: "DD_DEFAULT_DATA_PLANE_LINUX_ENABLED", Value: "true"})
+				assert.NotContains(t, operatorContainer.Env, v1.EnvVar{Name: "DD_DEFAULT_DATA_PLANE_LINUX_ENABLED", Value: "false"})
 			},
 			skipTest: SkipTest,
 		},
@@ -78,8 +78,8 @@ func Test_operator_chart(t *testing.T) {
 				var deployment appsv1.Deployment
 				common.Unmarshal(t, manifest, &deployment)
 				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
-				assert.Contains(t, operatorContainer.Args, "-defaultDataPlaneLinuxEnabled=false")
-				assert.NotContains(t, operatorContainer.Args, "-defaultDataPlaneLinuxEnabled=true")
+				assert.Contains(t, operatorContainer.Env, v1.EnvVar{Name: "DD_DEFAULT_DATA_PLANE_LINUX_ENABLED", Value: "false"})
+				assert.NotContains(t, operatorContainer.Env, v1.EnvVar{Name: "DD_DEFAULT_DATA_PLANE_LINUX_ENABLED", Value: "true"})
 			},
 			skipTest: SkipTest,
 		},

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -46,6 +46,44 @@ func Test_operator_chart(t *testing.T) {
 			skipTest:   SkipTest,
 		},
 		{
+			name: "defaultDataPlaneEnabled linux default renders true",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides:   map[string]string{},
+			},
+			assertions: func(t *testing.T, manifest string) {
+				var deployment appsv1.Deployment
+				common.Unmarshal(t, manifest, &deployment)
+				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+				assert.Contains(t, operatorContainer.Args, "-defaultDataPlaneLinuxEnabled=true")
+				assert.NotContains(t, operatorContainer.Args, "-defaultDataPlaneLinuxEnabled=false")
+			},
+			skipTest: SkipTest,
+		},
+		{
+			name: "defaultDataPlaneEnabled linux false renders false",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"defaultDataPlaneEnabled.linux": "false",
+				},
+			},
+			assertions: func(t *testing.T, manifest string) {
+				var deployment appsv1.Deployment
+				common.Unmarshal(t, manifest, &deployment)
+				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+				assert.Contains(t, operatorContainer.Args, "-defaultDataPlaneLinuxEnabled=false")
+				assert.NotContains(t, operatorContainer.Args, "-defaultDataPlaneLinuxEnabled=true")
+			},
+			skipTest: SkipTest,
+		},
+		{
 			name: "Rendering all does not fail",
 			command: common.HelmCommand{
 				ReleaseName: "datadog-operator",


### PR DESCRIPTION
#### What this PR does / why we need it:

Enables the Agent Data Plane by default for Linux Operator-managed workloads by setting `defaultDataPlaneEnabled.linux: true` in the `datadog-operator` chart. The chart passes that value to the Operator as `DD_DEFAULT_DATA_PLANE_LINUX_ENABLED`.

The Operator keeps CRD configuration and the legacy opt-out annotation authoritative, so individual workloads can opt out with `spec.features.dataPlane.enabled: false`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged)*
  - [DADP-182](https://datadoghq.atlassian.net/browse/DADP-182)

#### Special notes for your reviewer:

- This intentionally has no image-version guard; release coordination ensures the chart selects an Operator version that supports the flag.
- Windows is not affected. A future Windows-specific chart value can be introduced with the corresponding Operator support.
- The Operator applies this default only to selected Agent images at version 7.83 or later. Explicit CRD and legacy-annotation opt-ins remain authoritative for older Agent images.
- Companion Operator implementation: [DataDog/datadog-operator#3401](https://github.com/DataDog/datadog-operator/pull/3401).
- Chart release automation bumped the chart to `2.26.0-dev.5` and added the corresponding changelog entry.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commits-using-github-desktop/about-commit-signatures


[DADP-182]: https://datadoghq.atlassian.net/browse/DADP-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
