### PR TITLE
[datadog] Enable config sync when CWS or CSPM direct send is enabled

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.241.0
+
+* Enable config sync when CWS or CSPM direct send is active, by setting `DD_AGENT_IPC_PORT` (`5009`) and `DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL` (`60`) on the Agent and System Probe containers when `datadog.securityAgent.runtime.directSendFromSystemProbe` or `datadog.securityAgent.compliance.runInSystemProbe` is `true`. As with CNM direct send, System Probe submits the payloads itself and cannot resolve an `ENC[...]` secret handle, so without config sync a secret-backed `datadog.apiKey` prevented those payloads from being sent. Config sync is now also skipped when no System Probe container is rendered.
+
 ## 3.240.4
 
 * default to true for direct send if doNotCheckTag ([#2861](https://github.com/DataDog/helm-charts/pull/2861)).

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.240.4
+version: 3.241.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.240.4](https://img.shields.io/badge/Version-3.240.4-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.241.0](https://img.shields.io/badge/Version-3.241.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -122,12 +122,38 @@ true
 {{- end -}}
 
 {{/*
-Return true if config sync must be enabled for CNM direct send. With direct send, system-probe
-submits network payloads itself, and it cannot resolve an ENC[...] api_key because it wires the
-no-op secrets component. Config sync is what hands it the value the core agent already resolved.
+Return true if CWS direct send is enabled, meaning system-probe submits CWS events itself instead
+of handing them to security-agent. Unlike CNM this is an explicit opt-in, so there is no version gate.
+*/}}
+{{- define "cws-use-direct-send" -}}
+{{- if and .Values.datadog.securityAgent.runtime.enabled .Values.datadog.securityAgent.runtime.directSendFromSystemProbe -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if CSPM direct send is enabled, meaning compliance checks run in system-probe and their
+payloads are submitted from there instead of from security-agent. Explicit opt-in, so no version gate.
+*/}}
+{{- define "cspm-use-direct-send" -}}
+{{- if and .Values.datadog.securityAgent.compliance.enabled .Values.datadog.securityAgent.compliance.runInSystemProbe -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if config sync must be enabled because a feature submits its payloads directly from
+system-probe: CNM (network/service monitoring), CWS or CSPM. system-probe cannot resolve an ENC[...]
+api_key because it wires the no-op secrets component, so the payloads would never be sent. Config
+sync is what hands it the value the core agent already resolved. Gated on the system-probe container
+actually being rendered, so we never open the IPC port for a consumer that does not exist.
 */}}
 {{- define "should-enable-config-sync-for-direct-send" -}}
-{{- if and (eq (include "cnm-use-direct-send" .) "true") (or .Values.datadog.networkMonitoring.enabled .Values.datadog.serviceMonitoring.enabled) -}}
+{{- if and (eq (include "should-enable-system-probe" .) "true") (or (and (eq (include "cnm-use-direct-send" .) "true") (or .Values.datadog.networkMonitoring.enabled .Values.datadog.serviceMonitoring.enabled)) (eq (include "cws-use-direct-send" .) "true") (eq (include "cspm-use-direct-send" .) "true")) -}}
 true
 {{- else -}}
 false

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -1912,6 +1912,10 @@ spec:
               value: "false"
             - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
               value: "true"
+            - name: DD_AGENT_IPC_PORT
+              value: "5009"
+            - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+              value: "60"
             - name: DD_LOG_LEVEL
               value: INFO
             - name: DD_DOGSTATSD_PORT
@@ -2229,6 +2233,10 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
+            - name: DD_AGENT_IPC_PORT
+              value: "5009"
+            - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+              value: "60"
           image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -1941,6 +1941,10 @@ spec:
               value: "false"
             - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
               value: "true"
+            - name: DD_AGENT_IPC_PORT
+              value: "5009"
+            - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+              value: "60"
             - name: DD_LOG_LEVEL
               value: INFO
             - name: DD_DOGSTATSD_PORT
@@ -2258,6 +2262,10 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
+            - name: DD_AGENT_IPC_PORT
+              value: "5009"
+            - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+              value: "60"
           image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -1911,6 +1911,10 @@ spec:
               value: "false"
             - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
               value: "true"
+            - name: DD_AGENT_IPC_PORT
+              value: "5009"
+            - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+              value: "60"
             - name: DD_LOG_LEVEL
               value: INFO
             - name: DD_DOGSTATSD_PORT
@@ -2226,6 +2230,10 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
+            - name: DD_AGENT_IPC_PORT
+              value: "5009"
+            - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+              value: "60"
           image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -1920,6 +1920,10 @@ spec:
               value: "false"
             - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
               value: "true"
+            - name: DD_AGENT_IPC_PORT
+              value: "5009"
+            - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+              value: "60"
             - name: DD_LOG_LEVEL
               value: INFO
             - name: DD_DOGSTATSD_PORT
@@ -2097,6 +2101,10 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE
               value: "true"
+            - name: DD_AGENT_IPC_PORT
+              value: "5009"
+            - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+              value: "60"
           image: gcr.io/datadoghq/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -1912,6 +1912,10 @@ spec:
               value: "false"
             - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
               value: "true"
+            - name: DD_AGENT_IPC_PORT
+              value: "5009"
+            - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+              value: "60"
             - name: DD_LOG_LEVEL
               value: INFO
             - name: DD_DOGSTATSD_PORT
@@ -2225,6 +2229,10 @@ spec:
               value: /host/root
             - name: DD_DOGSTATSD_PORT
               value: "8125"
+            - name: DD_AGENT_IPC_PORT
+              value: "5009"
+            - name: DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL
+              value: "60"
           image: registry.datadoghq.com/agent:7.82.3
           imagePullPolicy: IfNotPresent
           name: system-probe


### PR DESCRIPTION
#### What this PR does / why we need it:

Same fix as #2870, for the two other features that submit from system-probe.

With `securityAgent.runtime.directSendFromSystemProbe` (CWS) or `securityAgent.compliance.runInSystemProbe` (CSPM), system-probe sends the payloads itself, and it cannot resolve an `ENC[...]` api_key because it wires the no-op secrets component. A secret-backed `datadog.apiKey` therefore silently broke CWS and CSPM. This sets `DD_AGENT_IPC_PORT` (`5009`) and `DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL` (`60`) on the Agent and System Probe containers in that case, reusing the values already used for CNM, the OTel Agent and the Host Profiler.

#### Special notes for your reviewer:

Unlike CNM, these two are explicit opt-ins, so there is no version gate.

One change beyond CWS/CSPM: `should-enable-config-sync-for-direct-send` is now also gated on `should-enable-system-probe`. On GKE GDC no system-probe container is rendered, so `runInSystemProbe: true` was opening the IPC port on the core Agent with nothing to consume it. That also drops the same dead config from the CNM path — inert before, inert now, just no longer rendered. Visible in the diff as `gdc_compliance_run_in_system_probe.yaml` staying unchanged.

No new E2E: the existing Autopilot system-probe E2E from #2870 already exercises these exact env var names against the WorkloadAllowlist.

#### Checklist
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`) — needs `datadog/minor-version`, I lack label permissions
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team
- [x] `CHANGELOG.md` has been updated

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
