### PR TITLE
feat(datadog-operator): support unhealthyPodEvictionPolicy on the PodDisruptionBudget

### DIFF
--- a/charts/datadog-operator/CHANGELOG.md
+++ b/charts/datadog-operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.26.0-dev.6
+
+* Add `podDisruptionBudget.unhealthyPodEvictionPolicy` to configure the PodDisruptionBudget eviction policy for unhealthy Datadog Operator PODs.
+
 ## 2.26.0-dev.5
 
 * Update Datadog Operator chart for 1.30.0-rc.3.

--- a/charts/datadog-operator/Chart.yaml
+++ b/charts/datadog-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datadog-operator
-version: 2.26.0-dev.5
+version: 2.26.0-dev.6
 appVersion: 1.30.0-rc.3
 description: Datadog Operator
 keywords:

--- a/charts/datadog-operator/README.md
+++ b/charts/datadog-operator/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![Version: 2.26.0-dev.5](https://img.shields.io/badge/Version-2.26.0--dev.5-informational?style=flat-square) ![AppVersion: 1.30.0-rc.3](https://img.shields.io/badge/AppVersion-1.30.0--rc.3-informational?style=flat-square)
+![Version: 2.26.0-dev.6](https://img.shields.io/badge/Version-2.26.0--dev.6-informational?style=flat-square) ![AppVersion: 1.30.0-rc.3](https://img.shields.io/badge/AppVersion-1.30.0--rc.3-informational?style=flat-square)
 
 ## Values
 
@@ -55,6 +55,8 @@
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Allows to schedule Datadog Operator on specific nodes |
 | operatorMetricsEnabled | string | `"true"` | Enable forwarding of Datadog Operator metrics and events to Datadog. |
 | podAnnotations | object | `{}` | Allows setting additional annotations for Datadog Operator PODs |
+| podDisruptionBudget | object | `{"unhealthyPodEvictionPolicy":""}` | Set the PodDisruptionBudget spec of the Datadog Operator PODs, only created when replicaCount is greater than 1 |
+| podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Policy for evicting unhealthy pods: "IfHealthyBudget" or "AlwaysAllow". Requires Kubernetes 1.26+. Empty uses the Kubernetes default (IfHealthyBudget). |
 | podLabels | object | `{}` | Allows setting additional labels for for Datadog Operator PODs |
 | priorityClassName | string | `nil` | Allows setting the priority class name for Datadog Operator PODs |
 | rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |

--- a/charts/datadog-operator/templates/pod_disruption_budget.yaml
+++ b/charts/datadog-operator/templates/pod_disruption_budget.yaml
@@ -8,6 +8,9 @@ metadata:
 {{ include "datadog-operator.labels" . | indent 4 }}
 spec:
   minAvailable: 1
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "datadog-operator.name" . }}

--- a/charts/datadog-operator/values.yaml
+++ b/charts/datadog-operator/values.yaml
@@ -5,6 +5,11 @@
 # replicaCount -- Number of instances of Datadog Operator
 replicaCount: 1
 
+# podDisruptionBudget -- Set the PodDisruptionBudget spec of the Datadog Operator PODs, only created when replicaCount is greater than 1
+podDisruptionBudget:
+  # podDisruptionBudget.unhealthyPodEvictionPolicy -- Policy for evicting unhealthy pods: "IfHealthyBudget" or "AlwaysAllow". Requires Kubernetes 1.26+. Empty uses the Kubernetes default (IfHealthyBudget).
+  unhealthyPodEvictionPolicy: ""
+
 # apiKey -- Your Datadog API key
 apiKey:  # <DATADOG_API_KEY>
 

--- a/test/datadog-operator/baseline/Operator_Deployment_default.yaml
+++ b/test/datadog-operator/baseline/Operator_Deployment_default.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: datadog-agent
   labels:
     app.kubernetes.io/name: datadog-operator
-    helm.sh/chart: datadog-operator-2.26.0-dev.5
+    helm.sh/chart: datadog-operator-2.26.0-dev.6
     app.kubernetes.io/instance: datadog-operator
     app.kubernetes.io/version: "1.30.0-rc.3"
     app.kubernetes.io/managed-by: Helm

--- a/test/datadog-operator/operator_deployment_test.go
+++ b/test/datadog-operator/operator_deployment_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/DataDog/helm-charts/test/common"
@@ -135,6 +136,44 @@ func Test_operator_chart(t *testing.T) {
 				operatorContainer := deployment.Spec.Template.Spec.Containers[0]
 				assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=false")
 				assert.NotContains(t, operatorContainer.Args, "-supportExtendedDaemonset=true")
+			},
+			skipTest: SkipTest,
+		},
+		{
+			name: "PodDisruptionBudget does not set unhealthyPodEvictionPolicy by default",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/pod_disruption_budget.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"replicaCount": "2",
+				},
+			},
+			assertions: func(t *testing.T, manifest string) {
+				var pdb policyv1.PodDisruptionBudget
+				common.Unmarshal(t, manifest, &pdb)
+				assert.Nil(t, pdb.Spec.UnhealthyPodEvictionPolicy)
+			},
+			skipTest: SkipTest,
+		},
+		{
+			name: "PodDisruptionBudget sets unhealthyPodEvictionPolicy when configured",
+			command: common.HelmCommand{
+				ReleaseName: "datadog-operator",
+				ChartPath:   "../../charts/datadog-operator",
+				ShowOnly:    []string{"templates/pod_disruption_budget.yaml"},
+				Values:      []string{"../../charts/datadog-operator/values.yaml"},
+				Overrides: map[string]string{
+					"replicaCount": "2",
+					"podDisruptionBudget.unhealthyPodEvictionPolicy": "AlwaysAllow",
+				},
+			},
+			assertions: func(t *testing.T, manifest string) {
+				var pdb policyv1.PodDisruptionBudget
+				common.Unmarshal(t, manifest, &pdb)
+				assert.NotNil(t, pdb.Spec.UnhealthyPodEvictionPolicy)
+				assert.Equal(t, policyv1.AlwaysAllow, *pdb.Spec.UnhealthyPodEvictionPolicy)
 			},
 			skipTest: SkipTest,
 		},


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `podDisruptionBudget.unhealthyPodEvictionPolicy` to the `datadog-operator` chart's PodDisruptionBudget. Only rendered when set, so existing releases keep the Kubernetes default of `IfHealthyBudget`. Setting it to `AlwaysAllow` lets a not-Ready replica be evicted during a node drain instead of blocking it, per the [Kubernetes drain recommendation](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#pdb-unhealthy-pod-eviction-policy).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Chart version bumped 2.26.0-dev.5 -> 2.26.0-dev.6 and CHANGELOG.md updated. This needs the `datadog-operator/minor-version` label since it's a new value/feature.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [ ] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)
- [x] For `datadog` or `datadog-operator` chart or value changes, update the test baselines (run: `make update-test-baselines`)
- [ ] For `datadog` chart changes, received ✅ from a member of your team

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated 
- [x] Variables are documented in the `README.md`

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
