### PR TITLE
feat(datadog-operator): add strategy and topologySpreadConstraints

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.26.0-dev.5
+
+* Add `topologySpreadConstraints` and `strategy` parameters to the Datadog Operator Deployment.
+
 ## 2.26.0-dev.4
 
 * Stop rendering unsupported ExtendedDaemonSet and registry override settings ([#2875](https://github.com/DataDog/helm-charts/pull/2875)).

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.26.0-dev.4
+version: 2.26.0-dev.5
 appVersion: 1.30.0-rc.2
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.26.0-dev.4](https://img.shields.io/badge/Version-2.26.0--dev.4-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
+![Version: 2.26.0-dev.5](https://img.shields.io/badge/Version-2.26.0--dev.5-informational?style=flat-square) ![AppVersion: 1.30.0-rc.2](https://img.shields.io/badge/AppVersion-1.30.0--rc.2-informational?style=flat-square)
 
 ## Values
 
@@ -69,8 +69,10 @@
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. If not set name is generated using the fullname template |
 | site | string | `nil` | The site of the Datadog intake to send data to (documentation: https://docs.datadoghq.com/getting_started/site/) |
+| strategy | object | `{}` | Allows to specify the deployment strategy for the Datadog Operator Deployment |
 | supportExtendedDaemonset | string | `"false"` | If true, supports using ExtendedDaemonSet CRD |
 | tolerations | list | `[]` | Allows to schedule Datadog Operator on tainted nodes |
+| topologySpreadConstraints | list | `[]` | Allows the Datadog Operator Deployment to schedule using pod topology spreading |
 | untaintController.enabled | bool | `false` | Enables the Untaint controller, which removes the `agent.datadoghq.com/not-ready=presence:NoSchedule` startup taint from nodes once the Agent is ready. Grants the operator `patch` permission on nodes. Requires v1.28.0+ |
 | untaintController.eventsEnabled | bool | `false` | Emit Kubernetes Events on Nodes for taint removals and timeout decisions. |
 | untaintController.schedulingTimeout | string | `""` | Scheduling timeout (Go duration, e.g. "5m") applied when no Agent pod has scheduled on the node. Empty uses the operator default (5m). |

--- a/charts/datadog-operator/ci/kubeconform-values.yaml
+++ b/charts/datadog-operator/ci/kubeconform-values.yaml
@@ -1,0 +1,13 @@
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: datadog-operator
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 0
+    maxUnavailable: 1

--- a/charts/datadog-operator/templates/deployment.yaml
+++ b/charts/datadog-operator/templates/deployment.yaml
@@ -11,6 +11,10 @@ metadata:
 {{ include "datadog-operator.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "datadog-operator.name" . }}
@@ -239,6 +243,10 @@ spec:
       {{- end }}
     {{- with .Values.affinity }}
       affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -157,6 +157,20 @@ nodeSelector:
 tolerations: []
 # affinity -- Allows to specify affinity for Datadog Operator PODs
 affinity: {}
+# topologySpreadConstraints -- Allows the Datadog Operator Deployment to schedule using pod topology spreading
+
+## By default, no constraints are set, allowing cluster defaults to be used for scheduling
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+# strategy -- Allows to specify the deployment strategy for the Datadog Operator Deployment
+
+## When unset, the Kubernetes default is used (RollingUpdate with maxSurge 25% and maxUnavailable 25%).
+## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+strategy: {}
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxSurge: 0
+#     maxUnavailable: 1
 # priorityClassName -- Allows setting the priority class name for Datadog Operator PODs
 priorityClassName:
 # dnsConfig -- Specify DNS configuration options for Datadog Operator PODs


### PR DESCRIPTION
### What this PR does

Adds two parameters to the `datadog-operator` chart's Deployment:

- `strategy` — the Deployment update strategy
- `topologySpreadConstraints` — pod topology spread constraints

Both default to empty, so rendered output is unchanged for existing users.

### Motivation

`templates/deployment.yaml` currently wires `affinity`, `nodeSelector` and `tolerations`, but there is no way to set the update strategy or topology spread constraints. If a user puts either key in their values file it is silently dropped at render time — no error, no warning, which makes it easy to believe the setting took effect when it did not.

This is also a gap relative to the sibling `datadog` chart in this repo, which already exposes both on `clusterAgent`, `clusterChecksRunner` and `otelAgentGateway`.

### Concrete failure this unblocks

The missing `strategy` knob becomes load-bearing as soon as `replicaCount` is raised for HA.

With `replicaCount: 3` and a hard `topology.kubernetes.io/zone` pod anti-affinity across 3 availability zones, the Kubernetes default strategy resolves to:

- `maxSurge: 25%` of 3 → rounds **up** → 1
- `maxUnavailable: 25%` of 3 → rounds **down** → 0

The Deployment controller must therefore place a 4th pod before it is permitted to retire any old one — and there is no 4th zone for that pod to schedule into. The rollout deadlocks indefinitely, until unrelated node churn happens to free a zone. We hit exactly this on two production EKS clusters, one of which sat wedged for roughly eight hours until a spot node was reclaimed.

Either of the two parameters added here resolves it: `strategy` with `maxSurge: 0` / `maxUnavailable: 1`, or expressing the spread as a `topologySpreadConstraints` entry (`maxSkew: 1`) rather than hard anti-affinity — the latter tolerates a 2-1-1 split during the surge and so never deadlocks.

### Contribution checklist

- [x] New parameters documented in `values.yaml` with helm-docs annotations
- [x] Chart version bumped in `Chart.yaml` (`2.26.0-dev.4` → `2.26.0-dev.5`)
- [x] Change described in `CHANGELOG.md`
- [x] New features covered in `ci/kubeconform-values.yaml`
- [x] Compatible with older Kubernetes versions (validated against the CI matrix floor, see below)
- [x] `README.md` regenerated with `.github/helm-docs.sh` after the version bump

### Validation

- `go test ./datadog-operator/...` from `test/` — passes, baseline files unchanged (defaults render identically)
- `kubeconform -strict` against k8s **1.16.4**, **1.22.17** and **1.31.1**, using the same schema locations as `.github/kubeconform.sh` — rendered Deployment reported valid at every version
- Rendering with default values confirms neither `strategy` nor `topologySpreadConstraints` is emitted

### Related

Closes #2888.
