### PR TITLE
feat(datadog): initial support for PAR split mode

### DIFF
--- a/charts/datadog/CHANGELOG.md
+++ b/charts/datadog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 3.243.0
+
+* Add support for the Private Action Runner in split deployment mode.
+
 ## 3.242.0
 
 * Grant the Cluster Agent read access to KubeRay and NVIDIA Dynamo custom resources collected by the orchestrator explorer.

--- a/charts/datadog/Chart.yaml
+++ b/charts/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: datadog
-version: 3.242.0
+version: 3.243.0
 appVersion: "7"
 description: Datadog Agent
 keywords:

--- a/charts/datadog/README.md
+++ b/charts/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-![Version: 3.242.0](https://img.shields.io/badge/Version-3.242.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
+![Version: 3.243.0](https://img.shields.io/badge/Version-3.243.0-informational?style=flat-square) ![AppVersion: 7](https://img.shields.io/badge/AppVersion-7-informational?style=flat-square)
 
 > [!WARNING]
 > The Datadog Operator is now enabled by default since version [3.157.0](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31570) to collect chart metadata for display in [Fleet Automation](https://docs.datadoghq.com/agent/fleet_automation/). We are aware of issues affecting some environments and are actively working on fixes. We apologize for the inconvenience and appreciate your patience while we address these issues.

--- a/charts/datadog/ci/private-action-runner-split-values.yaml
+++ b/charts/datadog/ci/private-action-runner-split-values.yaml
@@ -1,0 +1,9 @@
+datadog:
+  apiKey: "00000000000000000000000000000000"
+  privateActionRunner:
+    enabled: true
+    selfEnroll: true
+    splitEnabled: true
+agents:
+  image:
+    tag: 7.84.0

--- a/charts/datadog/templates/_container-private-action-runner.yaml
+++ b/charts/datadog/templates/_container-private-action-runner.yaml
@@ -3,7 +3,11 @@
 - name: private-action-runner
   image: "{{ include "image-path" (dict "root" .Values "image" .Values.agents.image) }}"
   imagePullPolicy: {{ .Values.agents.image.pullPolicy }}
+  {{- if .Values.datadog.privateActionRunner.splitEnabled }}
+  command: ["/opt/entrypoints/privateactionrunner"]
+  {{- else }}
   command: ["/opt/datadog-agent/embedded/bin/privateactionrunner", "run", "-c={{ template "datadog.confPath" . }}", "-E=/etc/privateactionrunner/privateactionrunner.yaml"]
+  {{- end }}
 {{ include "generate-security-context" (dict "securityContext" .Values.agents.containers.privateActionRunner.securityContext "targetSystem" .Values.targetSystem "seccomp" "" "kubeversion" .Capabilities.KubeVersion.Version) | nindent 2 }}
   resources:
 {{ toYaml .Values.agents.containers.privateActionRunner.resources | indent 4 }}
@@ -45,6 +49,14 @@
     - name: DD_DOGSTATSD_SOCKET
       value: {{ .Values.datadog.dogstatsd.socketPath | quote }}
     {{- end }}
+    {{- if .Values.datadog.privateActionRunner.splitEnabled }}
+    - name: DD_PRIVATE_ACTION_RUNNER_SPLIT_ENABLED
+      value: "true"
+    - name: DD_PRIVATE_ACTION_RUNNER_EXTRA_CONFIG_PATH
+      value: /etc/privateactionrunner/privateactionrunner.yaml
+    - name: DD_PM_SOCKET_PATH
+      value: /opt/datadog-agent/run/dd-procmgrd.sock
+    {{- end }}
     {{- include "additional-env-entries" .Values.agents.containers.privateActionRunner.env | indent 4 }}
     {{- include "additional-env-dict-entries" .Values.agents.containers.privateActionRunner.envDict | indent 4 }}
   volumeMounts:
@@ -62,6 +74,11 @@
     - name: {{ template "datadog.fullname" . }}-privateactionrunner-config
       mountPath: /etc/privateactionrunner
       readOnly: true
+    {{- if .Values.datadog.privateActionRunner.splitEnabled }}
+    - name: private-action-runner-run
+      mountPath: /opt/datadog-agent/run
+      readOnly: false
+    {{- end }}
     {{- if eq .Values.targetSystem "linux" }}
     - name: tmpdir
       mountPath: /tmp
@@ -92,5 +109,10 @@
     {{- end }}
 {{- if .Values.agents.volumeMounts }}
 {{ toYaml .Values.agents.volumeMounts | indent 4 }}
+{{- end }}
+{{- if .Values.datadog.privateActionRunner.splitEnabled }}
+  readinessProbe:
+    exec:
+      command: ["/par-probe.sh"]
 {{- end }}
 {{- end -}}

--- a/charts/datadog/templates/_daemonset-volumes-linux.yaml
+++ b/charts/datadog/templates/_daemonset-volumes-linux.yaml
@@ -5,6 +5,10 @@
   emptyDir: {}
 - name: s6-run
   emptyDir: {}
+{{- if and .Values.datadog.privateActionRunner.enabled .Values.datadog.privateActionRunner.splitEnabled }}
+- name: private-action-runner-run
+  emptyDir: {}
+{{- end }}
 {{- if (or (.Values.datadog.confd) (.Values.datadog.autoconf)) }}
 - name: confd
   configMap:

--- a/charts/datadog/templates/_helpers.tpl
+++ b/charts/datadog/templates/_helpers.tpl
@@ -1517,6 +1517,14 @@ Validate Node Agent Private Action Runner configuration
 */}}
 {{- define "validate-node-private-action-runner-config" -}}
 {{- if .Values.datadog.privateActionRunner.enabled -}}
+{{- if .Values.datadog.privateActionRunner.splitEnabled -}}
+{{- if or .Values.useFIPSAgent .Values.fips.enabled -}}
+{{- fail "Node Agent Private Action Runner split mode does not support FIPS." -}}
+{{- end -}}
+{{- if and (not .Values.agents.image.doNotCheckTag) (semverCompare "<7.84.0-0" (include "get-agent-version" .)) -}}
+{{- fail "Node Agent Private Action Runner split mode requires Datadog Agent 7.84.0 or newer." -}}
+{{- end -}}
+{{- end -}}
 {{- if not .Values.datadog.privateActionRunner.selfEnroll -}}
 {{- if and (not .Values.datadog.privateActionRunner.identityFromExistingSecret) (or (not .Values.datadog.privateActionRunner.urn) (not .Values.datadog.privateActionRunner.privateKey)) -}}
 {{- fail "Node Agent Private Action Runner: when selfEnroll is disabled, you must provide either datadog.privateActionRunner.identityFromExistingSecret or both datadog.privateActionRunner.urn and datadog.privateActionRunner.privateKey" }}

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -253,7 +253,9 @@ spec:
 {{- if .Values.agents.volumes }}
 {{ toYaml .Values.agents.volumes | indent 6 }}
 {{- end }}
-      {{- if .Values.agents.terminationGracePeriodSeconds }}
+      {{- if and .Values.datadog.privateActionRunner.enabled .Values.datadog.privateActionRunner.splitEnabled }}
+      terminationGracePeriodSeconds: {{ max 190 (.Values.agents.terminationGracePeriodSeconds | default 0) }}
+      {{- else if .Values.agents.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.agents.terminationGracePeriodSeconds }}
       {{- end }}
       tolerations:

--- a/test/datadog/gke_autopilot_allowlistedv2workload_test.go
+++ b/test/datadog/gke_autopilot_allowlistedv2workload_test.go
@@ -27,9 +27,10 @@ var allowlistedV2WorkloadExemptedHostPaths = map[string]interface{}{
 // (legacy) mode. HELM_FORCE_RENDER=false simulates clusters without WorkloadAllowlist CRDs.
 func Test_autopilotAllowlistedV2WorkloadConfigs(t *testing.T) {
 	tests := []struct {
-		name       string
-		command    common.HelmCommand
-		assertions func(t *testing.T, manifest string)
+		name          string
+		command       common.HelmCommand
+		errorContains string
+		assertions    func(t *testing.T, manifest string)
 	}{
 		{
 			name: "default",
@@ -47,12 +48,35 @@ func Test_autopilotAllowlistedV2WorkloadConfigs(t *testing.T) {
 			},
 			assertions: verifyDaemonsetAutopilotAllowlistedV2WorkloadMinimal,
 		},
+		{
+			name: "split private action runner rejected",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"agents.image.tag":                         "7.84.0",
+					"datadog.envDict.HELM_FORCE_RENDER":        "false",
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"providers.gke.autopilot":                  "true",
+					"datadog.privateActionRunner.enabled":      "true",
+					"datadog.privateActionRunner.splitEnabled": "true",
+					"datadog.privateActionRunner.selfEnroll":   "true",
+				},
+			},
+			errorContains: "Private Action Runner is not supported on GKE Autopilot / GDC environments",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manifest, err := common.RenderChart(t, tt.command)
-			assert.Nil(t, err, "couldn't render template")
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+				return
+			}
+			assert.NoError(t, err, "couldn't render template")
 			tt.assertions(t, manifest)
 		})
 	}

--- a/test/datadog/gke_autopilot_workloadallowlist_test.go
+++ b/test/datadog/gke_autopilot_workloadallowlist_test.go
@@ -63,9 +63,10 @@ var workloadAllowlistExemptedHostPaths = map[string]interface{}{
 // (GKE >= 1.32.1-gke.1729000). On real clusters the CRDs are detected automatically.
 func Test_autopilotWorkloadAllowlistConfigs(t *testing.T) {
 	tests := []struct {
-		name       string
-		command    common.HelmCommand
-		assertions func(t *testing.T, manifest string)
+		name          string
+		command       common.HelmCommand
+		errorContains string
+		assertions    func(t *testing.T, manifest string)
 	}{
 		{
 			name: "default",
@@ -87,6 +88,25 @@ func Test_autopilotWorkloadAllowlistConfigs(t *testing.T) {
 				requireContainerNames(t, ds, "agent", "system-probe")
 				verifyAutopilotWorkloadAllowlistConstraints(t, manifest)
 			},
+		},
+		{
+			name: "split private action runner rejected",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"agents.image.tag":                         "7.84.0",
+					"datadog.envDict.HELM_FORCE_RENDER":        "true",
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"providers.gke.autopilot":                  "true",
+					"datadog.privateActionRunner.enabled":      "true",
+					"datadog.privateActionRunner.splitEnabled": "true",
+					"datadog.privateActionRunner.selfEnroll":   "true",
+				},
+			},
+			errorContains: "Private Action Runner is not supported on GKE Autopilot / GDC environments",
 		},
 		{
 			name: "with agent-data-plane",
@@ -143,7 +163,11 @@ func Test_autopilotWorkloadAllowlistConfigs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manifest, err := common.RenderChart(t, tt.command)
-			assert.Nil(t, err, "couldn't render template")
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+				return
+			}
+			assert.NoError(t, err, "couldn't render template")
 			tt.assertions(t, manifest)
 		})
 	}

