### PR TITLE
[Host Profiler][PROF-15459] add feature option to deploy as dd-agent

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.242.0
+
+* [Host Profiler][PROF-15459] add feature option to deploy as dd-agent ([#2894](https://github.com/DataDog/helm-charts/pull/2894)).
+
 ## 3.241.0
 
 * Enable the DatadogInstrumentation CRD controller (`datadog.instrumentationCrd.enabled`) by default for all Agent versions at or above 7.82.0, and install its CRD without unrelated Datadog CRDs.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.241.0
+version: 3.242.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.241.0](https://img.shields.io/badge/Version-3.241.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.242.0](https://img.shields.io/badge/Version-3.242.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.
@@ -857,6 +857,7 @@ helm install <RELEASE_NAME> \
 | datadog.hostProfiler.image | string | `""` | Image the Host Profiler. This parameter is experimental and will be removed once official image is available. |
 | datadog.hostProfiler.imagePullPolicy | string | `""` | Pull policy for the Host Profiler image. Defaults to agents.image.pullPolicy when unset. |
 | datadog.hostProfiler.loggingSeccomp | bool | `false` | Use the seccomp profile that also permits logging syscalls |
+| datadog.hostProfiler.runAsNonRoot | bool | `false` | Run the Host Profiler as the dd-agent user (UID/GID 100). |
 | datadog.hostProfiler.seccomp | object | `{"enabled":true}` | Seccomp profile configuration for the Host Profiler |
 | datadog.hostProfiler.seccomp.enabled | bool | `true` | Apply the localhost seccomp profile to the host-profiler container and run the init container that installs it on the node. Disable to run the host-profiler container Unconfined (no init container, no profile installed on the node). |
 | datadog.hostProfiler.seccompRoot | string | `"/var/lib/kubelet/seccomp"` | Specify the seccomp profile root directory |

--- a/charts/datadog/templates/_container-host-profiler.yaml
+++ b/charts/datadog/templates/_container-host-profiler.yaml
@@ -9,7 +9,13 @@
   command:
     - "host-profiler"
     - "--core-config={{ template "datadog.confPath" .  }}/datadog.yaml"
-{{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.hostProfiler.securityContext "targetSystem" .Values.targetSystem "seccomp" (include "host-profiler-seccomp-profile" .) "kubeversion" .Capabilities.KubeVersion.Version "apparmor" (and .Values.agents.podSecurity.apparmor.enabled .Values.datadog.hostProfiler.apparmor)) | nindent 2 }}
+{{- $securityContext := deepCopy .Values.agents.containers.hostProfiler.securityContext -}}
+{{- if .Values.datadog.hostProfiler.runAsNonRoot }}
+{{- $_ := set $securityContext "runAsUser" 100 }}
+{{- $_ := set $securityContext "runAsGroup" 100 }}
+{{- $_ := set $securityContext "runAsNonRoot" true }}
+{{- end }}
+{{ include "generate-security-context" (dict "securityContext" $securityContext "targetSystem" .Values.targetSystem "seccomp" (include "host-profiler-seccomp-profile" .) "kubeversion" .Capabilities.KubeVersion.Version "apparmor" (and .Values.agents.podSecurity.apparmor.enabled .Values.datadog.hostProfiler.apparmor)) | nindent 2 }}
   resources:
 {{ toYaml .Values.agents.containers.hostProfiler.resources | indent 4 }}
 {{- if or .Values.datadog.envFrom .Values.agents.containers.hostProfiler.envFrom }}

--- a/charts/datadog/values.yaml
+++ b/charts/datadog/values.yaml
@@ -814,6 +814,8 @@ datadog:
   hostProfiler:
     # datadog.hostProfiler.enabled -- Enable the Host Profiler. This feature is experimental and subject to change.
     enabled: false
+    # datadog.hostProfiler.runAsNonRoot -- Run the Host Profiler as the dd-agent user (UID/GID 100).
+    runAsNonRoot: false
     # datadog.hostProfiler.image -- Image the Host Profiler. This parameter is experimental and will be removed once official image is available.
     image: ""
     # datadog.hostProfiler.imagePullPolicy -- Pull policy for the Host Profiler image. Defaults to agents.image.pullPolicy when unset.

--- a/test/datadog/host_profiler_test.go
+++ b/test/datadog/host_profiler_test.go
@@ -33,6 +33,21 @@ func renderHostProfilerDaemonSet(t *testing.T, overrides map[string]string) apps
 	return ds
 }
 
+func TestHostProfilerSecurityContext(t *testing.T) {
+	overrides := copyMap(hostProfilerBaseOverrides)
+	overrides["datadog.hostProfiler.runAsNonRoot"] = "true"
+	ds := renderHostProfilerDaemonSet(t, overrides)
+	hpContainer, ok := getContainer(t, ds.Spec.Template.Spec.Containers, "host-profiler")
+	require.True(t, ok)
+	require.NotNil(t, hpContainer.SecurityContext)
+	require.NotNil(t, hpContainer.SecurityContext.RunAsUser)
+	require.NotNil(t, hpContainer.SecurityContext.RunAsGroup)
+	require.NotNil(t, hpContainer.SecurityContext.RunAsNonRoot)
+	assert.Equal(t, int64(100), *hpContainer.SecurityContext.RunAsUser)
+	assert.Equal(t, int64(100), *hpContainer.SecurityContext.RunAsGroup)
+	assert.True(t, *hpContainer.SecurityContext.RunAsNonRoot)
+}
+
 func TestHostProfilerSeccomp(t *testing.T) {
 	ds := renderHostProfilerDaemonSet(t, hostProfilerBaseOverrides)
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `datadog.hostProfiler.runAsNonRoot` to allow helm users to easily enable the profiler run as non root (dd-agent UID/GID)
Supports https://github.com/DataDog/datadog-agent/pull/54004

It's disabled by default as for now most host profiler images don't include the necessary changes. The goal is to enable it by default later.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [ ] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [ ] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [ ] `CHANGELOG.md` has been updated 
- [ ] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits