### PR TITLE
Bump private location image to 1.73.0

### DIFF
--- a/charts/synthetics-private-location/CHANGELOG.md
+++ b/charts/synthetics-private-location/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datadog changelog
 
+## 0.17.32
+
+* Update private location image version to `1.73.0`.
+
 ## 0.17.31
 
 * Update private location image version to `1.72.0`.

--- a/charts/synthetics-private-location/Chart.yaml
+++ b/charts/synthetics-private-location/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: synthetics-private-location
-version: 0.17.31
-appVersion: 1.72.0
+version: 0.17.32
+appVersion: 1.73.0
 description: Datadog Synthetics Private Location
 keywords:
 - monitoring

--- a/charts/synthetics-private-location/README.md
+++ b/charts/synthetics-private-location/README.md
@@ -1,6 +1,6 @@
 # Datadog Synthetics Private Location
 
-![Version: 0.17.31](https://img.shields.io/badge/Version-0.17.31-informational?style=flat-square) ![AppVersion: 1.72.0](https://img.shields.io/badge/AppVersion-1.72.0-informational?style=flat-square)
+![Version: 0.17.32](https://img.shields.io/badge/Version-0.17.32-informational?style=flat-square) ![AppVersion: 1.73.0](https://img.shields.io/badge/AppVersion-1.73.0-informational?style=flat-square)
 
 [Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform. This chart adds a Datadog Synthetics Private Location Deployment. For more information about synthetics monitoring with Datadog, please refer to the [Datadog documentation website](https://docs.datadoghq.com/synthetics/private_locations/?tab=helmchart).
 
@@ -41,7 +41,7 @@ helm install <RELEASE_NAME> datadog/synthetics-private-location --set-file confi
 | hostAliases | list | `[]` | Add entries to Datadog Synthetics Private Location PODs' /etc/hosts |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Datadog Synthetics Private Location image |
 | image.repository | string | `"gcr.io/datadoghq/synthetics-private-location-worker"` | Repository to use for Datadog Synthetics Private Location image |
-| image.tag | string | `"1.72.0"` | Define the Datadog Synthetics Private Location version to use |
+| image.tag | string | `"1.73.0"` | Define the Datadog Synthetics Private Location version to use |
 | imagePullSecrets | list | `[]` | Datadog Synthetics Private Location repository pullSecret (ex: specify docker registry credentials) |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Datadog Synthetics Private Location on specific nodes |

--- a/charts/synthetics-private-location/values.yaml
+++ b/charts/synthetics-private-location/values.yaml
@@ -15,7 +15,7 @@ image:
   # image.pullPolicy -- Define the pullPolicy for Datadog Synthetics Private Location image
   pullPolicy: IfNotPresent
   # image.tag -- Define the Datadog Synthetics Private Location version to use
-  tag: 1.72.0
+  tag: 1.73.0
 
 # dnsPolicy -- DNS Policy to set to the Datadog Synthetics Private Location PODs
 dnsPolicy: ClusterFirst


### PR DESCRIPTION
<!-- dd-meta {"pullId":"0ef04245-041c-47af-ab2f-1e0ca18dd529","source":"chat","resourceId":"8a0835a9-91ac-49f7-b632-647da94d62f2","workflowId":"fd3a653e-d5c4-42f4-9d4d-b1c3dfd14423","codeChangeId":"fd3a653e-d5c4-42f4-9d4d-b1c3dfd14423","sourceType":"slack"} -->
#### What this PR does / why we need it:

##### Motivation

Release Synthetics Private Location worker 1.73.0 through the Helm chart so installations use the latest worker version by default.

##### Changes

- Bumps the synthetics-private-location chart patch version to 0.17.32.
- Updates the chart app version and default worker image tag to 1.73.0.
- Updates the generated documentation and chart changelog for the release.

##### Testing

- `helm lint charts/synthetics-private-location -f charts/synthetics-private-location/ci/kubeconform-values.yaml`
- Rendered the chart with its CI values and verified chart 0.17.32, app version 1.73.0, and worker image tag 1.73.0.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

Please add the `synthetics-private-location/patch-version` label.

#### Checklist

- [x] All commits are signed and show as "Verified" on GitHub (see: [signing commits][1])
- [x] Chart Version semver bump label has been added (use `<chartName>/minor-version`, `<chartName>/patch-version`, or `<chartName>/no-version-bump`)

GitHub CI takes care of the below, but are still required:
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] `CHANGELOG.md` has been updated

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/8a0835a9-91ac-49f7-b632-647da94d62f2)

Comment @datadog to request changes