--- a/test/datadog/gke_gdc_test.go
+++ b/test/datadog/gke_gdc_test.go
@@ -19,9 +19,10 @@ var allowedGDCHostPaths = map[string]interface{}{
 
 func Test_gdcConfigs(t *testing.T) {
 	tests := []struct {
-		name       string
-		command    common.HelmCommand
-		assertions func(t *testing.T, manifest string)
+		name          string
+		command       common.HelmCommand
+		errorContains string
+		assertions    func(t *testing.T, manifest string)
 	}{
 		{
 			name: "default",
@@ -43,12 +44,34 @@ func Test_gdcConfigs(t *testing.T) {
 			},
 			assertions: verifyDaemonsetGDCConstraints,
 		},
+		{
+			name: "split private action runner rejected",
+			command: common.HelmCommand{
+				ReleaseName: "datadog",
+				ChartPath:   "../../charts/datadog",
+				ShowOnly:    []string{"templates/daemonset.yaml"},
+				Values:      []string{"../../charts/datadog/values.yaml"},
+				Overrides: map[string]string{
+					"agents.image.tag":                         "7.84.0",
+					"datadog.apiKeyExistingSecret":             "datadog-secret",
+					"providers.gke.gdc":                        "true",
+					"datadog.privateActionRunner.enabled":      "true",
+					"datadog.privateActionRunner.splitEnabled": "true",
+					"datadog.privateActionRunner.selfEnroll":   "true",
+				},
+			},
+			errorContains: "Private Action Runner is not supported on GKE Autopilot / GDC environments",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manifest, err := common.RenderChart(t, tt.command)
-			assert.Nil(t, err, "couldn't render template")
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+				return
+			}
+			assert.NoError(t, err, "couldn't render template")
 			tt.assertions(t, manifest)
 		})
 	}

