### PR TITLE
fix(observability-pipelines-worker): correct sgc_path in bootstrap template

### DIFF
--- a/charts/observability-pipelines-worker/CHANGELOG.md
+++ b/charts/observability-pipelines-worker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.21.2
+
+* Fix `sgc_path` in bootstrap template: remove hardcoded path to `datadog-secret-backend` (renamed to `sgc` since 2.15.1) and defer to the worker's built-in default. Also skip emitting the auto-generated `secret:` block when `bootstrap.config` already defines one, preventing duplicate YAML key errors.
+
 ## 2.21.1
 
 * Official image `2.21.1`

--- a/charts/observability-pipelines-worker/Chart.yaml
+++ b/charts/observability-pipelines-worker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: observability-pipelines-worker
-version: 2.21.1
+version: 2.21.2
 description: Observability Pipelines Worker
 type: application
 keywords:

--- a/charts/observability-pipelines-worker/README.md
+++ b/charts/observability-pipelines-worker/README.md
@@ -1,6 +1,6 @@
 # Observability Pipelines Worker
 
-![Version: 2.21.1](https://img.shields.io/badge/Version-2.21.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.21.1](https://img.shields.io/badge/AppVersion-2.21.1-informational?style=flat-square)
+![Version: 2.21.2](https://img.shields.io/badge/Version-2.21.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.21.1](https://img.shields.io/badge/AppVersion-2.21.1-informational?style=flat-square)
 
 ## How to use Datadog Helm repository
 

--- a/charts/observability-pipelines-worker/templates/bootstrap.yaml
+++ b/charts/observability-pipelines-worker/templates/bootstrap.yaml
@@ -12,7 +12,6 @@ data:
   {{- end }}
   {{- if and .Values.datadog.bootstrap.secretFileContents (not (dig "secret" nil .Values.datadog.bootstrap.config)) }}
     secret:
-      sgc_path: /opt/datadog/observability-pipelines-worker/bin/sgc
       backend_type: json
       backend_config:
         file_path: /etc/observability-pipelines-secrets/secrets.json

--- a/charts/observability-pipelines-worker/templates/bootstrap.yaml
+++ b/charts/observability-pipelines-worker/templates/bootstrap.yaml
@@ -10,9 +10,9 @@ data:
   {{- if .Values.datadog.bootstrap.config }}
   {{- toYaml .Values.datadog.bootstrap.config | nindent 4 }}
   {{- end }}
-  {{- if .Values.datadog.bootstrap.secretFileContents }}
+  {{- if and .Values.datadog.bootstrap.secretFileContents (not (dig "secret" nil .Values.datadog.bootstrap.config)) }}
     secret:
-      sgc_path: /opt/datadog/observability-pipelines-worker/bin/datadog-secret-backend
+      sgc_path: /opt/datadog/observability-pipelines-worker/bin/sgc
       backend_type: json
       backend_config:
         file_path: /etc/observability-pipelines-secrets/secrets.json

--- a/charts/observability-pipelines-worker/templates/bootstrap.yaml
+++ b/charts/observability-pipelines-worker/templates/bootstrap.yaml
@@ -10,7 +10,7 @@ data:
   {{- if .Values.datadog.bootstrap.config }}
   {{- toYaml .Values.datadog.bootstrap.config | nindent 4 }}
   {{- end }}
-  {{- if and .Values.datadog.bootstrap.secretFileContents (not (dig "secret" nil .Values.datadog.bootstrap.config)) }}
+  {{- if and .Values.datadog.bootstrap.secretFileContents (not (hasKey (default dict .Values.datadog.bootstrap.config) "secret")) }}
     secret:
       backend_type: json
       backend_config:


### PR DESCRIPTION
## Summary

- Removes hardcoded `sgc_path` from `bootstrap.yaml` template, deferring to OPW's built-in default (`/opt/.../bin/sgc` since 2.13.0)
- Prevents duplicate `secret:` YAML block when both `bootstrap.config` and `secretFileContents` are set
- Uses `hasKey` instead of `dig` truthiness to correctly detect key presence regardless of value

## Problem

The `bootstrap.yaml` template hardcoded `sgc_path` as `/opt/datadog/observability-pipelines-worker/bin/datadog-secret-backend`, but the binary was renamed to `sgc` in 2.15.1:

```dockerfile
# Dockerfile:32
cp /opt/datadog-agent/embedded/bin/secret-generic-connector \
   /opt/datadog/observability-pipelines-worker/bin/sgc
```

OPW already defaults to the correct path when `sgc_path` is omitted ([`lib/config/src/bootstrap/mod.rs:35`](https://github.com/DataDog/observability-pipelines-worker/blob/2.21.1/lib/config/src/bootstrap/mod.rs#L35)):
```rust
const DEFAULT_SGC_INSTALL_PATH: &str = "/opt/datadog/observability-pipelines-worker/bin/sgc";
```

When `secretFileContents` was used, OPW failed to load pipeline config:
```
ERROR: Failed to reload remote configuration.
  "Error while retrieving secret from backend \"exec_backend\": No such file or directory (os error 2)"
```

Additionally, providing `bootstrap.config.secret` alongside `secretFileContents` to override the path produced a duplicate `secret:` YAML key, which OPW rejects.

## Fix

Three changes to `templates/bootstrap.yaml`:

1. Remove `sgc_path` line entirely, deferring to OPW's built-in default
2. Skip emitting the auto-generated `secret:` block when `bootstrap.config` already defines one
3. Use `hasKey` instead of `dig` to detect key presence (handles empty/null values correctly)

## Test plan - helm template render results

All 6 permutations verified locally via `helm template`:

### Case 1: `secretFileContents` only (most common path)

Expected: single `secret:` block with `backend_type`/`backend_config`, no `sgc_path`

```yaml
bootstrap.yaml: |-
  secret:
    backend_type: json
    backend_config:
      file_path: /etc/observability-pipelines-secrets/secrets.json
```

**Result: PASS** - single block, no `sgc_path`, OPW uses default

### Case 2: `bootstrap.config.secret` (vault) + `secretFileContents`

Expected: only user's vault config, no duplicate auto-generated block

```yaml
bootstrap.yaml: |-
  secret:
    backend_type: vault
    sgc_path: /custom/sgc
```

**Result: PASS** - user config wins, no duplicate

### Case 3: `bootstrap.config.secret=""` + `secretFileContents` (codex edge case)

Expected: user's `secret: ""` rendered, no duplicate auto block

```yaml
bootstrap.yaml: |-
  secret: ""
```

**Result: PASS** - `hasKey` detects key presence despite empty value, no duplicate

### Case 4: `bootstrap.config` (non-secret keys) + `secretFileContents`

Expected: user's non-secret config + auto `secret:` block (secret key absent from config)

```yaml
bootstrap.yaml: |-
  api:
    enabled: true
  secret:
    backend_type: json
    backend_config:
      file_path: /etc/observability-pipelines-secrets/secrets.json
```

**Result: PASS** - auto block correctly added when user config has no `secret` key

### Case 5: `bootstrap.config.secret` only (no `secretFileContents`)

Expected: user's config only, no auto block

```yaml
bootstrap.yaml: |-
  secret:
    backend_type: aws
```

**Result: PASS** - unchanged behavior

### Case 6: Neither `bootstrap.config` nor `secretFileContents`

Expected: no bootstrap configmap rendered at all

**Result: PASS** - 0 matches for "bootstrap" in rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)