### PR TITLE
Bump Datadog Helm chart images to 7.82.3

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.240.3
+
+* Update the default Agent, Cluster Agent, and Cluster Checks Runner image version to 7.82.3.
+
 ## 3.240.2
 
 * [PROF-15646] selinux annotation on install-seccomp ([#2873](https://github.com/DataDog/helm-charts/pull/2873)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.240.2
+version: 3.240.3
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.240.2](https://img.shields.io/badge/Version-3.240.2-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.240.3](https://img.shields.io/badge/Version-3.240.3-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -555,7 +555,7 @@ helm install <RELEASE_NAME> \
 | agents.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | agents.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | agents.image.repository | string | `nil` | Override default registry + image.name for Agent |
-| agents.image.tag | string | `"7.81.1"` | Define the Agent version to use |
+| agents.image.tag | string | `"7.82.3"` | Define the Agent version to use |
 | agents.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | agents.instanceLabelOverride | string | `nil` | Override the `app.kubernetes.io/instance` label on the Agent daemonset and pods. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label. |
 | agents.lifecycle | object | `{}` | Configure the lifecycle of the Agent. Note: The `exec` lifecycle handler is not supported in GKE Autopilot. |
@@ -649,7 +649,7 @@ helm install <RELEASE_NAME> \
 | clusterAgent.image.pullPolicy | string | `"IfNotPresent"` | Cluster Agent image pullPolicy |
 | clusterAgent.image.pullSecrets | list | `[]` | Cluster Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterAgent.image.repository | string | `nil` | Override default registry + image.name for Cluster Agent |
-| clusterAgent.image.tag | string | `"7.81.1"` | Cluster Agent image tag to use |
+| clusterAgent.image.tag | string | `"7.82.3"` | Cluster Agent image tag to use |
 | clusterAgent.instanceLabelOverride | string | `nil` | Override the `app.kubernetes.io/instance` label on the Cluster Agent deployment and pods. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label. |
 | clusterAgent.kubernetesApiserverCheck.disableUseComponentStatus | bool | `false` | Set this to true to disable use_component_status for the kube_apiserver integration. |
 | clusterAgent.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default Cluster Agent liveness probe settings |
@@ -718,7 +718,7 @@ helm install <RELEASE_NAME> \
 | clusterChecksRunner.image.pullPolicy | string | `"IfNotPresent"` | Datadog Agent image pull policy |
 | clusterChecksRunner.image.pullSecrets | list | `[]` | Datadog Agent repository pullSecret (ex: specify docker registry credentials) |
 | clusterChecksRunner.image.repository | string | `nil` | Override default registry + image.name for Cluster Check Runners |
-| clusterChecksRunner.image.tag | string | `"7.81.1"` | Define the Agent version to use |
+| clusterChecksRunner.image.tag | string | `"7.82.3"` | Define the Agent version to use |
 | clusterChecksRunner.image.tagSuffix | string | `""` | Suffix to append to Agent tag |
 | clusterChecksRunner.instanceLabelOverride | string | `nil` | Override the `app.kubernetes.io/instance` label on the cluster checks runner deployment and pods. Useful to restore the pre-3.140.0 value when callers (e.g. NetworkPolicies) match on that label. |
 | clusterChecksRunner.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default agent liveness probe settings |

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -10,7 +10,7 @@
 {{- $version = "6.55.1" -}}
 {{- end -}}
 {{- if and (eq $length 1) (or (eq $version "7") (eq $version "latest")) -}}
-{{- $version = "7.81.1" -}}
+{{- $version = "7.82.3" -}}
 {{- end -}}
 {{- $version -}}
 {{- end -}}
@@ -22,7 +22,7 @@
 {{- $version := .Values.clusterAgent.image.tag | toString -}}
 {{- $length := len (split "." $version) -}}
 {{- if and (eq $length 1) (eq $version "latest") -}}
-{{- $version = "7.81.1" -}}
+{{- $version = "7.82.3" -}}
 {{- end -}}
 {{- $version -}}
 {{- end -}}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -1536,7 +1536,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 7.81.1
+    tag: 7.82.3
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2159,7 +2159,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.81.1
+    tag: 7.82.3
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -2854,7 +2854,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.81.1
+    tag: 7.82.3
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -2423,7 +2423,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2496,7 +2496,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -2423,7 +2423,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2496,7 +2496,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -2020,7 +2020,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2178,7 +2178,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2257,7 +2257,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2367,7 +2367,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2408,7 +2408,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2435,7 +2435,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2756,7 +2756,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2813,7 +2813,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2826,7 +2826,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -3025,7 +3025,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3098,7 +3098,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -1987,7 +1987,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2147,7 +2147,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2228,7 +2228,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2338,7 +2338,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2381,7 +2381,7 @@ spec:
               value: '[{"products":["global"],"rules":{"containers":["container.name == \"redis\""]}},{"products":["logs","metrics"],"rules":{"pods":["pod.name.startsWith(''nginx'')"]}}]'
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2408,7 +2408,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2797,7 +2797,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2870,7 +2870,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -2109,7 +2109,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2182,7 +2182,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -2123,7 +2123,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2196,7 +2196,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -2054,7 +2054,7 @@ spec:
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_NAME
               value: agent
             - name: DD_ADMISSION_CONTROLLER_AGENT_SIDECAR_IMAGE_TAG
-              value: 7.81.1
+              value: 7.82.3
             - name: DD_REMOTE_CONFIGURATION_ENABLED
               value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
@@ -2119,7 +2119,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2192,7 +2192,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -2111,7 +2111,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2184,7 +2184,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -1986,7 +1986,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2144,7 +2144,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2229,7 +2229,7 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2350,7 +2350,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2391,7 +2391,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2418,7 +2418,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2813,7 +2813,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2886,7 +2886,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -2015,7 +2015,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2173,7 +2173,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2258,7 +2258,7 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2427,7 +2427,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -2470,7 +2470,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2511,7 +2511,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2538,7 +2538,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2937,7 +2937,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3010,7 +3010,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -1985,7 +1985,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2143,7 +2143,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2226,7 +2226,7 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2336,7 +2336,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2377,7 +2377,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2404,7 +2404,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2796,7 +2796,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2869,7 +2869,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -2056,7 +2056,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2214,7 +2214,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2293,7 +2293,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2403,7 +2403,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2444,7 +2444,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2474,7 +2474,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2798,7 +2798,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2855,7 +2855,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2868,7 +2868,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -3067,7 +3067,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3140,7 +3140,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -1985,7 +1985,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2143,7 +2143,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2222,7 +2222,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2332,7 +2332,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2373,7 +2373,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2400,7 +2400,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2789,7 +2789,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2862,7 +2862,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -1985,7 +1985,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2143,7 +2143,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2222,7 +2222,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2332,7 +2332,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2373,7 +2373,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2400,7 +2400,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2789,7 +2789,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2862,7 +2862,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -1039,7 +1039,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1146,7 +1146,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -1172,7 +1172,7 @@ spec:
           command:
             - pwsh
             - -Command
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1216,7 +1216,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -1430,7 +1430,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1503,7 +1503,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
@@ -1712,7 +1712,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1780,7 +1780,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1834,7 +1834,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2145,7 +2145,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2218,7 +2218,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -1712,7 +1712,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1780,7 +1780,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1834,7 +1834,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2145,7 +2145,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2218,7 +2218,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -1714,7 +1714,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1791,7 +1791,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -1845,7 +1845,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-gdc
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2162,7 +2162,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2235,7 +2235,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -1751,7 +1751,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1829,7 +1829,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1882,7 +1882,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2151,7 +2151,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2214,7 +2214,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2233,7 +2233,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2442,7 +2442,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2521,7 +2521,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -1723,7 +1723,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -1801,7 +1801,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -1852,7 +1852,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2187,7 +2187,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2266,7 +2266,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -1971,7 +1971,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2097,7 +2097,7 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2200,7 +2200,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2253,7 +2253,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2286,7 +2286,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2660,7 +2660,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2739,7 +2739,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1979,7 +1979,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2126,7 +2126,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -2218,7 +2218,7 @@ spec:
               value: "5009"
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2325,7 +2325,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2378,7 +2378,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2411,7 +2411,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2785,7 +2785,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2864,7 +2864,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1979,7 +1979,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2126,7 +2126,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources:
@@ -2218,7 +2218,7 @@ spec:
               value: "5009"
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2325,7 +2325,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2378,7 +2378,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2411,7 +2411,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2785,7 +2785,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2864,7 +2864,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1971,7 +1971,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2093,7 +2093,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2196,7 +2196,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2249,7 +2249,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2282,7 +2282,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2653,7 +2653,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2732,7 +2732,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -2020,7 +2020,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2139,7 +2139,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2288,7 +2288,7 @@ spec:
               value: "true"
             - name: DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR
               value: tcp://127.0.0.1:5102
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 12
@@ -2351,7 +2351,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2404,7 +2404,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2437,7 +2437,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2742,7 +2742,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2805,7 +2805,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2824,7 +2824,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -3033,7 +3033,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3112,7 +3112,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -2023,7 +2023,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2177,7 +2177,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2258,7 +2258,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2361,7 +2361,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2414,7 +2414,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2447,7 +2447,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2752,7 +2752,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2815,7 +2815,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2834,7 +2834,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -3043,7 +3043,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3122,7 +3122,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -2004,7 +2004,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2126,7 +2126,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2229,7 +2229,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2282,7 +2282,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2315,7 +2315,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2620,7 +2620,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2683,7 +2683,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2702,7 +2702,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2911,7 +2911,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2990,7 +2990,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -2006,7 +2006,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2141,7 +2141,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2244,7 +2244,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2297,7 +2297,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2330,7 +2330,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2644,7 +2644,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2707,7 +2707,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2726,7 +2726,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2935,7 +2935,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3014,7 +3014,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -2089,7 +2089,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2211,7 +2211,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources:
@@ -2369,7 +2369,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: gcr.io/datadoghq/ddot-collector:7.81.1
+          image: gcr.io/datadoghq/ddot-collector:7.82.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2409,7 +2409,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2462,7 +2462,7 @@ spec:
               value: "false"
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -2495,7 +2495,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2806,7 +2806,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: DD_PROVIDER_KIND
               value: gke-autopilot
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2869,7 +2869,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:
@@ -2888,7 +2888,7 @@ spec:
           command:
             - bash
             - -c
-          image: gcr.io/datadoghq/agent:7.81.1
+          image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources:
@@ -3097,7 +3097,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3176,7 +3176,7 @@ spec:
           command:
             - cp
             - -r
-          image: gcr.io/datadoghq/cluster-agent:7.81.1
+          image: gcr.io/datadoghq/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources:

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -1998,7 +1998,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2164,7 +2164,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2247,7 +2247,7 @@ spec:
               value: "8125"
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2370,7 +2370,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2411,7 +2411,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2438,7 +2438,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2840,7 +2840,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2913,7 +2913,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -1998,7 +1998,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2167,7 +2167,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2250,7 +2250,7 @@ spec:
               value: "8125"
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2372,7 +2372,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2413,7 +2413,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2440,7 +2440,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2843,7 +2843,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2916,7 +2916,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -2050,7 +2050,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2208,7 +2208,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2287,7 +2287,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2397,7 +2397,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2438,7 +2438,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2465,7 +2465,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2854,7 +2854,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2927,7 +2927,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1993,7 +1993,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2151,7 +2151,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2255,7 +2255,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2341,7 +2341,7 @@ spec:
               value: "5009"
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2455,7 +2455,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2496,7 +2496,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2523,7 +2523,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2915,7 +2915,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2988,7 +2988,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -2074,7 +2074,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2232,7 +2232,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2311,7 +2311,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2469,7 +2469,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.81.1
+          image: registry.datadoghq.com/ddot-collector:7.82.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2529,7 +2529,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2570,7 +2570,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2597,7 +2597,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2992,7 +2992,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3065,7 +3065,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -1999,7 +1999,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2157,7 +2157,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2236,7 +2236,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2394,7 +2394,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.81.1
+          image: registry.datadoghq.com/ddot-collector:7.82.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2448,7 +2448,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2489,7 +2489,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2516,7 +2516,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2911,7 +2911,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2984,7 +2984,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -2070,7 +2070,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2228,7 +2228,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2307,7 +2307,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2465,7 +2465,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.81.1
+          image: registry.datadoghq.com/ddot-collector:7.82.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2523,7 +2523,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2564,7 +2564,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2591,7 +2591,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2986,7 +2986,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3059,7 +3059,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -2022,7 +2022,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2180,7 +2180,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2259,7 +2259,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2417,7 +2417,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.81.1
+          image: registry.datadoghq.com/ddot-collector:7.82.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2483,7 +2483,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2524,7 +2524,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2551,7 +2551,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2955,7 +2955,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3028,7 +3028,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -2070,7 +2070,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2228,7 +2228,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2307,7 +2307,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2465,7 +2465,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.81.1
+          image: registry.datadoghq.com/ddot-collector:7.82.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2522,7 +2522,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2563,7 +2563,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2590,7 +2590,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2988,7 +2988,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3061,7 +3061,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -2070,7 +2070,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2228,7 +2228,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2307,7 +2307,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2465,7 +2465,7 @@ spec:
               value: kubernetes
             - name: DD_LOG_LEVEL
               value: INFO
-          image: registry.datadoghq.com/ddot-collector:7.81.1
+          image: registry.datadoghq.com/ddot-collector:7.82.3
           imagePullPolicy: IfNotPresent
           name: otel-agent
           ports:
@@ -2519,7 +2519,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2560,7 +2560,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2587,7 +2587,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2982,7 +2982,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3055,7 +3055,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -1985,7 +1985,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2143,7 +2143,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2222,7 +2222,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2332,7 +2332,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2373,7 +2373,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2400,7 +2400,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2789,7 +2789,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2862,7 +2862,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -1988,7 +1988,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2148,7 +2148,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2229,7 +2229,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2339,7 +2339,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2382,7 +2382,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2409,7 +2409,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2800,7 +2800,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2873,7 +2873,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -1999,7 +1999,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2189,7 +2189,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2268,7 +2268,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2378,7 +2378,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2419,7 +2419,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2446,7 +2446,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2853,7 +2853,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2926,7 +2926,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -2018,7 +2018,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2178,7 +2178,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2262,7 +2262,7 @@ spec:
               value: INFO
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2376,7 +2376,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2423,7 +2423,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2456,7 +2456,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2782,7 +2782,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2839,7 +2839,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2858,7 +2858,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -3067,7 +3067,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3144,7 +3144,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           securityContext:

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1994,7 +1994,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2152,7 +2152,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2256,7 +2256,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2344,7 +2344,7 @@ spec:
               value: "5009"
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2517,7 +2517,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -2560,7 +2560,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2601,7 +2601,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2628,7 +2628,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -3028,7 +3028,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -3101,7 +3101,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -2001,7 +2001,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2173,7 +2173,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2280,7 +2280,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2367,7 +2367,7 @@ spec:
               value: "5009"
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2440,7 +2440,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2483,7 +2483,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2510,7 +2510,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2865,7 +2865,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2938,7 +2938,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1993,7 +1993,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2151,7 +2151,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2255,7 +2255,7 @@ spec:
               value: /var/run/datadog/dsd.socket
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: process-agent
           resources: {}
@@ -2341,7 +2341,7 @@ spec:
               value: "5009"
             - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
               value: "60"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2455,7 +2455,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2496,7 +2496,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2523,7 +2523,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2915,7 +2915,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2988,7 +2988,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -1986,7 +1986,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2144,7 +2144,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2225,7 +2225,7 @@ spec:
               value: /host/root
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2394,7 +2394,7 @@ spec:
               value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: /var/run/datadog/dsd.socket
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: security-agent
           resources: {}
@@ -2437,7 +2437,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2478,7 +2478,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2505,7 +2505,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2902,7 +2902,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2975,7 +2975,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -1986,7 +1986,7 @@ spec:
               value: "false"
             - name: DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED
               value: "true"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2144,7 +2144,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             initialDelaySeconds: 15
@@ -2225,7 +2225,7 @@ spec:
               value: /host/root
             - name: DD_DOGSTATSD_PORT
               value: "8125"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe
           resources: {}
@@ -2346,7 +2346,7 @@ spec:
           command:
             - bash
             - -c
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           resources: {}
@@ -2387,7 +2387,7 @@ spec:
               value: "true"
             - name: DD_OTLP_CONFIG_LOGS_ENABLED
               value: "false"
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-config
           resources: {}
@@ -2414,7 +2414,7 @@ spec:
             - cp
             - /etc/config/system-probe-seccomp.json
             - /host/var/lib/kubelet/seccomp/system-probe
-          image: registry.datadoghq.com/agent:7.81.1
+          image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: seccomp-setup
           resources: {}
@@ -2809,7 +2809,7 @@ spec:
                 configMapKeyRef:
                   key: install_type
                   name: datadog-kpi-telemetry-configmap
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -2882,7 +2882,7 @@ spec:
           command:
             - cp
             - -r
-          image: registry.datadoghq.com/cluster-agent:7.81.1
+          image: registry.datadoghq.com/cluster-agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: init-volume
           volumeMounts:

--- a/test/datadog/instrumentation_crd_test.go
+++ b/test/datadog/instrumentation_crd_test.go
@@ -71,7 +71,7 @@ func Test_instrumentationCRDControllerVersionGate(t *testing.T) {
 				"agents.image.tag":                   "latest-jmx",
 				"clusterAgent.image.tag":             "7.82.0",
 			},
-			enabled: false,
+			enabled: true,
 		},
 		{
 			name: "floating cluster agent tag follows get-cluster-agent-version policy",
@@ -80,7 +80,7 @@ func Test_instrumentationCRDControllerVersionGate(t *testing.T) {
 				"agents.image.tag":                   "7.82.0",
 				"clusterAgent.image.tag":             "latest",
 			},
-			enabled: false,
+			enabled: true,
 		},
 		{
 			name: "enabled when both tag checks are skipped",


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the default Agent, Cluster Agent, and Cluster Checks Runner images to `7.82.3`. It also updates floating-tag version resolution, generated documentation, and test baselines.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

The chart patch version is bumped to `3.240.3`.

#### Checklist

- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:

- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits