### PR TITLE
feat(datadog): grant KServe collection RBAC

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.242.0
+
+* Grant the Cluster Agent read access to KServe custom resources collected by the orchestrator explorer.
+
 ## 3.241.0
 
 * Enable the DatadogInstrumentation CRD controller (`datadog.instrumentationCrd.enabled`) by default for all Agent versions at or above 7.82.0, and install its CRD without unrelated Datadog CRDs.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.241.0
+version: 3.242.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.241.0](https://img.shields.io/badge/Version-3.241.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.242.0](https://img.shields.io/badge/Version-3.242.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/templates/orchestrator-explorer-rbac.yaml
+++ b/charts/datadog/templates/orchestrator-explorer-rbac.yaml
@@ -167,6 +167,24 @@ rules:
   - list
   - watch
   - get
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterstoragecontainers
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - clusterservingruntimes
+  - inferencegraphs
+  - inferenceservices
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
 {{- if .Values.datadog.orchestratorExplorer.networkCRDs.enabled }}
 # Gateway API, service mesh, and ingress controller CRDs for internet-reachability analysis
 - apiGroups:

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.74.yaml
@@ -1286,6 +1286,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
+++ b/test/datadog/baseline/manifests/adp-enabled-dsd-enabled-7.75.yaml
@@ -1286,6 +1286,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/agent-clusterchecks-deployment_default.yaml
@@ -1571,6 +1571,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/agent-workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/agent-workload_exclude.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default.yaml
@@ -1567,6 +1567,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_advanced_AC_injection.yaml
@@ -1567,6 +1567,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_minimal_AC_injection.yaml
@@ -1567,6 +1567,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
+++ b/test/datadog/baseline/manifests/cluster-agent-deployment_default_workload_exclude.yaml
@@ -1567,6 +1567,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe.yaml
@@ -1555,6 +1555,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_cws_in_security_agent.yaml
@@ -1584,6 +1584,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
+++ b/test/datadog/baseline/manifests/compliance_run_in_system_probe_only.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/confd.yaml
+++ b/test/datadog/baseline/manifests/confd.yaml
@@ -1607,6 +1607,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/daemonset_default.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/default_all.yaml
+++ b/test/datadog/baseline/manifests/default_all.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/default_all_windows.yaml
+++ b/test/datadog/baseline/manifests/default_all_windows.yaml
@@ -644,6 +644,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gdc_compliance_run_in_system_probe.yaml
@@ -1301,6 +1301,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_default.yaml
@@ -1301,6 +1301,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/gdc_daemonset_logs_collection.yaml
@@ -1301,6 +1301,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_default.yaml
@@ -1316,6 +1316,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_allowlistedv2workload_kubelet_apiserver.yaml
@@ -1301,6 +1301,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_compliance_run_in_system_probe.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_npm.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_system_probe.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_usm.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_adp.yaml
@@ -1569,6 +1569,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_apm.yaml
@@ -1569,6 +1569,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_default.yaml
@@ -1569,6 +1569,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_logs.yaml
@@ -1569,6 +1569,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
+++ b/test/datadog/baseline/manifests/gke_autopilot_workloadallowlist_otel_feature_gates.yaml
@@ -1640,6 +1640,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gpu_monitoring.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring.yaml
@@ -1559,6 +1559,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
+++ b/test/datadog/baseline/manifests/gpu_monitoring_cos.yaml
@@ -1559,6 +1559,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
+++ b/test/datadog/baseline/manifests/kube-state-metrics-custom-resources.yaml
@@ -1619,6 +1619,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/npm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/npm_daemonset_default.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_config_ports.yaml
@@ -1625,6 +1625,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_configmap.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_configmap.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_container_ports.yaml
@@ -1625,6 +1625,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_logs_collection.yaml
@@ -1577,6 +1577,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
+++ b/test/datadog/baseline/manifests/otel-agent_volume_mounts.yaml
@@ -1625,6 +1625,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/otel_enabled.yaml
+++ b/test/datadog/baseline/manifests/otel_enabled.yaml
@@ -1625,6 +1625,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/other_default.yaml
+++ b/test/datadog/baseline/manifests/other_default.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/registry_migration_ap1.yaml
+++ b/test/datadog/baseline/manifests/registry_migration_ap1.yaml
@@ -1555,6 +1555,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/sbom_enabled.yaml
+++ b/test/datadog/baseline/manifests/sbom_enabled.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
+++ b/test/datadog/baseline/manifests/securityContextOverrides_allAgents.yaml
@@ -1569,6 +1569,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/system_probe_daemonset_default.yaml
@@ -1555,6 +1555,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
+++ b/test/datadog/baseline/manifests/talos_linux_with_system_probe.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/usm_daemonset_default.yaml
+++ b/test/datadog/baseline/manifests/usm_daemonset_default.yaml
@@ -1554,6 +1554,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/workload_protection.yaml
+++ b/test/datadog/baseline/manifests/workload_protection.yaml
@@ -1555,6 +1555,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
+++ b/test/datadog/baseline/manifests/workload_protection_direct_sender.yaml
@@ -1555,6 +1555,24 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterstoragecontainers
+      - llminferenceserviceconfigs
+      - llminferenceservices
+      - localmodelcaches
+      - localmodelnamespacecaches
+      - localmodelnodegroups
+      - localmodelnodes
+      - clusterservingruntimes
+      - inferencegraphs
+      - inferenceservices
+      - servingruntimes
+      - trainedmodels
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
#### What this PR does / why we need it:

Grants the Cluster Agent list/watch permissions for the 12 `serving.kserve.io` resources collected out of the box by DataDog/datadog-agent#55699.

The Datadog chart is bumped to 3.242.0, with its changelog, generated README, and manifest baselines updated.

#### Special notes for your reviewer:

This is the Helm installation companion to DataDog/datadog-agent#55699. DataDog/datadog-operator#3418 grants the same permissions for Operator-managed installations.

#### Checklist

- [ ] All commits are signed and show as "Verified" on GitHub
- [x] Chart Version semver bump label has been added
- [x] Test baselines have been updated
- [x] Documentation has been updated with helm-docs
- [x] CHANGELOG.md has been updated