### PR TITLE
Stop coupling Operator baselines to the default image tag

### DIFF
--- a/scripts/release-operator.sh
+++ b/scripts/release-operator.sh
@@ -276,7 +276,6 @@ phase_operator() {
     local changelog="$chart_dir/CHANGELOG.md"
     local values_yaml="$chart_dir/values.yaml"
     local helpers_tpl="$chart_dir/templates/_helpers.tpl"
-    local test_file="$ROOT_DIR/test/datadog-operator/operator_deployment_test.go"
 
     # Get current appVersion for replacement references
     local prev_version
@@ -313,20 +312,11 @@ phase_operator() {
     add_changelog_entry "$changelog" "$OPERATOR_CHART_VERSION" \
         "* Update Datadog Operator chart for ${OPERATOR_VERSION}."
 
-    # Step 8: Update test assertion
-    step "Updating operator_deployment_test.go image assertion"
-    sed_i "s|operator:${prev_version}|operator:${OPERATOR_VERSION}|g" "$test_file"
-
-    # Step 9: Run helm-docs
+    # Step 8: Run helm-docs
     step "Running helm-docs..."
     run_helm_docs
 
-    # Step 10: Update test baselines
-    step "Updating test baselines (make update-test-baselines-operator)..."
-    (cd "$ROOT_DIR" && make update-test-baselines-operator)
-    success "Test baselines updated"
-
-    # Step 11: Update clusterrole.yaml from upstream RBAC
+    # Step 9: Update clusterrole.yaml from upstream RBAC
     step "Updating clusterrole.yaml from upstream v${OPERATOR_VERSION}..."
     update_clusterrole "$OPERATOR_VERSION"
 

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: datadog-operator 
       containers:
         - name: datadog-operator
-          image: "registry.datadoghq.com/operator:1.30.0-rc.2"
+          image: "registry.datadoghq.com/operator:1.30.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/test/datadog-operator/baseline_test.go
+++ b/test/datadog-operator/baseline_test.go
@@ -10,6 +10,8 @@ import (
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
+const baselineOperatorImageTag = "1.30.0"
+
 func Test_baseline_manifests(t *testing.T) {
 	tests := []struct {
 		name                 string
@@ -25,7 +27,9 @@ func Test_baseline_manifests(t *testing.T) {
 				ChartPath:   "../../charts/datadog-operator",
 				ShowOnly:    []string{"templates/deployment.yaml"},
 				Values:      []string{"../../charts/datadog-operator/values.yaml"},
-				Overrides:   map[string]string{},
+				Overrides: map[string]string{
+					"image.tag": baselineOperatorImageTag,
+				},
 			},
 			baselineManifestPath: "./baseline/Operator_Deployment_default.yaml",
 			assertions:           verifyOperatorDeployment,

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -207,6 +207,26 @@ func Test_operator_chart(t *testing.T) {
 			},
 		},
 		{
+			name: "doNotCheckTag permits a non-semver Operator image tag",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/deployment.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"image.tag":           "latest",
+					"image.doNotCheckTag": "true",
+				},
+			},
+			skipTest: SkipTest,
+			assertions: func(t *testing.T, manifest string) {
+				var deployment appsv1.Deployment
+				common.Unmarshal(t, manifest, &deployment)
+				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
+				assert.Equal(t, "registry.datadoghq.com/operator:latest", operatorContainer.Image)
+			},
+		},
+		{
 			name: "untaintController disabled by default",
 			command: common.HelmCommand{
 				ReleaseName: "datadog-operator",
@@ -309,7 +329,7 @@ func verifyDeployment(t *testing.T, manifest string) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, v1.PullPolicy("IfNotPresent"), operatorContainer.ImagePullPolicy)
-	assert.Equal(t, "registry.datadoghq.com/operator:1.30.0-rc.2", operatorContainer.Image)
+	assert.NotEmpty(t, operatorContainer.Image)
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=false")
 	assert.NotContains(t, operatorContainer.Args, "-webhookEnabled=true")
 	assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=false")


### PR DESCRIPTION
#### ogWhat this PR does / why we need it:

Pins the Operator Deployment baseline to a test-owned image tag so releases can update the chart default without baseline churn. The default deployment test now checks that the image renders without asserting its current tag, while an explicit test preserves `image.doNotCheckTag` coverage.

The Operator release script no longer rewrites the image assertion or regenerates Operator baselines during a version bump.

#### Which issue this PR fixes

#### Special notes for your reviewer:

Repository-wide release-flow references do not read the Operator tag from the baselines in a later step.

#### Checklist

- [ ] All commits are signed and show as "Verified" on GitHub
- [ ] Chart Version semver bump label has been added (use `datadog-operator/no-version-bump`)
- [X] Updated the affected test baseline