--- a/test/datadog/private_action_runner_test.go
+++ b/test/datadog/private_action_runner_test.go
@@ -18,6 +18,9 @@ const (
 	DDPARPrivateKey       = "DD_PRIVATE_ACTION_RUNNER_PRIVATE_KEY"
 	DDPARActionsAllowlist = "DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST"
 	DDPARIdentitySecret   = "DD_PRIVATE_ACTION_RUNNER_IDENTITY_SECRET_NAME"
+	DDPARSplitEnabled     = "DD_PRIVATE_ACTION_RUNNER_SPLIT_ENABLED"
+	DDPARExtraConfigPath  = "DD_PRIVATE_ACTION_RUNNER_EXTRA_CONFIG_PATH"
+	DDPMPath              = "DD_PM_SOCKET_PATH"
 )
 
 func selectPAREnvVars(envVars []corev1.EnvVar) map[string]string {
@@ -28,6 +31,9 @@ func selectPAREnvVars(envVars []corev1.EnvVar) map[string]string {
 		DDPARPrivateKey,
 		DDPARActionsAllowlist,
 		DDPARIdentitySecret,
+		DDPARSplitEnabled,
+		DDPARExtraConfigPath,
+		DDPMPath,
 	}
 
 	selection := map[string]string{}
@@ -332,6 +338,118 @@ func Test_NodeAgent_PrivateActionRunner_Disabled(t *testing.T) {
 	assert.Nil(t, parContainer, "PAR container should not exist when disabled")
 }
 
+func Test_NodeAgent_PrivateActionRunner_SplitMode(t *testing.T) {
+	manifest, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/daemonset.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"agents.image.tag":                         "7.84.0",
+			"datadog.apiKeyExistingSecret":             "datadog-secret",
+			"datadog.privateActionRunner.enabled":      "true",
+			"datadog.privateActionRunner.splitEnabled": "true",
+			"datadog.privateActionRunner.selfEnroll":   "true",
+			"agents.terminationGracePeriodSeconds":     "240",
+		},
+	})
+	require.NoError(t, err)
+
+	var daemonset appsv1.DaemonSet
+	common.Unmarshal(t, manifest, &daemonset)
+	parContainer := findPARContainer(daemonset)
+	require.NotNil(t, parContainer)
+
+	assert.Equal(t, []string{"/opt/entrypoints/privateactionrunner"}, parContainer.Command)
+	require.NotNil(t, parContainer.ReadinessProbe)
+	require.NotNil(t, parContainer.ReadinessProbe.Exec)
+	assert.Equal(t, []string{"/par-probe.sh"}, parContainer.ReadinessProbe.Exec.Command)
+
+	envVars := selectPAREnvVars(parContainer.Env)
+	assert.Equal(t, "true", envVars[DDPARSplitEnabled])
+	assert.Equal(t, "/etc/privateactionrunner/privateactionrunner.yaml", envVars[DDPARExtraConfigPath])
+	assert.Equal(t, "/opt/datadog-agent/run/dd-procmgrd.sock", envVars[DDPMPath])
+
+	mounts := map[string]corev1.VolumeMount{}
+	for _, mount := range parContainer.VolumeMounts {
+		mounts[mount.Name] = mount
+	}
+	runMount, ok := mounts["private-action-runner-run"]
+	require.True(t, ok)
+	assert.Equal(t, "/opt/datadog-agent/run", runMount.MountPath)
+	assert.False(t, runMount.ReadOnly)
+
+	volumes := map[string]corev1.Volume{}
+	for _, volume := range daemonset.Spec.Template.Spec.Volumes {
+		volumes[volume.Name] = volume
+	}
+	runVolume, ok := volumes["private-action-runner-run"]
+	require.True(t, ok)
+	assert.NotNil(t, runVolume.EmptyDir)
+	require.NotNil(t, daemonset.Spec.Template.Spec.TerminationGracePeriodSeconds)
+	assert.Equal(t, int64(240), *daemonset.Spec.Template.Spec.TerminationGracePeriodSeconds)
+}
+
+func Test_NodeAgent_PrivateActionRunner_SplitModeMinimumGracePeriod(t *testing.T) {
+	manifest, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/daemonset.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"agents.image.tag":                         "7.84.0",
+			"datadog.apiKeyExistingSecret":             "datadog-secret",
+			"datadog.privateActionRunner.enabled":      "true",
+			"datadog.privateActionRunner.splitEnabled": "true",
+			"datadog.privateActionRunner.selfEnroll":   "true",
+			"agents.terminationGracePeriodSeconds":     "100",
+		},
+	})
+	require.NoError(t, err)
+
+	var daemonset appsv1.DaemonSet
+	common.Unmarshal(t, manifest, &daemonset)
+	require.NotNil(t, daemonset.Spec.Template.Spec.TerminationGracePeriodSeconds)
+	assert.Equal(t, int64(190), *daemonset.Spec.Template.Spec.TerminationGracePeriodSeconds)
+}
+
+func Test_NodeAgent_PrivateActionRunner_SplitModeRequiresCompatibleAgent(t *testing.T) {
+	_, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/daemonset.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"agents.image.tag":                         "7.83.1",
+			"datadog.apiKeyExistingSecret":             "datadog-secret",
+			"datadog.privateActionRunner.enabled":      "true",
+			"datadog.privateActionRunner.splitEnabled": "true",
+			"datadog.privateActionRunner.selfEnroll":   "true",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "split mode requires Datadog Agent 7.84.0 or newer")
+}
+
+func Test_NodeAgent_PrivateActionRunner_SplitModeRejectsFIPS(t *testing.T) {
+	_, err := common.RenderChart(t, common.HelmCommand{
+		ReleaseName: "datadog",
+		ChartPath:   "../../charts/datadog",
+		ShowOnly:    []string{"templates/daemonset.yaml"},
+		Values:      []string{"../../charts/datadog/values.yaml"},
+		Overrides: map[string]string{
+			"agents.image.tag":                         "7.84.0",
+			"datadog.apiKeyExistingSecret":             "datadog-secret",
+			"datadog.privateActionRunner.enabled":      "true",
+			"datadog.privateActionRunner.splitEnabled": "true",
+			"datadog.privateActionRunner.selfEnroll":   "true",
+			"useFIPSAgent":                             "true",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "split mode does not support FIPS")
+}
+
 func Test_NodeAgent_PrivateActionRunner_Enabled_SelfEnroll(t *testing.T) {
 	manifest, err := common.RenderChart(t, common.HelmCommand{
 		ReleaseName: "datadog",
@@ -352,6 +470,11 @@ func Test_NodeAgent_PrivateActionRunner_Enabled_SelfEnroll(t *testing.T) {
 
 	parContainer := findPARContainer(daemonset)
 	require.NotNil(t, parContainer, "PAR container should exist")
+
+	assert.Equal(t, []string{"/opt/datadog-agent/embedded/bin/privateactionrunner", "run", "-c=/etc/datadog-agent", "-E=/etc/privateactionrunner/privateactionrunner.yaml"}, parContainer.Command)
+	assert.Nil(t, parContainer.ReadinessProbe)
+	assert.Empty(t, selectPAREnvVars(parContainer.Env)[DDPARSplitEnabled])
+	assert.Nil(t, daemonset.Spec.Template.Spec.TerminationGracePeriodSeconds)
 
 	// Verify DD_APP_KEY is injected for self-enrollment
 	foundAppKey := false


### PR DESCRIPTION
## What this PR does / why we need it

Adds [PAR split mode](https://docs.google.com/document/d/1VS1aI_rKRSfx9qx-bZaHJKRq8_oZdtXL9dLda93_Gmo/edit?tab=t.0) support to the agent chart.

There will likely be followups to this chart as split mode gains deployment parity with the existing PAR, hence the "initial support" title.

## Special notes for your reviewer

- The new `splitEnabled` config option is intentionally omitted from the public documentation until split mode support is available across all agent deployment modes.
- The exact minimum agent version where split mode support will exist is unknown. But it's at least 7.84. We will bump it as needed if necessary.

## Validation

- Existing Agent Kubernetes E2E confirms existing behavior is preserved
- New Split-mode Agent Kubernetes E2E tests were run with this chart locally ([WIP branch](https://github.com/DataDog/datadog-agent/compare/ilya/split-mode-docker-setup...ilya/par-split-mode-helm-e2e?expand=1))

## Checklist

- [x] All commits are signed and show as Verified on GitHub
- [x] Chart Version semver bump label has been added
- [x] Test baselines were updated; no changes were produced
- [x] Documentation has been regenerated with `.github/helm-docs.sh`
- [x] `CHANGELOG.md` has been updated
